### PR TITLE
build: move required variables out of common.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -3,11 +3,9 @@
     'visibility%': 'hidden',         # V8's visibility setting
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture
-    'uv_library%': 'static_library', # allow override to 'shared_library' for DLL/.so builds
     'component%': 'static_library',  # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
     'gcc_version%': 'unknown',
-    'clang%': 0,
   },
 
   'target_defaults': {

--- a/uv.gyp
+++ b/uv.gyp
@@ -1,5 +1,8 @@
 {
   'variables': {
+    'clang%': 0,
+    # Allow override to 'shared_library' for DLL/.so builds.
+    'uv_library%': 'static_library',
     'uv_use_dtrace%': 'false',
     # uv_parent_path is the relative path to libuv in the parent project
     # this is only relevant when dtrace is enabled and libuv is a child project


### PR DESCRIPTION
Move 'clang' and 'uv_library' out of common.gypi and into uv.gyp.
That way, embedders don't have to declare them themselves or take a
dependency on common.gypi when including uv.gyp in their gyp file.

R=@indutny
