### PR TITLE
doc,build,include: update repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ through the process.
 
 ### FORK
 
-Fork the project [on GitHub](https://github.com/joyent/libuv) and check out
+Fork the project [on GitHub](https://github.com/libuv/libuv) and check out
 your copy.
 
 ```
 $ git clone https://github.com/username/libuv.git
 $ cd libuv
-$ git remote add upstream https://github.com/joyent/libuv.git
+$ git remote add upstream https://github.com/libuv/libuv.git
 ```
 
 Now decide if you want your feature or bug fix to go into the master branch
@@ -160,7 +160,7 @@ feature branch.  Post a comment in the pull request afterwards; GitHub does
 not send out notifications when you add commits.
 
 
-[issue tracker]: https://github.com/joyent/libuv/issues
+[issue tracker]: https://github.com/libuv/libuv/issues
 [libuv mailing list]: http://groups.google.com/group/libuv
 [IRC]: http://webchat.freelibuv.net/?channels=libuv
 [Google C/C++ style guide]: http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 libuv is a multi-platform support library with a focus on asynchronous I/O. It
 was primarily developed for use by [Node.js](http://nodejs.org), but it's also
 used by [Luvit](http://luvit.io/), [Julia](http://julialang.org/),
-[pyuv](https://github.com/saghul/pyuv), and [others](https://github.com/joyent/libuv/wiki/Projects-that-use-libuv).
+[pyuv](https://github.com/saghul/pyuv), and [others](https://github.com/libuv/libuv/wiki/Projects-that-use-libuv).
 
 ## Feature highlights
 
@@ -77,7 +77,7 @@ Documentation can be browsed online [here](http://docs.libuv.org).
    &mdash; An overview of libuv with tutorials.
  * [LXJS 2012 talk](http://www.youtube.com/watch?v=nGn60vDSxQ4)
    &mdash; High-level introductory talk about libuv.
- * [Tests and benchmarks](https://github.com/joyent/libuv/tree/master/test)
+ * [Tests and benchmarks](https://github.com/libuv/libuv/tree/master/test)
    &mdash; API specification and usage examples.
  * [libuv-dox](https://github.com/thlorenz/libuv-dox)
    &mdash; Documenting types and methods of libuv, mostly by reading uv.h.
@@ -181,5 +181,5 @@ See the [guidelines for contributing][].
 [GYP]: http://code.google.com/p/gyp/
 [Python]: https://www.python.org/downloads/
 [Visual Studio Express 2010]: http://www.microsoft.com/visualstudio/eng/products/visual-studio-2010-express
-[guidelines for contributing]: https://github.com/joyent/libuv/blob/master/CONTRIBUTING.md
-[libuv_banner]: https://raw.githubusercontent.com/joyent/libuv/master/img/banner.png
+[guidelines for contributing]: https://github.com/libuv/libuv/blob/master/CONTRIBUTING.md
+[libuv_banner]: https://raw.githubusercontent.com/libuv/libuv/master/img/banner.png

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 AC_PREREQ(2.57)
-AC_INIT([libuv], [1.0.0], [https://github.com/joyent/libuv/issues])
+AC_INIT([libuv], [1.0.0], [https://github.com/libuv/libuv/issues])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/libuv-extra-automake-flags.m4])
 m4_include([m4/as_case.m4])

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -11,13 +11,13 @@ was primarily developed for use by `Node.js`_, but it's also used by `Luvit`_,
 
 .. note::
     In case you find errors in this documentation you can help by sending
-    `pull requests <https://github.com/joyent/libuv>`_!
+    `pull requests <https://github.com/libuv/libuv>`_!
 
 .. _Node.js: http://nodejs.org
 .. _Luvit: http://luvit.io
 .. _Julia: http://julialang.org
 .. _pyuv: https://github.com/saghul/pyuv
-.. _others: https://github.com/joyent/libuv/wiki/Projects-that-use-libuv
+.. _others: https://github.com/libuv/libuv/wiki/Projects-that-use-libuv
 
 
 Features
@@ -46,7 +46,7 @@ libuv can be downloaded from `here <http://dist.libuv.org/dist/>`_.
 Installation
 ------------
 
-Installation instructions can be found on `the README <https://github.com/joyent/libuv/blob/master/README.md>`_.
+Installation instructions can be found on `the README <https://github.com/libuv/libuv/blob/master/README.md>`_.
 
 
 Upgrading

--- a/include/uv.h
+++ b/include/uv.h
@@ -19,7 +19,7 @@
  * IN THE SOFTWARE.
  */
 
-/* See https://github.com/joyent/libuv#documentation for documentation. */
+/* See https://github.com/libuv/libuv#documentation for documentation. */
 
 #ifndef UV_H
 #define UV_H


### PR DESCRIPTION
The canonical repository has moved from https://github.com/joyent/libuv
to https://github.com/libuv/libuv.  Update the links inside the repo.

R=@saghul
