### PR TITLE
test: canonicalize test runner path

### DIFF
--- a/test/run-benchmarks.c
+++ b/test/run-benchmarks.c
@@ -33,7 +33,8 @@ static int maybe_run_test(int argc, char **argv);
 
 
 int main(int argc, char **argv) {
-  platform_init(argc, argv);
+  if (platform_init(argc, argv))
+    return EXIT_FAILURE;
 
   switch (argc) {
   case 1: return run_tests(1);
@@ -41,8 +42,10 @@ int main(int argc, char **argv) {
   case 3: return run_test_part(argv[1], argv[2]);
   default:
     LOGF("Too many arguments.\n");
-    return 1;
+    return EXIT_FAILURE;
   }
+
+  return EXIT_SUCCESS;
 }
 
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -46,7 +46,8 @@ static int maybe_run_test(int argc, char **argv);
 
 
 int main(int argc, char **argv) {
-  platform_init(argc, argv);
+  if (platform_init(argc, argv))
+    return EXIT_FAILURE;
 
   argv = uv_setup_args(argc, argv);
 
@@ -56,8 +57,10 @@ int main(int argc, char **argv) {
   case 3: return run_test_part(argv[1], argv[2]);
   default:
     LOGF("Too many arguments.\n");
-    return 1;
+    return EXIT_FAILURE;
   }
+
+  return EXIT_SUCCESS;
 }
 
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -43,7 +43,7 @@
 
 
 /* Do platform-specific initialization. */
-void platform_init(int argc, char **argv) {
+int platform_init(int argc, char **argv) {
   const char* tap;
 
   tap = getenv("UV_TAP_OUTPUT");
@@ -66,6 +66,8 @@ void platform_init(int argc, char **argv) {
   setvbuf(stderr, NULL, _IONBF, 0);
 
   strcpy(executable_path, argv[0]);
+
+  return 0;
 }
 
 

--- a/test/runner.c
+++ b/test/runner.c
@@ -26,7 +26,7 @@
 #include "task.h"
 #include "uv.h"
 
-char executable_path[PATHMAX] = { '\0' };
+char executable_path[sizeof(executable_path)];
 
 int tap_output = 0;
 

--- a/test/runner.h
+++ b/test/runner.h
@@ -22,6 +22,7 @@
 #ifndef RUNNER_H_
 #define RUNNER_H_
 
+#include <limits.h> /* PATH_MAX */
 #include <stdio.h> /* FILE */
 
 
@@ -83,8 +84,11 @@ typedef struct {
 #define TEST_HELPER       HELPER_ENTRY
 #define BENCHMARK_HELPER  HELPER_ENTRY
 
-#define PATHMAX 1024
-extern char executable_path[PATHMAX];
+#ifdef PATH_MAX
+extern char executable_path[PATH_MAX];
+#else
+extern char executable_path[4096];
+#endif
 
 /*
  * Include platform-dependent definitions
@@ -130,7 +134,7 @@ void print_tests(FILE* stream);
  */
 
 /* Do platform-specific initialization. */
-void platform_init(int argc, char** argv);
+int platform_init(int argc, char** argv);
 
 /* Invoke "argv[0] test-name [test-part]". Store process info in *p. */
 /* Make sure that all stdio output of the processes is buffered up. */


### PR DESCRIPTION
The get_currentexe test requires a canonicalized argv[0] to check
against.  Before this commit, it failed when argv[0] contained symbolic
links.

Fixes libuv/libuv#18.

R=@saghul?
