### PR TITLE
test: skip tty test if detected width and height are 0

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -96,6 +96,13 @@ TEST_IMPL(tty) {
 
   printf("width=%d height=%d\n", width, height);
 
+  if (width == 0 && height == 0) {
+   /* Some environments such as containers or Jenkins behave like this
+    * sometimes */
+    MAKE_VALGRIND_HAPPY();
+    return TEST_SKIP;
+  }
+
   /*
    * Is it a safe assumption that most people have terminals larger than
    * 10x10?


### PR DESCRIPTION
This happens in certain build environments such as Jenkins if
some tweaking is not performed in the host system.

R=@bnoordhuis

This should fix some of the containerized Jenkins slaves.
