### PR TITLE
Revert "unix: use cfmakeraw() for setting raw TTY mode"

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -123,7 +123,12 @@ int uv_tty_set_mode(uv_tty_t* tty, int mode) {
     uv_spinlock_unlock(&termios_spinlock);
 
     raw = tty->orig_termios;
-    cfmakeraw(&raw);
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    raw.c_oflag |= (ONLCR);
+    raw.c_cflag |= (CS8);
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cc[VMIN] = 1;
+    raw.c_cc[VTIME] = 0;
 
     /* Put terminal in raw mode after draining */
     if (tcsetattr(fd, TCSADRAIN, &raw))


### PR DESCRIPTION
This reverts commit 0f25560c8aed4fb9f40120750d0832ac415ce092.

This change was introduced to make it possible to use the TTY for binary
I/O but unfortunately it breaks libuv users that depend on the OPOST and
ONLCR flags, like node.js.

There is no point in adding those flags after the call to cfmakeraw()
because that would once again make the TTY unsuitable for binary I/O.
Let's revert it for now and revisit it again later.

Fixes libuv/libuv#32, reverts joyent/libuv#1567.

R=@saghul
