### PR TITLE
unix: handle read errors more gracefully

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1118,8 +1118,13 @@ static void uv__read(uv_stream_t* stream) {
       } else {
         /* Error. User should call uv_close(). */
         stream->read_cb(stream, -errno, &buf);
-        assert(!uv__io_active(&stream->io_watcher, UV__POLLIN) &&
-               "stream->read_cb(status=-1) did not call uv_close()");
+        if (stream->flags & UV_STREAM_READING) {
+          stream->flags &= ~UV_STREAM_READING;
+          uv__io_stop(stream->loop, &stream->io_watcher, UV__POLLIN);
+          if (!uv__io_active(&stream->io_watcher, UV__POLLOUT))
+            uv__handle_stop(stream);
+          uv__stream_osx_interrupt_select(stream);
+        }
       }
       return;
     } else if (nread == 0) {


### PR DESCRIPTION
R=@bnoordhuis

This should close https://github.com/joyent/libuv/issues/1534 which is reported every now and then.

I can modify some tests and remove calls to `uv_read_stop`.
