### PR TITLE
test: test that closing a poll handle doesn't corrupt the stack

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -269,6 +269,7 @@ TEST_DECLARE   (ip4_addr)
 TEST_DECLARE   (ip6_addr_link_local)
 
 #ifdef _WIN32
+TEST_DECLARE   (poll_close_doesnt_corrupt_stack)
 TEST_DECLARE   (poll_closesocket)
 TEST_DECLARE   (spawn_detect_pipe_name_collisions_on_windows)
 TEST_DECLARE   (argument_escaping)
@@ -558,6 +559,7 @@ TASK_LIST_START
   TEST_ENTRY  (kill)
 
 #ifdef _WIN32
+  TEST_ENTRY  (poll_close_doesnt_corrupt_stack)
   TEST_ENTRY  (poll_closesocket)
   TEST_ENTRY  (spawn_detect_pipe_name_collisions_on_windows)
   TEST_ENTRY  (argument_escaping)

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -1,0 +1,113 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifdef _WIN32
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef _MSC_VER  /* msvc */
+# define NO_INLINE __declspec(noinline)
+#else  /* gcc */
+# define NO_INLINE __attribute__ ((noinline))
+#endif
+
+
+uv_os_sock_t sock;
+uv_poll_t handle;
+
+static int close_cb_called = 0;
+
+
+static void close_cb(uv_handle_t* h) {
+  close_cb_called++;
+}
+
+
+static void poll_cb(uv_poll_t* h, int status, int events) {
+  ASSERT(0 && "should never get here");
+}
+
+
+static void NO_INLINE close_socket_and_verify_stack() {
+  const uint32_t MARKER = 0xDEADBEEF;
+  const int VERIFY_AFTER = 10; /* ms */
+
+  volatile uint32_t data[65536];
+  size_t i;
+
+  for (i = 0; i < ARRAY_SIZE(data); i++)
+    data[i] = MARKER;
+
+  int r = closesocket(sock);
+  ASSERT(r == 0);
+
+  uv_sleep(VERIFY_AFTER);
+
+  for (i = 0; i < ARRAY_SIZE(data); i++)
+    ASSERT(data[i] == MARKER);
+}
+
+
+TEST_IMPL(poll_close_doesnt_corrupt_stack) {
+  struct WSAData wsa_data;
+  int r;
+  unsigned long on;
+  struct sockaddr_in addr;
+
+  r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+  ASSERT(r == 0);
+
+  sock = socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT(sock != INVALID_SOCKET);
+  on = 1;
+  r = ioctlsocket(sock, FIONBIO, &on);
+  ASSERT(r == 0);
+
+  r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+  ASSERT(r == 0);
+
+  r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
+  ASSERT(r != 0);
+  ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
+
+  r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
+  ASSERT(r == 0);
+  r = uv_poll_start(&handle, UV_READABLE | UV_WRITABLE, poll_cb);
+  ASSERT(r == 0);
+
+  uv_close((uv_handle_t*) &handle, close_cb);
+
+  close_socket_and_verify_stack();
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(close_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+#endif  /* _WIN32 */

--- a/uv.gyp
+++ b/uv.gyp
@@ -350,6 +350,7 @@
         'test/test-platform-output.c',
         'test/test-poll.c',
         'test/test-poll-close.c',
+        'test/test-poll-close-doesnt-corrupt-stack.c',
         'test/test-poll-closesocket.c',
         'test/test-process-title.c',
         'test/test-ref.c',


### PR DESCRIPTION
This is a regression test for an issue that was originally reported
in https://github.com/libuv/libuv/pull/36, and fixed in cd89452.

R=@saghul
