### PR TITLE
test: skip spawn_setuid_setgid if we get EACCES

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1051,6 +1051,9 @@ TEST_IMPL(spawn_setuid_setgid) {
   options.flags = UV_PROCESS_SETUID | UV_PROCESS_SETGID;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
+  if (r == UV_EACCES)
+    RETURN_SKIP("user 'nobody' cannot access the test runner");
+
   ASSERT(r == 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);


### PR DESCRIPTION
More often than not, users run the test suite from /root, which means
the 'nobody' user won't be able to access the test runner and the test
will fail because we drop privileges to that user. Just skip it then.

Fixes #65

R=@bnoordhuis
