### PR TITLE
Windows: fix autotools build of tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -172,6 +172,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-platform-output.c \
                          test/test-poll-close.c \
+                         test/test-poll-close-doesnt-corrupt-stack.c \
                          test/test-poll-closesocket.c \
                          test/test-poll.c \
                          test/test-process-title.c \


### PR DESCRIPTION
Add missing test file to match GYP definition and solve undefined reference.

Fixes #68 

Cheers.
