### PR TITLE
link against -pthread to fix underlinking issue

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -22,7 +22,7 @@ E=
 CSTDFLAG=--std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -g
 CPPFLAGS += -I$(SRCDIR)/src
-LDFLAGS=-lm
+LDFLAGS=-lm -pthread
 
 CPPFLAGS += -D_LARGEFILE_SOURCE
 CPPFLAGS += -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
Please see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773341 for more information. libuv uses some of pthread's symbols, but it doesn't link against it, which causes underlinking issues, especially in Ubuntu where we use ld --as-needed. The issue also shows up as warnings in Debian's build logs.
