### PR TITLE
win: scandir use 'ls' for formatting long strings

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -802,9 +802,9 @@ void fs__scandir(uv_fs_t* req) {
   if (len == 0) {
     fmt = L"./*";
   } else if (pathw[len - 1] == L'/' || pathw[len - 1] == L'\\') {
-    fmt = L"%s*";
+    fmt = L"%ls*";
   } else {
-    fmt = L"%s\\*";
+    fmt = L"%ls\\*";
   }
 
   /* Figure out whether path is a file or a directory. */


### PR DESCRIPTION
Change the format specifiers on Windows scandir to use ls (wide string). Under Windows 10 / MSVC 2015, this function errors due to parsing the wide strings as an ascii string : this patch fixed it. Tested also under Win8 / MSVC 2013.
