### PR TITLE
build: remove clang and gcc_version gyp defines

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -6,8 +6,6 @@
     'uv_library%': 'static_library', # allow override to 'shared_library' for DLL/.so builds
     'component%': 'static_library',  # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
-    'gcc_version%': 'unknown',
-    'clang%': 0,
   },
 
   'target_defaults': {
@@ -158,7 +156,7 @@
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],
-          [ 'visibility=="hidden" and (clang==1 or gcc_version >= 40)', {
+          [ 'visibility=="hidden"', {
             'cflags': [ '-fvisibility=hidden' ],
           }],
         ],

--- a/gyp_uv.py
+++ b/gyp_uv.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-import glob
-import platform
 import os
-import subprocess
+import platform
 import sys
 
 try:
@@ -33,16 +31,6 @@ def host_arch():
   if machine.startswith('arm'): return 'arm'
   if machine.startswith('mips'): return 'mips'
   return machine  # Return as-is and hope for the best.
-
-
-def compiler_version():
-  proc = subprocess.Popen(CC.split() + ['--version'], stdout=subprocess.PIPE)
-  is_clang = 'clang' in proc.communicate()[0].split('\n')[0]
-  proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
-  version = proc.communicate()[0].split('.')
-  version = map(int, version[:2])
-  version = tuple(version)
-  return (version, is_clang)
 
 
 def run_gyp(args):
@@ -85,9 +73,6 @@ if __name__ == '__main__':
     if 'eclipse' not in args and 'ninja' not in args:
       args.extend(['-Goutput_dir=' + output_dir])
       args.extend(['--generator-output', output_dir])
-    (major, minor), is_clang = compiler_version()
-    args.append('-Dgcc_version=%d' % (10 * major + minor))
-    args.append('-Dclang=%d' % int(is_clang))
 
   if not any(a.startswith('-Dhost_arch=') for a in args):
     args.append('-Dhost_arch=%s' % host_arch())

--- a/uv.gyp
+++ b/uv.gyp
@@ -17,28 +17,8 @@
       }],
     ],
     'xcode_settings': {
-        'conditions': [
-          [ 'clang==1', {
-            'WARNING_CFLAGS': [
-              '-Wall',
-              '-Wextra',
-              '-Wno-unused-parameter',
-              '-Wno-dollar-in-identifier-extension'
-            ]}, {
-           'WARNING_CFLAGS': [
-             '-Wall',
-             '-Wextra',
-             '-Wno-unused-parameter'
-          ]}
-        ]
-      ],
-      'OTHER_LDFLAGS': [
-      ],
-      'OTHER_CFLAGS': [
-        '-g',
-        '--std=gnu89',
-        '-pedantic'
-      ],
+      'WARNING_CFLAGS': [ '-Wall', '-Wextra', '-Wno-unused-parameter' ],
+      'OTHER_CFLAGS': [ '-g', '--std=gnu89', '-pedantic' ],
     }
   },
 


### PR DESCRIPTION
The clang and gcc_version defines were used to:
1. Conditionally enable -fvisibility=hidden, a switch introduced in
   gcc 4.0.  Because 4.2 is the minimum supported version, we can
   make it unconditional.  People that want to build with older
   versions, can use '-Dvisibility='.
2. To conditionally enable -Wno-dollar-in-identifier-extension,
   an Apple extension that suppressed warnings about sigils in
   dtrace probe names.  Dtrace probes were removed in cb514002.

R=@saghul
