### PR TITLE
Win. Use `uv_key_t` to store current thread handle in TLS on Windows prior Vista.

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -52,9 +52,6 @@
 # include <CoreServices/CoreServices.h>
 #endif
 
-#define STATIC_ASSERT(expr)                                                   \
-  void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
-
 #define ACCESS_ONCE(type, var)                                                \
   (*(volatile type*) &(var))
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -46,6 +46,9 @@
 #define container_of(ptr, type, member) \
   ((type *) ((char *) (ptr) - offsetof(type, member)))
 
+#define STATIC_ASSERT(expr)                                                   \
+  void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
+
 #ifndef _WIN32
 enum {
   UV__HANDLE_INTERNAL = 0x8000,

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -118,17 +118,10 @@ void uv_once(uv_once_t* guard, void (*callback)(void)) {
 }
 
 
-#ifndef _WIN32_WINNT_VISTA
-# define _WIN32_WINNT_VISTA 0x0600
-#endif
-
-
 #if _WIN32_WINNT < _WIN32_WINNT_VISTA
 
-#ifndef STATIC_ASSERT
-# define STATIC_ASSERT(expr)                                                   \
-    void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
-#endif
+/* Verify that uv_thread_t can be stored as uv_key_t */
+STATIC_ASSERT(sizeof(uv_thread_t) == sizeof(void*));
 
 static uv_once_t once = UV_ONCE_INIT;
 static uv_key_t uv__current_thread;
@@ -185,9 +178,6 @@ static UINT __stdcall uv__thread_start(void* arg) {
 
 #if _WIN32_WINNT < _WIN32_WINNT_VISTA
   uv_once(&once, init_once);
-
-  {STATIC_ASSERT(sizeof(uv_thread_t) == sizeof(void*));}
-
   uv_key_set(&uv__current_thread, (void*)ctx.self);
 #else
   uv__current_thread = ctx.self;

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -146,6 +146,11 @@ static void init_once(void) {
 #if defined(BUILDING_UV_SHARED)
 
 BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
+  #if defined(_MSC_VER) && defined(_MT) && defined(_DLL)
+    if (reason == DLL_THREAD_ATTACH)
+      DisableThreadLibraryCalls(instance);
+  #endif
+
   if ((reason == DLL_PROCESS_DETACH) && (reserved == NULL))
     cleanup();
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -144,23 +144,6 @@ static void init_once(void) {
 }
 
 
-#if defined(BUILDING_UV_SHARED)
-
-BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
-  #if defined(_MSC_VER) && defined(_MT) && defined(_DLL)
-    if (reason == DLL_THREAD_ATTACH)
-      DisableThreadLibraryCalls(instance);
-  #endif
-
-  if ((reason == DLL_PROCESS_DETACH) && (reserved == NULL))
-    cleanup();
-
-  return TRUE;
-}
-
-#endif
-
-
 struct thread_ctx {
   void (*entry)(void* arg);
   void* arg;

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -134,8 +134,8 @@ static uv_once_t once = UV_ONCE_INIT;
 static uv_key_t uv__current_thread;
 static volatile int initialized = 0;
 
-static void cleanup(void){
-  if(!initialized)
+static void cleanup(void) {
+  if (initialized == 0)
     return;
 
   uv_key_delete(&uv__current_thread);
@@ -144,15 +144,16 @@ static void cleanup(void){
 }
 
 static void init_once(void) {
-  if(uv_key_create(&uv__current_thread))
+  if (uv_key_create(&uv__current_thread))
     abort();
+
   initialized = 1;
 }
 
 #if defined(BUILDING_UV_SHARED)
 
 BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
-  if(reason == DLL_PROCESS_DETACH)
+  if (reason == DLL_PROCESS_DETACH)
     cleanup();
 
   return TRUE;
@@ -174,8 +175,7 @@ struct thread_ctx {
 };
 
 
-static UINT __stdcall uv__thread_start(void* arg)
-{
+static UINT __stdcall uv__thread_start(void* arg) {
   struct thread_ctx *ctx_p;
   struct thread_ctx ctx;
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -146,7 +146,7 @@ static void init_once(void) {
 #if defined(BUILDING_UV_SHARED)
 
 BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
-  if (reason == DLL_PROCESS_DETACH)
+  if ((reason == DLL_PROCESS_DETACH) && (reserved == NULL))
     cleanup();
 
   return TRUE;

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -151,7 +151,7 @@ static void init_once(void) {
 
 #if defined(BUILDING_UV_SHARED)
 
-UV_EXTERN BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
+BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
   if(reason == DLL_PROCESS_DETACH)
     cleanup();
 
@@ -295,7 +295,6 @@ int uv_rwlock_init(uv_rwlock_t* rwlock) {
   else
     return uv__rwlock_fallback_init(rwlock);
 }
-
 
 
 void uv_rwlock_destroy(uv_rwlock_t* rwlock) {

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -24,6 +24,9 @@
 
 #include <windows.h>
 
+#ifndef _WIN32_WINNT_VISTA
+# define _WIN32_WINNT_VISTA 0x0600
+#endif
 
 /*
  * Ntdll headers


### PR DESCRIPTION
When we use LoadLibrary to load libuv library process gets AV when trying assign to `uv__current_thread`.

PS. To build it also needs comment `'_WIN32_WINNT=0x0600',` line in `uv.gyp`.