### PR TITLE
linux: fix epoll_pwait() sigmask size calculation

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -33,7 +33,6 @@
 #include <sys/prctl.h>
 #include <sys/sysinfo.h>
 #include <unistd.h>
-#include <signal.h>
 #include <fcntl.h>
 #include <time.h>
 
@@ -131,8 +130,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct uv__epoll_event e;
   ngx_queue_t* q;
   uv__io_t* w;
-  sigset_t* pset;
-  sigset_t set;
+  uint64_t sigmask;
   uint64_t base;
   uint64_t diff;
   int nevents;
@@ -183,24 +181,21 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     w->events = w->pevents;
   }
 
-  pset = NULL;
-  if (loop->flags & UV_LOOP_BLOCK_SIGPROF) {
-    pset = &set;
-    sigemptyset(pset);
-    sigaddset(pset, SIGPROF);
-  }
+  sigmask = 0;
+  if (loop->flags & UV_LOOP_BLOCK_SIGPROF)
+    sigmask |= 1 << (SIGPROF - 1);
 
   assert(timeout >= -1);
   base = loop->time;
   count = 48; /* Benchmarks suggest this gives the best throughput. */
 
   for (;;) {
-    if (no_epoll_wait || pset != NULL) {
+    if (no_epoll_wait || sigmask) {
       nfds = uv__epoll_pwait(loop->backend_fd,
                              events,
                              ARRAY_SIZE(events),
                              timeout,
-                             pset);
+                             sigmask);
     } else {
       nfds = uv__epoll_wait(loop->backend_fd,
                             events,

--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -291,15 +291,15 @@ int uv__epoll_pwait(int epfd,
                     struct uv__epoll_event* events,
                     int nevents,
                     int timeout,
-                    const sigset_t* sigmask) {
+                    uint64_t sigmask) {
 #if defined(__NR_epoll_pwait)
   return syscall(__NR_epoll_pwait,
                  epfd,
                  events,
                  nevents,
                  timeout,
-                 sigmask,
-                 _NSIG / 8);
+                 &sigmask,
+                 sizeof(sigmask));
 #else
   return errno = ENOSYS, -1;
 #endif

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -130,7 +130,7 @@ int uv__epoll_pwait(int epfd,
                     struct uv__epoll_event* events,
                     int nevents,
                     int timeout,
-                    const sigset_t* sigmask);
+                    uint64_t sigmask);
 int uv__eventfd2(unsigned int count, int flags);
 int uv__inotify_init(void);
 int uv__inotify_init1(int flags);


### PR DESCRIPTION
Revisit the fix from commit b705b53.  The problem with using sigset_t
and _NSIG is that the size of sigset_t and the value of _NSIG depend
on what headers libuv picks up first, <signal.h> or <asm/signal.h>.
With the former, sizeof(sigset_t) = 128; with the latter, it's 8.

Simply sidestep the issue by calculating the signal mask as a 64 bits
integer, without using sigset_t or _NSIG.

This is a partial cherry-pick of commit 751ac48 from the v1.x branch.

Original PR-URL: https://github.com/libuv/libuv/pull/83

R=@saghul
