### PR TITLE
Implement a binary I/O terminal mode in uv_tty_set_mode

### DIFF
--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -16,6 +16,22 @@ Data types
 
     TTY handle type.
 
+.. c:type:: uv_tty_mode_t
+
+    TTY mode type:
+
+    ::
+
+        typedef enum {
+            /* Initial/normal terminal mode */
+            UV_TTY_MODE_NORMAL,
+            /* Raw input mode (On Windows, ENABLE_WINDOW_INPUT is also enabled) */
+            UV_TTY_MODE_RAW,
+            /* Binary-safe I/O mode for IPC (Unix-only) */
+            UV_TTY_MODE_IO
+        } uv_tty_mode_t;
+
+
 
 Public members
 ^^^^^^^^^^^^^^
@@ -43,9 +59,9 @@ API
     .. note::
         TTY streams which are not readable have blocking writes.
 
-.. c:function:: int uv_tty_set_mode(uv_tty_t*, int mode)
+.. c:function:: int uv_tty_set_mode(uv_tty_t*, uv_tty_mode_t mode)
 
-    Set the TTY mode. 0 for normal, 1 for raw.
+    Set the TTY using the specified terminal mode.
 
 .. c:function:: int uv_tty_reset_mode(void)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -628,10 +628,25 @@ struct uv_tty_s {
   UV_TTY_PRIVATE_FIELDS
 };
 
+typedef enum {
+  /* Initial/normal terminal mode */
+  UV_TTY_MODE_NORMAL,
+  /* Raw input mode (On Windows, ENABLE_WINDOW_INPUT is also enabled) */
+  UV_TTY_MODE_RAW,
+  /* Binary-safe I/O mode for IPC (Unix-only) */
+  UV_TTY_MODE_IO
+} uv_tty_mode_t;
+
 UV_EXTERN int uv_tty_init(uv_loop_t*, uv_tty_t*, uv_file fd, int readable);
-UV_EXTERN int uv_tty_set_mode(uv_tty_t*, int mode);
+UV_EXTERN int uv_tty_set_mode(uv_tty_t*, uv_tty_mode_t mode);
 UV_EXTERN int uv_tty_reset_mode(void);
 UV_EXTERN int uv_tty_get_winsize(uv_tty_t*, int* width, int* height);
+
+#ifdef __cplusplus
+inline int uv_tty_set_mode(uv_tty_t* handle, int mode) {
+  return uv_tty_set_mode(handle, static_cast<uv_tty_mode_t>(mode));
+}
+#endif
 
 UV_EXTERN uv_handle_type uv_guess_handle(uv_file file);
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -170,7 +170,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
 }
 
 
-int uv_tty_set_mode(uv_tty_t* tty, int mode) {
+int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   DWORD flags;
   unsigned char was_reading;
   uv_alloc_cb alloc_cb;
@@ -185,12 +185,15 @@ int uv_tty_set_mode(uv_tty_t* tty, int mode) {
     return 0;
   }
 
-  if (mode) {
-    /* Raw input */
-    flags = ENABLE_WINDOW_INPUT;
-  } else {
-    /* Line-buffered mode. */
-    flags = ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT;
+  switch (mode) {
+    case UV_TTY_MODE_NORMAL:
+      flags = ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT;
+      break;
+    case UV_TTY_MODE_RAW:
+      flags = ENABLE_WINDOW_INPUT;
+      break;
+    case UV_TTY_MODE_IO:
+      return UV_ENOTSUP;
   }
 
   if (!SetConsoleMode(tty->handle, flags)) {


### PR DESCRIPTION
- Introduce a uv_tty_mode_t enum with backward compatible values.
- New mode 2 (UV_TTY_MODE_IO), which uses cfmakeraw().
