### PR TITLE
Replace assert(0) with __builtin_unreachable

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -127,19 +127,18 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       pc.cmd = PS_ADD;
       if (pollset_ctl(loop->backend_fd, &pc, 1)) {
         if (errno != EINVAL) {
-          assert(0 && "Failed to add file descriptor (pc.fd) to pollset");
-          abort();
+          UNREACHABLE(assert(0 && "Failed to add file descriptor (pc.fd) \
+            to pollset"));
         }
         /* Check if the fd is already in the pollset */
         pqry.fd = pc.fd;
         rc = pollset_query(loop->backend_fd, &pqry);
         switch (rc) {
         case -1: 
-          assert(0 && "Failed to query pollset for file descriptor");
-          abort();
+          UNREACHABLE(assert(0 && "Failed to query pollset for \
+            file descriptor"));
         case 0:
-          assert(0 && "Pollset does not contain file descriptor");
-          abort();
+          UNREACHABLE(assert(0 && "Pollset does not contain file descriptor"));
         }
         /* If we got here then the pollset already contained the file descriptor even though
          * we didn't think it should. This probably shouldn't happen, but we can continue. */
@@ -155,13 +154,13 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
        * lazily remove events, squelching them in the mean time. */
       pc.cmd = PS_DELETE;
       if (pollset_ctl(loop->backend_fd, &pc, 1)) {
-        assert(0 && "Failed to delete file descriptor (pc.fd) from pollset");
-        abort();
+        UNREACHABLE(assert(0 && "Failed to delete file descriptor \
+            (pc.fd) from pollset"));
       }
       pc.cmd = PS_ADD;
       if (pollset_ctl(loop->backend_fd, &pc, 1)) {
-        assert(0 && "Failed to add file descriptor (pc.fd) to pollset");
-        abort();
+        UNREACHABLE(assert(0 && "Failed to add file descriptor (pc.fd) \
+          to pollset"));
       }
     }
 
@@ -751,7 +750,8 @@ static int uv__parse_data(char *buf, int *events, uv_fs_event_t* handle) {
 
   /* Check for BUF_WRAP */
   if (strncmp(buf, "BUF_WRAP", strlen("BUF_WRAP")) == 0) {
-    assert(0 && "Buffer wrap detected, Some event occurrences lost!");
+    UNREACHABLE(assert(0 && "Buffer wrap detected, Some event \
+      occurrences lost!"));
     return 0;
   }
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -157,7 +157,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
     return;
 
   default:
-    assert(0);
+    UNREACHABLE(assert(0));
   }
 
   uv__make_close_pending(handle);
@@ -234,7 +234,7 @@ static void uv__finish_close(uv_handle_t* handle) {
       break;
 
     default:
-      assert(0);
+      UNREACHABLE(assert(0));
       break;
   }
 

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -122,7 +122,7 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   else if (req->hostname)
     free(req->hostname);
   else
-    assert(0);
+    UNREACHABLE(assert(0));
 
   req->hints = NULL;
   req->service = NULL;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -75,19 +75,19 @@
  * Hence it's assumed that it will be available by default and not checked
 */
 #if defined(__clang__)
-#define UNREACHABLE(CODE)                                                     \
+#define UNREACHABLE()                                                     \
   do {                                                                        \
     __builtin_unreachable();                                                  \
   }                                                                           \
   while (0)
 #elif defined(GCC_VERSION) && GCC_VERSION >= 40500
-#  define UNREACHABLE(CODE)                                                   \
+#  define UNREACHABLE()                                                   \
     do {                                                                      \
       __builtin_unreachable();                                                \
     }                                                                         \
     while (0)
 #else
-# define UNREACHABLE(CODE)                                                    \
+# define UNREACHABLE()                                                    \
   do {                                                                        \
     assert(0 && "unreachable code");                                          \
     abort();                                                                  \

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -58,12 +58,46 @@
 #define ACCESS_ONCE(type, var)                                                \
   (*(volatile type*) &(var))
 
-#define UNREACHABLE()                                                         \
+
+/*
+  Macro to test version of gcc
+  To test for GCC > 4.5.0:
+  #if GCC_VERSION > 40500
+  #endif
+*/
+#if defined(__GNUC__)
+#define GCC_VERSION (__GNUC__ * 10000                                         \
+                     + __GNUC_MINOR__ * 100                                   \
+                     + __GNUC_PATCHLEVEL__)
+#endif
+
+/*clang has support for __builtin_unreachable starting from version 3.0
+ * Hence it's assumed that it will be available by default and not checked
+*/
+#if defined(__clang__)
+#define UNREACHABLE(CODE)                                                     \
+  do {                                                                        \
+    __builtin_unreachable();                                                  \
+  }                                                                           \
+  while (0)
+#elif defined(GCC_VERSION)
+# if(GCC_VERSION) >= 40500 /*__builtin_unreachable supported for gcc>=4.5*/
+#  define UNREACHABLE(CODE)                                                   \
+    do {                                                                      \
+      __builtin_unreachable();                                                \
+    }                                                                         \
+    while (0)
+# else
+#  define UNREACHABLE(CODE) CODE                                              \
+# endif
+#else
+# define UNREACHABLE(CODE)                                                    \
   do {                                                                        \
     assert(0 && "unreachable code");                                          \
     abort();                                                                  \
   }                                                                           \
   while (0)
+#endif
 
 #define SAVE_ERRNO(block)                                                     \
   do {                                                                        \

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -80,16 +80,12 @@
     __builtin_unreachable();                                                  \
   }                                                                           \
   while (0)
-#elif defined(GCC_VERSION)
-# if(GCC_VERSION) >= 40500 /*__builtin_unreachable supported for gcc>=4.5*/
+#elif defined(GCC_VERSION) && GCC_VERSION >= 40500
 #  define UNREACHABLE(CODE)                                                   \
     do {                                                                      \
       __builtin_unreachable();                                                \
     }                                                                         \
     while (0)
-# else
-#  define UNREACHABLE(CODE) CODE                                              \
-# endif
 #else
 # define UNREACHABLE(CODE)                                                    \
   do {                                                                        \

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -216,7 +216,7 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
     return 0;
 
   default:
-    assert(0 && "Unexpected flags");
+    UNREACHABLE(assert(0 && "Unexpected flags"));
     return -EINVAL;
   }
 }

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -360,8 +360,7 @@ static int uv__udp_maybe_deferred_bind(uv_udp_t* handle,
     break;
   }
   default:
-    assert(0 && "unsupported address family");
-    abort();
+    UNREACHABLE(assert(0 && "unsupported address family"));
   }
 
   return uv__udp_bind(handle, (const struct sockaddr*) &taddr, addrlen, flags);
@@ -690,8 +689,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
       return -errno;
     }
   } else {
-    assert(0 && "unexpected address family");
-    abort();
+    UNREACHABLE(assert(0 && "unexpected address family"));
   }
 
   return 0;

--- a/src/win/handle-inl.h
+++ b/src/win/handle-inl.h
@@ -156,7 +156,7 @@ INLINE static void uv_process_endgames(uv_loop_t* loop) {
         break;
 
       default:
-        assert(0);
+        UNREACHABLE();
         break;
     }
   }

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -68,7 +68,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb cb) {
   uv_loop_t* loop = handle->loop;
 
   if (handle->flags & UV__HANDLE_CLOSING) {
-    assert(0);
+    UNREACHABLE();
     return;
   }
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -40,9 +40,7 @@
 
 #ifndef UNREACHABLE
 # define UNREACHABLE(CODE) __assume(0)
-#else
-#  define UNREACHABLE(CODE) CODE
-# endif
+#endif
 
 
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -39,7 +39,7 @@
 
 
 #ifndef UNREACHABLE
-# define UNREACHABLE(CODE) __assume(0)
+# define UNREACHABLE() __assume(0)
 #endif
 
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -38,6 +38,14 @@
 #endif
 
 
+#ifndef UNREACHABLE
+# define UNREACHABLE(CODE) __assume(0)
+#else
+#  define UNREACHABLE(CODE) CODE
+# endif
+
+
+
 #ifdef _DEBUG
 
 extern UV_THREAD_LOCAL int uv__crt_assert_enabled;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -91,7 +91,7 @@ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
     handle->mask_events_1 = handle->events;
     handle->mask_events_2 = 0;
   } else {
-    assert(0);
+    UNREACHABLE();
     return;
   }
 
@@ -166,7 +166,7 @@ static void uv__fast_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
     handle->submitted_events_2 = 0;
     mask_events = handle->mask_events_2;
   } else {
-    assert(0);
+    UNREACHABLE();
     return;
   }
 
@@ -402,7 +402,7 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
     handle->mask_events_1 = handle->events;
     handle->mask_events_2 = 0;
   } else {
-    assert(0);
+    UNREACHABLE();
     return;
   }
 
@@ -429,7 +429,7 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
     handle->submitted_events_2 = 0;
     mask_events = handle->mask_events_2;
   } else {
-    assert(0);
+    UNREACHABLE();
     return;
   }
 

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -388,7 +388,7 @@ int uv__stdio_create(uv_loop_t* loop,
             break;
 
           default:
-            assert(0);
+            UNREACHABLE();
             return -1;
         }
 
@@ -434,7 +434,7 @@ int uv__stdio_create(uv_loop_t* loop,
       }
 
       default:
-        assert(0);
+        UNREACHABLE();
         return -1;
     }
   }

--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -125,7 +125,7 @@ INLINE static void uv_insert_pending_req(uv_loop_t* loop, uv_req_t* req) {
         break;                                                                \
                                                                               \
       default:                                                                \
-        assert(0);                                                            \
+        UNREACHABLE();                                                        \
     }                                                                         \
   } while (0)
 
@@ -203,7 +203,7 @@ INLINE static int uv_process_reqs(uv_loop_t* loop) {
         break;
 
       default:
-        assert(0);
+        UNREACHABLE();
     }
   }
 

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -215,7 +215,7 @@ static void uv__signal_unregister(int signum) {
 
     default:
       /* Libuv bug. */
-      assert(0 && "Invalid signum");
+      UNREACHABLE();
       return;
   }
 }

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -39,7 +39,7 @@ int uv_listen(uv_stream_t* stream, int backlog, uv_connection_cb cb) {
       err = uv_pipe_listen((uv_pipe_t*)stream, backlog, cb);
       break;
     default:
-      assert(0);
+      UNREACHABLE();
   }
 
   return uv_translate_sys_error(err);
@@ -58,7 +58,7 @@ int uv_accept(uv_stream_t* server, uv_stream_t* client) {
       err = uv_pipe_accept((uv_pipe_t*)server, client);
       break;
     default:
-      assert(0);
+      UNREACHABLE();
   }
 
   return uv_translate_sys_error(err);
@@ -89,7 +89,7 @@ int uv_read_start(uv_stream_t* handle, uv_alloc_cb alloc_cb,
       err = uv_tty_read_start((uv_tty_t*) handle, alloc_cb, read_cb);
       break;
     default:
-      assert(0);
+      UNREACHABLE();
   }
 
   return uv_translate_sys_error(err);
@@ -142,7 +142,7 @@ int uv_write(uv_write_t* req,
       err = uv_tty_write(loop, req, (uv_tty_t*) handle, bufs, nbufs, cb);
       break;
     default:
-      assert(0);
+    UNREACHABLE();
   }
 
   return uv_translate_sys_error(err);
@@ -174,7 +174,7 @@ int uv_write2(uv_write_t* req,
                            cb);
       break;
     default:
-      assert(0);
+      UNREACHABLE();
   }
 
   return uv_translate_sys_error(err);

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -725,8 +725,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
       return uv_translate_sys_error(WSAGetLastError());
     }
   } else {
-    assert(0 && "unexpected address family");
-    abort();
+    UNREACHABLE();
   }
 
   return 0;


### PR DESCRIPTION
The details of __builtin_unreachable() is described briefly here. 
[ nondot ] (http://nondot.org/sabre/LLVMNotes/BuiltinUnreachable.txt)

Have made changes for all platforms including Windows and AIX. But tested only on Linux as I have access 
only to Linux. If some body can spin a test. It will be great. 

