### PR TITLE
darwin: fix uv_exepath() UV_EPERM with tiny buffer

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -294,7 +294,7 @@ int uv_exepath(char* buffer, size_t* size) {
   int fd;
   char **argv;
 
-  if ((buffer == NULL) || (size == NULL))
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   snprintf(pp, sizeof(pp), "/proc/%lu/psinfo", (unsigned long) getpid());

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -65,28 +65,33 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
 
 
 int uv_exepath(char* buffer, size_t* size) {
-  uint32_t usize;
-  int result;
-  char* path;
-  char* fullpath;
+  /* realpath(exepath) may be > PATH_MAX so double it to be on the safe side. */
+  char abspath[PATH_MAX * 2 + 1];
+  char exepath[PATH_MAX + 1];
+  uint32_t exepath_size;
+  size_t abspath_size;
 
   if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
-  usize = *size;
-  result = _NSGetExecutablePath(buffer, &usize);
-  if (result) return result;
+  exepath_size = sizeof(exepath);
+  if (_NSGetExecutablePath(exepath, &exepath_size))
+    return -EIO;
 
-  path = malloc(2 * PATH_MAX);
-  fullpath = realpath(buffer, path);
-  if (fullpath == NULL) {
-    SAVE_ERRNO(free(path));
+  if (realpath(exepath, abspath) != abspath)
     return -errno;
-  }
 
-  strncpy(buffer, fullpath, *size);
-  free(fullpath);
-  *size = strlen(buffer);
+  abspath_size = strlen(abspath);
+  if (abspath_size == 0)
+    return -EIO;
+
+  *size -= 1;
+  if (*size > abspath_size)
+    *size = abspath_size;
+
+  memcpy(buffer, abspath, *size);
+  buffer[*size] = '\0';
+
   return 0;
 }
 

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -70,7 +70,7 @@ int uv_exepath(char* buffer, size_t* size) {
   char* path;
   char* fullpath;
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   usize = *size;

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -78,7 +78,7 @@ int uv_exepath(char* buffer, size_t* size) {
   int mib[4];
   size_t cb;
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
 #ifdef __DragonFly__

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -381,7 +381,10 @@ int uv_exepath(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
-  n = readlink("/proc/self/exe", buffer, *size - 1);
+  n = *size - 1;
+  if (n > 0)
+    n = readlink("/proc/self/exe", buffer, n);
+
   if (n == -1)
     return -errno;
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -378,7 +378,7 @@ void uv_loadavg(double avg[3]) {
 int uv_exepath(char* buffer, size_t* size) {
   ssize_t n;
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   n = readlink("/proc/self/exe", buffer, *size - 1);

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -83,7 +83,7 @@ int uv_exepath(char* buffer, size_t* size) {
   size_t cb;
   pid_t mypid;
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   mypid = getpid();

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -85,7 +85,7 @@ int uv_exepath(char* buffer, size_t* size) {
   pid_t mypid;
   int err;
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   mypid = getpid();

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -108,17 +108,19 @@ int uv_exepath(char* buffer, size_t* size) {
     }
     argsbuf_size *= 2U;
   }
+
   if (argsbuf[0] == NULL) {
     err = -EINVAL;  /* FIXME(bnoordhuis) More appropriate error. */
     goto out;
   }
+
+  *size -= 1;
   exepath_size = strlen(argsbuf[0]);
-  if (exepath_size >= *size) {
-    err = -EINVAL;
-    goto out;
-  }
-  memcpy(buffer, argsbuf[0], exepath_size + 1U);
-  *size = exepath_size;
+  if (*size > exepath_size)
+    *size = exepath_size;
+
+  memcpy(buffer, argsbuf[0], *size);
+  buffer[*size] = '\0';
   err = 0;
 
 out:

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -304,7 +304,11 @@ int uv_exepath(char* buffer, size_t* size) {
     return -EINVAL;
 
   snprintf(buf, sizeof(buf), "/proc/%lu/path/a.out", (unsigned long) getpid());
-  res = readlink(buf, buffer, *size - 1);
+
+  res = *size - 1;
+  if (res > 0)
+    res = readlink(buf, buffer, res);
+
   if (res == -1)
     return -errno;
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -300,7 +300,7 @@ int uv_exepath(char* buffer, size_t* size) {
   ssize_t res;
   char buf[128];
 
-  if (buffer == NULL || size == NULL)
+  if (buffer == NULL || size == NULL || *size == 0)
     return -EINVAL;
 
   snprintf(buf, sizeof(buf), "/proc/%lu/path/a.out", (unsigned long) getpid());

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -73,5 +73,14 @@ TEST_IMPL(get_currentexe) {
   ASSERT(size == 0);
   ASSERT(buffer[0] == '\0');
 
+  memset(buffer, -1, sizeof(buffer));
+
+  size = 2;
+  r = uv_exepath(buffer, &size);
+  ASSERT(r == 0);
+  ASSERT(size == 1);
+  ASSERT(buffer[0] != '\0');
+  ASSERT(buffer[1] == '\0');
+
   return 0;
 }

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -61,5 +61,9 @@ TEST_IMPL(get_currentexe) {
   r = uv_exepath(buffer, NULL);
   ASSERT(r == UV_EINVAL);
 
+  size = 0;
+  r = uv_exepath(buffer, &size);
+  ASSERT(r == UV_EINVAL);
+
   return 0;
 }

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -65,5 +65,13 @@ TEST_IMPL(get_currentexe) {
   r = uv_exepath(buffer, &size);
   ASSERT(r == UV_EINVAL);
 
+  memset(buffer, -1, sizeof(buffer));
+
+  size = 1;
+  r = uv_exepath(buffer, &size);
+  ASSERT(r == 0);
+  ASSERT(size == 0);
+  ASSERT(buffer[0] == '\0');
+
   return 0;
 }


### PR DESCRIPTION
Passing a buffer that was too small to hold the result made it fail
with UV_EPERM because the -1 status code from _NSGetExecutablePath()
was returned unmodified to the caller.

This commit rewrites uv_exepath() to:

1. Not allocate heap memory, and

2. Not clobber the result buffer on error, and

3. Handle _NSGetExecutablePath()'s and realpath()'s idiosyncracies, and

4. Store as much of the path in the output buffer as possible, don't
   fail with an error.  Makes it behave the same as other platforms.
   The result is always zero-terminated.

Fixes: libuv#103

R=@saghul