### PR TITLE
build: add AC_PROG_LIBTOOL to configure.ac

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -33,7 +33,7 @@ UV_EXTRA_AUTOMAKE_FLAGS=
 if test "$automake_version_major" -gt 1 || \
    test "$automake_version_major" -eq 1 && \
    test "$automake_version_minor" -gt 11; then
-  # serial-tests is available in v0.12 and newer.
+  # serial-tests is available in v1.12 and newer.
   UV_EXTRA_AUTOMAKE_FLAGS="$UV_EXTRA_AUTOMAKE_FLAGS serial-tests"
 fi
 echo "m4_define([UV_EXTRA_AUTOMAKE_FLAGS], [$UV_EXTRA_AUTOMAKE_FLAGS])" \

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,8 @@ AM_PROG_CC_C_O
 CC_CHECK_CFLAGS_APPEND([-Wno-dollar-in-identifier-extension])
 # AM_PROG_AR is not available in automake v0.11 but it's essential in v0.12.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+# autoconf complains if AC_PROG_LIBTOOL precedes AM_PROG_AR.
+AC_PROG_LIBTOOL
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 LT_INIT
 # TODO(bnoordhuis) Check for -pthread vs. -pthreads


### PR DESCRIPTION
It should fix the following build error with old autoconf/automake
versions:

    Makefile.am:24: Libtool library used but `LIBTOOL' is undefined
    Makefile.am:24: The usual way to define `LIBTOOL' is to add
    `AC_PROG_LIBTOOL'
    Makefile.am:24: to `configure.ac' and run `aclocal' and `autoconf'
    again.

Fixes: libuv#111

R=@rvagg