### PR TITLE
Update the autotools distfile generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ ipch
 
 *.xcodeproj
 *.xcworkspace
+
+# make dist output
+libuv-*.tar.*

--- a/Makefile.am
+++ b/Makefile.am
@@ -108,7 +108,24 @@ libuv_la_SOURCES += src/unix/async.c \
 endif  # WINNT
 
 EXTRA_DIST = test/fixtures/empty_file \
-             test/fixtures/load_error.node
+             test/fixtures/load_error.node \
+             include \
+             test \
+             docs \
+             img \
+             samples \
+             android-configure \
+             CONTRIBUTING.md \
+             LICENSE \
+             README.md \
+             checksparse.sh \
+             vcbuild.bat \
+             Makefile.mingw \
+             common.gypi \
+             gyp_uv.py \
+             uv.gyp
+
+
 
 TESTS = test/run-tests
 check_PROGRAMS = test/run-tests


### PR DESCRIPTION
I've successfully generated a dist on machine 1 (freebsd), transferred it to machine 2 (os x) and built with both automake and gyp. If someone could give it a go for MS it'd be greatly appreciated.

Steps to reproduce:
```bash
$ ./autogen.sh
$ ./configure
$ make dist
$ scp libuv-1.2.0.tar.gz target:
$ # etc
```

Refs #117.