### PR TITLE
win,tcp,tty: support uv_try_write()

### DIFF
--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -136,6 +136,8 @@ int uv_tcp_read_start(uv_tcp_t* handle, uv_alloc_cb alloc_cb,
     uv_read_cb read_cb);
 int uv_tcp_write(uv_loop_t* loop, uv_write_t* req, uv_tcp_t* handle,
     const uv_buf_t bufs[], unsigned int nbufs, uv_write_cb cb);
+int uv__tcp_try_write(uv_tcp_t* handle, const uv_buf_t bufs[],
+    unsigned int nbufs);
 
 void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle, uv_req_t* req);
 void uv_process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -213,6 +213,8 @@ int uv_tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
 int uv_tty_read_stop(uv_tty_t* handle);
 int uv_tty_write(uv_loop_t* loop, uv_write_t* req, uv_tty_t* handle,
     const uv_buf_t bufs[], unsigned int nbufs, uv_write_cb cb);
+int uv__tty_try_write(uv_tty_t* handle, const uv_buf_t bufs[],
+    unsigned int nbufs);
 void uv_tty_close(uv_tty_t* handle);
 
 void uv_process_tty_read_req(uv_loop_t* loop, uv_tty_t* handle,

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -184,8 +184,20 @@ int uv_write2(uv_write_t* req,
 int uv_try_write(uv_stream_t* stream,
                  const uv_buf_t bufs[],
                  unsigned int nbufs) {
-  /* NOTE: Won't work with overlapped writes */
-  return UV_ENOSYS;
+  if (stream->flags & UV__HANDLE_CLOSING)
+    return UV_EBADF;
+  if (!(stream->flags & UV_HANDLE_WRITABLE))
+    return UV_EPIPE;
+
+  switch (stream->type) {
+    case UV_TCP:
+    case UV_TTY:
+    case UV_NAMED_PIPE:
+      return UV_EAGAIN;
+    default:
+      assert(0);
+      return UV_ENOSYS;
+  }
 }
 
 

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -191,6 +191,7 @@ int uv_try_write(uv_stream_t* stream,
 
   switch (stream->type) {
     case UV_TCP:
+      return uv__tcp_try_write((uv_tcp_t*) stream, bufs, nbufs);
     case UV_TTY:
     case UV_NAMED_PIPE:
       return UV_EAGAIN;

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -193,6 +193,7 @@ int uv_try_write(uv_stream_t* stream,
     case UV_TCP:
       return uv__tcp_try_write((uv_tcp_t*) stream, bufs, nbufs);
     case UV_TTY:
+      return uv__tty_try_write((uv_tty_t*) stream, bufs, nbufs);
     case UV_NAMED_PIPE:
       return UV_EAGAIN;
     default:

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -876,6 +876,30 @@ int uv_tcp_write(uv_loop_t* loop,
 }
 
 
+int uv__tcp_try_write(uv_tcp_t* handle,
+                     const uv_buf_t bufs[],
+                     unsigned int nbufs) {
+  int result;
+  DWORD bytes;
+
+  if (handle->write_reqs_pending > 0)
+    return UV_EAGAIN;
+
+  result = WSASend(handle->socket,
+                   (WSABUF*) bufs,
+                   nbufs,
+                   &bytes,
+                   0,
+                   NULL,
+                   NULL);
+
+  if (result == SOCKET_ERROR)
+    return uv_translate_sys_error(WSAGetLastError());
+  else
+    return bytes;
+}
+
+
 void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
     uv_req_t* req) {
   DWORD bytes, flags, err;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -1878,6 +1878,21 @@ int uv_tty_write(uv_loop_t* loop,
 }
 
 
+int uv__tty_try_write(uv_tty_t* handle,
+                      const uv_buf_t bufs[],
+                      unsigned int nbufs) {
+  DWORD error;
+
+  if (handle->write_reqs_pending > 0)
+    return UV_EAGAIN;
+
+  if (uv_tty_write_bufs(handle, bufs, nbufs, &error))
+    return uv_translate_sys_error(error);
+
+  return uv__count_bufs(bufs, nbufs);
+}
+
+
 void uv_process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
   uv_write_t* req) {
   int err;

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -28,16 +28,6 @@
 
 #define MAX_BYTES 1024 * 1024
 
-#ifdef _WIN32
-
-TEST_IMPL(tcp_try_write) {
-
-  MAKE_VALGRIND_HAPPY();
-  return 0;
-}
-
-#else  /* !_WIN32 */
-
 static uv_tcp_t server;
 static uv_tcp_t client;
 static uv_tcp_t incoming;
@@ -138,5 +128,3 @@ TEST_IMPL(tcp_try_write) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
-
-#endif  /* !_WIN32 */


### PR DESCRIPTION
Support uv_try_write() for tcp and tty handles on windows.

I'm still not super excited about this API, but it seems to make node noticeably faster.
This does not change the API/ABI, so it's fine to land this in a patch release.

R=@saghul or @bnoordhuis 