### PR TITLE
win,unix: distil out common loop code

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -61,7 +61,7 @@
 #define RDWR_BUF_SIZE   4096
 #define EQ(a,b)         (strcmp(a,b) == 0)
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   loop->fs_fd = -1;
 
   /* Passing maxfd of -1 should mean the limit is determined

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -37,7 +37,7 @@
 #include <unistd.h>  /* sysconf */
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   loop->cf_state = NULL;
 
   if (uv__kqueue_init(loop))

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -58,7 +58,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -221,7 +221,7 @@ void uv__signal_loop_cleanup(uv_loop_t* loop);
 /* platform specific */
 uint64_t uv__hrtime(uv_clocktype_t type);
 int uv__kqueue_init(uv_loop_t* loop);
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop);
+int uv__platform_loop_init(uv_loop_t* loop);
 void uv__platform_loop_delete(uv_loop_t* loop);
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd);
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -74,7 +74,7 @@ static void read_speeds(unsigned int numcpus, uv_cpu_info_t* ci);
 static unsigned long read_cpufreq(unsigned int cpunum);
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   int fd;
 
   fd = uv__epoll_create1(UV__EPOLL_CLOEXEC);

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -49,7 +49,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -47,7 +47,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -62,7 +62,7 @@
 #endif
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   int err;
   int fd;
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -456,3 +456,73 @@ int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
 
   return err;
 }
+
+
+static uv_loop_t default_loop_struct;
+static uv_loop_t* default_loop_ptr;
+
+
+uv_loop_t* uv_default_loop(void) {
+  if (default_loop_ptr != NULL)
+    return default_loop_ptr;
+
+  if (uv_loop_init(&default_loop_struct))
+    return NULL;
+
+  default_loop_ptr = &default_loop_struct;
+  return default_loop_ptr;
+}
+
+
+uv_loop_t* uv_loop_new(void) {
+  uv_loop_t* loop;
+
+  loop = malloc(sizeof(*loop));
+  if (loop == NULL)
+    return NULL;
+
+  if (uv_loop_init(loop)) {
+    free(loop);
+    return NULL;
+  }
+
+  return loop;
+}
+
+
+int uv_loop_close(uv_loop_t* loop) {
+  QUEUE* q;
+  uv_handle_t* h;
+
+  if (!QUEUE_EMPTY(&(loop)->active_reqs))
+    return UV_EBUSY;
+
+  QUEUE_FOREACH(q, &loop->handle_queue) {
+    h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+    if (!(h->flags & UV__HANDLE_INTERNAL))
+      return UV_EBUSY;
+  }
+
+  uv__loop_close(loop);
+
+#ifndef NDEBUG
+  memset(loop, -1, sizeof(*loop));
+#endif
+  if (loop == default_loop_ptr)
+    default_loop_ptr = NULL;
+
+  return 0;
+}
+
+
+void uv_loop_delete(uv_loop_t* loop) {
+  uv_loop_t* default_loop;
+  int err;
+
+  default_loop = default_loop_ptr;
+
+  err = uv_loop_close(loop);
+  assert(err == 0);
+  if (loop != default_loop)
+    free(loop);
+}

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -65,6 +65,8 @@ enum {
 
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
 
+void uv__loop_close(uv_loop_t* loop);
+
 int uv__tcp_bind(uv_tcp_t* tcp,
                  const struct sockaddr* addr,
                  unsigned int addrlen,


### PR DESCRIPTION
I still have this additional warning:

```
  CC       src/libuv_la-uv-common.lo
src/uv-common.c: In function 'uv_loop_close':
src/uv-common.c:505:3: warning: implicit declaration of function 'uv__loop_close' [-Wimplicit-function-declaration]
   uv__loop_close(loop);
   ^
```

Don't know where I should put the definition for uv__loop_close.