### PR TITLE
doc: clarify uv_default_loop

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -80,6 +80,12 @@ API
     Returns the initialized default loop. It may return NULL in case of
     allocation failure.
 
+    This function is just a convenient way for having a global loop throughout
+    an application, the default loop is in no way different than the ones
+    initialized with :c:func:`uv_loop_init`. As such, the default loop can (and
+    should) be closed with :c:func:`uv_loop_close` so the resources associated
+    with it are freed.
+
 .. c:function:: int uv_run(uv_loop_t* loop, uv_run_mode mode)
 
     This function runs the event loop. It will act differently depending on the


### PR DESCRIPTION
Indicate that it can (and should) also be closed, currently it's not
"special" in any way.