### PR TITLE
unix, win: add synchronous uv_get{addr,name}info

### DIFF
--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -106,13 +106,9 @@ static void uv__getaddrinfo_work(struct uv__work* w) {
 
 static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   uv_getaddrinfo_t* req;
-  struct addrinfo *res;
 
   req = container_of(w, uv_getaddrinfo_t, work_req);
   uv__req_unregister(req->loop, req);
-
-  res = req->res;
-  req->res = NULL;
 
   /* See initialization in uv_getaddrinfo(). */
   if (req->hints)
@@ -133,7 +129,8 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
     req->retcode = UV_EAI_CANCELED;
   }
 
-  req->cb(req, req->retcode, res);
+  if (req->cb)
+    req->cb(req, req->retcode, req->res);
 }
 
 
@@ -149,7 +146,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   size_t len;
   char* buf;
 
-  if (req == NULL || cb == NULL || (hostname == NULL && service == NULL))
+  if (req == NULL || (hostname == NULL && service == NULL))
     return -EINVAL;
 
   hostname_len = hostname ? strlen(hostname) + 1 : 0;
@@ -185,12 +182,17 @@ int uv_getaddrinfo(uv_loop_t* loop,
   if (hostname)
     req->hostname = memcpy(buf + len, hostname, hostname_len);
 
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getaddrinfo_work,
-                  uv__getaddrinfo_done);
-
-  return 0;
+  if (cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getaddrinfo_work,
+                    uv__getaddrinfo_done);
+    return 0;
+  } else {
+    uv__getaddrinfo_work(&req->work_req);
+    uv__getaddrinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 }
 
 

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -69,7 +69,8 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
     service = req->service;
   }
 
-  req->getnameinfo_cb(req, req->retcode, host, service);
+  if (req->getnameinfo_cb)
+    req->getnameinfo_cb(req, req->retcode, host, service);
 }
 
 /*
@@ -82,7 +83,7 @@ int uv_getnameinfo(uv_loop_t* loop,
                    uv_getnameinfo_cb getnameinfo_cb,
                    const struct sockaddr* addr,
                    int flags) {
-  if (req == NULL || getnameinfo_cb == NULL || addr == NULL)
+  if (req == NULL || addr == NULL)
     return UV_EINVAL;
 
   if (addr->sa_family == AF_INET) {
@@ -105,10 +106,15 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->loop = loop;
   req->retcode = 0;
 
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getnameinfo_work,
-                  uv__getnameinfo_done);
-
-  return 0;
+  if (getnameinfo_cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getnameinfo_work,
+                    uv__getnameinfo_done);
+    return 0;
+  } else {
+    uv__getnameinfo_work(&req->work_req);
+    uv__getnameinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 }

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -98,7 +98,8 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
     service = req->service;
   }
 
-  req->getnameinfo_cb(req, req->retcode, host, service);
+  if (req->getnameinfo_cb)
+    req->getnameinfo_cb(req, req->retcode, host, service);
 }
 
 
@@ -112,7 +113,7 @@ int uv_getnameinfo(uv_loop_t* loop,
                    uv_getnameinfo_cb getnameinfo_cb,
                    const struct sockaddr* addr,
                    int flags) {
-  if (req == NULL || getnameinfo_cb == NULL || addr == NULL)
+  if (req == NULL || addr == NULL)
     return UV_EINVAL;
 
   if (addr->sa_family == AF_INET) {
@@ -136,10 +137,15 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->loop = loop;
   req->retcode = 0;
 
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getnameinfo_work,
-                  uv__getnameinfo_done);
-
-  return 0;
+  if (getnameinfo_cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getnameinfo_work,
+                    uv__getnameinfo_done);
+    return 0;
+  } else {
+    uv__getnameinfo_work(&req->work_req);
+    uv__getnameinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 }

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -97,6 +97,22 @@ TEST_IMPL(getaddrinfo_fail) {
 }
 
 
+TEST_IMPL(getaddrinfo_fail_sync) {
+  uv_getaddrinfo_t req;
+
+  ASSERT(0 > uv_getaddrinfo(uv_default_loop(),
+                            &req,
+                            NULL,
+                            "xyzzy.xyzzy.xyzzy",
+                            NULL,
+                            NULL));
+  uv_freeaddrinfo(req.res);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
 TEST_IMPL(getaddrinfo_basic) {
   int r;
   getaddrinfo_handle = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
@@ -112,6 +128,24 @@ TEST_IMPL(getaddrinfo_basic) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT(getaddrinfo_cbs == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
+TEST_IMPL(getaddrinfo_basic_sync) {
+  int r;
+  uv_getaddrinfo_t req;
+
+  r = uv_getaddrinfo(uv_default_loop(),
+                     &req,
+                     NULL,
+                     name,
+                     NULL,
+                     NULL);
+  ASSERT(r == 0);
+  uv_freeaddrinfo(req.res);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -44,6 +44,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
   ASSERT(service != NULL);
 }
 
+
 TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
@@ -62,6 +63,27 @@ TEST_IMPL(getnameinfo_basic_ip4) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+
+TEST_IMPL(getnameinfo_basic_ip4_sync) {
+  int r;
+
+  r = uv_ip4_addr(address_ip4, port, &addr4);
+  ASSERT(r == 0);
+
+  r = uv_getnameinfo(uv_default_loop(),
+                     &req,
+                     NULL,
+                     (const struct sockaddr*)&addr4,
+                     0);
+  ASSERT(r == 0);
+  ASSERT(req.host != NULL);
+  ASSERT(req.service != NULL);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
 
 TEST_IMPL(getnameinfo_basic_ip6) {
   int r;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -180,9 +180,12 @@ TEST_DECLARE   (get_memory)
 TEST_DECLARE   (handle_fileno)
 TEST_DECLARE   (hrtime)
 TEST_DECLARE   (getaddrinfo_fail)
+TEST_DECLARE   (getaddrinfo_fail_sync)
 TEST_DECLARE   (getaddrinfo_basic)
+TEST_DECLARE   (getaddrinfo_basic_sync)
 TEST_DECLARE   (getaddrinfo_concurrent)
 TEST_DECLARE   (getnameinfo_basic_ip4)
+TEST_DECLARE   (getnameinfo_basic_ip4_sync)
 TEST_DECLARE   (getnameinfo_basic_ip6)
 TEST_DECLARE   (getsockname_tcp)
 TEST_DECLARE   (getsockname_udp)
@@ -524,11 +527,14 @@ TASK_LIST_START
   TEST_ENTRY  (hrtime)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
+  TEST_ENTRY  (getaddrinfo_fail_sync)
 
   TEST_ENTRY  (getaddrinfo_basic)
+  TEST_ENTRY  (getaddrinfo_basic_sync)
   TEST_ENTRY  (getaddrinfo_concurrent)
 
   TEST_ENTRY  (getnameinfo_basic_ip4)
+  TEST_ENTRY  (getnameinfo_basic_ip4_sync)
   TEST_ENTRY  (getnameinfo_basic_ip6)
 
   TEST_ENTRY  (getsockname_tcp)


### PR DESCRIPTION
I think having the sync counterparts to uv_get{addr,name}info can be beneficial, some times it just doesn't matter that they are blocking and the user gains the cross-platform uniformity.

Now, this implementation is not 100% finalized, there are a number of issues I'd like to discuss, assuming we agree this should go forward.

* The `res` field of `uv_getaddrinfo_t` needs to be "public".
* On Windows, `res` doesn't hold the pointer to `struct addrinfo*`, it converts it from the `struct addrinfoW*` counterpart: https://github.com/libuv/libuv/blob/v1.x/src/win/getaddrinfo.c#L128-L208 I need to fix that somehow without breaking ABI. Suggestions are more than welcome.
* Shoudl this go into v1.x or master? Currently we return `UV_EINVAL` if the callback is NULL, now we'd do the operations synchronously, with might not count as "backwards compatible".

R=@bnoordhuis
R=@piscisaureus

