### PR TITLE
Testing: Fixed text/test-spawn

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -988,7 +988,7 @@ TEST_IMPL(environment_creation) {
       }
     }
     if (prev) { /* verify sort order -- requires Vista */
-#if _WIN32_WINNT >= 0x0600
+#if _WIN32_WINNT >= 0x0600 && !defined(__MINGW32__)
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
 #endif
     }


### PR DESCRIPTION
Here is the Mingw patch!

Changed test/test-spawn.c to support Windows MinGW32. Define CompareStringOrdinal in case of MinGW32 (from mingw.org).

I hope you like biicode ;)