### PR TITLE
Testing: Fixed text/test-spawn

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -988,7 +988,7 @@ TEST_IMPL(environment_creation) {
       }
     }
     if (prev) { /* verify sort order -- requires Vista */
-#if _WIN32_WINNT >= 0x0600
+#if _WIN32_WINNT >= 0x0600 && (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
 #endif
     }


### PR DESCRIPTION
I think now should be fine. CompareStringOrdinal supported in MinGW-w64 but not in MinGW-w32. 