### PR TITLE
windows: fix regression when cancelling getaddrinfo

### DIFF
--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -201,13 +201,13 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
     }
   }
 
-complete:
   /* return memory to system */
   if (req->addrinfow != NULL) {
     FreeAddrInfoW(req->addrinfow);
     req->addrinfow = NULL;
   }
 
+complete:
   uv__req_unregister(req->loop, req);
 
   /* finally do callback with converted result */


### PR DESCRIPTION
The req->addrinfow field contains the hints in that case, so we must not
free it.

This regression was introduced in f2bb8d3 by yours truly.

R=@piscisaureus
R=@bnoordhuis

This gives us a green build on Windows: https://jenkins-iojs.nodesource.com/view/libuv/job/libuv+any-pr+multi/60/