### PR TITLE
unix: Check Android support for pthread_cond_timedwait_monotonic_np

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -330,7 +330,7 @@ int uv_cond_init(uv_cond_t* cond) {
   if (err)
     return -err;
 
-#if !defined(__ANDROID__)
+#if !(defined(__ANDROID__) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC))
   err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
   if (err)
     goto error2;
@@ -388,7 +388,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   timeout += uv__hrtime(UV_CLOCK_PRECISE);
   ts.tv_sec = timeout / NANOSEC;
   ts.tv_nsec = timeout % NANOSEC;
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC)
   /*
    * The bionic pthread implementation doesn't support CLOCK_MONOTONIC,
    * but has this alternative function instead.


### PR DESCRIPTION
Since API level 21 (Android 5.0) the non-standard pthread function
pthread_cond_timedwait_monotonic_np has been removed in favour of
the standard pthread_cond_timedwait which libuv normally uses on
Linux.

This commit changes the detection of the Android OS to account for
the removal of the function via the #define
HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC which is only present in older
API levels.

Fixes #172