### PR TITLE
test: use modified path in test

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1015,7 +1015,7 @@ TEST_IMPL(spawn_with_an_odd_path) {
   char *path = getenv("PATH");
   ASSERT(path != NULL);
   snprintf(newpath, 2048, ";.;%s", path);
-  SetEnvironmentVariable("PATH", path);
+  SetEnvironmentVariable("PATH", newpath);
 
   init_process_options("", exit_cb);
   options.file = options.args[0] = "program-that-had-better-not-exist";


### PR DESCRIPTION
The Windows `spawn_with_an_odd_path` test builds a `PATH` variable that starts with `;.;`. However, the old path is then used to run the test. This commit updates the test to use the new path.

Found while looking into #183. cc: @piscisaureus 