### PR TITLE
unix: fix for uv_async data race (v0.10)

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -186,7 +186,7 @@ src/.buildstamp src/unix/.buildstamp test/.buildstamp:
 	mkdir -p $(@D)
 	touch $@
 
-src/unix/%.o src/unix/%.pic.o: src/unix/%.c include/uv.h include/uv-private/uv-unix.h src/unix/internal.h src/unix/.buildstamp $(DTRACE_HEADER)
+src/unix/%.o src/unix/%.pic.o: src/unix/%.c include/uv.h include/uv-private/uv-unix.h src/unix/atomic-ops.h src/unix/internal.h src/unix/.buildstamp $(DTRACE_HEADER)
 	$(CC) $(CSTDFLAG) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 src/%.o src/%.pic.o: src/%.c include/uv.h include/uv-private/uv-unix.h src/.buildstamp

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -24,6 +24,7 @@
 
 #include "uv.h"
 #include "internal.h"
+#include "atomic-ops.h"
 
 #include <errno.h>
 #include <assert.h>
@@ -34,7 +35,6 @@
 static void uv__async_event(uv_loop_t* loop,
                             struct uv__async* w,
                             unsigned int nevents);
-static int uv__async_make_pending(int* pending);
 static int uv__async_eventfd(void);
 
 
@@ -54,7 +54,11 @@ int uv_async_init(uv_loop_t* loop, uv_async_t* handle, uv_async_cb async_cb) {
 
 
 int uv_async_send(uv_async_t* handle) {
-  if (uv__async_make_pending(&handle->pending) == 0)
+  /* Do a cheap read first. */
+  if (ACCESS_ONCE(int, handle->pending) != 0)
+    return 0;
+
+  if (cmpxchgi(&handle->pending, 0, 1) == 0)
     uv__async_send(&handle->loop->async_watcher);
 
   return 0;
@@ -75,41 +79,12 @@ static void uv__async_event(uv_loop_t* loop,
 
   ngx_queue_foreach(q, &loop->async_handles) {
     h = ngx_queue_data(q, uv_async_t, queue);
-    if (!h->pending) continue;
-    h->pending = 0;
+
+    if (cmpxchgi(&h->pending, 1, 0) == 0)
+      continue;
+
     h->async_cb(h, 0);
   }
-}
-
-
-static int uv__async_make_pending(int* pending) {
-  /* Do a cheap read first. */
-  if (ACCESS_ONCE(int, *pending) != 0)
-    return 1;
-
-  /* Micro-optimization: use atomic memory operations to detect if we've been
-   * preempted by another thread and don't have to make an expensive syscall.
-   * This speeds up the heavily contended case by about 1-2% and has little
-   * if any impact on the non-contended case.
-   *
-   * Use XCHG instead of the CMPXCHG that __sync_val_compare_and_swap() emits
-   * on x86, it's about 4x faster. It probably makes zero difference in the
-   * grand scheme of things but I'm OCD enough not to let this one pass.
-   */
-#if defined(__i386__) || defined(__x86_64__)
-  {
-    unsigned int val = 1;
-    __asm__ __volatile__ ("xchgl %0, %1"
-                         : "+r" (val)
-                         : "m"  (*pending));
-    return val != 0;
-  }
-#elif defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 0)
-  return __sync_val_compare_and_swap(pending, 0, 1) != 0;
-#else
-  ACCESS_ONCE(int, *pending) = 1;
-  return 0;
-#endif
 }
 
 

--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2013, Ben Noordhuis <info@bnoordhuis.nl>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef UV_ATOMIC_OPS_H_
+#define UV_ATOMIC_OPS_H_
+
+#include "internal.h"  /* UV_UNUSED */
+
+UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval));
+UV_UNUSED(static long cmpxchgl(long* ptr, long oldval, long newval));
+UV_UNUSED(static void cpu_relax(void));
+
+/* Prefer hand-rolled assembly over the gcc builtins because the latter also
+ * issue full memory barriers.
+ */
+UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval)) {
+#if defined(__i386__) || defined(__x86_64__)
+  int out;
+  __asm__ __volatile__ ("lock; cmpxchg %2, %1;"
+                        : "=a" (out), "+m" (*(volatile int*) ptr)
+                        : "r" (newval), "0" (oldval)
+                        : "memory");
+  return out;
+#else
+  return __sync_val_compare_and_swap(ptr, oldval, newval);
+#endif
+}
+
+UV_UNUSED(static long cmpxchgl(long* ptr, long oldval, long newval)) {
+#if defined(__i386__) || defined(__x86_64__)
+  long out;
+  __asm__ __volatile__ ("lock; cmpxchg %2, %1;"
+                        : "=a" (out), "+m" (*(volatile long*) ptr)
+                        : "r" (newval), "0" (oldval)
+                        : "memory");
+  return out;
+#else
+  return __sync_val_compare_and_swap(ptr, oldval, newval);
+#endif
+}
+
+UV_UNUSED(static void cpu_relax(void)) {
+#if defined(__i386__) || defined(__x86_64__)
+  __asm__ __volatile__ ("rep; nop");  /* a.k.a. PAUSE */
+#endif
+}
+
+#endif  /* UV_ATOMIC_OPS_H_ */

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -66,6 +66,21 @@
   }                                                                           \
   while (0)
 
+/* The __clang__ and __INTEL_COMPILER checks are superfluous because they
+ * define __GNUC__. They are here to convey to you, dear reader, that these
+ * macros are enabled when compiling with clang or icc.
+ */
+#if defined(__clang__) ||                                                     \
+    defined(__GNUC__) ||                                                      \
+    defined(__INTEL_COMPILER) ||                                              \
+    defined(__SUNPRO_C)
+# define UV_DESTRUCTOR(declaration) __attribute__((destructor)) declaration
+# define UV_UNUSED(declaration)     __attribute__((unused)) declaration
+#else
+# define UV_DESTRUCTOR(declaration) declaration
+# define UV_UNUSED(declaration)     declaration
+#endif
+
 #if defined(__linux__)
 # define UV__POLLIN   UV__EPOLLIN
 # define UV__POLLOUT  UV__EPOLLOUT

--- a/uv.gyp
+++ b/uv.gyp
@@ -133,6 +133,7 @@
             'include/uv-private/uv-darwin.h',
             'include/uv-private/uv-bsd.h',
             'src/unix/async.c',
+            'src/unix/atomic-ops.h',
             'src/unix/core.c',
             'src/unix/dl.c',
             'src/unix/error.c',


### PR DESCRIPTION
I originally open a PR here: https://github.com/libuv/libuv/pull/50. This PR includes the changes requested in the  previous review.

There's a data race in the consuming side of uv_async. The "pending"
flag could be trampled by producing thread causing an async send event
to be missed.

This back ports the atomic operations added to v1.x in the commit
a3c3b37 ("unix: add atomic-ops.h").

