### PR TITLE
unix,windows: make uv_thread_create() return errno

### DIFF
--- a/docs/src/threading.rst
+++ b/docs/src/threading.rst
@@ -56,6 +56,9 @@ Threads
 ^^^^^^^
 
 .. c:function:: int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg)
+
+    .. versionchanged:: 1.5.0 returns a UV_E* error code on failure
+
 .. c:function:: uv_thread_t uv_thread_self(void)
 .. c:function:: int uv_thread_join(uv_thread_t *tid)
 .. c:function:: int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -68,7 +68,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   if (err)
     free(ctx);
 
-  return err ? -1 : 0;
+  return -err;
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -175,7 +175,18 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
     ResumeThread(thread);
   }
 
-  return err;
+  switch (err) {
+    case 0:
+      return 0;
+    case EACCES:
+      return UV_EACCES;
+    case EAGAIN:
+      return UV_EAGAIN;
+    case EINVAL:
+      return UV_EINVAL;
+  }
+
+  return UV_EIO;
 }
 
 


### PR DESCRIPTION
Before this commit, UNIX returned -1 on failure.  Windows sometimes
returned a UV_E* error code and sometimes a bogus status code, courtesy
of errno values not mapping to UV_E* error codes on that platform.

R=@saghul?

https://jenkins-iojs.nodesource.com/view/libuv/job/libuv+any-pr+multi/67/