### PR TITLE
common: map EHOSTDOWN errno

### DIFF
--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -399,4 +399,10 @@
 # define UV__EMLINK (-4032)
 #endif
 
+#if defined(EHOSTDOWN) && !defined(_WIN32)
+# define UV__EHOSTDOWN (-EHOSTDOWN)
+#else
+# define UV__EHOSTDOWN (-4031)
+#endif
+
 #endif /* UV_ERRNO_H_ */


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/195

R=@bnoordhuis

I know it's not a POSIX errno, but it will be defined to the system errno for any platform which defines it, and to our custom value otherwise, so we should be safe, I think.