### PR TITLE
unix: fixed glibc-2.20+ macro incompatibility

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -661,8 +661,12 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_birthtim.tv_nsec = src->st_birthtimespec.tv_nsec;
   dst->st_flags = src->st_flags;
   dst->st_gen = src->st_gen;
-#elif !defined(_AIX) && \
-  (defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || defined(_XOPEN_SOURCE))
+#elif !defined(_AIX) && (           \
+        defined(_BSD_SOURCE)     || \
+        defined(_SVID_SOURCE)    || \
+        defined(_XOPEN_SOURCE)   || \
+        defined(_DEFAULT_SOURCE)    \
+      )
   dst->st_atim.tv_sec = src->st_atim.tv_sec;
   dst->st_atim.tv_nsec = src->st_atim.tv_nsec;
   dst->st_mtim.tv_sec = src->st_mtim.tv_sec;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1094,7 +1094,8 @@ TEST_IMPL(fs_fstat) {
 #elif defined(__sun) || \
       defined(_BSD_SOURCE) || \
       defined(_SVID_SOURCE) || \
-      defined(_XOPEN_SOURCE)
+      defined(_XOPEN_SOURCE) || \
+      defined(_DEFAULT_SOURCE)
   ASSERT(s->st_atim.tv_sec == t.st_atim.tv_sec);
   ASSERT(s->st_atim.tv_nsec == t.st_atim.tv_nsec);
   ASSERT(s->st_mtim.tv_sec == t.st_mtim.tv_sec);


### PR DESCRIPTION
Since glibc-2.20 the _SVID_SOURCE macro is deprecated and the newer
_DEFAULT_SOURCE macro should be used instead.

This fixes bug #173