### PR TITLE
include, misc: Add more capable net interfaces list.

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -71,6 +71,36 @@ Data types
             } cpu_times;
         } uv_cpu_info_t;
 
+.. c:type:: uv_network_interface_t
+
+    Data type for network interfaces.
+
+    ::
+
+        typedef struct uv_network_interface_s {
+            char* name;
+            int is_up_and_running;
+            int is_loopback;
+            int is_point_to_point;
+            int is_promiscuous;
+            int has_broadcast;
+            int has_multicast;
+            char phys_addr[8]; /* Enough to store a firewire address. */
+            unsigned int phys_addr_len;
+            union {
+                struct sockaddr_in address4;
+                struct sockaddr_in6 address6;
+            } address;
+            union {
+                struct sockaddr_in broadcast4;
+                struct sockaddr_in6 broadcast6;
+            } broadcast;
+            union {
+                struct sockaddr_in netmask4;
+                struct sockaddr_in6 netmask6;
+            } netmask;
+        } uv_network_interface_t;
+
 .. c:type:: uv_interface_address_t
 
     Data type for interface addresses.
@@ -158,11 +188,26 @@ API
 
     Frees the `cpu_infos` array previously allocated with :c:func:`uv_cpu_info`.
 
+.. c:function:: int uv_network_interfaces(uv_network_interface_t** interfaces, int* count)
+
+    Gets information about internet network interfaces on the system. An array
+    of `count` elements is allocated and returned in `interfaces`. Includes up,
+    down, unattached interfaces and interfaces without addresses. Missing
+    addresses are marked with a family of `AF_UNSPEC` and their contents are
+    unspecified. At least one link-layer record is returned for each interface.
+    It must be freed by the user, calling :c:func:`uv_free_network_interfaces`.
+
+.. c:function:: void uv_free_network_interfaces(uv_network_interface_t* interfaces, int count)
+
+    Free an array of :c:type:`uv_network_interface_t` which was returned by
+    :c:func:`uv_network_interfaces`.
+
 .. c:function:: int uv_interface_addresses(uv_interface_address_t** addresses, int* count)
 
     Gets address information about the network interfaces on the system. An
-    array of `count` elements is allocated and returned in `addresses`. It must
-    be freed by the user, calling :c:func:`uv_free_interface_addresses`.
+    array of `count` elements is allocated and returned in `addresses`. Only
+    includes interfaces with `INET` or `INET6` addresses. It must be freed by
+    the user, calling :c:func:`uv_free_interface_addresses`.
 
 .. c:function:: void uv_free_interface_addresses(uv_interface_address_t* addresses, int count)
 

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -399,4 +399,20 @@
 # define UV__EMLINK (-4032)
 #endif
 
+/* EHOSTDOWN is not visible on BSD-like systems when _POSIX_C_SOURCE is
+ * defined. Fortunately, its value is always 64 so it's possible albeit
+ * icky to hard-code it.
+ */
+#if defined(EHOSTDOWN) && !defined(_WIN32)
+# define UV__EHOSTDOWN (-EHOSTDOWN)
+#elif defined(__APPLE__) || \
+      defined(__DragonFly__) || \
+      defined(__FreeBSD__) || \
+      defined(__NetBSD__) || \
+      defined(__OpenBSD__)
+# define UV__EHOSTDOWN (-64)
+#else
+# define UV__EHOSTDOWN (-4031)
+#endif
+
 #endif /* UV_ERRNO_H_ */

--- a/include/uv.h
+++ b/include/uv.h
@@ -228,6 +228,7 @@ typedef struct uv_work_s uv_work_t;
 /* None of the above. */
 typedef struct uv_cpu_info_s uv_cpu_info_t;
 typedef struct uv_interface_address_s uv_interface_address_t;
+typedef struct uv_network_interface_s uv_network_interface_t;
 typedef struct uv_dirent_s uv_dirent_t;
 
 typedef enum {
@@ -978,6 +979,30 @@ struct uv_interface_address_s {
     struct sockaddr_in6 netmask6;
   } netmask;
 };
+
+typedef struct uv_network_interface_s {
+  char* name;
+  int is_up_and_running;
+  int is_loopback;
+  int is_point_to_point;
+  int is_promiscuous;
+  int has_broadcast;
+  int has_multicast;
+  char phys_addr[8]; /* Enough to store a firewire address. */
+  unsigned int phys_addr_len;
+  union {
+    struct sockaddr_in address4;
+    struct sockaddr_in6 address6;
+  } address;
+  union {
+    struct sockaddr_in broadcast4;
+    struct sockaddr_in6 broadcast6;
+  } broadcast;
+  union {
+    struct sockaddr_in netmask4;
+    struct sockaddr_in6 netmask6;
+  } netmask;
+} uv_network_interface_s;
 
 typedef enum {
   UV_DIRENT_UNKNOWN,

--- a/include/uv.h
+++ b/include/uv.h
@@ -138,6 +138,7 @@ extern "C" {
   XX(EOF, "end of file")                                                      \
   XX(ENXIO, "no such device or address")                                      \
   XX(EMLINK, "too many links")                                                \
+  XX(EHOSTDOWN, "host is down")                                               \
 
 #define UV_HANDLE_TYPE_MAP(XX)                                                \
   XX(ASYNC, async)                                                            \

--- a/include/uv.h
+++ b/include/uv.h
@@ -1060,6 +1060,11 @@ UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses,
 UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
                                            int count);
 
+UV_EXTERN int uv_network_interfaces(uv_network_interface_t** interfaces,
+                                    int* count);
+UV_EXTERN void uv_free_network_interfaces(uv_network_interface_t* interfaces,
+                                          int count);
+
 
 typedef enum {
   UV_FS_UNKNOWN = -1,

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -329,3 +329,127 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
 
   free(addresses);
 }
+
+
+int uv_network_interfaces(uv_network_interface_t** interfaces, int* count) {
+  uv_network_interface_t* interface;
+  struct ifaddrs *addrs, *ent;
+  struct sockaddr_dl *sdl_addr;
+  int i;
+
+  if (getifaddrs(&addrs))
+    return -errno;
+
+  *count = 0;
+  *interfaces = NULL;
+
+  /* Count the number of interfaces. */
+  for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+    if (ent->ifa_addr->sa_family != AF_INET6 &&
+        ent->ifa_addr->sa_family != AF_INET &&
+        ent->ifa_addr->sa_family != AF_LINK) {
+      continue;
+    }
+    (*count)++;
+  }
+
+  if ((*count) == 0)
+    return 0;
+
+  *interfaces = malloc((*count) * sizeof(**interfaces));
+  if (!(*interfaces))
+    return -ENOMEM;
+
+  interface = *interfaces;
+  for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+    if (ent->ifa_addr->sa_family != AF_INET6 &&
+        ent->ifa_addr->sa_family != AF_INET &&
+        ent->ifa_addr->sa_family != AF_LINK) {
+      continue;
+    }
+
+  /* Meta. */
+    interface->name = strdup(ent->ifa_name);
+    interface->is_loopback       = !!(ent->ifa_flags & IFF_LOOPBACK);
+    interface->is_up_and_running = !!(ent->ifa_flags & (IFF_UP|IFF_RUNNING));
+    interface->is_point_to_point = !!(ent->ifa_flags & IFF_POINTOPOINT);
+    interface->is_promiscuous    = !!(ent->ifa_flags & IFF_PROMISC);
+    interface->has_broadcast     = !!(ent->ifa_flags & IFF_BROADCAST);
+    interface->has_multicast     = !!(ent->ifa_flags & IFF_MULTICAST);
+
+  /* Address. */
+    if (ent->ifa_addr != NULL) {
+      if (ent->ifa_addr->sa_family == AF_INET6) {
+        interface->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);
+      } else if (ent->ifa_addr->sa_family == AF_INET) {
+        interface->address.address4 = *((struct sockaddr_in*) ent->ifa_addr);
+      } else {
+        interface->address.address4.sin_family = AF_UNSPEC;
+      }
+    }
+
+  /* Broadcast or point-to-point. */
+    if (ent->ifa_broadaddr != NULL) {
+      if (ent->ifa_broadaddr->sa_family == AF_INET6) {
+        interface->broadcast.broadcast6 = *((struct sockaddr_in6*) ent->ifa_broadaddr);
+      } else if (ent->ifa_broadaddr->sa_family == AF_INET) {
+        interface->broadcast.broadcast4 = *((struct sockaddr_in*) ent->ifa_broadaddr);
+      } else {
+        interface->broadcast.broadcast4.sin_family = AF_UNSPEC;
+      }
+    } else if (ent->ifa_dstaddr != NULL) {
+      if (ent->ifa_dstaddr->sa_family == AF_INET6) {
+        interface->broadcast.broadcast6 = *((struct sockaddr_in6*) ent->ifa_dstaddr);
+      } else if (ent->ifa_dstaddr->sa_family == AF_INET) {
+        interface->broadcast.broadcast4 = *((struct sockaddr_in*) ent->ifa_dstaddr);
+      } else {
+        interface->broadcast.broadcast4.sin_family = AF_UNSPEC;
+      }
+    }
+
+  /* Netmask. */
+    if (ent->ifa_netmask != NULL) {
+      if (ent->ifa_netmask->sa_family == AF_INET6) {
+        interface->netmask.netmask6 = *((struct sockaddr_in6*) ent->ifa_netmask);
+      } else if (ent->ifa_netmask->sa_family == AF_INET) {
+        interface->netmask.netmask4 = *((struct sockaddr_in*) ent->ifa_netmask);
+      } else {
+        interface->netmask.netmask4.sin_family = AF_UNSPEC;
+      }
+    }
+
+    interface++;
+  }
+
+  /* Fill in physical interfaces for each interface */
+  for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+    if (ent->ifa_addr->sa_family != AF_LINK) {
+      continue;
+    }
+    interface = *interfaces;
+    for (i = 0; i < (*count); i++) {
+      if (strcmp(interface->name, ent->ifa_name) == 0) {
+        sdl_addr = (struct sockaddr_dl*)(ent->ifa_addr);
+        interface->phys_addr_len = sdl_addr->sdl_alen;
+        /* Clamp size to sizeof(interface) */
+        if (interface->phys_addr_len > sizeof(interface->phys_addr)) {
+          interface->phys_addr_len = sizeof(interface->phys_addr);
+        }
+        memcpy(interface->phys_addr, LLADDR(sdl_addr), interface->phys_addr_len);
+      }
+      interface++;
+    }
+  }
+
+  return 0;
+}
+
+void uv_free_network_interfaces(uv_network_interface_t* interfaces, int count) {
+  int i;
+
+  for (i = 0; i < count; i++) {
+    free(interfaces[i].name);
+  }
+
+  free(interfaces);
+}

--- a/test/task.h
+++ b/test/task.h
@@ -235,19 +235,19 @@ UNUSED static void close_loop(uv_loop_t* loop) {
 }
 
 UNUSED static int can_ipv6(void) {
-  uv_network_interface_t* interface;
+  uv_network_interface_t* interfaces;
   int supported;
   int count;
   int i;
 
-  if (uv_network_interfaces(&interface, &count))
+  if (uv_network_interfaces(&interfaces, &count))
     return 1;  /* Assume IPv6 support on failure. */
 
   supported = 0;
   for (i = 0; supported == 0 && i < count; i += 1)
-    supported = (AF_INET6 == interface[i].address.address6.sin6_family);
+    supported = (AF_INET6 == interfaces[i].address.address6.sin6_family);
 
-  uv_free_network_interfaces(interface, count);
+  uv_free_network_interfaces(interfaces, count);
   return supported;
 }
 

--- a/test/task.h
+++ b/test/task.h
@@ -235,19 +235,19 @@ UNUSED static void close_loop(uv_loop_t* loop) {
 }
 
 UNUSED static int can_ipv6(void) {
-  uv_interface_address_t* addr;
+  uv_network_interface_t* interface;
   int supported;
   int count;
   int i;
 
-  if (uv_interface_addresses(&addr, &count))
+  if (uv_network_interfaces(&interface, &count))
     return 1;  /* Assume IPv6 support on failure. */
 
   supported = 0;
   for (i = 0; supported == 0 && i < count; i += 1)
-    supported = (AF_INET6 == addr[i].address.address6.sin6_family);
+    supported = (AF_INET6 == interface[i].address.address6.sin6_family);
 
-  uv_free_interface_addresses(addr, count);
+  uv_free_network_interfaces(interface, count);
   return supported;
 }
 

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -33,8 +33,8 @@
 
 TEST_IMPL(ip6_addr_link_local) {
   char string_address[INET6_ADDRSTRLEN];
-  uv_interface_address_t* addresses;
-  uv_interface_address_t* address;
+  uv_network_interface_t* interfaces;
+  uv_network_interface_t* interface;
   struct sockaddr_in6 addr;
   unsigned int iface_index;
   const char* device_name;
@@ -43,25 +43,25 @@ TEST_IMPL(ip6_addr_link_local) {
   int count;
   int ix;
 
-  ASSERT(0 == uv_interface_addresses(&addresses, &count));
+  ASSERT(0 == uv_network_interfaces(&interfaces, &count));
 
   for (ix = 0; ix < count; ix++) {
-    address = addresses + ix;
+    interface = interfaces + ix;
 
-    if (address->address.address6.sin6_family != AF_INET6)
+    if (interface->address.address6.sin6_family != AF_INET6)
       continue;
 
     ASSERT(0 == uv_inet_ntop(AF_INET6,
-                             &address->address.address6.sin6_addr,
+                             &interface->address.address6.sin6_addr,
                              string_address,
                              sizeof(string_address)));
 
-    /* Skip addresses that are not link-local. */
+    /* Skip interfaces that are not link-local. */
     if (strncmp(string_address, "fe80::", 6) != 0)
       continue;
 
-    iface_index = address->address.address6.sin6_scope_id;
-    device_name = address->name;
+    iface_index = interface->address.address6.sin6_scope_id;
+    device_name = interface->name;
 
 #ifdef _WIN32
     snprintf(scoped_addr,
@@ -88,7 +88,7 @@ TEST_IMPL(ip6_addr_link_local) {
     ASSERT(iface_index == addr.sin6_scope_id);
   }
 
-  uv_free_interface_addresses(addresses, count);
+  uv_free_network_interfaces(interfaces, count);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -34,7 +34,7 @@
 TEST_IMPL(ip6_addr_link_local) {
   char string_address[INET6_ADDRSTRLEN];
   uv_network_interface_t* interfaces;
-  uv_network_interface_t* interface;
+  uv_network_interface_t* intf; /* `interface` name reserved on Win */
   struct sockaddr_in6 addr;
   unsigned int iface_index;
   const char* device_name;
@@ -46,13 +46,13 @@ TEST_IMPL(ip6_addr_link_local) {
   ASSERT(0 == uv_network_interfaces(&interfaces, &count));
 
   for (ix = 0; ix < count; ix++) {
-    interface = interfaces + ix;
+    intf = interfaces + ix;
 
-    if (interface->address.address6.sin6_family != AF_INET6)
+    if (intf->address.address6.sin6_family != AF_INET6)
       continue;
 
     ASSERT(0 == uv_inet_ntop(AF_INET6,
-                             &interface->address.address6.sin6_addr,
+                             &intf->address.address6.sin6_addr,
                              string_address,
                              sizeof(string_address)));
 
@@ -60,8 +60,8 @@ TEST_IMPL(ip6_addr_link_local) {
     if (strncmp(string_address, "fe80::", 6) != 0)
       continue;
 
-    iface_index = interface->address.address6.sin6_scope_id;
-    device_name = interface->name;
+    iface_index = intf->address.address6.sin6_scope_id;
+    device_name = intf->name;
 
 #ifdef _WIN32
     snprintf(scoped_addr,

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -37,24 +37,34 @@ TEST_IMPL(platform_output) {
   int i;
   int err;
 
+
+/* uv_get_process_title */
   err = uv_get_process_title(buffer, sizeof(buffer));
   ASSERT(err == 0);
   printf("uv_get_process_title: %s\n", buffer);
 
+
+/* uv_cwd */
   size = sizeof(buffer);
   err = uv_cwd(buffer, &size);
   ASSERT(err == 0);
   printf("uv_cwd: %s\n", buffer);
 
+
+/* uv_resident_set_memory */
   err = uv_resident_set_memory(&rss);
   ASSERT(err == 0);
   printf("uv_resident_set_memory: %llu\n", (unsigned long long) rss);
 
+
+/* uv_uptime */
   err = uv_uptime(&uptime);
   ASSERT(err == 0);
   ASSERT(uptime > 0);
   printf("uv_uptime: %f\n", uptime);
 
+
+/* uv_getrusage */
   err = uv_getrusage(&rusage);
   ASSERT(err == 0);
   ASSERT(rusage.ru_utime.tv_sec >= 0);
@@ -69,6 +79,8 @@ TEST_IMPL(platform_output) {
          (unsigned long long) rusage.ru_stime.tv_sec,
          (unsigned long long) rusage.ru_stime.tv_usec);
 
+
+/* uv_cpu_info */
   err = uv_cpu_info(&cpus, &count);
   ASSERT(err == 0);
 
@@ -87,6 +99,8 @@ TEST_IMPL(platform_output) {
   }
   uv_free_cpu_info(cpus, count);
 
+
+/* uv_interface_addresses */
   err = uv_interface_addresses(&interfaces, &count);
   ASSERT(err == 0);
 

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -32,6 +32,7 @@ TEST_IMPL(platform_output) {
   uv_rusage_t rusage;
   uv_cpu_info_t* cpus;
   uv_interface_address_t* interfaces;
+  uv_network_interface_t* network_interfaces;
   int count;
   int i;
   int err;
@@ -119,6 +120,85 @@ TEST_IMPL(platform_output) {
     printf("  netmask: %s\n", buffer);
   }
   uv_free_interface_addresses(interfaces, count);
+
+
+/* uv_network_interfaces */
+  err = uv_network_interfaces(&network_interfaces, &count);
+  ASSERT(err == 0);
+
+  printf("uv_network_interfaces:\n");
+  for (i = 0; i < count; i++) {
+
+    /* Meta & flags */
+    printf("  name: %s\n", network_interfaces[i].name);
+    printf("    is_up_and_running: %d\n", network_interfaces[i].is_up_and_running);
+    printf("    is_loopback: %d\n", network_interfaces[i].is_loopback);
+    printf("    is_point_to_point: %d\n", network_interfaces[i].is_point_to_point);
+    printf("    is_promiscuous: %d\n", network_interfaces[i].is_promiscuous);
+    printf("    has_broadcast: %d\n", network_interfaces[i].has_broadcast);
+    printf("    has_multicast: %d\n", network_interfaces[i].has_multicast);
+
+    /* Address */
+    if (network_interfaces[i].address.address4.sin_family == AF_INET6) {
+      uv_ip6_name(&network_interfaces[i].address.address6, buffer, sizeof(buffer));
+      printf("    address: inet6 %s\n", buffer);
+    } else if (network_interfaces[i].address.address4.sin_family == AF_INET) {
+      uv_ip4_name(&network_interfaces[i].address.address4, buffer, sizeof(buffer));
+      printf("    address: inet4 %s\n", buffer);
+    } else {
+      printf("    address: none\n");
+    }
+
+    /* Broadcast */
+    if (network_interfaces[i].broadcast.broadcast4.sin_family == AF_INET6) {
+      uv_ip6_name(&network_interfaces[i].broadcast.broadcast6, buffer, sizeof(buffer));
+      printf("    broadcast: inet6 %s\n", buffer);
+    } else if (network_interfaces[i].broadcast.broadcast4.sin_family == AF_INET) {
+      uv_ip4_name(&network_interfaces[i].broadcast.broadcast4, buffer, sizeof(buffer));
+      printf("    broadcast: inet4 %s\n", buffer);
+    } else {
+      printf("    broadcast: none\n");
+    }
+
+    /* Netmask */
+    if (network_interfaces[i].netmask.netmask4.sin_family == AF_INET6) {
+      uv_ip6_name(&network_interfaces[i].netmask.netmask6, buffer, sizeof(buffer));
+      printf("    netmask: inet6 %s\n", buffer);
+    } else if (network_interfaces[i].netmask.netmask4.sin_family == AF_INET) {
+      uv_ip4_name(&network_interfaces[i].netmask.netmask4, buffer, sizeof(buffer));
+      printf("    netmask: inet4 %s\n", buffer);
+    } else {
+      printf("    netmask: none\n");
+    }
+
+    /* Physical layer */
+    ASSERT(network_interfaces[i].phys_addr_len == 0 ||
+           network_interfaces[i].phys_addr_len == 6 ||
+           network_interfaces[i].phys_addr_len == 8);
+    if (network_interfaces[i].phys_addr_len == 6) {
+      printf("    physical address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+             (unsigned char)network_interfaces[i].phys_addr[0],
+             (unsigned char)network_interfaces[i].phys_addr[1],
+             (unsigned char)network_interfaces[i].phys_addr[2],
+             (unsigned char)network_interfaces[i].phys_addr[3],
+             (unsigned char)network_interfaces[i].phys_addr[4],
+             (unsigned char)network_interfaces[i].phys_addr[5]);
+    } else if (network_interfaces[i].phys_addr_len == 8) {
+      printf("    physical address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n",
+             (unsigned char)network_interfaces[i].phys_addr[0],
+             (unsigned char)network_interfaces[i].phys_addr[1],
+             (unsigned char)network_interfaces[i].phys_addr[2],
+             (unsigned char)network_interfaces[i].phys_addr[3],
+             (unsigned char)network_interfaces[i].phys_addr[4],
+             (unsigned char)network_interfaces[i].phys_addr[5],
+             (unsigned char)network_interfaces[i].phys_addr[6],
+             (unsigned char)network_interfaces[i].phys_addr[7]);
+    } else {
+      printf("    physical address: none\n");
+    }
+  }
+
+  uv_free_network_interfaces(network_interfaces, count);
 
   return 0;
 }


### PR DESCRIPTION
Follows from #158. Fixes #158, #208, iojs/io.js#498 and joyent/node#9029.

> Currently libuv provides a list of all addresses assigned to network interfaces on `uv_interface_addresses`, but this is limited to up and running interfaces having inet addresses, and as such there's no way to recover a full list of interfaces from it.

This pull adds `uv_network_interfaces` as a replacement of `uv_interface_addresses` that is also able to return interfaces that have no address or are down. The implementation is separate and doesn't affect existing code. Eventually, `uv_interface_address` can be refactored as a filter of `uv_network_interfaces` or deprecated.

As a bonus, this adds various common cross-platform flags, broadcast addresses, and support for 8-byte link-layer addresses to the struct.

To do:
- [x] Initial implementation / proof of concept
- [x] Awaiting initial feedback
- [ ] Implementations for platforms other than linux and darwin
- [ ] Refactor `uv_interface_addresses`
- [ ] Bikeshedding final names of things
- [ ] Squash

Implementations:
- [x] AIX
- [ ] Android
- [x] Darwin
- [ ] Dragonfly
- [ ] freeBSD
- [x] Linux
- [ ] NetBSD
- [ ] OpenBSD
- [x] SunOS
- [x] WinNT

Notes:
- Each interface has at least one record containing only the physical address. It is the link layer record. I'm not 100% convinced by that, but removing it would require a second pass as we don't know in advance whether we'll have to keep it or not — ie. it may be the only record we have for that interface. It would also be less regular.
- Interfaces without addresses are included in the list, so users must filter for `sa_family != AF_UNSPEC` to obtain the old behavior.
- Missing addresses have a family of `AF_UNSPEC`. Missing physical addresses have a `phys_addr_len` of zero.
- I don't think `is_promiscuous` will ever be supported on Windows, but I can see it being a wanted feature on other implementations.

An example of the new schema:

```
name: en1
is_up_and_running: true
is_loopback: false
is_point_to_point: false
is_promiscuous: false
has_broadcast: true
has_multicast: true
address: none
broadcast: none
netmask: none
physical address: xx:xx:xx:xx:xx:xx
```

See the full [output from `test-platform-output.c`](https://gist.github.com/zenoamaro/2382b9982049fd74adab) for current implementations.
