### PR TITLE
Fix Node test test-tls-ocsp-callback.js for AIX

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1218,16 +1218,23 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct pollfd* events;
   uintptr_t i;
   uintptr_t nfds;
+  struct poll_ctl pc;
 
   assert(loop->watchers != NULL);
 
   events = (struct pollfd*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
-  if (events == NULL)
-    return;
 
+  if (events != NULL)
   /* Invalidate events with same file descriptor */
   for (i = 0; i < nfds; i++)
     if ((int) events[i].fd == fd)
       events[i].fd = -1;
+
+  /* Remove the file descriptor from the poll set */
+  pc.events = 0;
+  pc.cmd = PS_DELETE;
+  pc.fd = fd;
+  if(loop->backend_fd >= 0)
+    pollset_ctl(loop->backend_fd, &pc, 1);
 }

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1226,10 +1226,10 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
 
   if (events != NULL)
-  /* Invalidate events with same file descriptor */
-  for (i = 0; i < nfds; i++)
-    if ((int) events[i].fd == fd)
-      events[i].fd = -1;
+    /* Invalidate events with same file descriptor */
+    for (i = 0; i < nfds; i++)
+      if ((int) events[i].fd == fd)
+        events[i].fd = -1;
 
   /* Remove the file descriptor from the poll set */
   pc.events = 0;


### PR DESCRIPTION
aix: Fix Node test test-tls-ocsp-callback.js

In debugging test-tls-ocsp-callback.js for the 0.12.0 Node on
AIX we discovered that there was code missing in
uv__platform_invalidate_fd() in aix.c which removes the file
descriptor from the pollset when needed.  We based the
impelementation in aix.c on the unix version in linux-core.cc.
We can see that this issue was addressed for linux in commit
780d8ad8e58c675dc60f5b73ea22a203760da2f2 to address joyent/libuv
issue #1099. This change introduces the same fix for AIX.
This change does not introduce any new failures when running
the tests on AIX. It also does not fix any existing failures,
but it does allow the node test test-tls-ocsp-callback.js to pass.

	modified:   src/unix/aix.c