### PR TITLE
unix: don't close the fds we just setup

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -316,7 +316,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
   for (fd = 0; fd < stdio_count; fd++) {
     use_fd = pipes[fd][1];
 
-    if (use_fd >= 0 && fd != use_fd)
+    if (use_fd >= stdio_count)
       close(use_fd);
   }
 


### PR DESCRIPTION
If a descriptor was being copied to an fd that *was not its current
value*, it should get closed after being copied. But the existing code
would close the fd, even when it no longer referred to the original
descriptor. Don't do this, only close fds that are not in the desired
range for the child process.

Fix https://github.com/iojs/io.js/issues/862