### PR TITLE
doc: Clarify that the thread pool primites are not thread safe.

### DIFF
--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -18,6 +18,10 @@ libuv preallocates and initializes the maximum number of threads allowed by
 ``UV_THREADPOOL_SIZE``. This causes a relatively minor memory overhead
 (~1MB for 128 threads) but increases the performance of threading at runtime.
 
+.. note::
+    Note that even though a global thread pool which is shared across all events
+    loops is used, the functions are not thread safe.
+
 
 Data types
 ----------


### PR DESCRIPTION
Someone was mislead to think that the functions are thread safe since the thread pool is global:
http://logs.nodejs.org/libuv/latest#09:33:04.542

So I took the liberty to add additional information right after that line.