### PR TITLE
stream: ignore EINVAL for SO_OOBINLINE on OS X

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -394,7 +394,8 @@ int uv__stream_open(uv_stream_t* stream, int fd, int flags) {
 #if defined(__APPLE__)
   enable = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_OOBINLINE, &enable, sizeof(enable)) &&
-      errno != ENOTSOCK) {
+      errno != ENOTSOCK &&
+      errno != EINVAL) {
     return -errno;
   }
 #endif


### PR DESCRIPTION
Calling `setsockopt()` on shutdown fds/stdio will result in EINVAL.
There is not much problem here as the OOB data can't be sent to already
shutdown fds. Just ignore it and go on.