### PR TITLE
win: fix pipe blocking writes

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1347,7 +1347,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
     }
 
     /* Request queued by the kernel. */
-    req->queued_bytes = uv__count_bufs(bufs, nbufs);
+    req->queued_bytes = bufs[0].len;
     handle->write_queue_size += req->queued_bytes;
   } else if (handle->flags & UV_HANDLE_BLOCKING_WRITES) {
     /* Using overlapped IO, but wait for completion before returning */
@@ -1373,6 +1373,8 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
       req->queued_bytes = 0;
     } else {
       /* Request queued by the kernel. */
+      req->queued_bytes = bufs[0].len;
+      handle->write_queue_size += req->queued_bytes;
       if (WaitForSingleObject(req->overlapped.hEvent, INFINITE) !=
           WAIT_OBJECT_0) {
         err = GetLastError();
@@ -1402,7 +1404,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
       req->queued_bytes = 0;
     } else {
       /* Request queued by the kernel. */
-      req->queued_bytes = uv__count_bufs(bufs, nbufs);
+      req->queued_bytes = bufs[0].len;
       handle->write_queue_size += req->queued_bytes;
     }
 

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1372,12 +1372,11 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
       /* Request completed immediately. */
       req->queued_bytes = 0;
     } else {
-      assert(ipc_header_req != NULL);
       /* Request queued by the kernel. */
-      if (WaitForSingleObject(ipc_header_req->overlapped.hEvent, INFINITE) !=
+      if (WaitForSingleObject(req->overlapped.hEvent, INFINITE) !=
           WAIT_OBJECT_0) {
         err = GetLastError();
-        CloseHandle(ipc_header_req->overlapped.hEvent);
+        CloseHandle(req->overlapped.hEvent);
         return uv_translate_sys_error(err);
       }
     }
@@ -1386,7 +1385,6 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
     REGISTER_HANDLE_REQ(loop, handle, req);
     handle->reqs_pending++;
     handle->write_reqs_pending++;
-    POST_COMPLETION_FOR_REQ(loop, req);
     return 0;
   } else {
     result = WriteFile(handle->handle,

--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -93,6 +93,17 @@ INLINE static uv_req_t* uv_overlapped_to_req(OVERLAPPED* overlapped) {
 INLINE static void uv_insert_pending_req(uv_loop_t* loop, uv_req_t* req) {
   req->next_req = NULL;
   if (loop->pending_reqs_tail) {
+#ifdef _DEBUG
+    /* Ensure the request is not already in the queue, or the queue
+     * will get corrupted.
+     */
+    uv_req_t* current = loop->pending_reqs_tail;
+    do {
+      assert(req != current);
+      current = current->next_req;
+    } while(current != loop->pending_reqs_tail);
+#endif
+
     req->next_req = loop->pending_reqs_tail->next_req;
     loop->pending_reqs_tail->next_req = req;
     loop->pending_reqs_tail = req;


### PR DESCRIPTION
In the code path for pipe blocking writes, WriteFile is already
posting a completion packet to the I/O completion port.
POST_COMPLETION_FOR_REQ was causing the same request to get
returned twice by GetCompletionStatusEx.

This fixes a bunch of child_process errors in Node: https://github.com/joyent/node/pull/9179