### PR TITLE
win: name all public anonymous structs/unions

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -366,8 +366,8 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
     struct {                                                                  \
       OVERLAPPED overlapped;                                                  \
       size_t queued_bytes;                                                    \
-    };                                                                        \
-  };                                                                          \
+    } io;                                                                     \
+  } u;                                                                        \
   struct uv_req_s* next_req;
 
 #define UV_WRITE_PRIVATE_FIELDS                                               \
@@ -419,9 +419,9 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   int activecnt;                                                              \
   uv_read_t read_req;                                                         \
   union {                                                                     \
-    struct { uv_stream_connection_fields };                                   \
-    struct { uv_stream_server_fields     };                                   \
-  };
+    struct { uv_stream_connection_fields } conn;                              \
+    struct { uv_stream_server_fields     } serv;                              \
+  } stream;
 
 #define uv_tcp_server_fields                                                  \
   uv_tcp_accept_t* accept_reqs;                                               \
@@ -437,9 +437,9 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   SOCKET socket;                                                              \
   int delayed_error;                                                          \
   union {                                                                     \
-    struct { uv_tcp_server_fields };                                          \
-    struct { uv_tcp_connection_fields };                                      \
-  };
+    struct { uv_tcp_server_fields } serv;                                     \
+    struct { uv_tcp_connection_fields } conn;                                 \
+  } tcp;
 
 #define UV_UDP_PRIVATE_FIELDS                                                 \
   SOCKET socket;                                                              \
@@ -476,9 +476,9 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   HANDLE handle;                                                              \
   WCHAR* name;                                                                \
   union {                                                                     \
-    struct { uv_pipe_server_fields };                                         \
-    struct { uv_pipe_connection_fields };                                     \
-  };
+    struct { uv_pipe_server_fields } serv;                                    \
+    struct { uv_pipe_connection_fields } conn;                                \
+  } pipe;
 
 /* TODO: put the parser states in an union - TTY handles are always */
 /* half-duplex so read-state can safely overlap write-state. */
@@ -496,7 +496,7 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
       unsigned char last_key_len;                                             \
       WCHAR last_utf16_high_surrogate;                                        \
       INPUT_RECORD last_input_record;                                         \
-    };                                                                        \
+    } rd;                                                                     \
     struct {                                                                  \
       /* Used for writable TTY handles */                                     \
       /* utf8-to-utf16 conversion state */                                    \
@@ -510,8 +510,8 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
       unsigned short ansi_csi_argv[4];                                        \
       COORD saved_position;                                                   \
       WORD saved_attributes;                                                  \
-    };                                                                        \
-  };
+    } wr;                                                                     \
+  } tty;
 
 #define UV_POLL_PRIVATE_FIELDS                                                \
   SOCKET socket;                                                              \
@@ -600,7 +600,7 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
     /* TODO: remove me in 0.9. */                                             \
     WCHAR* pathw;                                                             \
     int fd;                                                                   \
-  };                                                                          \
+  } file;                                                                     \
   union {                                                                     \
     struct {                                                                  \
       int mode;                                                               \
@@ -611,12 +611,12 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
       uv_buf_t* bufs;                                                         \
       int64_t offset;                                                         \
       uv_buf_t bufsml[4];                                                     \
-    };                                                                        \
+    } info;                                                                   \
     struct {                                                                  \
       double atime;                                                           \
       double mtime;                                                           \
-    };                                                                        \
-  };
+    } time;                                                                   \
+  } fs;
 
 #define UV_WORK_PRIVATE_FIELDS                                                \
   struct uv__work work_req;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -379,15 +379,28 @@ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
   return 0;
 }
 
+/* The windows implementation does not have the same structure layout as
+ * the unix implementation (nbufs is not directly inside req but is
+ * contained in a nested union/struct) so this function locates it.
+*/
+static unsigned int* uv__get_nbufs(uv_fs_t* req) {
+#ifdef _WIN32
+  return &req->fs.info.nbufs;
+#else
+  return &req->nbufs;
+#endif
+}
 
 void uv__fs_scandir_cleanup(uv_fs_t* req) {
   uv__dirent_t** dents;
 
+  unsigned int* nbufs = uv__get_nbufs(req);
+
   dents = req->ptr;
-  if (req->nbufs > 0 && req->nbufs != (unsigned int) req->result)
-    req->nbufs--;
-  for (; req->nbufs < (unsigned int) req->result; req->nbufs++)
-    free(dents[req->nbufs]);
+  if (*nbufs > 0 && *nbufs != (unsigned int) req->result)
+    (*nbufs)--;
+  for (; *nbufs < (unsigned int) req->result; (*nbufs)++)
+    free(dents[*nbufs]);
 }
 
 
@@ -395,20 +408,22 @@ int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent) {
   uv__dirent_t** dents;
   uv__dirent_t* dent;
 
+  unsigned int* nbufs = uv__get_nbufs(req);
+
   dents = req->ptr;
 
   /* Free previous entity */
-  if (req->nbufs > 0)
-    free(dents[req->nbufs - 1]);
+  if (*nbufs > 0)
+    free(dents[*nbufs - 1]);
 
   /* End was already reached */
-  if (req->nbufs == (unsigned int) req->result) {
+  if (*nbufs == (unsigned int) req->result) {
     free(dents);
     req->ptr = NULL;
     return UV_EOF;
   }
 
-  dent = dents[req->nbufs++];
+  dent = dents[(*nbufs)++];
 
   ent->name = dent->d_name;
 #ifdef HAVE_DIRENT_TYPES

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -39,7 +39,8 @@ static void uv_fs_event_queue_readdirchanges(uv_loop_t* loop,
   assert(handle->dir_handle != INVALID_HANDLE_VALUE);
   assert(!handle->req_pending);
 
-  memset(&(handle->req.overlapped), 0, sizeof(handle->req.overlapped));
+  memset(&(handle->req.u.io.overlapped), 0,
+         sizeof(handle->req.u.io.overlapped));
   if (!ReadDirectoryChangesW(handle->dir_handle,
                              handle->buffer,
                              uv_directory_watcher_buffer_size,
@@ -53,7 +54,7 @@ static void uv_fs_event_queue_readdirchanges(uv_loop_t* loop,
                                FILE_NOTIFY_CHANGE_CREATION     |
                                FILE_NOTIFY_CHANGE_SECURITY,
                              NULL,
-                             &handle->req.overlapped,
+                             &handle->req.u.io.overlapped,
                              NULL)) {
     /* Make this req pending reporting an error. */
     SET_REQ_ERROR(&handle->req, GetLastError());
@@ -232,7 +233,8 @@ int uv_fs_event_start(uv_fs_event_t* handle,
     uv_fatal_error(ERROR_OUTOFMEMORY, "malloc");
   }
 
-  memset(&(handle->req.overlapped), 0, sizeof(handle->req.overlapped));
+  memset(&(handle->req.u.io.overlapped), 0,
+         sizeof(handle->req.u.io.overlapped));
 
   if (!ReadDirectoryChangesW(handle->dir_handle,
                              handle->buffer,
@@ -247,7 +249,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
                                FILE_NOTIFY_CHANGE_CREATION     |
                                FILE_NOTIFY_CHANGE_SECURITY,
                              NULL,
-                             &handle->req.overlapped,
+                             &handle->req.u.io.overlapped,
                              NULL)) {
     last_error = GetLastError();
     goto error;
@@ -349,7 +351,7 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
   file_info = (FILE_NOTIFY_INFORMATION*)(handle->buffer + offset);
 
   if (REQ_SUCCESS(req)) {
-    if (req->overlapped.InternalHigh > 0) {
+    if (req->u.io.overlapped.InternalHigh > 0) {
       do {
         file_info = (FILE_NOTIFY_INFORMATION*)((char*)file_info + offset);
         assert(!filename);

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -161,8 +161,8 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
 
 
   if (buf_sz == 0) {
-    req->pathw = NULL;
-    req->new_pathw = NULL;
+    req->file.pathw = NULL;
+    req->fs.info.new_pathw = NULL;
     req->path = NULL;
     return 0;
   }
@@ -182,10 +182,10 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
                                   (WCHAR*) pos,
                                   pathw_len);
     assert(r == (DWORD) pathw_len);
-    req->pathw = (WCHAR*) pos;
+    req->file.pathw = (WCHAR*) pos;
     pos += r * sizeof(WCHAR);
   } else {
-    req->pathw = NULL;
+    req->file.pathw = NULL;
   }
 
   if (new_path != NULL) {
@@ -196,10 +196,10 @@ INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
                                   (WCHAR*) pos,
                                   new_pathw_len);
     assert(r == (DWORD) new_pathw_len);
-    req->new_pathw = (WCHAR*) pos;
+    req->fs.info.new_pathw = (WCHAR*) pos;
     pos += r * sizeof(WCHAR);
   } else {
-    req->new_pathw = NULL;
+    req->fs.info.new_pathw = NULL;
   }
 
   if (!copy_path) {
@@ -388,7 +388,7 @@ void fs__open(uv_fs_t* req) {
   DWORD attributes = 0;
   HANDLE file;
   int fd, current_umask;
-  int flags = req->file_flags;
+  int flags = req->fs.info.file_flags;
 
   /* Obtain the active umask. umask() never fails and returns the previous */
   /* umask. */
@@ -450,7 +450,7 @@ void fs__open(uv_fs_t* req) {
 
   attributes |= FILE_ATTRIBUTE_NORMAL;
   if (flags & _O_CREAT) {
-    if (!((req->mode & ~current_umask) & _S_IWRITE)) {
+    if (!((req->fs.info.mode & ~current_umask) & _S_IWRITE)) {
       attributes |= FILE_ATTRIBUTE_READONLY;
     }
   }
@@ -480,7 +480,7 @@ void fs__open(uv_fs_t* req) {
   /* Setting this flag makes it possible to open a directory. */
   attributes |= FILE_FLAG_BACKUP_SEMANTICS;
 
-  file = CreateFileW(req->pathw,
+  file = CreateFileW(req->file.pathw,
                      access,
                      share,
                      NULL,
@@ -523,7 +523,7 @@ void fs__open(uv_fs_t* req) {
 }
 
 void fs__close(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   int result;
 
   VERIFY_FD(fd, req);
@@ -534,8 +534,8 @@ void fs__close(uv_fs_t* req) {
 
 
 void fs__read(uv_fs_t* req) {
-  int fd = req->fd;
-  int64_t offset = req->offset;
+  int fd = req->file.fd;
+  int64_t offset = req->fs.info.offset;
   HANDLE handle;
   OVERLAPPED overlapped, *overlapped_ptr;
   LARGE_INTEGER offset_;
@@ -572,13 +572,13 @@ void fs__read(uv_fs_t* req) {
     }
 
     result = ReadFile(handle,
-                      req->bufs[index].base,
-                      req->bufs[index].len,
+                      req->fs.info.bufs[index].base,
+                      req->fs.info.bufs[index].len,
                       &incremental_bytes,
                       overlapped_ptr);
     bytes += incremental_bytes;
     ++index;
-  } while (result && index < req->nbufs);
+  } while (result && index < req->fs.info.nbufs);
 
   if (result || bytes > 0) {
     SET_REQ_RESULT(req, bytes);
@@ -594,8 +594,8 @@ void fs__read(uv_fs_t* req) {
 
 
 void fs__write(uv_fs_t* req) {
-  int fd = req->fd;
-  int64_t offset = req->offset;
+  int fd = req->file.fd;
+  int64_t offset = req->fs.info.offset;
   HANDLE handle;
   OVERLAPPED overlapped, *overlapped_ptr;
   LARGE_INTEGER offset_;
@@ -630,13 +630,13 @@ void fs__write(uv_fs_t* req) {
     }
 
     result = WriteFile(handle,
-                       req->bufs[index].base,
-                       req->bufs[index].len,
+                       req->fs.info.bufs[index].base,
+                       req->fs.info.bufs[index].len,
                        &incremental_bytes,
                        overlapped_ptr);
     bytes += incremental_bytes;
     ++index;
-  } while (result && index < req->nbufs);
+  } while (result && index < req->fs.info.nbufs);
 
   if (result || bytes > 0) {
     SET_REQ_RESULT(req, bytes);
@@ -647,13 +647,13 @@ void fs__write(uv_fs_t* req) {
 
 
 void fs__rmdir(uv_fs_t* req) {
-  int result = _wrmdir(req->pathw);
+  int result = _wrmdir(req->file.pathw);
   SET_REQ_RESULT(req, result);
 }
 
 
 void fs__unlink(uv_fs_t* req) {
-  const WCHAR* pathw = req->pathw;
+  const WCHAR* pathw = req->file.pathw;
   HANDLE handle;
   BY_HANDLE_FILE_INFORMATION info;
   FILE_DISPOSITION_INFORMATION disposition;
@@ -722,7 +722,7 @@ void fs__unlink(uv_fs_t* req) {
 
 void fs__mkdir(uv_fs_t* req) {
   /* TODO: use req->mode. */
-  int result = _wmkdir(req->pathw);
+  int result = _wmkdir(req->file.pathw);
   SET_REQ_RESULT(req, result);
 }
 
@@ -740,8 +740,8 @@ void fs__mkdtemp(uv_fs_t* req) {
   uint64_t v;
   BOOL released;
 
-  len = wcslen(req->pathw);
-  ep = req->pathw + len;
+  len = wcslen(req->file.pathw);
+  ep = req->file.pathw + len;
   if (len < num_x || wcsncmp(ep - num_x, L"XXXXXX", num_x)) {
     SET_REQ_UV_ERROR(req, UV_EINVAL, ERROR_INVALID_PARAMETER);
     return;
@@ -766,7 +766,7 @@ void fs__mkdtemp(uv_fs_t* req) {
       v /= num_chars;
     }
 
-    if (_wmkdir(req->pathw) == 0) {
+    if (_wmkdir(req->file.pathw) == 0) {
       len = strlen(req->path);
       wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
       SET_REQ_RESULT(req, 0);
@@ -810,7 +810,7 @@ void fs__scandir(uv_fs_t* req) {
 
   /* Open the directory. */
   dir_handle =
-      CreateFileW(req->pathw,
+      CreateFileW(req->file.pathw,
                   FILE_LIST_DIRECTORY | SYNCHRONIZE,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   NULL,
@@ -956,7 +956,7 @@ void fs__scandir(uv_fs_t* req) {
   SET_REQ_RESULT(req, dirents_used);
 
   /* `nbufs` will be used as index by uv_fs_scandir_next. */
-  req->nbufs = 0;
+  req->fs.info.nbufs = 0;
 
   return;
 
@@ -1125,7 +1125,7 @@ INLINE static void fs__stat_impl(uv_fs_t* req, int do_lstat) {
     flags |= FILE_FLAG_OPEN_REPARSE_POINT;
   }
 
-  handle = CreateFileW(req->pathw,
+  handle = CreateFileW(req->file.pathw,
                        FILE_READ_ATTRIBUTES,
                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                        NULL,
@@ -1159,19 +1159,19 @@ INLINE static void fs__stat_impl(uv_fs_t* req, int do_lstat) {
 
 
 static void fs__stat(uv_fs_t* req) {
-  fs__stat_prepare_path(req->pathw);
+  fs__stat_prepare_path(req->file.pathw);
   fs__stat_impl(req, 0);
 }
 
 
 static void fs__lstat(uv_fs_t* req) {
-  fs__stat_prepare_path(req->pathw);
+  fs__stat_prepare_path(req->file.pathw);
   fs__stat_impl(req, 1);
 }
 
 
 static void fs__fstat(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   HANDLE handle;
 
   VERIFY_FD(fd, req);
@@ -1194,7 +1194,7 @@ static void fs__fstat(uv_fs_t* req) {
 
 
 static void fs__rename(uv_fs_t* req) {
-  if (!MoveFileExW(req->pathw, req->new_pathw, MOVEFILE_REPLACE_EXISTING)) {
+  if (!MoveFileExW(req->file.pathw, req->fs.info.new_pathw, MOVEFILE_REPLACE_EXISTING)) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
     return;
   }
@@ -1204,7 +1204,7 @@ static void fs__rename(uv_fs_t* req) {
 
 
 INLINE static void fs__sync_impl(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   int result;
 
   VERIFY_FD(fd, req);
@@ -1229,7 +1229,7 @@ static void fs__fdatasync(uv_fs_t* req) {
 
 
 static void fs__ftruncate(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   HANDLE handle;
   NTSTATUS status;
   IO_STATUS_BLOCK io_status;
@@ -1239,7 +1239,7 @@ static void fs__ftruncate(uv_fs_t* req) {
 
   handle = uv__get_osfhandle(fd);
 
-  eof_info.EndOfFile.QuadPart = req->offset;
+  eof_info.EndOfFile.QuadPart = req->fs.info.offset;
 
   status = pNtSetInformationFile(handle,
                                  &io_status,
@@ -1256,9 +1256,9 @@ static void fs__ftruncate(uv_fs_t* req) {
 
 
 static void fs__sendfile(uv_fs_t* req) {
-  int fd_in = req->fd, fd_out = req->fd_out;
-  size_t length = req->bufsml[0].len;
-  int64_t offset = req->offset;
+  int fd_in = req->file.fd, fd_out = req->fs.info.fd_out;
+  size_t length = req->fs.info.bufsml[0].len;
+  int64_t offset = req->fs.info.offset;
   const size_t max_buf_size = 65536;
   size_t buf_size = length < max_buf_size ? length : max_buf_size;
   int n, result = 0;
@@ -1303,7 +1303,7 @@ static void fs__sendfile(uv_fs_t* req) {
 
 
 static void fs__access(uv_fs_t* req) {
-  DWORD attr = GetFileAttributesW(req->pathw);
+  DWORD attr = GetFileAttributesW(req->file.pathw);
 
   if (attr == INVALID_FILE_ATTRIBUTES) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
@@ -1322,13 +1322,13 @@ static void fs__access(uv_fs_t* req) {
 
 
 static void fs__chmod(uv_fs_t* req) {
-  int result = _wchmod(req->pathw, req->mode);
+  int result = _wchmod(req->file.pathw, req->fs.info.mode);
   SET_REQ_RESULT(req, result);
 }
 
 
 static void fs__fchmod(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   HANDLE handle;
   NTSTATUS nt_status;
   IO_STATUS_BLOCK io_status;
@@ -1349,7 +1349,7 @@ static void fs__fchmod(uv_fs_t* req) {
     return;
   }
 
-  if (req->mode & _S_IWRITE) {
+  if (req->fs.info.mode & _S_IWRITE) {
     file_info.FileAttributes &= ~FILE_ATTRIBUTE_READONLY;
   } else {
     file_info.FileAttributes |= FILE_ATTRIBUTE_READONLY;
@@ -1387,7 +1387,7 @@ INLINE static int fs__utime_handle(HANDLE handle, double atime, double mtime) {
 static void fs__utime(uv_fs_t* req) {
   HANDLE handle;
 
-  handle = CreateFileW(req->pathw,
+  handle = CreateFileW(req->file.pathw,
                        FILE_WRITE_ATTRIBUTES,
                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                        NULL,
@@ -1400,7 +1400,7 @@ static void fs__utime(uv_fs_t* req) {
     return;
   }
 
-  if (fs__utime_handle(handle, req->atime, req->mtime) != 0) {
+  if (fs__utime_handle(handle, req->fs.time.atime, req->fs.time.mtime) != 0) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
     CloseHandle(handle);
     return;
@@ -1413,7 +1413,7 @@ static void fs__utime(uv_fs_t* req) {
 
 
 static void fs__futime(uv_fs_t* req) {
-  int fd = req->fd;
+  int fd = req->file.fd;
   HANDLE handle;
   VERIFY_FD(fd, req);
 
@@ -1424,7 +1424,7 @@ static void fs__futime(uv_fs_t* req) {
     return;
   }
 
-  if (fs__utime_handle(handle, req->atime, req->mtime) != 0) {
+  if (fs__utime_handle(handle, req->fs.time.atime, req->fs.time.mtime) != 0) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
     return;
   }
@@ -1434,7 +1434,7 @@ static void fs__futime(uv_fs_t* req) {
 
 
 static void fs__link(uv_fs_t* req) {
-  DWORD r = CreateHardLinkW(req->new_pathw, req->pathw, NULL);
+  DWORD r = CreateHardLinkW(req->fs.info.new_pathw, req->file.pathw, NULL);
   if (r == 0) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
   } else {
@@ -1614,9 +1614,9 @@ error:
 
 
 static void fs__symlink(uv_fs_t* req) {
-  WCHAR* pathw = req->pathw;
-  WCHAR* new_pathw = req->new_pathw;
-  int flags = req->file_flags;
+  WCHAR* pathw = req->file.pathw;
+  WCHAR* new_pathw = req->fs.info.new_pathw;
+  int flags = req->fs.info.file_flags;
   int result;
 
 
@@ -1640,7 +1640,7 @@ static void fs__symlink(uv_fs_t* req) {
 static void fs__readlink(uv_fs_t* req) {
   HANDLE handle;
 
-  handle = CreateFileW(req->pathw,
+  handle = CreateFileW(req->file.pathw,
                        0,
                        0,
                        NULL,
@@ -1739,14 +1739,14 @@ void uv_fs_req_cleanup(uv_fs_t* req) {
     return;
 
   if (req->flags & UV_FS_FREE_PATHS)
-    free(req->pathw);
+    free(req->file.pathw);
 
   if (req->flags & UV_FS_FREE_PTR)
     free(req->ptr);
 
   req->path = NULL;
-  req->pathw = NULL;
-  req->new_pathw = NULL;
+  req->file.pathw = NULL;
+  req->fs.info.new_pathw = NULL;
   req->ptr = NULL;
 
   req->flags |= UV_FS_CLEANEDUP;
@@ -1764,8 +1764,8 @@ int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
     return uv_translate_sys_error(err);
   }
 
-  req->file_flags = flags;
-  req->mode = mode;
+  req->fs.info.file_flags = flags;
+  req->fs.info.mode = mode;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1779,7 +1779,7 @@ int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
 
 int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_CLOSE, cb);
-  req->fd = fd;
+  req->file.fd = fd;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1800,19 +1800,19 @@ int uv_fs_read(uv_loop_t* loop,
                uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_READ, cb);
 
-  req->fd = fd;
+  req->file.fd = fd;
 
-  req->nbufs = nbufs;
-  req->bufs = req->bufsml;
-  if (nbufs > ARRAY_SIZE(req->bufsml))
-    req->bufs = malloc(nbufs * sizeof(*bufs));
+  req->fs.info.nbufs = nbufs;
+  req->fs.info.bufs = req->fs.info.bufsml;
+  if (nbufs > ARRAY_SIZE(req->fs.info.bufsml))
+    req->fs.info.bufs = malloc(nbufs * sizeof(*bufs));
 
-  if (req->bufs == NULL)
+  if (req->fs.info.bufs == NULL)
     return UV_ENOMEM;
 
-  memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
+  memcpy(req->fs.info.bufs, bufs, nbufs * sizeof(*bufs));
 
-  req->offset = offset;
+  req->fs.info.offset = offset;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1833,19 +1833,19 @@ int uv_fs_write(uv_loop_t* loop,
                 uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_WRITE, cb);
 
-  req->fd = fd;
+  req->file.fd = fd;
 
-  req->nbufs = nbufs;
-  req->bufs = req->bufsml;
-  if (nbufs > ARRAY_SIZE(req->bufsml))
-    req->bufs = malloc(nbufs * sizeof(*bufs));
+  req->fs.info.nbufs = nbufs;
+  req->fs.info.bufs = req->fs.info.bufsml;
+  if (nbufs > ARRAY_SIZE(req->fs.info.bufsml))
+    req->fs.info.bufs = malloc(nbufs * sizeof(*bufs));
 
-  if (req->bufs == NULL)
+  if (req->fs.info.bufs == NULL)
     return UV_ENOMEM;
 
-  memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
+  memcpy(req->fs.info.bufs, bufs, nbufs * sizeof(*bufs));
 
-  req->offset = offset;
+  req->fs.info.offset = offset;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1889,7 +1889,7 @@ int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
     return uv_translate_sys_error(err);
   }
 
-  req->mode = mode;
+  req->fs.info.mode = mode;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1952,7 +1952,7 @@ int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
     return uv_translate_sys_error(err);
   }
 
-  req->file_flags = flags;
+  req->fs.info.file_flags = flags;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -1996,7 +1996,7 @@ int uv_fs_symlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
     return uv_translate_sys_error(err);
   }
 
-  req->file_flags = flags;
+  req->fs.info.file_flags = flags;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2106,7 +2106,7 @@ int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
 
 int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FSTAT, cb);
-  req->fd = fd;
+  req->file.fd = fd;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2141,7 +2141,7 @@ int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
 int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FSYNC, cb);
-  req->fd = fd;
+  req->file.fd = fd;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2155,7 +2155,7 @@ int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
 
 int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FDATASYNC, cb);
-  req->fd = fd;
+  req->file.fd = fd;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2171,8 +2171,8 @@ int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_file fd,
     int64_t offset, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FTRUNCATE, cb);
 
-  req->fd = fd;
-  req->offset = offset;
+  req->file.fd = fd;
+  req->fs.info.offset = offset;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2189,10 +2189,10 @@ int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_file fd_out,
     uv_file fd_in, int64_t in_offset, size_t length, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_SENDFILE, cb);
 
-  req->fd = fd_in;
-  req->fd_out = fd_out;
-  req->offset = in_offset;
-  req->bufsml[0].len = length;
+  req->file.fd = fd_in;
+  req->fs.info.fd_out = fd_out;
+  req->fs.info.offset = in_offset;
+  req->fs.info.bufsml[0].len = length;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2240,7 +2240,7 @@ int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
     return uv_translate_sys_error(err);
   }
 
-  req->mode = mode;
+  req->fs.info.mode = mode;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2256,8 +2256,8 @@ int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_file fd, int mode,
     uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FCHMOD, cb);
 
-  req->fd = fd;
-  req->mode = mode;
+  req->file.fd = fd;
+  req->fs.info.mode = mode;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2280,8 +2280,8 @@ int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime,
     return uv_translate_sys_error(err);
   }
 
-  req->atime = atime;
-  req->mtime = mtime;
+  req->fs.time.atime = atime;
+  req->fs.time.mtime = mtime;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);
@@ -2297,9 +2297,9 @@ int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_file fd, double atime,
     double mtime, uv_fs_cb cb) {
   uv_fs_req_init(loop, req, UV_FS_FUTIME, cb);
 
-  req->fd = fd;
-  req->atime = atime;
-  req->mtime = mtime;
+  req->file.fd = fd;
+  req->fs.time.atime = atime;
+  req->fs.time.mtime = mtime;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -95,15 +95,15 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int ipc) {
   handle->reqs_pending = 0;
   handle->handle = INVALID_HANDLE_VALUE;
   handle->name = NULL;
-  handle->ipc_pid = 0;
-  handle->remaining_ipc_rawdata_bytes = 0;
-  QUEUE_INIT(&handle->pending_ipc_info.queue);
-  handle->pending_ipc_info.queue_len = 0;
+  handle->pipe.conn.ipc_pid = 0;
+  handle->pipe.conn.remaining_ipc_rawdata_bytes = 0;
+  QUEUE_INIT(&handle->pipe.conn.pending_ipc_info.queue);
+  handle->pipe.conn.pending_ipc_info.queue_len = 0;
   handle->ipc = ipc;
-  handle->non_overlapped_writes_tail = NULL;
-  handle->readfile_thread = NULL;
+  handle->pipe.conn.non_overlapped_writes_tail = NULL;
+  handle->pipe.conn.readfile_thread = NULL;
 
-  uv_req_init(loop, (uv_req_t*) &handle->ipc_header_write_req);
+  uv_req_init(loop, (uv_req_t*) &handle->pipe.conn.ipc_header_write_req);
 
   return 0;
 }
@@ -112,11 +112,11 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int ipc) {
 static void uv_pipe_connection_init(uv_pipe_t* handle) {
   uv_connection_init((uv_stream_t*) handle);
   handle->read_req.data = handle;
-  handle->eof_timer = NULL;
+  handle->pipe.conn.eof_timer = NULL;
   assert(!(handle->flags & UV_HANDLE_PIPESERVER));
   if (pCancelSynchronousIo &&
       handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) {
-      uv_mutex_init(&handle->readfile_mutex);
+      uv_mutex_init(&handle->pipe.conn.readfile_mutex);
       handle->flags |= UV_HANDLE_PIPE_READ_CANCELABLE;
   }
 }
@@ -330,16 +330,16 @@ void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
 
   if (handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE) {
     handle->flags &= ~UV_HANDLE_PIPE_READ_CANCELABLE;
-    uv_mutex_destroy(&handle->readfile_mutex);
+    uv_mutex_destroy(&handle->pipe.conn.readfile_mutex);
   }
 
   if ((handle->flags & UV_HANDLE_CONNECTION) &&
-      handle->shutdown_req != NULL &&
-      handle->write_reqs_pending == 0) {
-    req = handle->shutdown_req;
+      handle->stream.conn.shutdown_req != NULL &&
+      handle->stream.conn.write_reqs_pending == 0) {
+    req = handle->stream.conn.shutdown_req;
 
     /* Clear the shutdown_req field so we don't go here again. */
-    handle->shutdown_req = NULL;
+    handle->stream.conn.shutdown_req = NULL;
 
     if (handle->flags & UV__HANDLE_CLOSING) {
       UNREGISTER_HANDLE_REQ(loop, handle, req);
@@ -408,11 +408,11 @@ void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
 
     if (handle->flags & UV_HANDLE_CONNECTION) {
       /* Free pending sockets */
-      while (!QUEUE_EMPTY(&handle->pending_ipc_info.queue)) {
+      while (!QUEUE_EMPTY(&handle->pipe.conn.pending_ipc_info.queue)) {
         QUEUE* q;
         SOCKET socket;
 
-        q = QUEUE_HEAD(&handle->pending_ipc_info.queue);
+        q = QUEUE_HEAD(&handle->pipe.conn.pending_ipc_info.queue);
         QUEUE_REMOVE(q);
         item = QUEUE_DATA(q, uv__ipc_queue_item_t, member);
 
@@ -428,7 +428,7 @@ void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
         if (socket != INVALID_SOCKET)
           closesocket(socket);
       }
-      handle->pending_ipc_info.queue_len = 0;
+      handle->pipe.conn.pending_ipc_info.queue_len = 0;
 
       if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
         if (handle->read_req.wait_handle != INVALID_HANDLE_VALUE) {
@@ -443,9 +443,9 @@ void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
     }
 
     if (handle->flags & UV_HANDLE_PIPESERVER) {
-      assert(handle->accept_reqs);
-      free(handle->accept_reqs);
-      handle->accept_reqs = NULL;
+      assert(handle->pipe.serv.accept_reqs);
+      free(handle->pipe.serv.accept_reqs);
+      handle->pipe.serv.accept_reqs = NULL;
     }
 
     uv__handle_close(handle);
@@ -454,7 +454,7 @@ void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
 
 
 void uv_pipe_pending_instances(uv_pipe_t* handle, int count) {
-  handle->pending_instances = count;
+  handle->pipe.serv.pending_instances = count;
   handle->flags |= UV_HANDLE_PIPESERVER;
 }
 
@@ -474,17 +474,17 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   }
 
   if (!(handle->flags & UV_HANDLE_PIPESERVER)) {
-    handle->pending_instances = default_pending_pipe_instances;
+    handle->pipe.serv.pending_instances = default_pending_pipe_instances;
   }
 
-  handle->accept_reqs = (uv_pipe_accept_t*)
-    malloc(sizeof(uv_pipe_accept_t) * handle->pending_instances);
-  if (!handle->accept_reqs) {
+  handle->pipe.serv.accept_reqs = (uv_pipe_accept_t*)
+    malloc(sizeof(uv_pipe_accept_t) * handle->pipe.serv.pending_instances);
+  if (!handle->pipe.serv.accept_reqs) {
     uv_fatal_error(ERROR_OUTOFMEMORY, "malloc");
   }
 
-  for (i = 0; i < handle->pending_instances; i++) {
-    req = &handle->accept_reqs[i];
+  for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
+    req = &handle->pipe.serv.accept_reqs[i];
     uv_req_init(loop, (uv_req_t*) req);
     req->type = UV_ACCEPT;
     req->data = handle;
@@ -508,13 +508,13 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
    * Attempt to create the first pipe with FILE_FLAG_FIRST_PIPE_INSTANCE.
    * If this fails then there's already a pipe server for the given pipe name.
    */
-  handle->accept_reqs[0].pipeHandle = CreateNamedPipeW(handle->name,
+  handle->pipe.serv.accept_reqs[0].pipeHandle = CreateNamedPipeW(handle->name,
       PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED |
       FILE_FLAG_FIRST_PIPE_INSTANCE,
       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
       PIPE_UNLIMITED_INSTANCES, 65536, 65536, 0, NULL);
 
-  if (handle->accept_reqs[0].pipeHandle == INVALID_HANDLE_VALUE) {
+  if (handle->pipe.serv.accept_reqs[0].pipeHandle == INVALID_HANDLE_VALUE) {
     err = GetLastError();
     if (err == ERROR_ACCESS_DENIED) {
       err = WSAEADDRINUSE;  /* Translates to UV_EADDRINUSE. */
@@ -524,12 +524,15 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
     goto error;
   }
 
-  if (uv_set_pipe_handle(loop, handle, handle->accept_reqs[0].pipeHandle, 0)) {
+  if (uv_set_pipe_handle(loop,
+                         handle,
+                         handle->pipe.serv.accept_reqs[0].pipeHandle,
+                         0)) {
     err = GetLastError();
     goto error;
   }
 
-  handle->pending_accepts = NULL;
+  handle->pipe.serv.pending_accepts = NULL;
   handle->flags |= UV_HANDLE_PIPESERVER;
   handle->flags |= UV_HANDLE_BOUND;
 
@@ -541,9 +544,9 @@ error:
     handle->name = NULL;
   }
 
-  if (handle->accept_reqs[0].pipeHandle != INVALID_HANDLE_VALUE) {
-    CloseHandle(handle->accept_reqs[0].pipeHandle);
-    handle->accept_reqs[0].pipeHandle = INVALID_HANDLE_VALUE;
+  if (handle->pipe.serv.accept_reqs[0].pipeHandle != INVALID_HANDLE_VALUE) {
+    CloseHandle(handle->pipe.serv.accept_reqs[0].pipeHandle);
+    handle->pipe.serv.accept_reqs[0].pipeHandle = INVALID_HANDLE_VALUE;
   }
 
   return uv_translate_sys_error(err);
@@ -677,15 +680,15 @@ void uv__pipe_pause_read(uv_pipe_t* handle) {
          any access to a NamedPipe to deadlock if
          any process has called ReadFile */
       HANDLE h;
-      uv_mutex_lock(&handle->readfile_mutex);
-      h = handle->readfile_thread;
+      uv_mutex_lock(&handle->pipe.conn.readfile_mutex);
+      h = handle->pipe.conn.readfile_thread;
       while (h) {
         /* spinlock: we expect this to finish quickly,
            or we are probably about to deadlock anyways
            (in the kernel), so it doesn't matter */
         pCancelSynchronousIo(h);
         SwitchToThread(); /* yield thread control briefly */
-        h = handle->readfile_thread;
+        h = handle->pipe.conn.readfile_thread;
       }
   }
 }
@@ -693,7 +696,7 @@ void uv__pipe_pause_read(uv_pipe_t* handle) {
 
 void uv__pipe_unpause_read(uv_pipe_t* handle) {
   if (handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE) {
-    uv_mutex_unlock(&handle->readfile_mutex);
+    uv_mutex_unlock(&handle->pipe.conn.readfile_mutex);
   }
 }
 
@@ -719,11 +722,11 @@ void uv_pipe_cleanup(uv_loop_t* loop, uv_pipe_t* handle) {
   }
 
   if (handle->flags & UV_HANDLE_PIPESERVER) {
-    for (i = 0; i < handle->pending_instances; i++) {
-      pipeHandle = handle->accept_reqs[i].pipeHandle;
+    for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
+      pipeHandle = handle->pipe.serv.accept_reqs[i].pipeHandle;
       if (pipeHandle != INVALID_HANDLE_VALUE) {
         CloseHandle(pipeHandle);
-        handle->accept_reqs[i].pipeHandle = INVALID_HANDLE_VALUE;
+        handle->pipe.serv.accept_reqs[i].pipeHandle = INVALID_HANDLE_VALUE;
       }
     }
   }
@@ -796,9 +799,9 @@ static void uv_pipe_queue_accept(uv_loop_t* loop, uv_pipe_t* handle,
   assert(req->pipeHandle != INVALID_HANDLE_VALUE);
 
   /* Prepare the overlapped structure. */
-  memset(&(req->overlapped), 0, sizeof(req->overlapped));
+  memset(&(req->u.io.overlapped), 0, sizeof(req->u.io.overlapped));
 
-  if (!ConnectNamedPipe(req->pipeHandle, &req->overlapped) &&
+  if (!ConnectNamedPipe(req->pipeHandle, &req->u.io.overlapped) &&
       GetLastError() != ERROR_IO_PENDING) {
     if (GetLastError() == ERROR_PIPE_CONNECTED) {
       SET_REQ_SUCCESS(req);
@@ -826,14 +829,14 @@ int uv_pipe_accept(uv_pipe_t* server, uv_stream_t* client) {
   int err;
 
   if (server->ipc) {
-    if (QUEUE_EMPTY(&server->pending_ipc_info.queue)) {
+    if (QUEUE_EMPTY(&server->pipe.conn.pending_ipc_info.queue)) {
       /* No valid pending sockets. */
       return WSAEWOULDBLOCK;
     }
 
-    q = QUEUE_HEAD(&server->pending_ipc_info.queue);
+    q = QUEUE_HEAD(&server->pipe.conn.pending_ipc_info.queue);
     QUEUE_REMOVE(q);
-    server->pending_ipc_info.queue_len--;
+    server->pipe.conn.pending_ipc_info.queue_len--;
     item = QUEUE_DATA(q, uv__ipc_queue_item_t, member);
 
     err = uv_tcp_import((uv_tcp_t*)client,
@@ -849,7 +852,7 @@ int uv_pipe_accept(uv_pipe_t* server, uv_stream_t* client) {
 
     /* Find a connection instance that has been connected, but not yet */
     /* accepted. */
-    req = server->pending_accepts;
+    req = server->pipe.serv.pending_accepts;
 
     if (!req) {
       /* No valid connections found, so we error out. */
@@ -862,7 +865,7 @@ int uv_pipe_accept(uv_pipe_t* server, uv_stream_t* client) {
     pipe_client->flags |= UV_HANDLE_READABLE | UV_HANDLE_WRITABLE;
 
     /* Prepare the req to pick up a new connection */
-    server->pending_accepts = req->next_pending;
+    server->pipe.serv.pending_accepts = req->next_pending;
     req->next_pending = NULL;
     req->pipeHandle = INVALID_HANDLE_VALUE;
 
@@ -881,7 +884,7 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
   int i;
 
   if (handle->flags & UV_HANDLE_LISTENING) {
-    handle->connection_cb = cb;
+    handle->stream.serv.connection_cb = cb;
   }
 
   if (!(handle->flags & UV_HANDLE_BOUND)) {
@@ -898,13 +901,13 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
 
   handle->flags |= UV_HANDLE_LISTENING;
   INCREASE_ACTIVE_COUNT(loop, handle);
-  handle->connection_cb = cb;
+  handle->stream.serv.connection_cb = cb;
 
   /* First pipe handle should have already been created in uv_pipe_bind */
-  assert(handle->accept_reqs[0].pipeHandle != INVALID_HANDLE_VALUE);
+  assert(handle->pipe.serv.accept_reqs[0].pipeHandle != INVALID_HANDLE_VALUE);
 
-  for (i = 0; i < handle->pending_instances; i++) {
-    uv_pipe_queue_accept(loop, handle, &handle->accept_reqs[i], i == 0);
+  for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
+    uv_pipe_queue_accept(loop, handle, &handle->pipe.serv.accept_reqs[i], i == 0);
   }
 
   return 0;
@@ -919,7 +922,7 @@ static DWORD WINAPI uv_pipe_zero_readfile_thread_proc(void* parameter) {
   uv_loop_t* loop = handle->loop;
   HANDLE hThread = NULL;
   DWORD err;
-  uv_mutex_t *m = &handle->readfile_mutex;
+  uv_mutex_t *m = &handle->pipe.conn.readfile_mutex;
 
   assert(req != NULL);
   assert(req->type == UV_READ);
@@ -930,7 +933,7 @@ static DWORD WINAPI uv_pipe_zero_readfile_thread_proc(void* parameter) {
     if (DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
                         GetCurrentProcess(), &hThread,
                         0, TRUE, DUPLICATE_SAME_ACCESS)) {
-      handle->readfile_thread = hThread;
+      handle->pipe.conn.readfile_thread = hThread;
     } else {
       hThread = NULL;
     }
@@ -948,10 +951,10 @@ restart_readfile:
         handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE) {
       if (handle->flags & UV_HANDLE_READING) {
         /* just a brief break to do something else */
-        handle->readfile_thread = NULL;
+        handle->pipe.conn.readfile_thread = NULL;
         /* resume after it is finished */
         uv_mutex_lock(m);
-        handle->readfile_thread = hThread;
+        handle->pipe.conn.readfile_thread = hThread;
         uv_mutex_unlock(m);
         goto restart_readfile;
       } else {
@@ -960,9 +963,9 @@ restart_readfile:
     }
   }
   if (hThread) {
-    assert(hThread == handle->readfile_thread);
+    assert(hThread == handle->pipe.conn.readfile_thread);
     /* mutex does not control clearing readfile_thread */
-    handle->readfile_thread = NULL;
+    handle->pipe.conn.readfile_thread = NULL;
     uv_mutex_lock(m);
     /* only when we hold the mutex lock is it safe to
        open or close the handle */
@@ -1017,9 +1020,9 @@ static void CALLBACK post_completion_read_wait(void* context, BOOLEAN timed_out)
   assert(!timed_out);
 
   if (!PostQueuedCompletionStatus(handle->loop->iocp,
-                                  req->overlapped.InternalHigh,
+                                  req->u.io.overlapped.InternalHigh,
                                   0,
-                                  &req->overlapped)) {
+                                  &req->u.io.overlapped)) {
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");
   }
 }
@@ -1036,9 +1039,9 @@ static void CALLBACK post_completion_write_wait(void* context, BOOLEAN timed_out
   assert(!timed_out);
 
   if (!PostQueuedCompletionStatus(handle->loop->iocp,
-                                  req->overlapped.InternalHigh,
+                                  req->u.io.overlapped.InternalHigh,
                                   0,
-                                  &req->overlapped)) {
+                                  &req->u.io.overlapped)) {
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");
   }
 }
@@ -1064,9 +1067,9 @@ static void uv_pipe_queue_read(uv_loop_t* loop, uv_pipe_t* handle) {
       goto error;
     }
   } else {
-    memset(&req->overlapped, 0, sizeof(req->overlapped));
+    memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
     if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
-      req->overlapped.hEvent = (HANDLE) ((uintptr_t) req->event_handle | 1);
+      req->u.io.overlapped.hEvent = (HANDLE) ((uintptr_t) req->event_handle | 1);
     }
 
     /* Do 0-read */
@@ -1074,7 +1077,7 @@ static void uv_pipe_queue_read(uv_loop_t* loop, uv_pipe_t* handle) {
                       &uv_zero_,
                       0,
                       NULL,
-                      &req->overlapped);
+                      &req->u.io.overlapped);
 
     if (!result && GetLastError() != ERROR_IO_PENDING) {
       /* Make this req pending reporting an error. */
@@ -1091,7 +1094,7 @@ static void uv_pipe_queue_read(uv_loop_t* loop, uv_pipe_t* handle) {
       }
       if (req->wait_handle == INVALID_HANDLE_VALUE) {
         if (!RegisterWaitForSingleObject(&req->wait_handle,
-            req->overlapped.hEvent, post_completion_read_wait, (void*) req,
+            req->u.io.overlapped.hEvent, post_completion_read_wait, (void*) req,
             INFINITE, WT_EXECUTEINWAITTHREAD)) {
           SET_REQ_ERROR(req, GetLastError());
           goto error;
@@ -1135,14 +1138,14 @@ int uv_pipe_read_start(uv_pipe_t* handle,
 static void uv_insert_non_overlapped_write_req(uv_pipe_t* handle,
     uv_write_t* req) {
   req->next_req = NULL;
-  if (handle->non_overlapped_writes_tail) {
+  if (handle->pipe.conn.non_overlapped_writes_tail) {
     req->next_req =
-      handle->non_overlapped_writes_tail->next_req;
-    handle->non_overlapped_writes_tail->next_req = (uv_req_t*)req;
-    handle->non_overlapped_writes_tail = req;
+      handle->pipe.conn.non_overlapped_writes_tail->next_req;
+    handle->pipe.conn.non_overlapped_writes_tail->next_req = (uv_req_t*)req;
+    handle->pipe.conn.non_overlapped_writes_tail = req;
   } else {
     req->next_req = (uv_req_t*)req;
-    handle->non_overlapped_writes_tail = req;
+    handle->pipe.conn.non_overlapped_writes_tail = req;
   }
 }
 
@@ -1150,13 +1153,13 @@ static void uv_insert_non_overlapped_write_req(uv_pipe_t* handle,
 static uv_write_t* uv_remove_non_overlapped_write_req(uv_pipe_t* handle) {
   uv_write_t* req;
 
-  if (handle->non_overlapped_writes_tail) {
-    req = (uv_write_t*)handle->non_overlapped_writes_tail->next_req;
+  if (handle->pipe.conn.non_overlapped_writes_tail) {
+    req = (uv_write_t*)handle->pipe.conn.non_overlapped_writes_tail->next_req;
 
-    if (req == handle->non_overlapped_writes_tail) {
-      handle->non_overlapped_writes_tail = NULL;
+    if (req == handle->pipe.conn.non_overlapped_writes_tail) {
+      handle->pipe.conn.non_overlapped_writes_tail = NULL;
     } else {
-      handle->non_overlapped_writes_tail->next_req =
+      handle->pipe.conn.non_overlapped_writes_tail->next_req =
         req->next_req;
     }
 
@@ -1213,7 +1216,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
   req->ipc_header = 0;
   req->event_handle = NULL;
   req->wait_handle = INVALID_HANDLE_VALUE;
-  memset(&req->overlapped, 0, sizeof(req->overlapped));
+  memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
 
   if (handle->ipc) {
     assert(!(handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE));
@@ -1223,7 +1226,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
     if (send_handle) {
       tcp_send_handle = (uv_tcp_t*)send_handle;
 
-      err = uv_tcp_duplicate_socket(tcp_send_handle, handle->ipc_pid,
+      err = uv_tcp_duplicate_socket(tcp_send_handle, handle->pipe.conn.ipc_pid,
           &ipc_frame.socket_info_ex.socket_info);
       if (err) {
         return err;
@@ -1255,8 +1258,8 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
        * Try to use the preallocated write req if it's available.
        * Otherwise allocate a new one.
        */
-      if (handle->ipc_header_write_req.type != UV_WRITE) {
-        ipc_header_req = (uv_write_t*)&handle->ipc_header_write_req;
+      if (handle->pipe.conn.ipc_header_write_req.type != UV_WRITE) {
+        ipc_header_req = (uv_write_t*)&handle->pipe.conn.ipc_header_write_req;
       } else {
         ipc_header_req = (uv_write_t*)malloc(sizeof(uv_write_t));
         if (!ipc_header_req) {
@@ -1272,12 +1275,13 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
     }
 
     /* Write the header or the whole frame. */
-    memset(&ipc_header_req->overlapped, 0, sizeof(ipc_header_req->overlapped));
+    memset(&ipc_header_req->u.io.overlapped, 0,
+           sizeof(ipc_header_req->u.io.overlapped));
 
     /* Using overlapped IO, but wait for completion before returning.
        This write is blocking because ipc_frame is on stack. */
-    ipc_header_req->overlapped.hEvent = CreateEvent(NULL, 1, 0, NULL);
-    if (!ipc_header_req->overlapped.hEvent) {
+    ipc_header_req->u.io.overlapped.hEvent = CreateEvent(NULL, 1, 0, NULL);
+    if (!ipc_header_req->u.io.overlapped.hEvent) {
       uv_fatal_error(GetLastError(), "CreateEvent");
     }
 
@@ -1286,29 +1290,29 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
                         ipc_frame.header.flags & UV_IPC_TCP_SERVER ?
                           sizeof(ipc_frame) : sizeof(ipc_frame.header),
                         NULL,
-                        &ipc_header_req->overlapped);
+                        &ipc_header_req->u.io.overlapped);
     if (!result && GetLastError() != ERROR_IO_PENDING) {
       err = GetLastError();
-      CloseHandle(ipc_header_req->overlapped.hEvent);
+      CloseHandle(ipc_header_req->u.io.overlapped.hEvent);
       return err;
     }
 
     if (!result) {
       /* Request not completed immediately. Wait for it.*/
-      if (WaitForSingleObject(ipc_header_req->overlapped.hEvent, INFINITE) !=
+      if (WaitForSingleObject(ipc_header_req->u.io.overlapped.hEvent, INFINITE) !=
           WAIT_OBJECT_0) {
         err = GetLastError();
-        CloseHandle(ipc_header_req->overlapped.hEvent);
+        CloseHandle(ipc_header_req->u.io.overlapped.hEvent);
         return err;
       }
     }
-    ipc_header_req->queued_bytes = 0;
-    CloseHandle(ipc_header_req->overlapped.hEvent);
-    ipc_header_req->overlapped.hEvent = NULL;
+    ipc_header_req->u.io.queued_bytes = 0;
+    CloseHandle(ipc_header_req->u.io.overlapped.hEvent);
+    ipc_header_req->u.io.overlapped.hEvent = NULL;
 
     REGISTER_HANDLE_REQ(loop, handle, ipc_header_req);
     handle->reqs_pending++;
-    handle->write_reqs_pending++;
+    handle->stream.conn.write_reqs_pending++;
 
     /* If we don't have any raw data to write - we're done. */
     if (!(ipc_frame.header.flags & UV_IPC_RAW_DATA)) {
@@ -1331,28 +1335,28 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
       return err;
     } else {
       /* Request completed immediately. */
-      req->queued_bytes = 0;
+      req->u.io.queued_bytes = 0;
     }
 
     REGISTER_HANDLE_REQ(loop, handle, req);
     handle->reqs_pending++;
-    handle->write_reqs_pending++;
+    handle->stream.conn.write_reqs_pending++;
     POST_COMPLETION_FOR_REQ(loop, req);
     return 0;
   } else if (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) {
     req->write_buffer = bufs[0];
     uv_insert_non_overlapped_write_req(handle, req);
-    if (handle->write_reqs_pending == 0) {
+    if (handle->stream.conn.write_reqs_pending == 0) {
       uv_queue_non_overlapped_write(handle);
     }
 
     /* Request queued by the kernel. */
-    req->queued_bytes = uv__count_bufs(bufs, nbufs);
-    handle->write_queue_size += req->queued_bytes;
+    req->u.io.queued_bytes = uv__count_bufs(bufs, nbufs);
+    handle->write_queue_size += req->u.io.queued_bytes;
   } else if (handle->flags & UV_HANDLE_BLOCKING_WRITES) {
     /* Using overlapped IO, but wait for completion before returning */
-    req->overlapped.hEvent = CreateEvent(NULL, 1, 0, NULL);
-    if (!req->overlapped.hEvent) {
+    req->u.io.overlapped.hEvent = CreateEvent(NULL, 1, 0, NULL);
+    if (!req->u.io.overlapped.hEvent) {
       uv_fatal_error(GetLastError(), "CreateEvent");
     }
 
@@ -1360,32 +1364,32 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
                        bufs[0].base,
                        bufs[0].len,
                        NULL,
-                       &req->overlapped);
+                       &req->u.io.overlapped);
 
     if (!result && GetLastError() != ERROR_IO_PENDING) {
       err = GetLastError();
-      CloseHandle(req->overlapped.hEvent);
+      CloseHandle(req->u.io.overlapped.hEvent);
       return err;
     }
 
     if (result) {
       /* Request completed immediately. */
-      req->queued_bytes = 0;
+      req->u.io.queued_bytes = 0;
     } else {
       assert(ipc_header_req != NULL);
       /* Request queued by the kernel. */
-      if (WaitForSingleObject(ipc_header_req->overlapped.hEvent, INFINITE) !=
+      if (WaitForSingleObject(ipc_header_req->u.io.overlapped.hEvent, INFINITE) !=
           WAIT_OBJECT_0) {
         err = GetLastError();
-        CloseHandle(ipc_header_req->overlapped.hEvent);
+        CloseHandle(ipc_header_req->u.io.overlapped.hEvent);
         return uv_translate_sys_error(err);
       }
     }
-    CloseHandle(req->overlapped.hEvent);
+    CloseHandle(req->u.io.overlapped.hEvent);
 
     REGISTER_HANDLE_REQ(loop, handle, req);
     handle->reqs_pending++;
-    handle->write_reqs_pending++;
+    handle->stream.conn.write_reqs_pending++;
     POST_COMPLETION_FOR_REQ(loop, req);
     return 0;
   } else {
@@ -1393,7 +1397,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
                        bufs[0].base,
                        bufs[0].len,
                        NULL,
-                       &req->overlapped);
+                       &req->u.io.overlapped);
 
     if (!result && GetLastError() != ERROR_IO_PENDING) {
       return GetLastError();
@@ -1401,11 +1405,11 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
 
     if (result) {
       /* Request completed immediately. */
-      req->queued_bytes = 0;
+      req->u.io.queued_bytes = 0;
     } else {
       /* Request queued by the kernel. */
-      req->queued_bytes = uv__count_bufs(bufs, nbufs);
-      handle->write_queue_size += req->queued_bytes;
+      req->u.io.queued_bytes = uv__count_bufs(bufs, nbufs);
+      handle->write_queue_size += req->u.io.queued_bytes;
     }
 
     if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
@@ -1414,7 +1418,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
         uv_fatal_error(GetLastError(), "CreateEvent");
       }
       if (!RegisterWaitForSingleObject(&req->wait_handle,
-          req->overlapped.hEvent, post_completion_write_wait, (void*) req,
+          req->u.io.overlapped.hEvent, post_completion_write_wait, (void*) req,
           INFINITE, WT_EXECUTEINWAITTHREAD)) {
         return GetLastError();
       }
@@ -1423,7 +1427,7 @@ static int uv_pipe_write_impl(uv_loop_t* loop,
 
   REGISTER_HANDLE_REQ(loop, handle, req);
   handle->reqs_pending++;
-  handle->write_reqs_pending++;
+  handle->stream.conn.write_reqs_pending++;
 
   return 0;
 }
@@ -1500,8 +1504,8 @@ void uv__pipe_insert_pending_socket(uv_pipe_t* handle,
 
   memcpy(&item->socket_info_ex, info, sizeof(item->socket_info_ex));
   item->tcp_connection = tcp_connection;
-  QUEUE_INSERT_TAIL(&handle->pending_ipc_info.queue, &item->member);
-  handle->pending_ipc_info.queue_len++;
+  QUEUE_INSERT_TAIL(&handle->pipe.conn.pending_ipc_info.queue, &item->member);
+  handle->pipe.conn.pending_ipc_info.queue_len++;
 }
 
 
@@ -1544,7 +1548,7 @@ void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle,
 
       if (handle->ipc) {
         /* Use the IPC framing protocol to read the incoming data. */
-        if (handle->remaining_ipc_rawdata_bytes == 0) {
+        if (handle->pipe.conn.remaining_ipc_rawdata_bytes == 0) {
           /* We're reading a new frame.  First, read the header. */
           assert(avail >= sizeof(ipc_frame.header));
 
@@ -1587,12 +1591,12 @@ void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle,
           }
 
           if (ipc_frame.header.flags & UV_IPC_RAW_DATA) {
-            handle->remaining_ipc_rawdata_bytes =
+            handle->pipe.conn.remaining_ipc_rawdata_bytes =
               ipc_frame.header.raw_data_length;
             continue;
           }
         } else {
-          avail = min(avail, (DWORD)handle->remaining_ipc_rawdata_bytes);
+          avail = min(avail, (DWORD)handle->pipe.conn.remaining_ipc_rawdata_bytes);
         }
       }
 
@@ -1610,9 +1614,9 @@ void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle,
                    NULL)) {
         /* Successful read */
         if (handle->ipc) {
-          assert(handle->remaining_ipc_rawdata_bytes >= bytes);
-          handle->remaining_ipc_rawdata_bytes =
-            handle->remaining_ipc_rawdata_bytes - bytes;
+          assert(handle->pipe.conn.remaining_ipc_rawdata_bytes >= bytes);
+          handle->pipe.conn.remaining_ipc_rawdata_bytes =
+            handle->pipe.conn.remaining_ipc_rawdata_bytes - bytes;
         }
         handle->read_cb((uv_stream_t*)handle, bytes, &buf);
 
@@ -1643,8 +1647,8 @@ void uv_process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
 
   assert(handle->type == UV_NAMED_PIPE);
 
-  assert(handle->write_queue_size >= req->queued_bytes);
-  handle->write_queue_size -= req->queued_bytes;
+  assert(handle->write_queue_size >= req->u.io.queued_bytes);
+  handle->write_queue_size -= req->u.io.queued_bytes;
 
   UNREGISTER_HANDLE_REQ(loop, handle, req);
 
@@ -1660,7 +1664,7 @@ void uv_process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
   }
 
   if (req->ipc_header) {
-    if (req == &handle->ipc_header_write_req) {
+    if (req == &handle->pipe.conn.ipc_header_write_req) {
       req->type = UV_UNKNOWN_REQ;
     } else {
       free(req);
@@ -1672,16 +1676,16 @@ void uv_process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
     }
   }
 
-  handle->write_reqs_pending--;
+  handle->stream.conn.write_reqs_pending--;
 
   if (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE &&
-      handle->non_overlapped_writes_tail) {
-    assert(handle->write_reqs_pending > 0);
+      handle->pipe.conn.non_overlapped_writes_tail) {
+    assert(handle->stream.conn.write_reqs_pending > 0);
     uv_queue_non_overlapped_write(handle);
   }
 
-  if (handle->shutdown_req != NULL &&
-      handle->write_reqs_pending == 0) {
+  if (handle->stream.conn.shutdown_req != NULL &&
+      handle->stream.conn.write_reqs_pending == 0) {
     uv_want_endgame(loop, (uv_handle_t*)handle);
   }
 
@@ -1704,11 +1708,11 @@ void uv_process_pipe_accept_req(uv_loop_t* loop, uv_pipe_t* handle,
 
   if (REQ_SUCCESS(req)) {
     assert(req->pipeHandle != INVALID_HANDLE_VALUE);
-    req->next_pending = handle->pending_accepts;
-    handle->pending_accepts = req;
+    req->next_pending = handle->pipe.serv.pending_accepts;
+    handle->pipe.serv.pending_accepts = req;
 
-    if (handle->connection_cb) {
-      handle->connection_cb((uv_stream_t*)handle, 0);
+    if (handle->stream.serv.connection_cb) {
+      handle->stream.serv.connection_cb((uv_stream_t*)handle, 0);
     }
   } else {
     if (req->pipeHandle != INVALID_HANDLE_VALUE) {
@@ -1781,23 +1785,23 @@ void uv_process_pipe_shutdown_req(uv_loop_t* loop, uv_pipe_t* handle,
 static void eof_timer_init(uv_pipe_t* pipe) {
   int r;
 
-  assert(pipe->eof_timer == NULL);
+  assert(pipe->pipe.conn.eof_timer == NULL);
   assert(pipe->flags & UV_HANDLE_CONNECTION);
 
-  pipe->eof_timer = (uv_timer_t*) malloc(sizeof *pipe->eof_timer);
+  pipe->pipe.conn.eof_timer = (uv_timer_t*) malloc(sizeof *pipe->pipe.conn.eof_timer);
 
-  r = uv_timer_init(pipe->loop, pipe->eof_timer);
+  r = uv_timer_init(pipe->loop, pipe->pipe.conn.eof_timer);
   assert(r == 0); /* timers can't fail */
-  pipe->eof_timer->data = pipe;
-  uv_unref((uv_handle_t*) pipe->eof_timer);
+  pipe->pipe.conn.eof_timer->data = pipe;
+  uv_unref((uv_handle_t*) pipe->pipe.conn.eof_timer);
 }
 
 
 static void eof_timer_start(uv_pipe_t* pipe) {
   assert(pipe->flags & UV_HANDLE_CONNECTION);
 
-  if (pipe->eof_timer != NULL) {
-    uv_timer_start(pipe->eof_timer, eof_timer_cb, eof_timeout, 0);
+  if (pipe->pipe.conn.eof_timer != NULL) {
+    uv_timer_start(pipe->pipe.conn.eof_timer, eof_timer_cb, eof_timeout, 0);
   }
 }
 
@@ -1805,8 +1809,8 @@ static void eof_timer_start(uv_pipe_t* pipe) {
 static void eof_timer_stop(uv_pipe_t* pipe) {
   assert(pipe->flags & UV_HANDLE_CONNECTION);
 
-  if (pipe->eof_timer != NULL) {
-    uv_timer_stop(pipe->eof_timer);
+  if (pipe->pipe.conn.eof_timer != NULL) {
+    uv_timer_stop(pipe->pipe.conn.eof_timer);
   }
 }
 
@@ -1829,7 +1833,7 @@ static void eof_timer_cb(uv_timer_t* timer) {
   /* Therefore we check here if the read request has completed but will */
   /* be processed later. */
   if ((pipe->flags & UV_HANDLE_READ_PENDING) &&
-      HasOverlappedIoCompleted(&pipe->read_req.overlapped)) {
+      HasOverlappedIoCompleted(&pipe->read_req.u.io.overlapped)) {
     return;
   }
 
@@ -1850,9 +1854,9 @@ static void eof_timer_cb(uv_timer_t* timer) {
 static void eof_timer_destroy(uv_pipe_t* pipe) {
   assert(pipe->flags & UV_HANDLE_CONNECTION);
 
-  if (pipe->eof_timer) {
-    uv_close((uv_handle_t*) pipe->eof_timer, eof_timer_close_cb);
-    pipe->eof_timer = NULL;
+  if (pipe->pipe.conn.eof_timer) {
+    uv_close((uv_handle_t*) pipe->pipe.conn.eof_timer, eof_timer_close_cb);
+    pipe->pipe.conn.eof_timer = NULL;
   }
 }
 
@@ -1903,8 +1907,8 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
 
   if (pipe->ipc) {
     assert(!(pipe->flags & UV_HANDLE_NON_OVERLAPPED_PIPE));
-    pipe->ipc_pid = uv_parent_pid();
-    assert(pipe->ipc_pid != -1);
+    pipe->pipe.conn.ipc_pid = uv_parent_pid();
+    assert(pipe->pipe.conn.ipc_pid != -1);
   }
   return 0;
 }
@@ -2027,7 +2031,7 @@ cleanup:
 int uv_pipe_pending_count(uv_pipe_t* handle) {
   if (!handle->ipc)
     return 0;
-  return handle->pending_ipc_info.queue_len;
+  return handle->pipe.conn.pending_ipc_info.queue_len;
 }
 
 
@@ -2060,7 +2064,7 @@ int uv_pipe_getpeername(const uv_pipe_t* handle, char* buffer, size_t* size) {
 uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
   if (!handle->ipc)
     return UV_UNKNOWN_HANDLE;
-  if (handle->pending_ipc_info.queue_len == 0)
+  if (handle->pipe.conn.pending_ipc_info.queue_len == 0)
     return UV_UNKNOWN_HANDLE;
   else
     return UV_TCP;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -112,12 +112,12 @@ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
     afd_poll_info->Handles[0].Events |= AFD_POLL_SEND | AFD_POLL_CONNECT_FAIL;
   }
 
-  memset(&req->overlapped, 0, sizeof req->overlapped);
+  memset(&req->u.io.overlapped, 0, sizeof req->u.io.overlapped);
 
   result = uv_msafd_poll((SOCKET) handle->peer_socket,
                          afd_poll_info,
                          afd_poll_info,
-                         &req->overlapped);
+                         &req->u.io.overlapped);
   if (result != 0 && WSAGetLastError() != WSA_IO_PENDING) {
     /* Queue this req, reporting an error. */
     SET_REQ_ERROR(req, WSAGetLastError());
@@ -380,7 +380,7 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
   }
 
   SET_REQ_SUCCESS(req);
-  req->overlapped.InternalHigh = (DWORD) reported_events;
+  req->u.io.overlapped.InternalHigh = (DWORD) reported_events;
   POST_COMPLETION_FOR_REQ(handle->loop, req);
 
   return 0;
@@ -442,7 +442,7 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
     }
   } else {
     /* Got some events. */
-    int events = req->overlapped.InternalHigh & handle->events & ~mask_events;
+    int events = req->u.io.overlapped.InternalHigh & handle->events & ~mask_events;
     if (events != 0) {
       handle->poll_cb(handle, 0, events);
     }

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1124,7 +1124,7 @@ int uv_spawn(uv_loop_t* loop,
     if (fdopt->flags & UV_CREATE_PIPE &&
         fdopt->data.stream->type == UV_NAMED_PIPE &&
         ((uv_pipe_t*) fdopt->data.stream)->ipc) {
-      ((uv_pipe_t*) fdopt->data.stream)->ipc_pid = info.dwProcessId;
+      ((uv_pipe_t*) fdopt->data.stream)->pipe.conn.ipc_pid = info.dwProcessId;
     }
   }
 

--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -29,7 +29,7 @@
 
 
 #define SET_REQ_STATUS(req, status)                                     \
-   (req)->overlapped.Internal = (ULONG_PTR) (status)
+   (req)->u.io.overlapped.Internal = (ULONG_PTR) (status)
 
 #define SET_REQ_ERROR(req, error)                                       \
   SET_REQ_STATUS((req), NTSTATUS_FROM_WIN32((error)))
@@ -38,7 +38,7 @@
   SET_REQ_STATUS((req), STATUS_SUCCESS)
 
 #define GET_REQ_STATUS(req)                                             \
-  ((NTSTATUS) (req)->overlapped.Internal)
+  ((NTSTATUS) (req)->u.io.overlapped.Internal)
 
 #define REQ_SUCCESS(req)                                                \
   (NT_SUCCESS(GET_REQ_STATUS((req))))
@@ -74,7 +74,7 @@
   if (!PostQueuedCompletionStatus((loop)->iocp,                         \
                                   0,                                    \
                                   0,                                    \
-                                  &((req)->overlapped))) {              \
+                                  &((req)->u.io.overlapped))) {         \
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");       \
   }
 
@@ -86,7 +86,7 @@ INLINE static void uv_req_init(uv_loop_t* loop, uv_req_t* req) {
 
 
 INLINE static uv_req_t* uv_overlapped_to_req(OVERLAPPED* overlapped) {
-  return CONTAINING_RECORD(overlapped, uv_req_t, overlapped);
+  return CONTAINING_RECORD(overlapped, uv_req_t, u.io.overlapped);
 }
 
 

--- a/src/win/stream-inl.h
+++ b/src/win/stream-inl.h
@@ -41,7 +41,7 @@ INLINE static void uv_stream_init(uv_loop_t* loop,
 
 INLINE static void uv_connection_init(uv_stream_t* handle) {
   handle->flags |= UV_HANDLE_CONNECTION;
-  handle->write_reqs_pending = 0;
+  handle->stream.conn.write_reqs_pending = 0;
 
   uv_req_init(handle->loop, (uv_req_t*) &(handle->read_req));
   handle->read_req.event_handle = NULL;
@@ -49,7 +49,7 @@ INLINE static void uv_connection_init(uv_stream_t* handle) {
   handle->read_req.type = UV_READ;
   handle->read_req.data = handle;
 
-  handle->shutdown_req = NULL;
+  handle->stream.conn.shutdown_req = NULL;
 }
 
 

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -216,7 +216,7 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
   req->cb = cb;
 
   handle->flags &= ~UV_HANDLE_WRITABLE;
-  handle->shutdown_req = req;
+  handle->stream.conn.shutdown_req = req;
   handle->reqs_pending++;
   REGISTER_HANDLE_REQ(loop, handle, req);
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -149,13 +149,13 @@ static int uv_tcp_set_socket(uv_loop_t* loop, uv_tcp_t* handle,
 int uv_tcp_init(uv_loop_t* loop, uv_tcp_t* handle) {
   uv_stream_init(loop, (uv_stream_t*) handle, UV_TCP);
 
-  handle->accept_reqs = NULL;
-  handle->pending_accepts = NULL;
+  handle->tcp.serv.accept_reqs = NULL;
+  handle->tcp.serv.pending_accepts = NULL;
   handle->socket = INVALID_SOCKET;
   handle->reqs_pending = 0;
-  handle->func_acceptex = NULL;
-  handle->func_connectex = NULL;
-  handle->processed_accepts = 0;
+  handle->tcp.serv.func_acceptex = NULL;
+  handle->tcp.conn.func_connectex = NULL;
+  handle->tcp.serv.processed_accepts = 0;
   handle->delayed_error = 0;
 
   return 0;
@@ -168,10 +168,10 @@ void uv_tcp_endgame(uv_loop_t* loop, uv_tcp_t* handle) {
   uv_tcp_accept_t* req;
 
   if (handle->flags & UV_HANDLE_CONNECTION &&
-      handle->shutdown_req != NULL &&
-      handle->write_reqs_pending == 0) {
+      handle->stream.conn.shutdown_req != NULL &&
+      handle->stream.conn.write_reqs_pending == 0) {
 
-    UNREGISTER_HANDLE_REQ(loop, handle, handle->shutdown_req);
+    UNREGISTER_HANDLE_REQ(loop, handle, handle->stream.conn.shutdown_req);
 
     err = 0;
     if (handle->flags & UV__HANDLE_CLOSING) {
@@ -180,12 +180,12 @@ void uv_tcp_endgame(uv_loop_t* loop, uv_tcp_t* handle) {
       err = WSAGetLastError();
     }
 
-    if (handle->shutdown_req->cb) {
-      handle->shutdown_req->cb(handle->shutdown_req,
+    if (handle->stream.conn.shutdown_req->cb) {
+      handle->stream.conn.shutdown_req->cb(handle->stream.conn.shutdown_req,
                                uv_translate_sys_error(err));
     }
 
-    handle->shutdown_req = NULL;
+    handle->stream.conn.shutdown_req = NULL;
     DECREASE_PENDING_REQ_COUNT(handle);
     return;
   }
@@ -200,10 +200,10 @@ void uv_tcp_endgame(uv_loop_t* loop, uv_tcp_t* handle) {
       handle->flags |= UV_HANDLE_TCP_SOCKET_CLOSED;
     }
 
-    if (!(handle->flags & UV_HANDLE_CONNECTION) && handle->accept_reqs) {
+    if (!(handle->flags & UV_HANDLE_CONNECTION) && handle->tcp.serv.accept_reqs) {
       if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
         for (i = 0; i < uv_simultaneous_server_accepts; i++) {
-          req = &handle->accept_reqs[i];
+          req = &handle->tcp.serv.accept_reqs[i];
           if (req->wait_handle != INVALID_HANDLE_VALUE) {
             UnregisterWait(req->wait_handle);
             req->wait_handle = INVALID_HANDLE_VALUE;
@@ -215,8 +215,8 @@ void uv_tcp_endgame(uv_loop_t* loop, uv_tcp_t* handle) {
         }
       }
 
-      free(handle->accept_reqs);
-      handle->accept_reqs = NULL;
+      free(handle->tcp.serv.accept_reqs);
+      handle->tcp.serv.accept_reqs = NULL;
     }
 
     if (handle->flags & UV_HANDLE_CONNECTION &&
@@ -327,9 +327,9 @@ static void CALLBACK post_completion(void* context, BOOLEAN timed_out) {
   assert(!timed_out);
 
   if (!PostQueuedCompletionStatus(handle->loop->iocp,
-                                  req->overlapped.InternalHigh,
+                                  req->u.io.overlapped.InternalHigh,
                                   0,
-                                  &req->overlapped)) {
+                                  &req->u.io.overlapped)) {
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");
   }
 }
@@ -346,9 +346,9 @@ static void CALLBACK post_write_completion(void* context, BOOLEAN timed_out) {
   assert(!timed_out);
 
   if (!PostQueuedCompletionStatus(handle->loop->iocp,
-                                  req->overlapped.InternalHigh,
+                                  req->u.io.overlapped.InternalHigh,
                                   0,
-                                  &req->overlapped)) {
+                                  &req->u.io.overlapped)) {
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");
   }
 }
@@ -390,19 +390,19 @@ static void uv_tcp_queue_accept(uv_tcp_t* handle, uv_tcp_accept_t* req) {
   }
 
   /* Prepare the overlapped structure. */
-  memset(&(req->overlapped), 0, sizeof(req->overlapped));
+  memset(&(req->u.io.overlapped), 0, sizeof(req->u.io.overlapped));
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
-    req->overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
+    req->u.io.overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
   }
 
-  success = handle->func_acceptex(handle->socket,
-                                  accept_socket,
-                                  (void*)req->accept_buffer,
-                                  0,
-                                  sizeof(struct sockaddr_storage),
-                                  sizeof(struct sockaddr_storage),
-                                  &bytes,
-                                  &req->overlapped);
+  success = handle->tcp.serv.func_acceptex(handle->socket,
+                                          accept_socket,
+                                          (void*)req->accept_buffer,
+                                          0,
+                                          sizeof(struct sockaddr_storage),
+                                          sizeof(struct sockaddr_storage),
+                                          &bytes,
+                                          &req->u.io.overlapped);
 
   if (UV_SUCCEEDED_WITHOUT_IOCP(success)) {
     /* Process the req without IOCP. */
@@ -432,7 +432,7 @@ static void uv_tcp_queue_accept(uv_tcp_t* handle, uv_tcp_accept_t* req) {
     closesocket(accept_socket);
     /* Destroy the event handle */
     if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
-      CloseHandle(req->overlapped.hEvent);
+      CloseHandle(req->u.io.overlapped.hEvent);
       req->event_handle = NULL;
     }
   }
@@ -449,7 +449,7 @@ static void uv_tcp_queue_read(uv_loop_t* loop, uv_tcp_t* handle) {
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
 
   req = &handle->read_req;
-  memset(&req->overlapped, 0, sizeof(req->overlapped));
+  memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
 
   /*
    * Preallocate a read buffer if the number of active streams is below
@@ -457,13 +457,13 @@ static void uv_tcp_queue_read(uv_loop_t* loop, uv_tcp_t* handle) {
   */
   if (loop->active_tcp_streams < uv_active_tcp_streams_threshold) {
     handle->flags &= ~UV_HANDLE_ZERO_READ;
-    handle->alloc_cb((uv_handle_t*) handle, 65536, &handle->read_buffer);
-    if (handle->read_buffer.len == 0) {
-      handle->read_cb((uv_stream_t*) handle, UV_ENOBUFS, &handle->read_buffer);
+    handle->alloc_cb((uv_handle_t*) handle, 65536, &handle->tcp.conn.read_buffer);
+    if (handle->tcp.conn.read_buffer.len == 0) {
+      handle->read_cb((uv_stream_t*) handle, UV_ENOBUFS, &handle->tcp.conn.read_buffer);
       return;
     }
-    assert(handle->read_buffer.base != NULL);
-    buf = handle->read_buffer;
+    assert(handle->tcp.conn.read_buffer.base != NULL);
+    buf = handle->tcp.conn.read_buffer;
   } else {
     handle->flags |= UV_HANDLE_ZERO_READ;
     buf.base = (char*) &uv_zero_;
@@ -471,10 +471,10 @@ static void uv_tcp_queue_read(uv_loop_t* loop, uv_tcp_t* handle) {
   }
 
   /* Prepare the overlapped structure. */
-  memset(&(req->overlapped), 0, sizeof(req->overlapped));
+  memset(&(req->u.io.overlapped), 0, sizeof(req->u.io.overlapped));
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
     assert(req->event_handle);
-    req->overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
+    req->u.io.overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
   }
 
   flags = 0;
@@ -483,13 +483,13 @@ static void uv_tcp_queue_read(uv_loop_t* loop, uv_tcp_t* handle) {
                    1,
                    &bytes,
                    &flags,
-                   &req->overlapped,
+                   &req->u.io.overlapped,
                    NULL);
 
   if (UV_SUCCEEDED_WITHOUT_IOCP(result == 0)) {
     /* Process the req without IOCP. */
     handle->flags |= UV_HANDLE_READ_PENDING;
-    req->overlapped.InternalHigh = bytes;
+    req->u.io.overlapped.InternalHigh = bytes;
     handle->reqs_pending++;
     uv_insert_pending_req(loop, (uv_req_t*)req);
   } else if (UV_SUCCEEDED_WITH_IOCP(result == 0)) {
@@ -522,7 +522,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
   assert(backlog > 0);
 
   if (handle->flags & UV_HANDLE_LISTENING) {
-    handle->connection_cb = cb;
+    handle->stream.serv.connection_cb = cb;
   }
 
   if (handle->flags & UV_HANDLE_READING) {
@@ -544,8 +544,8 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
       return handle->delayed_error;
   }
 
-  if (!handle->func_acceptex) {
-    if (!uv_get_acceptex_function(handle->socket, &handle->func_acceptex)) {
+  if (!handle->tcp.serv.func_acceptex) {
+    if (!uv_get_acceptex_function(handle->socket, &handle->tcp.serv.func_acceptex)) {
       return WSAEAFNOSUPPORT;
     }
   }
@@ -556,21 +556,21 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
   }
 
   handle->flags |= UV_HANDLE_LISTENING;
-  handle->connection_cb = cb;
+  handle->stream.serv.connection_cb = cb;
   INCREASE_ACTIVE_COUNT(loop, handle);
 
   simultaneous_accepts = handle->flags & UV_HANDLE_TCP_SINGLE_ACCEPT ? 1
     : uv_simultaneous_server_accepts;
 
-  if(!handle->accept_reqs) {
-    handle->accept_reqs = (uv_tcp_accept_t*)
+  if(!handle->tcp.serv.accept_reqs) {
+    handle->tcp.serv.accept_reqs = (uv_tcp_accept_t*)
       malloc(uv_simultaneous_server_accepts * sizeof(uv_tcp_accept_t));
-    if (!handle->accept_reqs) {
+    if (!handle->tcp.serv.accept_reqs) {
       uv_fatal_error(ERROR_OUTOFMEMORY, "malloc");
     }
 
     for (i = 0; i < simultaneous_accepts; i++) {
-      req = &handle->accept_reqs[i];
+      req = &handle->tcp.serv.accept_reqs[i];
       uv_req_init(loop, (uv_req_t*)req);
       req->type = UV_ACCEPT;
       req->accept_socket = INVALID_SOCKET;
@@ -593,7 +593,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
     /* doesn't know how how many requests were initialized, so it will */
     /* try to clean up {uv_simultaneous_server_accepts} requests. */
     for (i = simultaneous_accepts; i < uv_simultaneous_server_accepts; i++) {
-      req = &handle->accept_reqs[i];
+      req = &handle->tcp.serv.accept_reqs[i];
       uv_req_init(loop, (uv_req_t*) req);
       req->type = UV_ACCEPT;
       req->accept_socket = INVALID_SOCKET;
@@ -612,7 +612,7 @@ int uv_tcp_accept(uv_tcp_t* server, uv_tcp_t* client) {
   int err = 0;
   int family;
 
-  uv_tcp_accept_t* req = server->pending_accepts;
+  uv_tcp_accept_t* req = server->tcp.serv.pending_accepts;
 
   if (!req) {
     /* No valid connections found, so we error out. */
@@ -643,7 +643,7 @@ int uv_tcp_accept(uv_tcp_t* server, uv_tcp_t* client) {
   }
 
   /* Prepare the req to pick up a new connection */
-  server->pending_accepts = req->next_pending;
+  server->tcp.serv.pending_accepts = req->next_pending;
   req->next_pending = NULL;
   req->accept_socket = INVALID_SOCKET;
 
@@ -655,15 +655,15 @@ int uv_tcp_accept(uv_tcp_t* server, uv_tcp_t* client) {
       /* We better be switching to a single pending accept. */
       assert(server->flags & UV_HANDLE_TCP_SINGLE_ACCEPT);
 
-      server->processed_accepts++;
+      server->tcp.serv.processed_accepts++;
 
-      if (server->processed_accepts >= uv_simultaneous_server_accepts) {
-        server->processed_accepts = 0;
+      if (server->tcp.serv.processed_accepts >= uv_simultaneous_server_accepts) {
+        server->tcp.serv.processed_accepts = 0;
         /*
          * All previously queued accept requests are now processed.
          * We now switch to queueing just a single accept.
          */
-        uv_tcp_queue_accept(server, &server->accept_reqs[0]);
+        uv_tcp_queue_accept(server, &server->tcp.serv.accept_reqs[0]);
         server->flags &= ~UV_HANDLE_TCP_ACCEPT_STATE_CHANGING;
         server->flags |= UV_HANDLE_TCP_SINGLE_ACCEPT;
       }
@@ -732,8 +732,8 @@ static int uv_tcp_try_connect(uv_connect_t* req,
       return handle->delayed_error;
   }
 
-  if (!handle->func_connectex) {
-    if (!uv_get_connectex_function(handle->socket, &handle->func_connectex)) {
+  if (!handle->tcp.conn.func_connectex) {
+    if (!uv_get_connectex_function(handle->socket, &handle->tcp.conn.func_connectex)) {
       return WSAEAFNOSUPPORT;
     }
   }
@@ -742,15 +742,15 @@ static int uv_tcp_try_connect(uv_connect_t* req,
   req->type = UV_CONNECT;
   req->handle = (uv_stream_t*) handle;
   req->cb = cb;
-  memset(&req->overlapped, 0, sizeof(req->overlapped));
+  memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
 
-  success = handle->func_connectex(handle->socket,
-                                   addr,
-                                   addrlen,
-                                   NULL,
-                                   0,
-                                   &bytes,
-                                   &req->overlapped);
+  success = handle->tcp.conn.func_connectex(handle->socket,
+                                           addr,
+                                           addrlen,
+                                           NULL,
+                                           0,
+                                           &bytes,
+                                           &req->u.io.overlapped);
 
   if (UV_SUCCEEDED_WITHOUT_IOCP(success)) {
     /* Process the req without IOCP. */
@@ -828,13 +828,13 @@ int uv_tcp_write(uv_loop_t* loop,
   req->cb = cb;
 
   /* Prepare the overlapped structure. */
-  memset(&(req->overlapped), 0, sizeof(req->overlapped));
+  memset(&(req->u.io.overlapped), 0, sizeof(req->u.io.overlapped));
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
     req->event_handle = CreateEvent(NULL, 0, 0, NULL);
     if (!req->event_handle) {
       uv_fatal_error(GetLastError(), "CreateEvent");
     }
-    req->overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
+    req->u.io.overlapped.hEvent = (HANDLE) ((ULONG_PTR) req->event_handle | 1);
     req->wait_handle = INVALID_HANDLE_VALUE;
   }
 
@@ -843,23 +843,23 @@ int uv_tcp_write(uv_loop_t* loop,
                    nbufs,
                    &bytes,
                    0,
-                   &req->overlapped,
+                   &req->u.io.overlapped,
                    NULL);
 
   if (UV_SUCCEEDED_WITHOUT_IOCP(result == 0)) {
     /* Request completed immediately. */
-    req->queued_bytes = 0;
+    req->u.io.queued_bytes = 0;
     handle->reqs_pending++;
-    handle->write_reqs_pending++;
+    handle->stream.conn.write_reqs_pending++;
     REGISTER_HANDLE_REQ(loop, handle, req);
     uv_insert_pending_req(loop, (uv_req_t*) req);
   } else if (UV_SUCCEEDED_WITH_IOCP(result == 0)) {
     /* Request queued by the kernel. */
-    req->queued_bytes = uv__count_bufs(bufs, nbufs);
+    req->u.io.queued_bytes = uv__count_bufs(bufs, nbufs);
     handle->reqs_pending++;
-    handle->write_reqs_pending++;
+    handle->stream.conn.write_reqs_pending++;
     REGISTER_HANDLE_REQ(loop, handle, req);
-    handle->write_queue_size += req->queued_bytes;
+    handle->write_queue_size += req->u.io.queued_bytes;
     if (handle->flags & UV_HANDLE_EMULATE_IOCP &&
         !RegisterWaitForSingleObject(&req->wait_handle,
           req->event_handle, post_write_completion, (void*) req,
@@ -882,7 +882,7 @@ int uv__tcp_try_write(uv_tcp_t* handle,
   int result;
   DWORD bytes;
 
-  if (handle->write_reqs_pending > 0)
+  if (handle->stream.conn.write_reqs_pending > 0)
     return UV_EAGAIN;
 
   result = WSASend(handle->socket,
@@ -916,7 +916,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
       handle->flags &= ~UV_HANDLE_READING;
       DECREASE_ACTIVE_COUNT(loop, handle);
       buf = (handle->flags & UV_HANDLE_ZERO_READ) ?
-            uv_buf_init(NULL, 0) : handle->read_buffer;
+            uv_buf_init(NULL, 0) : handle->tcp.conn.read_buffer;
 
       err = GET_REQ_SOCK_ERROR(req);
 
@@ -934,13 +934,13 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
   } else {
     if (!(handle->flags & UV_HANDLE_ZERO_READ)) {
       /* The read was done with a non-zero buffer length. */
-      if (req->overlapped.InternalHigh > 0) {
+      if (req->u.io.overlapped.InternalHigh > 0) {
         /* Successful read */
         handle->read_cb((uv_stream_t*)handle,
-                        req->overlapped.InternalHigh,
-                        &handle->read_buffer);
+                        req->u.io.overlapped.InternalHigh,
+                        &handle->tcp.conn.read_buffer);
         /* Read again only if bytes == buf.len */
-        if (req->overlapped.InternalHigh < handle->read_buffer.len) {
+        if (req->u.io.overlapped.InternalHigh < handle->tcp.conn.read_buffer.len) {
           goto done;
         }
       } else {
@@ -953,7 +953,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
 
         buf.base = 0;
         buf.len = 0;
-        handle->read_cb((uv_stream_t*)handle, UV_EOF, &handle->read_buffer);
+        handle->read_cb((uv_stream_t*)handle, UV_EOF, &handle->tcp.conn.read_buffer);
         goto done;
       }
     }
@@ -1032,8 +1032,8 @@ void uv_process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
 
   assert(handle->type == UV_TCP);
 
-  assert(handle->write_queue_size >= req->queued_bytes);
-  handle->write_queue_size -= req->queued_bytes;
+  assert(handle->write_queue_size >= req->u.io.queued_bytes);
+  handle->write_queue_size -= req->u.io.queued_bytes;
 
   UNREGISTER_HANDLE_REQ(loop, handle, req);
 
@@ -1057,9 +1057,9 @@ void uv_process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
     req->cb(req, err);
   }
 
-  handle->write_reqs_pending--;
-  if (handle->shutdown_req != NULL &&
-      handle->write_reqs_pending == 0) {
+  handle->stream.conn.write_reqs_pending--;
+  if (handle->stream.conn.shutdown_req != NULL &&
+      handle->stream.conn.write_reqs_pending == 0) {
     uv_want_endgame(loop, (uv_handle_t*)handle);
   }
 
@@ -1082,10 +1082,10 @@ void uv_process_tcp_accept_req(uv_loop_t* loop, uv_tcp_t* handle,
     if (handle->flags & UV_HANDLE_LISTENING) {
       handle->flags &= ~UV_HANDLE_LISTENING;
       DECREASE_ACTIVE_COUNT(loop, handle);
-      if (handle->connection_cb) {
+      if (handle->stream.serv.connection_cb) {
         err = GET_REQ_SOCK_ERROR(req);
-        handle->connection_cb((uv_stream_t*)handle,
-                              uv_translate_sys_error(err));
+        handle->stream.serv.connection_cb((uv_stream_t*)handle,
+                                      uv_translate_sys_error(err));
       }
     }
   } else if (REQ_SUCCESS(req) &&
@@ -1094,12 +1094,12 @@ void uv_process_tcp_accept_req(uv_loop_t* loop, uv_tcp_t* handle,
                   SO_UPDATE_ACCEPT_CONTEXT,
                   (char*)&handle->socket,
                   sizeof(handle->socket)) == 0) {
-    req->next_pending = handle->pending_accepts;
-    handle->pending_accepts = req;
+    req->next_pending = handle->tcp.serv.pending_accepts;
+    handle->tcp.serv.pending_accepts = req;
 
     /* Accept and SO_UPDATE_ACCEPT_CONTEXT were successful. */
-    if (handle->connection_cb) {
-      handle->connection_cb((uv_stream_t*)handle, 0);
+    if (handle->stream.serv.connection_cb) {
+      handle->stream.serv.connection_cb((uv_stream_t*)handle, 0);
     }
   } else {
     /* Error related to accepted socket is ignored because the server */
@@ -1357,7 +1357,7 @@ void uv_tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
     }
 
   } else if ((tcp->flags & UV_HANDLE_SHARED_TCP_SOCKET) &&
-             tcp->accept_reqs != NULL) {
+             tcp->tcp.serv.accept_reqs != NULL) {
     /* Under normal circumstances closesocket() will ensure that all pending */
     /* accept reqs are canceled. However, when the socket is shared the */
     /* presence of another reference to the socket in another process will */
@@ -1371,9 +1371,9 @@ void uv_tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
       /* cause the connection to be aborted. */
       unsigned int i;
       for (i = 0; i < uv_simultaneous_server_accepts; i++) {
-        uv_tcp_accept_t* req = &tcp->accept_reqs[i];
+        uv_tcp_accept_t* req = &tcp->tcp.serv.accept_reqs[i];
         if (req->accept_socket != INVALID_SOCKET &&
-            !HasOverlappedIoCompleted(&req->overlapped)) {
+            !HasOverlappedIoCompleted(&req->u.io.overlapped)) {
           closesocket(req->accept_socket);
           req->accept_socket = INVALID_SOCKET;
         }


### PR DESCRIPTION
This addresses issue #205, by naming the anonymous structs and unions in `uv-win.h` to conform to the C89 spec and updating all the affected code. I tried to give meaningful and consistent names to the different private field groups, e.g.:
```c
union {
  struct { uv_stream_connection_fields };
  struct { uv_stream_server_fields };
};
```
becomes:
```c
union {
  struct { uv_stream_connection_fields } conn;
  struct { uv_stream_server_fields } serv;
} stream;
```
With similar naming for pipe, tcp, tty, fs and the overlapped I/O fields. Since it's a direct replacement it's a bit verbose, and it hits quite a lot of files since the private fields are used basically everywhere, I think it's nice that the fields are now all properly segmented and qualified since it indicates where they belong, though.

However I came across one issue and would like some comments: in `uv-common.c`, some functions assume the existence of an `nbufs` member directly inside the `uv_fs_t` struct, which is defined in `UV_FS_PRIVATE_FIELDS`. To me this doesn't seem compatible with the struct/union design currently being used in `uv-win.h` without anonymous structs/unions - should there be some internal functions to bridge the gap between the private field `nbufs` and its usage in the common libuv implementation?

----

What do you guys think, is this going in the right direction? Also, I'm intending to rebase and tidy up the comments and make a better git commit message, just looking for some feedback before I proceed since this is quite a large and intrusive commit for the windows implementation.