### PR TITLE
linux: work around epoll bug in kernels 3.10-3.19

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -130,8 +130,13 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
    *
    * We pass in a dummy epoll_event, to work around a bug in old kernels.
    */
-  if (loop->backend_fd >= 0)
+  if (loop->backend_fd >= 0) {
+    /* Work around a bug in kernels 3.10 to 3.19 where passing a struct that
+     * has the EPOLLWAKEUP flag set generates spurious audit syslog warnings.
+     */
+    memset(&dummy, 0, sizeof(dummy));
     uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_DEL, fd, &dummy);
+  }
 }
 
 


### PR DESCRIPTION
Work around a bug in kernels 3.10 to 3.19 where passing a struct that
has the EPOLLWAKEUP flag set generates spurious syslog audit warnings.

A bad check makes the kernel read the events field when it should not
and complain when the process lacks the CAP_BLOCK_SUSPEND capability.

R=@saghul