### PR TITLE
use `extern "c++"` for defining C++ code

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -650,13 +650,13 @@ UV_EXTERN int uv_tty_reset_mode(void);
 UV_EXTERN int uv_tty_get_winsize(uv_tty_t*, int* width, int* height);
 
 #ifdef __cplusplus
-}  /* extern "C" */
+extern "C++" {
 
 inline int uv_tty_set_mode(uv_tty_t* handle, int mode) {
   return uv_tty_set_mode(handle, static_cast<uv_tty_mode_t>(mode));
 }
 
-extern "C" {
+}
 #endif
 
 UV_EXTERN uv_handle_type uv_guess_handle(uv_file file);


### PR DESCRIPTION
At the moment, `uv_tty_set_mode` is defined after closing `extern "C"` opened at the beginning of uv.h, in the hope that it would be defined as a C++ function.  However there is no such guarantee, the line that included uv.h might be surrounded by `extern "C"`.

This PR uses `extern "C++"` instead to define the C++-only function.

fixes #254 