### PR TITLE
aix: ignore ENOTCONN error on shutdown in uv__drain

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -661,7 +661,11 @@ static void uv__drain(uv_stream_t* stream) {
 
     err = 0;
     if (shutdown(uv__stream_fd(stream), SHUT_WR))
+#if defined(_AIX)
+      err = errno == ENOTCONN ? 0 : -errno;
+#else
       err = -errno;
+#endif /* defined(_AIX) */
 
     if (err == 0)
       stream->flags |= UV_STREAM_SHUT;


### PR DESCRIPTION
On AIX we were seing failures in the Node test: 

simple/test-child-process-execsync.js

where the error was ENOTCONN. We identified that the
ENOTCONN a result of the call to uv_spawn in libuv.

When uv_spawn is called the child is fork/exec'd and the
parent waits for the child to terminate.  Once the child
terminates it gathers the child's execution result. As
part of this process shutdown is called on the streams
which connect it to the child. At the time the parent 
calls shutdown() the child will have already closed 
its side of the streams.  The call to shutdown is in 
uv__drain() within src/unix/stream.c

Based on c test cases we ran, when run on AIX calling 
shutdown on a stream for which the other side has been
closed results in the error ENOTCONN being returned. 
When running the same test case on linux no error 
is returned.  

It appears that in uv_drain within src/unix/stream.c
the intention is to ensure we can no longer write to
the stream.  If the other side is already closed this
will be the case so we believe the best course of 
action is to simply ignore the ENOTCONN error in 
uv__drain. And hence this pull request.

This change does not introduce any new failures when
running the tests on AIX. It also does not fix any
existing failures, but it does allow the node test
simple/test-child-process-execsync.js to pass.