### PR TITLE
win: remove unnecessary malloc.h #includes.

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -22,7 +22,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -21,7 +21,6 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <malloc.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -21,7 +21,6 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <direct.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <malloc.h>
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -20,7 +20,6 @@
 */
 
 #include <assert.h>
-#include <malloc.h>
 #include <stdio.h>
 
 #include "uv.h"

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -22,7 +22,6 @@
 #include <assert.h>
 #include <direct.h>
 #include <limits.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
Several windows .c files are including malloc.h unnecessarily.
This commit removes #includes that should have been removed
when we switched over to uv__malloc and uv__free (in commit
c272f1f1bc0bda625e6441d798c110b4064a6ce2).