### PR TITLE
thread: support for affinity and detach

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1392,6 +1392,12 @@ UV_EXTERN void uv_key_set(uv_key_t* key, void* value);
 typedef void (*uv_thread_cb)(void* arg);
 
 UV_EXTERN int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg);
+UV_EXTERN int uv_thread_create_on(int proc_num,
+                                  uv_thread_t* tid,
+                                  uv_thread_cb entry,
+                                  void *arg);
+UV_EXTERN int uv_thread_setaffinity(uv_thread_t* tid, int proc_num);
+UV_EXTERN int uv_thread_detach(uv_thread_t* tid);
 UV_EXTERN uv_thread_t uv_thread_self(void);
 UV_EXTERN int uv_thread_join(uv_thread_t *tid);
 UV_EXTERN int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -19,10 +19,13 @@
  * IN THE SOFTWARE.
  */
 
+#define _GNU_SOURCE
+
 #include "uv.h"
 #include "internal.h"
 
 #include <pthread.h>
+#include <sched.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -72,9 +75,58 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 }
 
 
+int uv_thread_create_on(int proc_num,
+                        uv_thread_t *tid,
+                        void (*entry)(void *arg),
+                        void *arg) {
+  pthread_attr_t attr;
+  cpu_set_t cset;
+  struct thread_ctx* ctx;
+  int err;
+
+  ctx = malloc(sizeof(*ctx));
+  if (ctx == NULL)
+    return UV_ENOMEM;
+
+  ctx->entry = entry;
+  ctx->arg = arg;
+
+  pthread_attr_init(&attr);
+  if (proc_num >= 0) {
+    CPU_ZERO(&cset);
+    CPU_SET(proc_num, &cset);
+    pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &cset);
+  }
+
+  err = pthread_create(tid, &attr, uv__thread_start, ctx);
+
+  if (err)
+    free(ctx);
+
+  pthread_attr_destroy(&attr);
+
+  return err ? -1 : 0;
+}
+
+
+int uv_thread_setaffinity(uv_thread_t *tid, int proc_num) {
+  cpu_set_t cset;
+
+  CPU_ZERO(&cset);
+  CPU_SET(proc_num, &cset);
+  return -pthread_setaffinity_np(*tid, sizeof(cpu_set_t), &cset);
+}
+
+
+int uv_thread_detach(uv_thread_t *tid) {
+  return -pthread_detach(*tid);
+}
+
+
 uv_thread_t uv_thread_self(void) {
   return pthread_self();
 }
+
 
 int uv_thread_join(uv_thread_t *tid) {
   return -pthread_join(*tid, NULL);

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -189,6 +189,58 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 }
 
 
+int uv_thread_create_on(int proc_num,
+                        uv_thread_t *tid,
+                        void (*entry)(void *arg),
+                        void *arg) {
+  struct thread_ctx* ctx;
+  int err;
+  HANDLE thread;
+
+  ctx = malloc(sizeof(*ctx));
+  if (ctx == NULL)
+    return UV_ENOMEM;
+
+  ctx->entry = entry;
+  ctx->arg = arg;
+
+  /* Create the thread in suspended state so we have a chance to pass
+   * its own creation handle to it */   
+  thread = (HANDLE) _beginthreadex(NULL,
+                                   0,
+                                   uv__thread_start,
+                                   ctx,
+                                   CREATE_SUSPENDED,
+                                   NULL);
+  if (thread == NULL) {
+    err = errno;
+    free(ctx);
+  } else {
+    err = 0;
+    *tid = thread;
+    ctx->self = thread;
+    if (proc_num >= 0)
+        SetThreadAffinityMask(thread, (1 << proc_num));
+    ResumeThread(thread);
+  }
+
+  return err;
+}
+
+
+int uv_thread_setaffinity(uv_thread_t *tid, int proc_num) {
+  if (!SetThreadAffinityMask(*tid, (1 << proc_num)))
+    return uv_translate_sys_error(GetLastError());
+  return 0;
+}
+
+
+int uv_thread_detach(uv_thread_t *tid) {
+  CloseHandle(*tid);
+  return 0;
+}
+
+
 uv_thread_t uv_thread_self(void) {
   return (uv_thread_t) uv_key_get(&uv__current_thread_key);
 }


### PR DESCRIPTION
uv_thread_create_on() takes a processor number (not a mask), and sets the thread's affinity (pthread_setaffinity_np and SetThreadAffinityMask).

uv_thread_setaffinity() sets the specified thread's affinity.

uv_thread_detach() detaches the thread so it will be cleaned up on exit automatically--joining it is no longer necessary or possible (pthread_detach and CloseHandle).

This compiles on Linux. I've added code for Windows, but cannot check it.

Does this merit a test case? It isn't clear how to easily check this functionality.