### PR TITLE
fix zombies on exec failure

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -367,6 +367,7 @@ int uv_spawn(uv_loop_t* loop,
   int err;
   int exec_errorno;
   int i;
+  int status;
 
   assert(options->file != NULL);
   assert(!(options->flags & ~(UV_PROCESS_DETACHED |
@@ -453,10 +454,18 @@ int uv_spawn(uv_loop_t* loop,
 
   if (r == 0)
     ; /* okay, EOF */
-  else if (r == sizeof(exec_errorno))
-    ; /* okay, read errorno */
-  else if (r == -1 && errno == EPIPE)
-    ; /* okay, got EPIPE */
+  else if (r == sizeof(exec_errorno)) {
+    do
+      err = waitpid(pid, &status, 0); /* okay, read errorno */
+    while (err == -1 && errno == EINTR);
+    assert(err == pid);
+  }
+  else if (r == -1 && errno == EPIPE) {
+    do
+      err = waitpid(pid, &status, 0); /* okay, got EPIPE */
+    while (err == -1 && errno == EINTR);
+    assert(err == pid);
+  }
   else
     abort();
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -190,6 +190,9 @@ TEST_DECLARE   (fail_always)
 TEST_DECLARE   (pass_always)
 TEST_DECLARE   (socket_buffer_size)
 TEST_DECLARE   (spawn_fails)
+#ifndef _WIN32
+TEST_DECLARE   (spawn_fails_check_for_waitpid_cleanup)
+#endif
 TEST_DECLARE   (spawn_exit_code)
 TEST_DECLARE   (spawn_stdout)
 TEST_DECLARE   (spawn_stdin)
@@ -541,6 +544,9 @@ TASK_LIST_START
   TEST_ENTRY  (socket_buffer_size)
 
   TEST_ENTRY  (spawn_fails)
+#ifndef _WIN32
+  TEST_ENTRY  (spawn_fails_check_for_waitpid_cleanup)
+#endif
   TEST_ENTRY  (spawn_exit_code)
   TEST_ENTRY  (spawn_stdout)
   TEST_ENTRY  (spawn_stdin)

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -34,6 +34,7 @@
 # include <wchar.h>
 #else
 # include <unistd.h>
+# include <sys/wait.h>
 #endif
 
 
@@ -178,6 +179,33 @@ TEST_IMPL(spawn_fails) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+#ifndef _WIN32
+TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
+  int r;
+  int status;
+  int err;
+
+  init_process_options("", fail_cb);
+  options.file = options.args[0] = "program-that-had-better-not-exist";
+
+  r = uv_spawn(uv_default_loop(), &process, &options);
+  ASSERT(r == UV_ENOENT || r == UV_EACCES);
+  ASSERT(0 == uv_is_active((uv_handle_t*) &process));
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  /* verify the child is successfully cleaned up within libuv */
+  do
+    err = waitpid(process.pid, &status, 0);
+  while (err == -1 && errno == EINTR);
+  ASSERT(err == -1);
+
+  uv_close((uv_handle_t*) &process, NULL);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+#endif
 
 
 TEST_IMPL(spawn_exit_code) {


### PR DESCRIPTION
If execvp fails, then the child process is not reaped with a waitpid