### PR TITLE
windows: fix handle leak on EMFILE

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -511,6 +511,7 @@ void fs__open(uv_fs_t* req) {
       SET_REQ_WIN32_ERROR(req, GetLastError());
     else
       SET_REQ_WIN32_ERROR(req, UV_UNKNOWN);
+    CloseHandle(file);
     return;
   }
 


### PR DESCRIPTION
If CreateFileW succeeds, but _open_osfhandle fails, the handle must be closed.