### PR TITLE
android: fix compilation warning

### DIFF
--- a/src/unix/android-ifaddrs.c
+++ b/src/unix/android-ifaddrs.c
@@ -24,6 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "android-ifaddrs.h"
+#include "uv-common.h"
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
R=@bnoordhuis

uv__malloc and uv__free are used here.