### PR TITLE
windows: never close stdio handles

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -528,7 +528,7 @@ void fs__close(uv_fs_t* req) {
 
   VERIFY_FD(fd, req);
 
-  result = _close(fd);
+  result = fd <= 2 ? 0 : _close(fd);
   SET_REQ_RESULT(req, result);
 }
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -330,6 +330,7 @@ uint64_t uv__hrtime(double scale);
 int uv_parent_pid();
 __declspec(noreturn) void uv_fatal_error(const int errorno, const char* syscall);
 
+int uv__is_stdio_handle(HANDLE handle);
 
 /*
  * Process stdio handles.

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -738,7 +738,8 @@ void uv_pipe_cleanup(uv_loop_t* loop, uv_pipe_t* handle) {
 
   if ((handle->flags & UV_HANDLE_CONNECTION)
       && handle->handle != INVALID_HANDLE_VALUE) {
-    CloseHandle(handle->handle);
+    if (!uv__is_stdio_handle(handle->handle))
+      CloseHandle(handle->handle);
     handle->handle = INVALID_HANDLE_VALUE;
   }
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1435,6 +1435,9 @@ int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock) {
     return uv_translate_sys_error(err);
   }
 
+  if (uv__is_stdio_handle((HANDLE)sock))
+    handle->flags |= UV_HANDLE_SHARED_TCP_SOCKET;
+
   return 0;
 }
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -1916,7 +1916,8 @@ void uv_process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
 
 
 void uv_tty_close(uv_tty_t* handle) {
-  CloseHandle(handle->handle);
+  if (!uv__is_stdio_handle(handle->handle))
+    CloseHandle(handle->handle);
 
   if (handle->flags & UV_HANDLE_READING)
     uv_tty_read_stop(handle);

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -358,6 +358,13 @@ int uv_parent_pid() {
 }
 
 
+int uv__is_stdio_handle(HANDLE handle) {
+  return handle == GetStdHandle(STD_INPUT_HANDLE) ||
+         handle == GetStdHandle(STD_OUTPUT_HANDLE) ||
+         handle == GetStdHandle(STD_ERROR_HANDLE);
+}
+
+
 char** uv_setup_args(int argc, char** argv) {
   return argv;
 }


### PR DESCRIPTION
See https://github.com/libuv/libuv/issues/277

Commit message:

> Closing a stdio handle makes the entire process unusable, even if the
process isn't using stdio anymore due to causing all kinds of weird
use-after-free inside windows libraries.

> This also makes libuv more consistent across platforms, on unix libuv
doesn't close stdio handles either.

TODO: tests? How to test this (I can only confirm it fixes my io.js issue)? Existing tests pass though :-)

@piscisaureus 
