### PR TITLE
Add documentation for ninja support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Note for UNIX users: compile your project with `-D_LARGEFILE_SOURCE` and
 To use ninja for build on ninja supported platforms, run:
 
     $ ./gyp_uv.py -f ninja
-    $ ninja -C out/Debug  -- for debug build OR
+    $ ninja -C out/Debug     #for debug build OR
     $ ninja -C out/Release
 
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ Run:
 Note for UNIX users: compile your project with `-D_LARGEFILE_SOURCE` and
 `-D_FILE_OFFSET_BITS=64`. GYP builds take care of that automatically.
 
+### Using Ninja
+
+To use ninja for build on ninja supported platforms, run:
+
+    $ ./gyp_uv.py -f ninja
+    $ ninja -C out/Debug  -- for debug build OR
+    $ ninja -C out/Release
+
+
 ### Running tests
 
 Run:


### PR DESCRIPTION
This PR add documentation on how to use ninja for building libuv.

ninja files can be generated by gyp and we don't need any code change.
Please let me know, if this has to be updated in the master also