### PR TITLE
win: make uv_exepath resolve symbolic links

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -106,15 +106,74 @@ int uv_utf8_to_utf16(const char* utf8Buffer, WCHAR* utf16Buffer,
 }
 
 
-int uv_exepath(char* buffer, size_t* size_ptr) {
+/* Gets the offset to the end of a \\?\ or \\?\UNC\ path prefix. */
+static size_t unc_prefix_offset(WCHAR* str)
+{
+  if (str == NULL) {
+    return 0;
+  }
 
+  if (wcsstr(str, L"\\\\?\\UNC\\") != NULL) {
+    return 8; /* length of '\\?\UNC\' */
+  } else if (wcsstr(str, L"\\\\?\\") != NULL) {
+    return 4; /* length of '\\?\' */
+  } else {
+    return 0;
+  }
+}
+
+
+static int exe_get_module_path(WCHAR* buf, size_t* size)
+{
+  size_t outlen = GetModuleFileNameW(NULL, buf, *size);
+
+  if (outlen >= *size) { /* For XP */
+    return UV_EIO;
+  } else if (outlen == 0) {
+    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+      return UV_EIO;
+    } else {
+      return GetLastError();
+    }
+  }
+
+  buf[outlen] = L'\0';
+  *size = outlen;
+  return 0;
+}
+
+
+static int exe_get_resolved_path(HANDLE handle, DWORD flags,
+                                 WCHAR* buf, size_t* size)
+{
+  size_t outlen = GetFinalPathNameByHandleW(handle, buf, *size - 1, flags);
+
+  if (outlen >= *size) {
+    return UV_EIO;
+  } else if (outlen == 0) {
+    return GetLastError();
+  }
+
+  buf[outlen] = L'\0';
+  *size = outlen;
+  return 0;
+}
+
+
+int uv_exepath(char* buffer, size_t* size_ptr) {
   /* According to MSDN the maximum (unicode) length of an NT-style file path */
-  /* is 32767 characters, excluding the null character. Apparently it can be */
-  /* a bit larger due to \\?\, but this probably won't be an issue here. */
-  WCHAR full_path[32768];
-  DWORD result_len;
-  int utf8_len;
-  HANDLE exe_handle;
+  /* is exactly 32767 characters, excluding the null termination character. */
+  WCHAR module_path[32768], resolved_path[32768];
+  size_t module_len = ARRAY_SIZE(module_path);
+  size_t resolved_len = ARRAY_SIZE(resolved_path);
+  HANDLE exe_handle = INVALID_HANDLE_VALUE;
+  WCHAR *final_path;
+  size_t final_len;
+  enum {
+    MODULE_PATH         = 1,
+    RESOLVED_DOS_PATH   = 2,
+    RESOLVED_GUID_PATH  = 3
+  } status = 0;
   int err;
 
   if (buffer == NULL || size_ptr == NULL || *size_ptr == 0) {
@@ -124,32 +183,21 @@ int uv_exepath(char* buffer, size_t* size_ptr) {
   /* We're going to be working on lengths of at most 32768 characters anyway, */
   /* so truncate the input size to that length. Note that since size_t is */
   /* guaranteed to be able to hold values 0 through 65535, this is safe. */
-  if (*size_ptr > ARRAY_SIZE(full_path)) {
-      *size_ptr = ARRAY_SIZE(full_path);
+  if (*size_ptr > 32768) {
+    *size_ptr = 32768;
   }
 
   /* Get the path to the module as UTF-16. Normally this should not fail due */
-  /* to the full_path buffer being too short, so if it actually is, return */
-  /* UV_EIO defensively to indicate an internal error. */
-  result_len = GetModuleFileNameW(NULL, full_path, ARRAY_SIZE(full_path));
-  if (result_len == ARRAY_SIZE(full_path)) {
-    err = UV_EIO;
-    goto error;
-  } else if (result_len == 0) {
-    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-      err = UV_EIO;
-      goto error;
-    } else {
-      err = GetLastError();
-      goto error;
-    }
+  /* to the module_path buffer being too short, but if it does, the helper */
+  /* function will return UV_EIO to signal an internal error. */
+  if ((err = exe_get_module_path(module_path, &module_len)) == 0) {
+    status = MODULE_PATH;
+  } else {
+    goto final;
   }
 
-  /* The path should be null-terminated on success, but take no chances. */
-  full_path[result_len] = L'\0';
-
   /* Open the executable at that path in read mode to fully resolve it. */
-  exe_handle = CreateFileW(full_path,
+  exe_handle = CreateFileW(module_path,
                            FILE_READ_ATTRIBUTES,
                            FILE_SHARE_READ |
                            FILE_SHARE_WRITE |
@@ -158,53 +206,77 @@ int uv_exepath(char* buffer, size_t* size_ptr) {
                            OPEN_EXISTING,
                            FILE_ATTRIBUTE_NORMAL,
                            NULL);
+
   if (exe_handle == INVALID_HANDLE_VALUE) {
-    err = GetLastError();
-    goto error;
+    goto final;
   }
 
-  /* Resolve the path to a full path (dereferencing any symlinks). The second */
-  /* parameter takes the size of the destination buffer not including the null */
-  /* termination character. Again, this shouldn't fail due to full_path being */
-  /* too short, but check it anyway just in case. */
-  result_len = GetFinalPathNameByHandleW(exe_handle, full_path,
-                                        ARRAY_SIZE(full_path) - 1,
-                                        VOLUME_NAME_DOS);
-  CloseHandle(exe_handle); /* We're done with the handle at this point */
-  if (result_len >= ARRAY_SIZE(full_path)) {
-    err = UV_EIO;
-    goto error;
-  } else if (result_len == 0) {
-    err = GetLastError();
-    goto error;
+  /* Resolve the path to a full path (dereferencing any symlinks). First try */
+  /* to get a DOS path. If that fails with ERROR_PATH_NOT_FOUND, try again */
+  /* but with a GUID path. If that also fails, we have to give up. */
+  if ((err = exe_get_resolved_path(exe_handle, VOLUME_NAME_DOS,
+                                   resolved_path, &resolved_len)) == 0) {
+    status = RESOLVED_DOS_PATH;
+  } else {
+    if (err == ERROR_PATH_NOT_FOUND) { /* Maybe we just need a GUID path */
+      if ((err = exe_get_resolved_path(exe_handle, VOLUME_NAME_GUID,
+                                       resolved_path, &resolved_len)) == 0) {
+        status = RESOLVED_GUID_PATH;
+      }
+    }
   }
 
-  /* On success again append the null-termination character, and also truncate */
-  /* the full_path to the number of characters available in the (UTF-8) input */
-  /* buffer, i.e. put a \0 at either result_len or *size_ptr - 1, whichever */
-  /* comes first. This way len(full_path) <= capacity(buffer) always. */
-  full_path[*size_ptr - 1 < result_len ? *size_ptr - 1 : result_len] = L'\0';
-
-  /* Convert to UTF-8 */
-  utf8_len = WideCharToMultiByte(CP_UTF8,
-                                 0,
-                                 full_path,
-                                 -1,
-                                 buffer,
-                                 (int)*size_ptr,
-                                 NULL,
-                                 NULL);
-  if (utf8_len == 0) {
-    err = GetLastError();
-    goto error;
+final:
+  if (exe_handle != INVALID_HANDLE_VALUE) {
+    CloseHandle(exe_handle);
   }
 
-  /* utf8_len *does* include the terminating null at this point, but the */
-  /* returned size shouldn't. */
-  *size_ptr = utf8_len - 1;
-  return 0;
+  /* Depending on what type of path we managed to retrieve, determine what */
+  /* we should return to the user here (also strip off \\?\ if needed). */
+  switch (status) {
+    size_t unc_offset;
+    case RESOLVED_GUID_PATH:
+      final_path = resolved_path;
+      final_len = resolved_len;
+      break;
+    case RESOLVED_DOS_PATH:
+      unc_offset = unc_prefix_offset(resolved_path);
+      final_path = resolved_path + unc_offset;
+      final_len = resolved_len - unc_offset;
+      break;
+    case MODULE_PATH:
+      unc_offset = unc_prefix_offset(module_path);
+      final_path = module_path + unc_offset;
+      final_len = module_len - unc_offset;
+      break;
+    default:
+      final_path = NULL;
+      final_len = 0;
+  }
 
- error:
+  if (final_path != NULL) {
+    int utf8_len;
+  
+    /* Need to make sure the final path fits in the output buffer. */
+    if (*size_ptr - 1 < final_len) {
+      final_path[*size_ptr - 1] = L'\0';
+    }
+    
+    /* Convert to UTF-8 */
+    utf8_len = WideCharToMultiByte(CP_UTF8, 0,
+                                   final_path, -1,
+                                   buffer, (int)*size_ptr,
+                                   NULL, NULL);
+
+    /* utf8_len *does* include the terminating null at this point, but the */
+    /* returned size shouldn't. */
+    if (utf8_len != 0) {
+      *size_ptr = (size_t)(utf8_len - 1);
+    } else {
+      err = GetLastError();
+    }
+  }
+
   return uv_translate_sys_error(err);
 }
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -150,8 +150,10 @@ int uv_exepath(char* buffer, size_t* size_ptr) {
 
   /* Open the executable at that path in read mode to fully resolve it. */
   exe_handle = CreateFileW(full_path,
-                           GENERIC_READ,
-                           FILE_SHARE_READ,
+                           FILE_READ_ATTRIBUTES,
+                           FILE_SHARE_READ |
+                           FILE_SHARE_WRITE |
+                           FILE_SHARE_DELETE,
                            NULL,
                            OPEN_EXISTING,
                            FILE_ATTRIBUTE_NORMAL,


### PR DESCRIPTION
This is a draft of a possible fix to #206. It uses `GetModuleFileNameW` as before to get some kind of path to the executable, and then gets a handle to the file and resolves the full path (without any symlinks) using `GetFinalPathNameByHandleW`. It's not finished, of course, I have a few questions. With this commit the function will read through symbolic links and return resolved paths like:

    \\?\C:\libuv\Debug\run-tests.exe

Which are completely valid (and fully resolved) Windows paths, but the `VOLUME_NAME_DOS` flag used means that the file actually needs to be on a mounted drive with an assigned drive letter or the function will fail with `ERROR_PATH_NOT_FOUND`, [as MSDN states](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364962.aspx). The file could be on a mounted drive with no drive letter assigned, and in this case I assume it could be addressed via its GUID (via `VOLUME_NAME_GUID`) as a long UNC path. But is this realistic?

Basically should the function return "usual" paths like `C:\path\to\executable.exe` or should it return full-blown UNC paths (which, by the way, apparently can be slightly longer than 32768 characters)? Or whichever is shorter? Does anyone have an opinion on this?

I mean, logically the function should never fail (besides out of resource errors) since the executable always exists somewhere, but this could be a faulty assumption?

EDIT: actually I noticed that the exepath test expects the passed buffer to be filled and truncated if it is too short, so since `uv_exepath` is a two-step process now it might be necessary to allocate 32KB of memory upfront to reliably get the initial path and then have the `GetFinalPathNameByHandleW` function handle the truncation for us, assuming it does (since the expanded full path may be longer than the symlink). I'll need to look into that.