### PR TITLE
unix: fix uv_interface_addresses() potential hazard

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1115,14 +1115,14 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   }
 
   if (ioctl(sockfd, SIOCGSIZIFCONF, &size) == -1) {
-    uv__close(sockfd);
-    return -ENOSYS;
+    SAVE_ERRNO(uv__close(sockfd));
+    return -errno;
   }
 
   ifc.ifc_req = (struct ifreq*)uv__malloc(size);
   ifc.ifc_len = size;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
-    uv__close(sockfd);
+    SAVE_ERRNO(uv__close(sockfd));
     return -errno;
   }
 
@@ -1141,7 +1141,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
-      uv__close(sockfd);
+      SAVE_ERRNO(uv__close(sockfd));
       return -errno;
     }
 

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1111,7 +1111,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   *count = 0;
 
   if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP))) {
-    return -ENOSYS;
+    return -errno;
   }
 
   if (ioctl(sockfd, SIOCGSIZIFCONF, &size) == -1) {
@@ -1123,7 +1123,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   ifc.ifc_len = size;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     uv__close(sockfd);
-    return -ENOSYS;
+    return -errno;
   }
 
 #define ADDR_SIZE(p) MAX((p).sa_len, sizeof(p))
@@ -1142,7 +1142,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return -ENOSYS;
+      return -errno;
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))


### PR DESCRIPTION
uv_interface_addresses fails. return value policy unmatch with other OS

socet() or ioctl()  failed before uv__malloc()  called . uv_interface_addresses() return "-ENOSYS" and "addresses pointer" is Indefinite.
```
  if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP))) {
    return -ENOSYS;
  }

  if (ioctl(sockfd, SIOCGSIZIFCONF, &size) == -1) {
    uv__close(sockfd);
    return -ENOSYS;
  }
....
```

ioctl() function failed after uv__malloc()  called . uv_interface_addresses() return "-ENOSYS" and "addresses pointer" is allocated address.
https://github.com/joyent/libuv/blob/v1.x/src/unix/aix.c#L1176

user application is not possible to determine whether to call  uv_free_interface_addresses().
