### PR TITLE
uv_buf_t: Document member fields.

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -15,6 +15,17 @@ Data types
 
     Buffer data type.
 
+    .. c:member:: char* uv_buf_t.base
+
+        Pointer to the base of the buffer. Readonly.
+
+    .. c:member:: size_t uv_buf_t.len
+
+        Total bytes in the buffer. Readonly.
+
+        .. note::
+            On Windows this field is ULONG.
+
 .. c:type:: uv_malloc_func
 
     Function pointer type for the malloc override used by


### PR DESCRIPTION
It is sometimes useful to read the base pointer or length stored in a uv_buf_t.  This change documents those fields.

This is a followup to issue #305.  I'm unsure if it's important to document the difference with Windows since it seems to have no effect on source compatibility.