### PR TITLE
win: fix uv_fs_access on directories

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1310,14 +1310,21 @@ static void fs__access(uv_fs_t* req) {
     return;
   }
 
-  if ((req->flags & W_OK) &&
-      ((attr & FILE_ATTRIBUTE_READONLY) ||
-      (attr & FILE_ATTRIBUTE_DIRECTORY))) {
+  /*
+   * Access is possible if
+   * - write access wasn't requested,
+   * - or the file isn't read-only,
+   * - or it's a directory.
+   * (Directories cannot be read-only on Windows.)
+   */
+  if (!(req->flags & W_OK) ||
+      !(attr & FILE_ATTRIBUTE_READONLY) ||
+      (attr & FILE_ATTRIBUTE_DIRECTORY)) {
+    SET_REQ_RESULT(req, 0);
+  } else {
     SET_REQ_WIN32_ERROR(req, UV_EPERM);
-    return;
   }
 
-  SET_REQ_RESULT(req, 0);
 }
 
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1156,6 +1156,7 @@ TEST_IMPL(fs_access) {
 
   /* Setup. */
   unlink("test_file");
+  rmdir("test_dir");
 
   loop = uv_default_loop();
 
@@ -1199,6 +1200,16 @@ TEST_IMPL(fs_access) {
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
+  /* Directory access */
+  r = uv_fs_mkdir(loop, &req, "test_dir", 0777, NULL);
+  ASSERT(r == 0);
+  uv_fs_req_cleanup(&req);
+
+  r = uv_fs_access(loop, &req, "test_dir", W_OK, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
+
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
    * calls. This should drop out immediately.
@@ -1207,6 +1218,7 @@ TEST_IMPL(fs_access) {
 
   /* Cleanup. */
   unlink("test_file");
+  rmdir("test_dir");
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
For posterity, these are the rules for access on Windows (taken from
CPython's implementation), Access is possible if:

* Write access wasn't requested
* The file isn't read-only
* It's a directory (directories cannot be read-only on Windows)

R=@piscisaureus
/cc @cjihrig

Should fix: https://github.com/iojs/io.js/issues/1397