### PR TITLE
Introduce uv_threadpool_t

### DIFF
--- a/include/uv-threadpool.h
+++ b/include/uv-threadpool.h
@@ -31,6 +31,7 @@ struct uv__work {
   void (*work)(struct uv__work *w);
   void (*done)(struct uv__work *w, int status);
   struct uv_loop_s* loop;
+  struct uv_threadpool_s* threadpool;
   void* wq[2];
 };
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -213,6 +213,7 @@ typedef struct uv_process_s uv_process_t;
 typedef struct uv_fs_event_s uv_fs_event_t;
 typedef struct uv_fs_poll_s uv_fs_poll_t;
 typedef struct uv_signal_s uv_signal_t;
+typedef struct uv_threadpool_s uv_threadpool_t;
 
 /* Request types. */
 typedef struct uv_req_s uv_req_t;
@@ -951,6 +952,12 @@ struct uv_work_s {
   uv_after_work_cb after_work_cb;
   UV_WORK_PRIVATE_FIELDS
 };
+
+UV_EXTERN int uv_queue_tp_work(uv_loop_t* loop,
+                            uv_threadpool_t *tp,
+                            uv_work_t* req,
+                            uv_work_cb work_cb,
+                            uv_after_work_cb after_work_cb);
 
 UV_EXTERN int uv_queue_work(uv_loop_t* loop,
                             uv_work_t* req,

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -110,6 +110,12 @@ void uv__fs_poll_close(uv_fs_poll_t* handle);
 
 int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
+void uv__work_tp_submit(uv_loop_t* loop,
+                     uv_threadpool_t *pool,
+                     struct uv__work *w,
+                     void (*work)(struct uv__work *w),
+                     void (*done)(struct uv__work *w, int status));
+
 void uv__work_submit(uv_loop_t* loop,
                      struct uv__work *w,
                      void (*work)(struct uv__work *w),


### PR DESCRIPTION
This is a very quick'n'dirty
attempt to introduce more
explicit threadpools, as discussed
in https://github.com/libuv/leps/pull/4
and https://github.com/libuv/libuv/issues/267

If more customization of the threadpool
is required (struct uv_threadpool_s)
can be expanded to include pointers
to functions doing the real work.

Names are ugly right now; C99 struct initialization
required.