### PR TITLE
unix: only accept Unix socket fds in uv_pipe_open

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -125,7 +125,12 @@ void uv__pipe_close(uv_pipe_t* handle) {
 
 
 int uv_pipe_open(uv_pipe_t* handle, uv_file fd) {
+  uv_handle_type type;
   int err;
+
+  type = uv_guess_handle(fd);
+  if (type != UV_NAMED_PIPE)
+    return -EINVAL;
 
   err = uv__nonblock(fd, 1);
   if (err)


### PR DESCRIPTION
R=@bnoordhuis

I was motivated to do this because some pyuv use created a Pipe handle with the stdin fileno and if input was redirected from a file, libuv aborts, which is not very nice.

If this sounds ok I'll do the same for uv_tcp_open and uv_udp_open. Now, the problem here is that if we are too strict we could break some people's code, I'm not 100% sure though.

Thoughts?