### PR TITLE
Fix old issue 1382 Test runner won't run with a shared libuv

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -179,10 +179,15 @@ enum test_status {
 
 #include <stdarg.h>
 
+/* Define inline for MSVC */
+# ifdef _MSC_VER
+#  define inline __inline
+# endif
+
 /* Emulate snprintf() on Windows, _snprintf() doesn't zero-terminate the buffer
  * on overflow...
  */
-static int snprintf(char* buf, size_t len, const char* fmt, ...) {
+inline int snprintf(char* buf, size_t len, const char* fmt, ...) {
   va_list ap;
   int n;
 

--- a/uv.gyp
+++ b/uv.gyp
@@ -167,11 +167,10 @@
               'cflags': [ '-fPIC' ],
             }],
             ['uv_library=="shared_library" and OS!="mac"', {
-              'link_settings': {
-                # Must correspond with UV_VERSION_MAJOR and UV_VERSION_MINOR
-                # in include/uv-version.h
-                'libraries': [ '-Wl,-soname,libuv.so.1.0' ],
-              },
+              # This will cause gyp to set soname
+              # Must correspond with UV_VERSION_MAJOR
+              # in include/uv-version.h
+              'product_extension': 'so.1',
             }],
           ],
         }],


### PR DESCRIPTION
Cheers

Three commits for joyent/libuv#1382
1. In Unix the SONAME setting was broken and the run-tests linking arguments were preventing us from running run-tests against a shared library
2. Disable run-tests when building a shared library in windows
3. Fix snprintf declaration

**EDIT:** added snprintf fix, rebased and changed description
