### PR TITLE
core: refactor uv_replace_allocator

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -26,15 +26,23 @@ Data types
         .. note::
             On Windows this field is ULONG.
 
-.. c:type:: uv_malloc_func
+.. c:type:: uv_allocator_t
 
-    Function pointer type for the malloc override used by
-    :c:func:`uv_replace_allocator`.
+    Struct type containing the replacement allocator functions.
+    Used as the argument to :c:func:`uv_replace_allocator`
+    when overriding system default allocator.
 
-.. c:type:: uv_free_func
+    .. c:member:: void* (*local_malloc)(size_t size)
 
-    Function pointer type for the free override used by
-    :c:func:`uv_replace_allocator`.
+        Replacement function for :man:`malloc(3)`.
+
+    .. c:member:: void* (*local_realloc)(void* ptr, size_t size)
+
+        Replacement function for :man:`realloc(3)`.
+
+    .. c:member void (*local_free)(void* ptr)
+
+        Replacement function for :man:`free(3)`.
 
 .. c:type:: uv_file
 
@@ -136,15 +144,16 @@ API
     Returns the libuv version number as a string. For non-release versions
     "-pre" is appended, so the version number could be "1.2.3-pre".
 
-.. c:function:: int uv_replace_allocator(uv_malloc_func malloc_func, uv_free_func free_func)
+.. c:function:: int uv_replace_allocator(const uv_allocator_t* allocator)
 
     .. versionadded:: 1.5.0
 
-    Override the use of the standard library's malloc and free functions for
-    memory allocation. If used, this function must be called before any
-    other libuv function is called. On success, it returns 0. If called more
-    than once, the replacement request is ignored and the function returns
-    ``UV_EINVAL``.
+    Override the use of the standard library's :man:`malloc(3)`,
+    :man:`calloc(3)`, :man:`realloc(3)`, :man:`free(3)`,
+    :man:`strdup(3)`, and :man:`strndup(3)` memory allocation functions.
+    This function must be called before any other libuv function is called.
+    On success, it returns 0. If called more than once or if called after
+    :c:func:`uv_loop_init`, if fails with ``UV_EINVAL``.
 
 .. c:function:: uv_buf_t uv_buf_init(char* base, unsigned int len)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -244,11 +244,13 @@ typedef enum {
 UV_EXTERN unsigned int uv_version(void);
 UV_EXTERN const char* uv_version_string(void);
 
-typedef void* (*uv_malloc_func)(size_t size);
-typedef void (*uv_free_func)(void* ptr);
+typedef struct {
+  void* (*local_malloc)(size_t size);
+  void* (*local_realloc)(void* ptr, size_t size);
+  void (*local_free)(void* ptr);
+} uv_allocator_t;
 
-UV_EXTERN int uv_replace_allocator(uv_malloc_func malloc_func,
-                                   uv_free_func free_func);
+UV_EXTERN int uv_replace_allocator(const uv_allocator_t* allocator);
 
 UV_EXTERN uv_loop_t* uv_default_loop(void);
 UV_EXTERN int uv_loop_init(uv_loop_t* loop);

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -67,7 +67,7 @@ int uv_fs_poll_start(uv_fs_poll_t* handle,
 
   loop = handle->loop;
   len = strlen(path);
-  ctx = calloc(1, sizeof(*ctx) + len);
+  ctx = uv__calloc(1, sizeof(*ctx) + len);
 
   if (ctx == NULL)
     return UV_ENOMEM;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -781,7 +781,7 @@ static int uv__parse_data(char *buf, int *events, uv_fs_event_t* handle) {
 
         /* Scan out the name of the file that triggered the event*/
         if (sscanf(p, "BEGIN_EVPROD_INFO\n%sEND_EVPROD_INFO", filename) == 1) {
-          handle->dir_filename = strdup((const char*)&filename);
+          handle->dir_filename = uv__strdup((const char*)&filename);
         } else
           return -1;
         }
@@ -931,7 +931,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   /* Setup/Initialize all the libuv routines */
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__ahafs_event, fd);
-  handle->path = strdup((const char*)&absolute_path);
+  handle->path = uv__strdup((const char*)&absolute_path);
   handle->cb = cb;
 
   uv__io_start(handle->loop, &handle->event_watcher, UV__POLLIN);
@@ -1075,7 +1075,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   cpu_info = *cpu_infos;
   while (idx < ncpus) {
     cpu_info->speed = (int)(ps_total.processorHZ / 1000000);
-    cpu_info->model = strdup(ps_total.description);
+    cpu_info->model = uv__strdup(ps_total.description);
     cpu_info->cpu_times.user = ps_cpus[idx].user;
     cpu_info->cpu_times.sys = ps_cpus[idx].sys;
     cpu_info->cpu_times.idle = ps_cpus[idx].idle;
@@ -1181,7 +1181,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
     /* All conditions above must match count loop */
 
-    address->name = strdup(p->ifr_name);
+    address->name = uv__strdup(p->ifr_name);
 
     if (p->ifr_addr.sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) &p->ifr_addr);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -745,8 +745,8 @@ static void maybe_resize(uv_loop_t* loop, unsigned int len) {
   }
 
   nwatchers = next_power_of_two(len + 2) - 2;
-  watchers = realloc(loop->watchers,
-                     (nwatchers + 2) * sizeof(loop->watchers[0]));
+  watchers = uv__realloc(loop->watchers,
+                         (nwatchers + 2) * sizeof(loop->watchers[0]));
 
   if (watchers == NULL)
     abort();

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -213,7 +213,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->cpu_times.idle = (uint64_t)(info[i].cpu_ticks[2]) * multiplier;
     cpu_info->cpu_times.irq = 0;
 
-    cpu_info->model = strdup(model);
+    cpu_info->model = uv__strdup(model);
     cpu_info->speed = cpuspeed/1000000;
   }
   vm_deallocate(mach_task_self(), (vm_address_t)info, msg_type);
@@ -275,7 +275,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (ent->ifa_addr->sa_family == AF_LINK)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/unix/dl.c
+++ b/src/unix/dl.c
@@ -73,7 +73,7 @@ static int uv__dlerror(uv_lib_t* lib) {
   errmsg = dlerror();
 
   if (errmsg) {
-    lib->errmsg = strdup(errmsg);
+    lib->errmsg = uv__strdup(errmsg);
     return -1;
   }
   else {

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -151,7 +151,7 @@ void uv_loadavg(double avg[3]) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  process_title = argc ? strdup(argv[0]) : NULL;
+  process_title = argc ? uv__strdup(argv[0]) : NULL;
   return argv;
 }
 
@@ -160,7 +160,7 @@ int uv_set_process_title(const char* title) {
   int oid[4];
 
   if (process_title) uv__free(process_title);
-  process_title = strdup(title);
+  process_title = uv__strdup(title);
 
   oid[0] = CTL_KERN;
   oid[1] = KERN_PROC;
@@ -315,7 +315,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->cpu_times.idle = (uint64_t)(cp_times[CP_IDLE+cur]) * multiplier;
     cpu_info->cpu_times.irq = (uint64_t)(cp_times[CP_INTR+cur]) * multiplier;
 
-    cpu_info->model = strdup(model);
+    cpu_info->model = uv__strdup(model);
     cpu_info->speed = cpuspeed;
 
     cur+=CPUSTATES;
@@ -379,7 +379,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (ent->ifa_addr->sa_family == AF_LINK)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -73,7 +73,7 @@
 
 #define PATH                                                                  \
   do {                                                                        \
-    (req)->path = strdup(path);                                               \
+    (req)->path = uv__strdup(path);                                           \
     if ((req)->path == NULL)                                                  \
       return -ENOMEM;                                                         \
   }                                                                           \
@@ -1003,7 +1003,7 @@ int uv_fs_mkdtemp(uv_loop_t* loop,
                   const char* tpl,
                   uv_fs_cb cb) {
   INIT(MKDTEMP);
-  req->path = strdup(tpl);
+  req->path = uv__strdup(tpl);
   if (req->path == NULL)
     return -ENOMEM;
   POST;

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -584,7 +584,7 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   if (err)
     return err;
 
-  state = calloc(1, sizeof(*state));
+  state = uv__calloc(1, sizeof(*state));
   if (state == NULL)
     return -ENOMEM;
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -363,7 +363,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);
-  handle->path = strdup(path);
+  handle->path = uv__strdup(path);
   handle->cb = cb;
 
 #if defined(__APPLE__)

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -523,7 +523,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   assert(numcpus != (unsigned int) -1);
   assert(numcpus != 0);
 
-  ci = calloc(numcpus, sizeof(*ci));
+  ci = uv__calloc(numcpus, sizeof(*ci));
   if (ci == NULL)
     return -ENOMEM;
 
@@ -595,7 +595,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
     if (model_idx < numcpus) {
       if (strncmp(buf, model_marker, sizeof(model_marker) - 1) == 0) {
         model = buf + sizeof(model_marker) - 1;
-        model = strndup(model, strlen(model) - 1);  /* Strip newline. */
+        model = uv__strndup(model, strlen(model) - 1);  /* Strip newline. */
         if (model == NULL) {
           fclose(fp);
           return -ENOMEM;
@@ -614,7 +614,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
 #endif
       if (strncmp(buf, model_marker, sizeof(model_marker) - 1) == 0) {
         model = buf + sizeof(model_marker) - 1;
-        model = strndup(model, strlen(model) - 1);  /* Strip newline. */
+        model = uv__strndup(model, strlen(model) - 1);  /* Strip newline. */
         if (model == NULL) {
           fclose(fp);
           return -ENOMEM;
@@ -645,7 +645,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
     inferred_model = ci[model_idx - 1].model;
 
   while (model_idx < numcpus) {
-    model = strndup(inferred_model, strlen(inferred_model));
+    model = uv__strndup(inferred_model, strlen(inferred_model));
     if (model == NULL)
       return -ENOMEM;
     ci[model_idx++].model = model;
@@ -812,7 +812,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     if (ent->ifa_addr->sa_family == PF_PACKET)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -27,10 +27,20 @@
 #include <string.h>
 #include <unistd.h>
 
+static uv_allocator_t uv__default_allocator = {
+  malloc,
+  realloc,
+  free,
+};
+
+
 int uv_loop_init(uv_loop_t* loop) {
   int err;
 
   uv__signal_global_once_init();
+
+  /* Mark allocator functions as configured to prevent further remapping. */
+  uv_replace_allocator(&uv__default_allocator);
 
   memset(loop, 0, sizeof(*loop));
   heap_init((struct heap*) &loop->timer_heap);

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -131,7 +131,7 @@ uint64_t uv_get_total_memory(void) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  process_title = argc ? strdup(argv[0]) : NULL;
+  process_title = argc ? uv__strdup(argv[0]) : NULL;
   return argv;
 }
 
@@ -139,7 +139,7 @@ char** uv_setup_args(int argc, char** argv) {
 int uv_set_process_title(const char* title) {
   if (process_title) uv__free(process_title);
 
-  process_title = strdup(title);
+  process_title = uv__strdup(title);
   setproctitle("%s", title);
 
   return 0;
@@ -255,7 +255,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->cpu_times.sys = (uint64_t)(cp_times[CP_SYS+cur]) * multiplier;
     cpu_info->cpu_times.idle = (uint64_t)(cp_times[CP_IDLE+cur]) * multiplier;
     cpu_info->cpu_times.irq = (uint64_t)(cp_times[CP_INTR+cur]) * multiplier;
-    cpu_info->model = strdup(model);
+    cpu_info->model = uv__strdup(model);
     cpu_info->speed = (int)(cpuspeed/(uint64_t) 1e6);
     cur += CPUSTATES;
   }
@@ -313,7 +313,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (ent->ifa_addr->sa_family != PF_INET)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -91,7 +91,7 @@ int uv_exepath(char* buffer, size_t* size) {
   mypid = getpid();
   for (;;) {
     err = -ENOMEM;
-    argsbuf_tmp = realloc(argsbuf, argsbuf_size);
+    argsbuf_tmp = uv__realloc(argsbuf, argsbuf_size);
     if (argsbuf_tmp == NULL)
       goto out;
     argsbuf = argsbuf_tmp;
@@ -155,14 +155,14 @@ uint64_t uv_get_total_memory(void) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  process_title = argc ? strdup(argv[0]) : NULL;
+  process_title = argc ? uv__strdup(argv[0]) : NULL;
   return argv;
 }
 
 
 int uv_set_process_title(const char* title) {
   if (process_title) uv__free(process_title);
-  process_title = strdup(title);
+  process_title = uv__strdup(title);
   setproctitle(title);
   return 0;
 }
@@ -270,7 +270,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->cpu_times.idle = (uint64_t)(info[CP_IDLE]) * multiplier;
     cpu_info->cpu_times.irq = (uint64_t)(info[CP_INTR]) * multiplier;
 
-    cpu_info->model = strdup(model);
+    cpu_info->model = uv__strdup(model);
     cpu_info->speed = cpuspeed;
   }
 
@@ -328,7 +328,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     if (ent->ifa_addr->sa_family != PF_INET)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -54,7 +54,7 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
     return -EINVAL;
 
   /* Make a copy of the file name, it outlives this function's scope. */
-  pipe_fname = strdup(name);
+  pipe_fname = uv__strdup(name);
   if (pipe_fname == NULL)
     return -ENOMEM;
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -990,9 +990,9 @@ static int uv__stream_queue_fd(uv_stream_t* stream, int fd) {
     /* Grow */
   } else if (queued_fds->size == queued_fds->offset) {
     queue_size = queued_fds->size + 8;
-    queued_fds = realloc(queued_fds,
-                         (queue_size - 1) * sizeof(*queued_fds->fds) +
-                             sizeof(*queued_fds));
+    queued_fds = uv__realloc(queued_fds,
+                             (queue_size - 1) * sizeof(*queued_fds->fds) +
+                              sizeof(*queued_fds));
 
     /*
      * Allocation failure, report back.

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -433,7 +433,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   }
 
   uv__handle_start(handle);
-  handle->path = strdup(path);
+  handle->path = uv__strdup(path);
   handle->fd = PORT_UNUSED;
   handle->cb = cb;
 
@@ -605,7 +605,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
       knp = kstat_data_lookup(ksp, (char*) "brand");
       assert(knp->data_type == KSTAT_DATA_STRING);
-      cpu_info->model = strdup(KSTAT_NAMED_STR_PTR(knp));
+      cpu_info->model = uv__strdup(KSTAT_NAMED_STR_PTR(knp));
     }
 
     lookup_instance++;
@@ -705,7 +705,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (ent->ifa_addr == NULL)
       continue;
 
-    address->name = strdup(ent->ifa_name);
+    address->name = uv__strdup(ent->ifa_name);
 
     if (ent->ifa_addr->sa_family == AF_INET6) {
       address->address.address6 = *((struct sockaddr_in6*) ent->ifa_addr);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -33,33 +33,62 @@
 # include <net/if.h> /* if_nametoindex */
 #endif
 
-static uv_malloc_func replaced_malloc;
-static uv_free_func replaced_free;
 
+static uv_allocator_t uv__allocator = {
+  malloc,
+  realloc,
+  free,
+};
+
+void* uv__calloc(size_t count, size_t size) {
+  /* Note: the multiplcation is not safe if
+   * the result overflows a 'size_t' */
+  size_t total = count * size;
+  void* m = uv__malloc(total);
+  if (m == NULL)
+      return NULL;
+  return memset(m, 0, total);
+}
+
+char* uv__strdup(const char *s) {
+  size_t len = strlen(s) + 1;
+  char* m = uv__malloc(len);
+  if (m == NULL)
+      return NULL;
+  return memcpy(m, s, len);
+}
+
+char* uv__strndup(const char *s, size_t n) {
+  size_t len = strnlen(s, n);
+  char* m = uv__malloc(len + 1);
+  if (m == NULL)
+      return NULL;
+  m[len] = '\0';
+  return memcpy(m, s, len);
+}
 
 void* uv__malloc(size_t size) {
-  if (replaced_malloc)
-    return (*replaced_malloc)(size);
-  return malloc(size);
+  return uv__allocator.local_malloc(size);
 }
-
 
 void uv__free(void* ptr) {
-  if (replaced_free)
-    (*replaced_free)(ptr);
-  else
-    free(ptr);
+  uv__allocator.local_free(ptr);
 }
 
+void* uv__realloc(void* ptr, size_t size) {
+  return uv__allocator.local_realloc(ptr, size);
+}
 
-int uv_replace_allocator(uv_malloc_func malloc_func, uv_free_func free_func) {
-  if (replaced_malloc || replaced_free)
+int uv_replace_allocator(const uv_allocator_t *allocator) {
+  static int allocator_assigned = 0;
+
+  if (allocator_assigned)
     return UV_EINVAL;
-  replaced_malloc = malloc_func;
-  replaced_free = free_func;
+
+  uv__allocator = *allocator;
+  allocator_assigned = 1;
   return 0;
 }
-
 
 #define XX(uc, lc) case UV_##uc: return sizeof(uv_##lc##_t);
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -63,10 +63,6 @@ enum {
 # define UV__HANDLE_CLOSING   0x01
 #endif
 
-void* uv__malloc(size_t size);
-
-void uv__free(void* ptr);
-
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
 
 void uv__loop_close(uv_loop_t* loop);
@@ -214,5 +210,14 @@ void uv__fs_scandir_cleanup(uv_fs_t* req);
     uv__handle_platform_init(h);                                              \
   }                                                                           \
   while (0)
+
+
+/* Allocator prototypes */
+void *uv__calloc(size_t count, size_t size);
+char *uv__strdup(const char *s);
+char *uv__strndup(const char *s, size_t n);
+void* uv__malloc(size_t size);
+void uv__free(void* ptr);
+void* uv__realloc(void* ptr, size_t size);
 
 #endif /* UV_COMMON_H_ */

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -41,6 +41,12 @@ static uv_loop_t* default_loop_ptr;
 /* uv_once initialization guards */
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 
+static uv_allocator_t uv__default_allocator = {
+  malloc,
+  realloc,
+  free,
+};
+
 
 #if defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
 /* Our crt debug report handler allows us to temporarily disable asserts
@@ -85,6 +91,9 @@ static void uv_init(void) {
   /* Tell Windows that we will handle critical errors. */
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
                SEM_NOOPENFILEERRORBOX);
+
+  /* Mark allocator functions as configured to prevent further remapping. */
+  uv_replace_allocator(&uv__default_allocator);
 
   /* Tell the CRT to not exit the application when an invalid parameter is
    * passed. The main issue is that invalid FDs will trigger this behavior.

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -137,7 +137,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
     return UV_EINVAL;
 
   handle->cb = cb;
-  handle->path = strdup(path);
+  handle->path = uv__strdup(path);
   if (!handle->path) {
     uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
   }

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -878,7 +878,7 @@ void fs__scandir(uv_fs_t* req) {
         size_t new_dirents_size =
             dirents_size == 0 ? dirents_initial_size : dirents_size << 1;
         uv__dirent_t** new_dirents =
-            realloc(dirents, new_dirents_size * sizeof *dirents);
+            uv__realloc(dirents, new_dirents_size * sizeof *dirents);
 
         if (new_dirents == NULL)
           goto out_of_memory_error;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -401,7 +401,7 @@ int uv_set_process_title(const char* title) {
 
   EnterCriticalSection(&process_title_lock);
   uv__free(process_title);
-  process_title = strdup(title);
+  process_title = uv__strdup(title);
   LeaveCriticalSection(&process_title_lock);
 
   err = 0;
@@ -625,7 +625,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   GetSystemInfo(&system_info);
   cpu_count = system_info.dwNumberOfProcessors;
 
-  cpu_infos = calloc(cpu_count, sizeof *cpu_infos);
+  cpu_infos = uv__calloc(cpu_count, sizeof *cpu_infos);
   if (cpu_infos == NULL) {
     err = ERROR_OUTOFMEMORY;
     goto error;


### PR DESCRIPTION
Previously, `uv_replace_allocator` was added to replace
malloc(3) and free(3), but we must replace _all_ allocator
functions or else we will crash in spectacular ways.

For a complete allocator replacement, we must redefine:
  - malloc
  - calloc
  - realloc
  - free
  - strdup
  - strndup

Now `uv_replace_allocator` takes a struct `uv_allocator_t` with
three function pointers to malloc, realloc, and free.  The remaining
functions of calloc, strdup, and strndup are implemented
on top of our (optionally) user-provided malloc, realloc, and free functions.

Also, we call `uv_replace_allocator` the first time libuv is initialized
(windows) or every time a loop is created (unix) to make
sure we are locked into our current allocator configuration.  Users
must only call `uv_replace_allocator` *before* they create their
first event loop.

Adapted by @saghul.