### PR TITLE
doc: fix uv_run(UV_RUN_DEFAULT) description

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -92,7 +92,9 @@ API
     specified mode:
 
     - UV_RUN_DEFAULT: Runs the event loop until there are no more active and
-      referenced handles or requests. Always returns zero.
+      referenced handles or requests. Returns non-zero if :c:func:`uv_stop`
+      was called and there are still active handles or requests.  Returns
+      zero in all other cases.
     - UV_RUN_ONCE: Poll for i/o once. Note that this function blocks if
       there are no pending callbacks. Returns zero when done (no active handles
       or requests left), or non-zero if more callbacks are expected (meaning


### PR DESCRIPTION
Saying uv_run() always returns zero is incorrect in the presence of
calls to uv_stop().

R=@saghul?