### PR TITLE
windows: Enable building with MSVC 2015

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -184,7 +184,8 @@ enum test_status {
 #  define inline __inline
 # endif
 
-/* Emulate snprintf() on Windows, _snprintf() doesn't zero-terminate the buffer
+# if defined(_MSC_VER) && _MSC_VER < 1900
+/* Emulate snprintf() on MSVC<2015, _snprintf() doesn't zero-terminate the buffer
  * on overflow...
  */
 inline int snprintf(char* buf, size_t len, const char* fmt, ...) {
@@ -205,6 +206,7 @@ inline int snprintf(char* buf, size_t len, const char* fmt, ...) {
 
   return n;
 }
+# endif
 
 #endif
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,6 +44,14 @@ goto next-arg
 if defined WindowsSDKDir goto select-target
 if defined VCINSTALLDIR goto select-target
 
+@rem Look for Visual Studio 2015
+if not defined VS140COMNTOOLS goto vc-set-2013
+if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2013
+call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" %vs_toolset%
+set GYP_MSVS_VERSION=2015
+goto select-target
+
+:vc-set-2013
 @rem Look for Visual Studio 2013
 if not defined VS120COMNTOOLS goto vc-set-2012
 if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012


### PR DESCRIPTION
snprintf() was added in MSVC 2015, added a version check to disable
the snprintf replacement when _MSC_VER >= 1900.