### PR TITLE
aix: fix setsockopt for multicast options

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -666,13 +666,13 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
  * so hardcode the size of these options on this platform,
  * and use the general uv__setsockopt_maybe_char call on other platforms.
  */
-#if defined(__sun)
+#if defined(__sun) || defined(_AIX)
   return uv__setsockopt(handle,
                         IP_TTL,
                         IPV6_UNICAST_HOPS,
                         &ttl,
                         sizeof(ttl));
-#endif /* defined(__sun) */
+#endif /* defined(__sun) || defined(_AIX) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_TTL,
@@ -688,14 +688,14 @@ int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
  * IP_MULTICAST_TTL, so hardcode the size of the option in the IPv6 case,
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
-#if defined(__sun)
+#if defined(__sun) || defined(_AIX)
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_TTL,
                           IPV6_MULTICAST_HOPS,
                           &ttl,
                           sizeof(ttl));
-#endif /* defined(__sun) */
+#endif /* defined(__sun) || defined(_AIX) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_TTL,
@@ -711,14 +711,14 @@ int uv_udp_set_multicast_loop(uv_udp_t* handle, int on) {
  * IP_MULTICAST_LOOP, so hardcode the size of the option in the IPv6 case,
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
-#if defined(__sun)
+#if defined(__sun) || defined(_AIX)
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_LOOP,
                           IPV6_MULTICAST_LOOP,
                           &on,
                           sizeof(on));
-#endif /* defined(__sun) */
+#endif /* defined(__sun) || defined(_AIX) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_LOOP,


### PR DESCRIPTION
On AIX the length of socket options
for multicast and ttl options is not always sizeof(char).

AIX has the same issue as solaris which was fixed under
PR-URL: https://github.com/libuv/libuv/pull/243

This PR extends the fix to cover AIX as well.

	modified:   src/unix/udp.c