### PR TITLE
unix: removed double-checked read from uv_async

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -58,10 +58,6 @@ int uv_async_init(uv_loop_t* loop, uv_async_t* handle, uv_async_cb async_cb) {
 
 
 int uv_async_send(uv_async_t* handle) {
-  /* Do a cheap read first. */
-  if (ACCESS_ONCE(int, handle->pending) != 0)
-    return 0;
-
   if (cmpxchgi(&handle->pending, 0, 1) == 0)
     uv__async_send(&handle->loop->async_watcher);
 


### PR DESCRIPTION
This provides only a negligible increase in performance, but can cause
incorrect results. The ACCESS_ONCE() macro only provides a weak compiler
barrier on GCC. The problem is this "handle->pending" load can be
reordered before a store that occurs in the client application causing
the write to be missed on the consuming side of uv_async_send(). From the
Intel manual: "Loads May Be Reordered with Earlier Stores to Different
Locations". This is also likely to cause a similar issue on other
architectures that are not as strictly ordered as x86.