### PR TITLE
unix: use libc-provided epoll_pwait wrapper

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,5 +63,9 @@ AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])
 AS_IF([test "x$PKG_CONFIG" != "x"], [
     AC_CONFIG_FILES([libuv.pc])
 ])
+AM_COND_IF([LINUX], [
+    AC_CHECK_HEADERS([sys/epoll.h], , [AC_MSG_ERROR([Could not find sys/epoll.h])])
+    AC_CHECK_FUNCS([epoll_pwait], , [AC_MSG_ERROR([Could not find epoll_pwait()])])
+])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -117,16 +117,6 @@
 # endif
 #endif /* __NR_epoll_wait */
 
-#ifndef __NR_epoll_pwait
-# if defined(__x86_64__)
-#  define __NR_epoll_pwait 281
-# elif defined(__i386__)
-#  define __NR_epoll_pwait 319
-# elif defined(__arm__)
-#  define __NR_epoll_pwait (UV_SYSCALL_BASE + 346)
-# endif
-#endif /* __NR_epoll_pwait */
-
 #ifndef __NR_inotify_init
 # if defined(__x86_64__)
 #  define __NR_inotify_init 253
@@ -319,31 +309,6 @@ int uv__epoll_wait(int epfd,
 #if defined(__NR_epoll_wait)
   int result;
   result = syscall(__NR_epoll_wait, epfd, events, nevents, timeout);
-#if MSAN_ACTIVE
-  if (result > 0)
-    __msan_unpoison(events, sizeof(events[0]) * result);
-#endif
-  return result;
-#else
-  return errno = ENOSYS, -1;
-#endif
-}
-
-
-int uv__epoll_pwait(int epfd,
-                    struct uv__epoll_event* events,
-                    int nevents,
-                    int timeout,
-                    uint64_t sigmask) {
-#if defined(__NR_epoll_pwait)
-  int result;
-  result = syscall(__NR_epoll_pwait,
-                   epfd,
-                   events,
-                   nevents,
-                   timeout,
-                   &sigmask,
-                   sizeof(sigmask));
 #if MSAN_ACTIVE
   if (result > 0)
     __msan_unpoison(events, sizeof(events[0]) * result);

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -127,11 +127,6 @@ int uv__epoll_wait(int epfd,
                    struct uv__epoll_event* events,
                    int nevents,
                    int timeout);
-int uv__epoll_pwait(int epfd,
-                    struct uv__epoll_event* events,
-                    int nevents,
-                    int timeout,
-                    uint64_t sigmask);
 int uv__eventfd2(unsigned int count, int flags);
 int uv__inotify_init(void);
 int uv__inotify_init1(int flags);


### PR DESCRIPTION
Further fix for sigmask size calculation on top of 751ac48.
We now use epoll_pwait() wrapper from libc, which takes care
of passing proper sigset_t size to kernel.

This is more portable, as some arch have a larger sigmask and
kernel explicitely checks size parameter to match sizeof(sigset_t).
Spotted as a uv_loop_configure regression on MIPS.

This fixes #335.

Signed-off-by: Luca Bruno <lucab@debian.org>