### PR TITLE
[WIN32] fix infinite-loop bug on process_read_last_line

### DIFF
--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -287,6 +287,11 @@ int process_read_last_line(process_info_t *p,
       break;
   }
 
+  if (start < 0) {
+	  /* In case of no CRLF */
+	  start = 0;
+  }
+
   if (start > 0)
     memmove(buffer, buffer + start, read - start);
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -261,7 +261,7 @@ int process_read_last_line(process_info_t *p,
                            size_t buffer_len) {
   DWORD size;
   DWORD read;
-  DWORD start;
+  int start;
   OVERLAPPED overlapped;
 
   ASSERT(buffer_len > 0);


### PR DESCRIPTION
minor thing but it can be infinite-loop
