### PR TITLE
Add appveyor config and NSIS script for Windows packaging.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+version: v1.5.0.{build}
+
+install:
+  - cinst -y nsis
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - platform: x86
+      configuration: Release
+    - platform: x64
+      configuration: Release
+
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Release
+
+build_script:
+  # Fixed tag version number if using a tag.
+  - cmd: if "%APPVEYOR_REPO_TAG%" == "true" set APPVEYOR_BUILD_VERSION=%APPVEYOR_REPO_TAG_NAME%
+  # vcbuild overwrites the platform variable.
+  - cmd: set ARCH=%platform%
+  - cmd: vcbuild.bat release shared %ARCH%
+
+after_build:
+  - '"%PROGRAMFILES(x86)%\NSIS\makensis" /DVERSION=%APPVEYOR_BUILD_VERSION% /DARCH=%ARCH% libuv.nsi'
+
+artifacts:
+  - name: Installer
+    path: 'libuv-*.exe'
+
+deploy:
+  # Deploy to github on new tag
+  - provider: GitHub
+    artifact: Installer
+    draft: false
+    prerelease: false
+    auth_token:
+      secure: replace-with-encrypted-github-token
+    on:
+      appveyor_repo_tag: true # deploy on tag push only
+
+cache:
+  - C:\projects\libuv\build\gyp

--- a/libuv.nsi
+++ b/libuv.nsi
@@ -1,0 +1,86 @@
+; NSIS installer script for libuv
+
+!include "MUI2.nsh"
+
+Name "libuv"
+OutFile "libuv-windows-${ARCH}-${VERSION}.exe"
+
+!include "x64.nsh"
+# Default install location, for 32-bit files
+InstallDir "$PROGRAMFILES\libuv"
+
+# Override install and registry locations if this is a 64-bit install.
+function .onInit
+	${If} ${ARCH} == "x64"
+		SetRegView 64
+		StrCpy $INSTDIR "$PROGRAMFILES64\libuv"
+	${EndIf}
+functionEnd
+
+;--------------------------------
+; Installer pages
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+
+;--------------------------------
+; Uninstaller pages
+!insertmacro MUI_UNPAGE_WELCOME
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+;--------------------------------
+; Languages
+!insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+; Installer sections
+
+Section "Files" SecInstall
+	SectionIn RO
+	SetOutPath "$INSTDIR"
+	File "Release\*.dll"
+	File "Release\*.lib"
+	File "LICENSE"
+	File "README.md"
+
+	SetOutPath "$INSTDIR\include"
+	File "include\uv.h"
+	File "include\uv-errno.h"
+	File "include\uv-threadpool.h"
+	File "include\uv-version.h"
+	File "include\uv-win.h"
+	File "include\tree.h"
+
+	WriteUninstaller "$INSTDIR\Uninstall.exe"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "DisplayName" "libuv-${ARCH}-${VERSION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "HelpLink" "http://libuv.org/"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "URLInfoAbout" "http://libuv.org/"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "DisplayVersion" "${VERSION}"
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "NoModify" "1"
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}" "NoRepair" "1"
+SectionEnd
+
+Section "Uninstall"
+	Delete "$INSTDIR\libuv.dll"
+	Delete "$INSTDIR\libuv.lib"
+	Delete "$INSTDIR\LICENSE"
+	Delete "$INSTDIR\README.md"
+
+	Delete "$INSTDIR\include\uv.h"
+	Delete "$INSTDIR\include\uv-errno.h"
+	Delete "$INSTDIR\include\uv-threadpool.h"
+	Delete "$INSTDIR\include\uv-version.h"
+	Delete "$INSTDIR\include\uv-win.h"
+	Delete "$INSTDIR\include\tree.h"
+
+	Delete "$INSTDIR\Uninstall.exe"
+	RMDir "$INSTDIR"
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\libuv-${ARCH}-${VERSION}"
+SectionEnd
+


### PR DESCRIPTION
This is a working but still incomplete configuration file for automated
building of libuv for Windows x86 and x64 on appveyor.com and
subsequent deployment to github.

It will produce installer packages using NSIS for all pushes to the
github repository.

It can also be configured to deploy the installers to a github release 
when a tag is pushed to the repository. This requires an encrypted 
github token with "public_repo" permissions to be added to appveyor.yml.

This is still incomplete because the output version is fixed at 1.5.0.{build}, where {build} is the appveyor build number for this project. I would like to be able to have the version set as e.g. testing-1.5.0.{build} for the everyday pushes to the repository, then to use the exact tag name when a tag is pushed.

Building on appveyor will also fail at the moment because it builds shared libraries on Windows. This is the related bug report: https://github.com/joyent/libuv/issues/1382 I have tested everything, including deploying to github by making a temporary fix for that bug (not included in this pull request).
