### PR TITLE
unix: remove the uv_pending function.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -263,6 +263,8 @@ UV_EXTERN size_t uv_loop_size(void);
 UV_EXTERN int uv_loop_alive(const uv_loop_t* loop);
 UV_EXTERN int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...);
 
+UV_EXTERN int uv_pending(uv_loop_t* loop);
+
 UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
 UV_EXTERN void uv_stop(uv_loop_t*);
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -263,8 +263,6 @@ UV_EXTERN size_t uv_loop_size(void);
 UV_EXTERN int uv_loop_alive(const uv_loop_t* loop);
 UV_EXTERN int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...);
 
-UV_EXTERN int uv_pending(const uv_loop_t* loop);
-
 UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
 UV_EXTERN void uv_stop(uv_loop_t*);
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -263,7 +263,7 @@ UV_EXTERN size_t uv_loop_size(void);
 UV_EXTERN int uv_loop_alive(const uv_loop_t* loop);
 UV_EXTERN int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...);
 
-UV_EXTERN int uv_pending(uv_loop_t* loop);
+UV_EXTERN int uv_pending(const uv_loop_t* loop);
 
 UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
 UV_EXTERN void uv_stop(uv_loop_t*);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -308,7 +308,7 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   int timeout;
   int r;
   int ran_pending;
-  int active_handles;
+  unsigned int active_handles;
 
   r = uv__loop_alive(loop);
   if (!r)

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -307,6 +307,11 @@ int uv_pending(uv_loop_t* loop) {
     return (QUEUE_EMPTY(&loop->pending_queue) == 0);
 }
 
+int uv_pending(const v_loop_t* loop) {
+  return !QUEUE_EMPTY(&loop->pending_queue);
+}
+
+
 int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   int timeout;
   int r;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -303,9 +303,11 @@ int uv_loop_alive(const uv_loop_t* loop) {
     return uv__loop_alive(loop);
 }
 
-int uv_pending(uv_loop_t* loop) {
-    return (QUEUE_EMPTY(&loop->pending_queue) == 0);
+
+int uv_pending(const uv_loop_t* loop) {
+  return !QUEUE_EMPTY(&loop->pending_queue);
 }
+
 
 int uv_pending(const v_loop_t* loop) {
   return !QUEUE_EMPTY(&loop->pending_queue);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -303,6 +303,9 @@ int uv_loop_alive(const uv_loop_t* loop) {
     return uv__loop_alive(loop);
 }
 
+int uv_pending(uv_loop_t* loop) {
+    return (QUEUE_EMPTY(&loop->pending_queue) == 0);
+}
 
 int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   int timeout;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -309,11 +309,6 @@ int uv_pending(const uv_loop_t* loop) {
 }
 
 
-int uv_pending(const v_loop_t* loop) {
-  return !QUEUE_EMPTY(&loop->pending_queue);
-}
-
-
 int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   int timeout;
   int r;


### PR DESCRIPTION
Make changes to uv_run in order to make it easier to integrate with glib event loop.