### PR TITLE
windows: MSVC 2015 has C99 inline

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -179,8 +179,8 @@ enum test_status {
 
 #include <stdarg.h>
 
-/* Define inline for MSVC */
-# ifdef _MSC_VER
+/* Define inline for MSVC<2015 */
+# if defined(_MSC_VER) && _MSC_VER < 1900
 #  define inline __inline
 # endif
 


### PR DESCRIPTION
Prior to MSVC 2015, the standard C99 `inline` keyword was missing,
added a compiler version check and disabled the inline replacement for
MSVC >= 2015 in test/task.h.

Refs: #341