### PR TITLE
windows: Proper snprintf fallback for MSVC < 2015

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -185,27 +185,10 @@ enum test_status {
 # endif
 
 # if defined(_MSC_VER) && _MSC_VER < 1900
-/* Emulate snprintf() on MSVC<2015, _snprintf() doesn't zero-terminate the buffer
- * on overflow...
+/* Use snprintf() on MSVC<2015, _snprintf_s() for previous versions
+ * 
  */
-inline int snprintf(char* buf, size_t len, const char* fmt, ...) {
-  va_list ap;
-  int n;
-
-  va_start(ap, fmt);
-  n = _vsprintf_p(buf, len, fmt, ap);
-  va_end(ap);
-
-  /* It's a sad fact of life that no one ever checks the return value of
-   * snprintf(). Zero-terminating the buffer hopefully reduces the risk
-   * of gaping security holes.
-   */
-  if (n < 0)
-    if (len > 0)
-      buf[0] = '\0';
-
-  return n;
-}
+# define snprintf _snprintf_s
 # endif
 
 #endif


### PR DESCRIPTION
The information on SO is misleading http://stackoverflow.com/q/2915672
The correct fallback (since at least VS 2005) is `_snprint_s`.

Docs: https://msdn.microsoft.com/en-us/library/f30dzcf6(v=vs.100).aspx
