### PR TITLE
test: Fixed `platform_output` netmask printing.

### DIFF
--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -112,11 +112,13 @@ TEST_IMPL(platform_output) {
 
     if (interfaces[i].netmask.netmask4.sin_family == AF_INET) {
       uv_ip4_name(&interfaces[i].netmask.netmask4, buffer, sizeof(buffer));
+      printf("  netmask: %s\n", buffer);
     } else if (interfaces[i].netmask.netmask4.sin_family == AF_INET6) {
       uv_ip6_name(&interfaces[i].netmask.netmask6, buffer, sizeof(buffer));
+      printf("  netmask: %s\n", buffer);
+    } else {
+      printf("  netmask: none\n");
     }
-
-    printf("  netmask: %s\n", buffer);
   }
   uv_free_interface_addresses(interfaces, count);
 


### PR DESCRIPTION
The implementation will leave the family set to `AF_UNSPEC` if a
netmask is not present, but the test driver would always print the
uninitialized buffer as an `AF_INET4` address.  It will now print
"none" if there is no netmask (e.g., for loopback interfaces).