### PR TITLE
win: add XP support to uv_os_homedir()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ include_HEADERS += include/uv-win.h include/tree.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/win \
                -DWIN32_LEAN_AND_MEAN \
                -D_WIN32_WINNT=0x0600
-LIBS += -lws2_32 -lpsapi -liphlpapi -lole32 -lshell32
+LIBS += -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
 libuv_la_SOURCES += src/win/async.c \
                     src/win/atomicops-inl.h \
                     src/win/core.c \

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -232,7 +232,7 @@ API
     Gets the current user's home directory. On Windows, `uv_os_homedir()` first
     checks the `USERPROFILE` environment variable using
     `GetEnvironmentVariableW()`. If `USERPROFILE` is not set,
-    `SHGetKnownFolderPath()` is called. On all other operating systems,
+    `GetUserProfileDirectoryW()` is called. On all other operating systems,
     `uv_os_homedir()` first checks the `HOME` environment variable using
     :man:`getenv(3)`. If `HOME` is not set, :man:`getpwuid_r(3)` is called. The
     user's home directory is stored in `buffer`. When `uv_os_homedir()` is

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1166,10 +1166,8 @@ int uv_os_homedir(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  bufsize = MAX_PATH;
-
   /* Check if the USERPROFILE environment variable is set first */
-  len = GetEnvironmentVariableW(L"USERPROFILE", path, bufsize);
+  len = GetEnvironmentVariableW(L"USERPROFILE", path, MAX_PATH);
 
   if (len == 0) {
     r = GetLastError();
@@ -1204,6 +1202,8 @@ int uv_os_homedir(char* buffer, size_t* size) {
   /* USERPROFILE is not set, so call GetUserProfileDirectoryW() */
   if (OpenProcessToken(GetCurrentProcess(), TOKEN_READ, &token) == 0)
     return uv_translate_sys_error(GetLastError());
+
+  bufsize = MAX_PATH;
 
   if (!GetUserProfileDirectoryW(token, path, &bufsize)) {
     r = GetLastError();

--- a/uv.gyp
+++ b/uv.gyp
@@ -108,9 +108,9 @@
             'libraries': [
               '-ladvapi32',
               '-liphlpapi',
-              '-lole32',
               '-lpsapi',
               '-lshell32',
+              '-luserenv',
               '-lws2_32'
             ],
           },


### PR DESCRIPTION
The previous Windows implementation used `SHGetKnownFolderPath()`, which is only supported on Vista and up. This commit switches to `GetUserProfileDirectoryW()`, which returns the same information,
but is supported back to Windows 2000, and is not deprecated. Closes #374.