### PR TITLE
win: include "malloc.h"

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -29,7 +29,9 @@
 #include <stdlib.h> /* malloc */
 #include <string.h> /* memset */
 
-#if !defined(_WIN32)
+#if defined(_WIN32)
+# include <malloc.h> /* malloc */
+#else
 # include <net/if.h> /* if_nametoindex */
 #endif
 


### PR DESCRIPTION
As stated in [malloc's docs](https://msdn.microsoft.com/en-us/library/6ewkz86d.aspx), the `malloc.h` is required for using the `malloc` function, and from `malloc.h`'s source code (which can be found under installed VS), `malloc` is defined as a macro that has different behaviors under different configurations. 

So using `malloc` without including `malloc.h` is very dangerous, and in Electron when we update to io.js v2.2.1 which uses libuv v1.5.0, we observed crash caused by writing to memory allocated by libuv:

```
0:000> g
(e08.918): Access violation - code c0000005 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
ntdll!memcpy+0x220:
00007ffc`6d295020 f30f7f40f0      movdqu  xmmword ptr [rax-10h],xmm0 ds:ffffffff`a1ccae8e=????????????????????????????????
0:000> k
Child-SP          RetAddr           Call Site
0000008f`9fdfe0e8 00007ffc`6d227b06 ntdll!memcpy+0x220
0000008f`9fdfe0f0 00007ffc`6d2256d3 ntdll!RtlCopyUnicodeString+0x46
*** ERROR: Symbol file could not be found.  Defaulted to export symbols for C:\Windows\system32\KERNELBASE.dll - 
0000008f`9fdfe120 00007ffc`6a762571 ntdll!LdrGetDllFullName+0x53
*** WARNING: Unable to verify checksum for C:\cygwin\home\zcbenz\codes\electron\out\D\node.dll
0000008f`9fdfe170 00007ffc`54fd80c6 KERNELBASE!GetModuleFileNameW+0x71
0000008f`9fdfe1b0 00007ffc`54d1c049 node!uv_exepath+0xa6 [c:\cygwin\home\zcbenz\codes\electron\vendor\node\deps\uv\src\win\util.c @ 131]
0000008f`9fdfe220 00007ffc`54d0e7f3 node!node::SetupProcessObject+0x2359 [c:\cygwin\home\zcbenz\codes\electron\vendor\node\src\node.cc @ 2860]
*** WARNING: Unable to verify checksum for electron.exe
0000008f`9fdfef80 00007ff7`5f1c44ac node!node::CreateEnvironment+0x353 [c:\cygwin\home\zcbenz\codes\electron\vendor\node\src\node.cc @ 3898]
0000008f`9fdff0c0 00007ff7`5f186d02 electron!atom::NodeBindings::CreateEnvironment+0x33c [c:\cygwin\home\zcbenz\codes\electron\atom\common\node_bindings.cc @ 160]
*** WARNING: Unable to verify checksum for C:\cygwin\home\zcbenz\codes\electron\out\D\content.dll
*** ERROR: Symbol file could not be found.  Defaulted to export symbols for C:\cygwin\home\zcbenz\codes\electron\out\D\content.dll - 
0000008f`9fdff510 00007ffc`4ff3aaf3 electron!atom::AtomBrowserMainParts::PostEarlyInitialization+0xf2 [c:\cygwin\home\zcbenz\codes\electron\atom\browser\atom_browser_main_parts.cc @ 63]
0000008f`9fdff590 00007ffc`4ff3e55a content!ResourceMsg_ReceivedResponse::Read+0x171f71
0000008f`9fdff660 00007ffc`4ff36052 content!ResourceMsg_ReceivedResponse::Read+0x1759d8
0000008f`9fdff750 00007ffc`4fe51d5e content!ResourceMsg_ReceivedResponse::Read+0x16d4d0
0000008f`9fdff7b0 00007ffc`4fe51bd5 content!ResourceMsg_ReceivedResponse::Read+0x891dc
0000008f`9fdff800 00007ffc`4fe4ad50 content!ResourceMsg_ReceivedResponse::Read+0x89053
0000008f`9fdff8a0 00007ff7`5f16003a content!ResourceMsg_ReceivedResponse::Read+0x821ce
0000008f`9fdff8d0 00007ff7`5f3f22a6 electron!wWinMain+0x56a [c:\cygwin\home\zcbenz\codes\electron\atom\app\atom_main.cc @ 159]
*** ERROR: Symbol file could not be found.  Defaulted to export symbols for C:\Windows\system32\KERNEL32.DLL - 
0000008f`9fdffb90 00007ffc`6aca13d2 electron!__tmainCRTStartup+0x162 [f:\dd\vctools\crt\crtw32\dllstuff\crtexe.c @ 618]
0000008f`9fdffbd0 00007ffc`6d215444 KERNEL32!BaseThreadInitThunk+0x22
0000008f`9fdffc00 00000000`00000000 ntdll!RtlUserThreadStart+0x34
```

![screen shot 2015-06-10 at 7 59 38 pm](https://cloud.githubusercontent.com/assets/639601/8083709/32fe8544-0fb9-11e5-9914-42e48cb7c56f.png)

From the stack trace, the crash is caused by `memcpy` writing to an invalid address, which is allocated by `malloc` in `uv_exepath`, and after bring back the `include "malloc.h"`, the crash is gone.

And if it is possible, please consider [applying this patch](https://github.com/atom/node/commit/ab1b3ba0b0076d7aa72e80caf8045fb6f7a68be0) to io.js, since it affects users that using io.js as a library.