### PR TITLE
[wip] do the right thing with close

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -406,7 +406,10 @@ struct uv_shutdown_s {
   /* private */                                                               \
   uv_close_cb close_cb;                                                       \
   void* handle_queue[2];                                                      \
-  void* reserved[4];                                                          \
+  union {                                                                     \
+    int fd;                                                                   \
+    void* reserved[4];                                                        \
+  } u;                                                                        \
   UV_HANDLE_PRIVATE_FIELDS                                                    \
 
 /* The abstract base class of all handles. */

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -196,7 +196,7 @@ void uv__fs_scandir_cleanup(uv_fs_t* req);
   (((h)->flags & UV__HANDLE_REF) != 0)
 
 #if defined(_WIN32)
-# define uv__handle_platform_init(h)
+# define uv__handle_platform_init(h) ((h)->u.fd = -1)
 #else
 # define uv__handle_platform_init(h) ((h)->next_closing = NULL)
 #endif

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -528,7 +528,11 @@ void fs__close(uv_fs_t* req) {
 
   VERIFY_FD(fd, req);
 
-  result = _close(fd);
+  if (fd > 2)
+    result = _close(fd);
+  else
+    result = 0;
+
   SET_REQ_RESULT(req, result);
 }
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -106,10 +106,9 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
   HANDLE handle;
   CONSOLE_SCREEN_BUFFER_INFO screen_buffer_info;
 
-  handle = (HANDLE) _get_osfhandle(fd);
-  if (handle == INVALID_HANDLE_VALUE) {
+  handle = (HANDLE) uv__get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
     return UV_EBADF;
-  }
 
   if (!readable) {
     /* Obtain the screen buffer info with the output handle. */


### PR DESCRIPTION
The goal of this PR is to:
* Avoid closing inherited stdandard handles
* Avoid closing CRT file descriptors <= 2
* Close CRT file descriptors >2 with `close()` (instead of closing their underlying windows handles with `CloseHandle`).