### PR TITLE
test: fix tcp_create_early_bad_bind on OSX

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -121,8 +121,13 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 #endif
 
   errno = 0;
-  if (bind(tcp->io_watcher.fd, addr, addrlen) && errno != EADDRINUSE)
+  if (bind(tcp->io_watcher.fd, addr, addrlen) && errno != EADDRINUSE) {
+    if (errno == EAFNOSUPPORT)
+      /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
+       * socket created with AF_INET to an AF_INET6 address or vice versa. */
+      return -EINVAL;
     return -errno;
+  }
   tcp->delayed_error = -errno;
 
   if (addr->sa_family == AF_INET6)

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -321,6 +321,10 @@ int uv__udp_bind(uv_udp_t* handle,
 
   if (bind(fd, addr, addrlen)) {
     err = -errno;
+    if (errno == EAFNOSUPPORT)
+      /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
+       * socket created with AF_INET to an AF_INET6 address or vice versa. */
+      err = -EINVAL;
     goto out;
   }
 


### PR DESCRIPTION
Binding to a socket of the wrong address returns EAFNOSUPPORT on OSX.

R=@bnoordhuis