### PR TITLE
skip udp_multicast_join6 test if no multicast route for ipv6 is defined on system

### DIFF
--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -124,6 +124,11 @@ TEST_IMPL(udp_multicast_join6) {
 #else
   r = uv_udp_set_membership(&client, "ff02::1", NULL, UV_JOIN_GROUP);
 #endif
+  if(r == UV_ENODEV) {
+    MAKE_VALGRIND_HAPPY();
+    RETURN_SKIP("No ipv6 multicast route");
+  }
+
   ASSERT(r == 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, cl_recv_cb);


### PR DESCRIPTION
<a href="https://github.com/joyent/libuv/issues/1401#issuecomment-115826070">issue</a>