### PR TITLE
win: fix returning thread id in uv_thread_self

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -191,6 +191,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 
 
 uv_thread_t uv_thread_self(void) {
+  uv_once(&uv__current_thread_init_guard, uv__init_current_thread_key);
   return (uv_thread_t) uv_key_get(&uv__current_thread_key);
 }
 


### PR DESCRIPTION
The main thread does not have the thread id TLS created.

Fixes: https://github.com/joyent/node/issues/25602

R=@piscisaureus, @orangemocha 