### PR TITLE
common: use offsetof for QUEUE_DATA

### DIFF
--- a/src/queue.h
+++ b/src/queue.h
@@ -16,6 +16,8 @@
 #ifndef QUEUE_H_
 #define QUEUE_H_
 
+#include <stddef.h>
+
 typedef void *QUEUE[2];
 
 /* Private macros. */
@@ -26,7 +28,7 @@ typedef void *QUEUE[2];
 
 /* Public macros. */
 #define QUEUE_DATA(ptr, type, field)                                          \
-  ((type *) ((char *) (ptr) - ((char *) &((type *) 0)->field)))
+  ((type *) ((char *) (ptr) - offsetof(type, field)))
 
 #define QUEUE_FOREACH(q, h)                                                   \
   for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))


### PR DESCRIPTION
Silences the following runtime errors when compiling UBSan:

../src/unix/linux-core.c:181:9: runtime error: member access within null
pointer of type 'uv__io_t' (aka 'struct uv__io_s')
../src/unix/process.c:67:15: runtime error: member access within null
pointer of type 'uv_process_t' (aka 'struct uv_process_s')
../src/unix/process.c:91:15: runtime error: member access within null
pointer of type 'uv_process_t' (aka 'struct uv_process_s')
...

R=@bnoordhuis