### PR TITLE
test,unix: reduce stack size of watchdog threads

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -174,6 +174,7 @@ int process_wait(process_info_t* vec, int n, int timeout) {
   process_info_t* p;
   dowait_args args;
   pthread_t tid;
+  pthread_attr_t attr;
   unsigned int elapsed_ms;
   struct timeval timebase;
   struct timeval tv;
@@ -202,7 +203,17 @@ int process_wait(process_info_t* vec, int n, int timeout) {
     return -1;
   }
 
-  r = pthread_create(&tid, NULL, dowait, &args);
+  if (pthread_attr_init(&attr))
+    abort();
+
+  if (pthread_attr_setstacksize(&attr, 256 * 1024))
+    abort();
+
+  r = pthread_create(&tid, &attr, dowait, &args);
+
+  if (pthread_attr_destroy(&attr))
+    abort();
+
   if (r) {
     perror("pthread_create()");
     retval = -1;


### PR DESCRIPTION
Some 32 bits architectures, linux/mips and linux/mipsel in particular,
suffer from address space fragmentation when spawning many threads
with the default 8 MB stack size.  The watchdog threads don't need
much stack space, all they do is sleep until the monitored process
exits, so lower it to 256 kB.

Fixes: https://github.com/libuv/libuv/issues/408

R=@saghul, /cc @lucab

CI: https://jenkins-iojs.nodesource.com/view/libuv/job/libuv+any-pr+multi/118/