### PR TITLE
doc: document the procedure for verifying releases

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,36 @@
+
+# Project Maintainers
+
+libuv is currently managed by the following individuals:
+
+* **Ben Noordhuis** ([@bnoordhuis](https://github.com/bnoordhuis))
+  - GPG key: 46AB89B9 (pubkey-bnoordhuis)
+* **Bert Belder** ([@piscisaureus](https://github.com/piscisaureus))
+* **Fedor Indutny** ([@indutny](https://github.com/indutny))
+  - GPG key: 19B7E890 (pubkey-indutny)
+* **Saúl Ibarra Corretgé** ([@saghul](https://github.com/saghul))
+  - GPG key: AE9BC059 (pubkey-saghul)
+
+## Storing a maintainer key in Git
+
+It's quite handy to store a maintainer's signature as a git blob, and have
+that object tagged and signed with such key.
+
+Export your public key:
+
+    $ gpg --armor --export saghul@gmail.com > saghul.asc
+
+Store it as a blob on the repo:
+
+    $ git hash-object -w saghul.asc
+
+The previous command returns a hash, copy it. For the sake of this explanation,
+we'll assume it's 'abcd1234'. Storing the blob in git is not enough, it could
+be garbage collected since nothing references it, so we'll create a tag for it:
+
+    $ git tag -s pubkey-saghul abcd1234
+
+Commit the changes and push:
+
+    $ git push origin pubkey-saghul
+

--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ also serve as API specification and usage examples.
 These resources are not handled by libuv maintainers and might be out of
 date. Please verify it before opening new issues.
 
+## Downloading
+
+libuv can be downloaded either from the
+[GitHub repository](https://github.com/libuv/libuv)
+or from the [downloads site](http://dist.libuv.org/dist/).
+
+Before verifying the git tags or signature files, importing the relevant keys
+is necessary. Key IDs are listed in the
+[MAINTAINERS](https://github.com/libuv/libuv/blob/master/MAINTAINERS.md)
+file, but are also available as git blob objects for easier use.
+
+Importing a key the usual way:
+
+    $ gpg --keyserver pool.sks-keyservers.net \
+      --recv-keys AE9BC059
+
+Importing a key from a git blob object:
+
+    $ git show pubkey-saghul | gpg --import
+
+### Verifying releases
+
+Git tags are signed with the developer's key, they can be verified as follows:
+
+    $ git verify-tag v1.6.1
+
+Starting with libuv 1.7.0, the tarballs stored in the
+[downloads site](http://dist.libuv.org/dist/) are signed and an accomanying
+signature file sit alongside each. Once both the release tarball and the
+signature file are downloaded, the file can be verified as follows:
+
+    $ gpg --verify libuv-1.7.0.tar.gz.sign
+
 ## Build Instructions
 
 For GCC there are two build methods: via autotools or via [GYP][].

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ libuv can be downloaded either from the
 [GitHub repository](https://github.com/libuv/libuv)
 or from the [downloads site](http://dist.libuv.org/dist/).
 
+Starting with libuv 1.7.0, binaries for Windows are also provided. This is to
+be considered EXPERIMENTAL.
+
 Before verifying the git tags or signature files, importing the relevant keys
 is necessary. Key IDs are listed in the
 [MAINTAINERS](https://github.com/libuv/libuv/blob/master/MAINTAINERS.md)


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/issues/409

TO BE MERGED RIGHT WHEN RELEASING 1.7.0.

R=@bnoordhuis, @piscisaureus, @indutny 

Can I have your GPG key IDs to list them in the maintainers file please? Also, follow the instructions to put your key as a blob when you can.