### PR TITLE
Fixing build scripts to support android build.

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -6,7 +6,7 @@ $1/build/tools/make-standalone-toolchain.sh \
     --toolchain=arm-linux-androideabi-4.8 \
     --arch=arm \
     --install-dir=$TOOLCHAIN \
-    --platform=android-9
+    --platform=android-21
 export PATH=$TOOLCHAIN/bin:$PATH
 export AR=arm-linux-androideabi-ar
 export CC=arm-linux-androideabi-gcc
@@ -16,5 +16,5 @@ export PLATFORM=android
 
 if [ $2 -a $2 == 'gyp' ]
   then
-    ./gyp_uv.py -Dtarget_arch=arm -DOS=android
+    ./gyp_uv.py -Dtarget_arch=arm -DOS=android -f make-android
 fi

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,13 @@
         'xcode_settings': {
           'GCC_OPTIMIZATION_LEVEL': '0',
           'OTHER_CFLAGS': [ '-Wno-strict-aliasing' ],
-        }
+        },
+        'conditions': [
+          ['OS == "android"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ]
+          }]
+        ]
       },
       'Release': {
         'defines': [ 'NDEBUG' ],


### PR DESCRIPTION
Provides proper android gyp flag and add position-independent executable compiler flags for android builds.