### PR TITLE
Support uv_backend_fd() on Windows

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -303,7 +303,7 @@ typedef struct {
 RB_HEAD(uv_timer_tree_s, uv_timer_s);
 
 #define UV_LOOP_PRIVATE_FIELDS                                                \
-    /* The loop's I/O completion port */                                      \
+  /* The loop's I/O completion port */                                        \
   HANDLE iocp;                                                                \
   /* The current time according to the event loop. in msecs. */               \
   uint64_t time;                                                              \
@@ -337,7 +337,14 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   /* Threadpool */                                                            \
   void* wq[2];                                                                \
   uv_mutex_t wq_mutex;                                                        \
-  uv_async_t wq_async;
+  uv_async_t wq_async;                                                        \
+  /* The following fields are only used when the loop is configured with */   \
+  /* UV_LOOP_EMBED */                                                         \
+  HANDLE backend_event;                                                       \
+  /* Pending IOCP poll thread requests (in reverse order) */                  \
+  uv_req_t* iocp_poll_reqs;                                                   \
+  /* Thread that does the IOCP polling. */                                    \
+  uv_thread_t iocp_poll_thread;
 
 #define UV_REQ_TYPE_PRIVATE                                                   \
   /* TODO: remove the req suffix */                                           \

--- a/include/uv.h
+++ b/include/uv.h
@@ -231,7 +231,11 @@ typedef struct uv_interface_address_s uv_interface_address_t;
 typedef struct uv_dirent_s uv_dirent_t;
 
 typedef enum {
-  UV_LOOP_BLOCK_SIGNAL
+  UV_LOOP_BLOCK_SIGNAL,
+  /* Embedding is important. Enable uv_backend_fd on Windows
+   * for a small performance hit.
+   */
+  UV_LOOP_EMBED
 } uv_loop_option;
 
 typedef enum {
@@ -283,7 +287,11 @@ UV_EXTERN int uv_has_ref(const uv_handle_t*);
 UV_EXTERN void uv_update_time(uv_loop_t*);
 UV_EXTERN uint64_t uv_now(const uv_loop_t*);
 
+#ifdef _WIN32
+UV_EXTERN HANDLE uv_backend_fd(const uv_loop_t*);
+#else
 UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+#endif
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -41,6 +41,11 @@ static uv_loop_t* default_loop_ptr;
 /* uv_once initialization guards */
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 
+#ifdef NDEBUG
+#define UV_VERIFY(expr) (expr)
+#else
+#define UV_VERIFY(expr) assert(expr)
+#endif
 
 #if defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
 /* Our crt debug report handler allows us to temporarily disable asserts
@@ -79,6 +84,18 @@ static void uv__crt_invalid_parameter_handler(const wchar_t* expression,
   /* No-op. */
 }
 #endif
+
+
+INLINE static uv_req_t *uv__reverse_req_list(uv_req_t* reqs) {
+  uv_req_t* prev = NULL;
+  while (reqs != NULL) {
+    uv_req_t* next = reqs->next_req;
+    reqs->next_req = prev;
+    prev = reqs;
+    reqs = next;
+  }
+  return prev;
+}
 
 
 static void uv_init(void) {
@@ -174,6 +191,9 @@ int uv_loop_init(uv_loop_t* loop) {
   uv__handle_unref(&loop->wq_async);
   loop->wq_async.flags |= UV__HANDLE_INTERNAL;
 
+  loop->backend_event = NULL;
+  loop->iocp_poll_reqs = NULL;
+
   return 0;
 }
 
@@ -205,16 +225,91 @@ void uv__loop_close(uv_loop_t* loop) {
   uv_mutex_destroy(&loop->wq_mutex);
 
   CloseHandle(loop->iocp);
+
+  if (loop->backend_event != NULL) {
+    /* Invalidating the IOCP handle will end the thread. */
+    uv_thread_join(&loop->iocp_poll_thread);
+    CloseHandle(loop->backend_event);
+  }
+}
+
+
+static void iocp_poll_thread(void* arg) {
+  uv_loop_t* loop = (uv_loop_t*)arg;
+
+  for (;;) {
+    DWORD bytes;
+    ULONG_PTR key;
+    OVERLAPPED* overlapped;
+
+    /* TODO: Use pGetQueuedCompletionStatusEx when available. */
+    GetQueuedCompletionStatus(loop->iocp,
+                              &bytes,
+                              &key,
+                              &overlapped,
+                              INFINITE);
+
+    if (overlapped) {
+      uv_req_t* req;
+      uv_req_t* iocp_poll_reqs;
+
+      /* Package was dequeued */
+      req = uv_overlapped_to_req(overlapped);
+
+      do {
+        req->next_req = loop->iocp_poll_reqs;
+        iocp_poll_reqs = InterlockedCompareExchangePointer(&loop->iocp_poll_reqs,
+                                                           req,
+                                                           req->next_req);
+      } while (iocp_poll_reqs != req->next_req);
+      /* If the list was empty wake up the loop thread by signaling the event.
+       * Otherwise, the event was already signaled by us in the past.
+       */
+      if (iocp_poll_reqs == NULL)
+        UV_VERIFY(SetEvent(loop->backend_event));
+    } else if (GetLastError() == ERROR_INVALID_HANDLE ||
+               GetLastError() == ERROR_ABANDONED_WAIT_0) {
+      /* The loop is closing. Our work is done.
+       * NOTE: Closing the loop will close the completion port handle.
+       * If this happens between calls to GetQueuedCompletionStatus the error
+       * will be ERROR_INVALID_HANDLE if the call is outstanding the error
+       * will be ERROR_ABANDONED_WAIT_0.
+       */
+      return;
+    } else {
+      /* Serious error */
+      uv_fatal_error(GetLastError(), "GetQueuedCompletionStatus");
+    }
+  }
 }
 
 
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
-  return UV_ENOSYS;
+  int err;
+
+  if (option != UV_LOOP_EMBED)
+    return UV_ENOSYS;
+
+  if (loop->backend_event != NULL)
+    return 0;
+
+  loop->backend_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (loop->backend_event == NULL)
+    return uv_translate_sys_error(GetLastError());
+
+  err = uv_thread_create(&loop->iocp_poll_thread, iocp_poll_thread, loop);
+  if (err) {
+    CloseHandle(loop->backend_event);
+    loop->backend_event = NULL;
+    return err;
+  }
+
+  return 0;
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
-  return -1;
+HANDLE uv_backend_fd(const uv_loop_t* loop) {
+  return loop->backend_event;
 }
 
 
@@ -238,7 +333,45 @@ int uv_backend_timeout(const uv_loop_t* loop) {
 }
 
 
-static void uv_poll(uv_loop_t* loop, DWORD timeout) {
+static void uv_poll_event(uv_loop_t* loop, DWORD timeout) {
+  DWORD status = WaitForSingleObject(loop->backend_event, timeout);
+
+  if (status == WAIT_OBJECT_0) {
+    uv_req_t* reqs;
+    /* Reset the event so we may block again. */
+    UV_VERIFY(ResetEvent(loop->backend_event));
+    /* Dequeue any requests. There may be none if the event was
+     * signaled "spuriously". e.g. the user manually called
+     * SetEvent(uv_backend_fd()).
+     */
+    reqs = InterlockedExchangePointer(&loop->iocp_poll_reqs, NULL);
+    /* The list is backwards. Reverse it. */
+    reqs = uv__reverse_req_list(reqs);
+    /* Now traverse the list forwards, adding the requests to the pending
+     * list.
+     */
+    while (reqs != NULL) {
+      uv_req_t* next = reqs->next_req;
+      uv_insert_pending_req(loop, reqs);
+      reqs = next;
+    }
+    /* Some time might have passed waiting for I/O,
+     * so update the loop time here.
+     */
+    uv_update_time(loop);
+  } else if (status != WAIT_TIMEOUT) {
+    /* Serious error */
+    uv_fatal_error(GetLastError(), "WaitForSingleObject");
+  } else if (timeout > 0) {
+    /* WaitForSingleObject can occasionally return a little early.
+     * Make sure that the desired timeout is reflected in the loop time.
+     */
+    uv__time_forward(loop, timeout);
+  }
+}
+
+
+static void uv_poll_iocp(uv_loop_t* loop, DWORD timeout) {
   DWORD bytes;
   ULONG_PTR key;
   OVERLAPPED* overlapped;
@@ -271,7 +404,7 @@ static void uv_poll(uv_loop_t* loop, DWORD timeout) {
 }
 
 
-static void uv_poll_ex(uv_loop_t* loop, DWORD timeout) {
+static void uv_poll_iocp_ex(uv_loop_t* loop, DWORD timeout) {
   BOOL success;
   uv_req_t* req;
   OVERLAPPED_ENTRY overlappeds[128];
@@ -326,10 +459,12 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
   int ran_pending;
   void (*poll)(uv_loop_t* loop, DWORD timeout);
 
-  if (pGetQueuedCompletionStatusEx)
-    poll = &uv_poll_ex;
+  if (loop->backend_event)
+    poll = &uv_poll_event;
+  else if (pGetQueuedCompletionStatusEx)
+    poll = &uv_poll_iocp_ex;
   else
-    poll = &uv_poll;
+    poll = &uv_poll_iocp;
 
   r = uv__loop_alive(loop);
   if (!r)


### PR DESCRIPTION
This commit adds loop option UV_LOOP_EMBED which enables uv_backend_fd()
on Windows for a small performance hit. This is useful when the uv event
loop must be embedded in another event loop. On Windows uv_backend_fd()
will return a handle to a Windows event object which will become signaled
when there are new asynchronous requests to process. When the event is
signaled, uv_run() is guaranteed not to wait. The event may also be set
to signaled by the user to wake up a thread waiting in uv_run() spuriously.

In this mode, the IOCP polling is moved to another thread which signals the
event object when completion port packets have been dequeued. uv_run() polls
by waiting on the event object instead of directly on the completion port
queue.

NOTE: This changes the return type of uv_backend_fd() on Windows from int
to HANDLE.