### PR TITLE
pthread-fixes.c: include <signal.h> to fix compiler error: Implicit declaration of function 'sigprocmask'

### DIFF
--- a/src/unix/pthread-fixes.c
+++ b/src/unix/pthread-fixes.c
@@ -35,6 +35,7 @@
  * */
 #include <errno.h>
 #include <pthread.h>
+#include <signal.h>
 
 int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset) {
   static int workaround;


### PR DESCRIPTION
When adding libuv sources to an XCode project and building I get the following error:

```pthread-fixes.c:43:12: Implicit declaration of function 'sigprocmask' is invalid in C99.```

XCode 6.4 targeting iOS
