### PR TITLE
tests: skip some tests when network is unreachable

### DIFF
--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -59,14 +59,18 @@ TEST_IMPL(tcp_close_while_connecting) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
   uv_loop_t* loop;
+  int r;
 
   loop = uv_default_loop();
   ASSERT(0 == uv_ip4_addr("1.2.3.4", TEST_PORT, &addr));
   ASSERT(0 == uv_tcp_init(loop, &tcp_handle));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
+  r = uv_tcp_connect(&connect_req,
                              &tcp_handle,
                              (const struct sockaddr*) &addr,
-                             connect_cb));
+                             connect_cb);
+  if (r == UV_ENETUNREACH)
+    RETURN_SKIP("Network unreachable.");
+  ASSERT(r == 0);
   ASSERT(0 == uv_timer_init(loop, &timer1_handle));
   ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 50, 0));
   ASSERT(0 == uv_timer_init(loop, &timer2_handle));

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -79,6 +79,8 @@ TEST_IMPL(tcp_connect_timeout) {
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
+  if (r == UV_ENETUNREACH)
+    RETURN_SKIP("Network unreachable.");
   ASSERT(r == 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT(status == 0 || status == UV_ENETUNREACH);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -116,6 +116,8 @@ TEST_IMPL(udp_multicast_join) {
 
   /* join the multicast channel */
   r = uv_udp_set_membership(&client, "239.255.0.1", NULL, UV_JOIN_GROUP);
+  if (r == UV_ENODEV)
+    RETURN_SKIP("No multicast support.");
   ASSERT(r == 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, cl_recv_cb);

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT(status == 0 || status == UV_ENETUNREACH);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;


### PR DESCRIPTION
Do not hard-fail network tests when libuv is built on
an isolated host/container.

Signed-off-by: Luca Bruno <lucab@debian.org>