### PR TITLE
[v0.10] Do not fail tests when running with CAP_DAC_OVERRIDE and without networking

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -196,9 +196,16 @@ static void chown_root_cb(uv_fs_t* req) {
   /* On windows, chown is a no-op and always succeeds. */
   ASSERT(req->result == 0);
 #else
-  /* On unix, chown'ing the root directory is not allowed. */
-  ASSERT(req->result == -1);
-  ASSERT(req->errorno == UV_EPERM);
+  /* On unix, chown'ing the root directory is not allowed -
+   * unless you're root, of course.
+   */
+  if (geteuid() == 0) {
+    ASSERT(req->result == 0);
+  }
+  else {
+    ASSERT(req->result == -1);
+    ASSERT(req->errorno == UV_EPERM);
+  }
 #endif
   chown_cb_count++;
   uv_fs_req_cleanup(req);

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -60,12 +60,16 @@ TEST_IMPL(tcp_close_while_connecting) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
   uv_loop_t* loop;
+  int r;
 
   addr = uv_ip4_addr("1.2.3.4", TEST_PORT);
   loop = uv_default_loop();
 
   ASSERT(0 == uv_tcp_init(loop, &tcp_handle));
-  ASSERT(0 == uv_tcp_connect(&connect_req, &tcp_handle, addr, connect_cb));
+  r = uv_tcp_connect(&connect_req, &tcp_handle, addr, connect_cb);
+  if (r == -1 && uv_last_error(uv_default_loop()).code == UV_ENETUNREACH)
+    RETURN_SKIP("Network unreachable.");
+  ASSERT(r == 0);
   ASSERT(0 == uv_timer_init(loop, &timer1_handle));
   ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 50, 0));
   ASSERT(0 == uv_timer_init(loop, &timer2_handle));

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -76,6 +76,8 @@ TEST_IMPL(tcp_connect_timeout) {
   ASSERT(r == 0);
 
   r = uv_tcp_connect(&connect_req, &conn, addr, connect_cb);
+  if (r == -1 && uv_last_error(uv_default_loop()).code == UV_ENETUNREACH)
+    RETURN_SKIP("Network unreachable.");
   ASSERT(r == 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -113,6 +113,8 @@ TEST_IMPL(udp_multicast_join) {
 
   /* join the multicast channel */
   r = uv_udp_set_membership(&client, "239.255.0.1", NULL, UV_JOIN_GROUP);
+  if (r == -1 && uv_last_error(uv_default_loop()).code == UV_ENODEV)
+    RETURN_SKIP("No multicast support.");
   ASSERT(r == 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, cl_recv_cb);

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -44,7 +44,11 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  if (status == -1) {
+    ASSERT(uv_last_error(uv_default_loop()).code == UV_ENETUNREACH);
+  } else {
+    ASSERT(status == 0);
+  }
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;


### PR DESCRIPTION
libuv fails to build if you have CAP_DAC_OVERRIDE (e.g. you're running the build as root), or when running the build without public networking.
This PR backports two commits from v1.x to fix both issues.

Bug originally reported at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=792064