### PR TITLE
doc: add a note about uv_dirent_t.type

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -214,6 +214,10 @@ API
     .. note::
         Unlike `scandir(3)`, this function does not return the "." and ".." entries.
 
+    .. note::
+        On Linux, getting the type of an entry is only supported by some filesystems (btrfs, ext2,
+        ext3 and ext4 at the time of this writing), check the :man:`getdents(2)` man page.
+
 .. c:function:: int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 .. c:function:: int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
 .. c:function:: int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)


### PR DESCRIPTION
On Linux getting the type is only supported by some filesystems, check
getdents(2).

R=@bnoordhuis

/cc @creationix 