### PR TITLE
[v0.10] unix: do not discard environmental LDFLAGS

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -22,7 +22,7 @@ E=
 CSTDFLAG=--std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -g
 CPPFLAGS += -I$(SRCDIR)/src
-LDFLAGS=-lm -pthread
+LDFLAGS += -lm -pthread
 
 CPPFLAGS += -D_LARGEFILE_SOURCE
 CPPFLAGS += -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
The build environment may carry additional global LDFLAGS, which
are currently being discarded.
Debian uses them for distro-wide hardening, see dpkg-buildflags(1).
Fix by not overwriting the variable.

Signed-off-by: Luca Bruno <lucab@debian.org>