### PR TITLE
refactoring uv__hrtime

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -381,7 +381,7 @@ update_timeout:
 uint64_t uv__hrtime(uv_clocktype_t type) {
   static clock_t fast_clock_id = -1;
   struct timespec t;
-  clock_t clock_id;
+  clock_t clock_id = CLOCK_MONOTONIC;
 
   /* Prefer CLOCK_MONOTONIC_COARSE if available but only when it has
    * millisecond granularity or better.  CLOCK_MONOTONIC_COARSE is
@@ -391,18 +391,18 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
   /* TODO(bnoordhuis) Use CLOCK_MONOTONIC_COARSE for UV_CLOCK_PRECISE
    * when it has microsecond granularity or better (unlikely).
    */
-  if (type == UV_CLOCK_FAST && fast_clock_id == -1) {
-    if (clock_getres(CLOCK_MONOTONIC_COARSE, &t) == 0 &&
-        t.tv_nsec <= 1 * 1000 * 1000) {
-      fast_clock_id = CLOCK_MONOTONIC_COARSE;
-    } else {
-      fast_clock_id = CLOCK_MONOTONIC;
+  if (type == UV_CLOCK_FAST) {
+    if(fast_clock_id == -1) {
+        if (clock_getres(CLOCK_MONOTONIC_COARSE, &t) == 0 &&
+                t.tv_nsec <= 1 * 1000 * 1000) {
+            fast_clock_id = CLOCK_MONOTONIC_COARSE;
+        } else {
+            fast_clock_id = CLOCK_MONOTONIC;
+        }
     }
-  }
 
-  clock_id = CLOCK_MONOTONIC;
-  if (type == UV_CLOCK_FAST)
     clock_id = fast_clock_id;
+  }
 
   if (clock_gettime(clock_id, &t))
     return 0;  /* Not really possible. */


### PR DESCRIPTION
There are two places I want to refactor
```
if(type == UV_CLOCK_FAST && fast_clock_id == -1) {...}
```
`fast_clock_id` is a static variable and it is changed only on first call of `uv__hrtime`. I think it'll be beter to swap the components of if 
```
if(fast_clock_id == -1 && type == UV_CLOCK_FAST) {...}
```

And second. In 
```
clock_id = CLOCK_MONOTONIC;
if(type == UV_CLOCK_FAST)
  clock_id = fast_clock_id;
```
the `type==UV_CLOCK_FAST` is repeated. 

I moved `clock_id = CLOCK_MONOTONIC` at the declaration of variables and gathered all in the statement
```
if(type == UV_CLOCK_FAST) { ... }
```