### PR TITLE
test: fix clang compilation warning

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -42,6 +42,7 @@
 #ifdef __clang__
 # pragma clang diagnostic ignored "-Wvariadic-macros"
 # pragma clang diagnostic ignored "-Wc99-extensions"
+# pragma clang diagnostic ignored "-Wlong-long"
 #endif
 
 #define TEST_PORT 9123


### PR DESCRIPTION
Using long long types was causing the following when compiling with
clang:

warning: 'long long' is an extension when C99 mode is not enabled [-Wlong-long]
