### PR TITLE
unix,windows: don't assert on unknown error code

### DIFF
--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -322,8 +322,10 @@ API
 
 .. c:function:: const char* uv_strerror(int err)
 
-    Returns the error message for the given error code.
+    Returns the error message for the given error code.  Leaks a few bytes
+    of memory when you call it with an unknown error code.
 
 .. c:function:: const char* uv_err_name(int err)
 
-    Returns the error name for the given error code.
+    Returns the error name for the given error code.  Leaks a few bytes
+    of memory when you call it with an unknown error code.

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -137,14 +137,23 @@ uv_buf_t uv_buf_init(char* base, unsigned int len) {
 }
 
 
+static const char* uv__unknown_err_code(int err) {
+  char buf[32];
+  char* copy;
+
+  snprintf(buf, sizeof(buf), "Unknown system error %d", err);
+  copy = uv__strdup(buf);
+
+  return copy != NULL ? copy : "Unknown system error";
+}
+
+
 #define UV_ERR_NAME_GEN(name, _) case UV_ ## name: return #name;
 const char* uv_err_name(int err) {
   switch (err) {
     UV_ERRNO_MAP(UV_ERR_NAME_GEN)
-    default:
-      assert(0);
-      return NULL;
   }
+  return uv__unknown_err_code(err);
 }
 #undef UV_ERR_NAME_GEN
 
@@ -153,9 +162,8 @@ const char* uv_err_name(int err) {
 const char* uv_strerror(int err) {
   switch (err) {
     UV_ERRNO_MAP(UV_STRERROR_GEN)
-    default:
-      return "Unknown system error";
   }
+  return uv__unknown_err_code(err);
 }
 #undef UV_STRERROR_GEN
 


### PR DESCRIPTION
Make uv_err_name() and uv_strerror() return a dynamically allocated
string when the error code is not recognized.

It leaks a few bytes of memory but that can't be helped.  Asserting
and aborting is, in my opinion, much less helpful.

Fixes: https://github.com/nodejs/node/issues/63

R=@saghul

In libuv v2.x, we should probably modify the function signatures to make them accept a buffer to write to.