### PR TITLE
unix, stream: fix clashing flag definitions

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -148,9 +148,9 @@ enum {
   UV_TCP_NODELAY          = 0x400,  /* Disable Nagle. */
   UV_TCP_KEEPALIVE        = 0x800,  /* Turn on keep-alive. */
   UV_TCP_SINGLE_ACCEPT    = 0x1000, /* Only accept() when idle. */
-  UV_STREAM_DISCONNECT    = 0x2000, /* Remote end is forcibly closed */
   UV_HANDLE_IPV6          = 0x10000, /* Handle is bound to a IPv6 socket. */
-  UV_UDP_PROCESSING       = 0x20000  /* Handle is running the send callback queue. */
+  UV_UDP_PROCESSING       = 0x20000, /* Handle is running the send callback queue. */
+  UV_STREAM_DISCONNECT    = 0x40000  /* Remote end is forcibly closed */
 };
 
 /* loop flags */


### PR DESCRIPTION
UV_STREAM_DISCONNECT was defined as 0x2000, the same as UV__HANDLE_REF,
which made things go terribly bad.

Thanks @btrask for the test case which pointed me in the right
direction.

Fixes: https://github.com/libuv/libuv/issues/468

R=@bnoordhuis