### PR TITLE
OpenBSD's setsockopt requires an unsigned char for IP_MULTICAST_(LOOP…

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -668,6 +668,8 @@ static int uv__setsockopt_maybe_char(uv_udp_t* handle,
                                      int val) {
 #if defined(__sun) || defined(_AIX)
   char arg = val;
+#elif defined(__OpenBSD__)
+  unsigned char arg = val;
 #else
   int arg = val;
 #endif
@@ -702,13 +704,13 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
  * so hardcode the size of these options on this platform,
  * and use the general uv__setsockopt_maybe_char call on other platforms.
  */
-#if defined(__sun) || defined(_AIX)
+#if defined(__sun) || defined(_AIX) || defined(__OpenBSD__)
   return uv__setsockopt(handle,
                         IP_TTL,
                         IPV6_UNICAST_HOPS,
                         &ttl,
                         sizeof(ttl));
-#endif /* defined(__sun) || defined(_AIX) */
+#endif /* defined(__sun) || defined(_AIX) || defined (__OpenBSD__) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_TTL,


### PR DESCRIPTION
…|TTL)

I'm trying to get libuv's tests to pass on OpenBSD 5.7 and this is the first bug I've had to track down. OpenBSD (and also probably NetBSD, but I haven't tested it there) requires an unsigned char for the option_value argument in setsockopt() when setting IP_MULTICAST_LOOP and IP_MULTICAST_TTL (similar to Solaris). 