### PR TITLE
Document idempotency of uv_stream_stop()

### DIFF
--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -142,6 +142,8 @@ API
     Stop reading data from the stream. The :c:type:`uv_read_cb` callback will
     no longer be called.
 
+    This function is idempotent and may be safely called on a stopped stream.
+
 .. c:function:: int uv_write(uv_write_t* req, uv_stream_t* handle, const uv_buf_t bufs[], unsigned int nbufs, uv_write_cb cb)
 
     Write data to stream. Buffers are written in order. Example:


### PR DESCRIPTION
I had to check the source code to verify this. The source code makes it pretty explicit that this is intended behavior. Documenting it will make it easier for people to rely on it.

This is literally my first time trying Github's inline editing feature, so let me know if something's mangled or incorrect about the commit metadata.

Thanks!