### PR TITLE
unix: don't copy arguments for sync fs requests

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -58,10 +58,12 @@
 # include <sys/sendfile.h>
 #endif
 
-#define INIT(type)                                                            \
+#define INIT(subtype)                                                         \
   do {                                                                        \
-    uv__req_init(loop, req, UV_FS);                                           \
-    req->fs_type = UV_FS_ ## type;                                            \
+    req->type = UV_FS;                                                        \
+    if (cb != NULL)                                                           \
+      uv__req_init(loop, req, UV_FS);                                         \
+    req->fs_type = UV_FS_ ## subtype;                                         \
     req->result = 0;                                                          \
     req->ptr = NULL;                                                          \
     req->loop = loop;                                                         \
@@ -112,7 +114,6 @@
     }                                                                         \
     else {                                                                    \
       uv__fs_work(&req->work_req);                                            \
-      uv__fs_done(&req->work_req, 0);                                         \
       return req->result;                                                     \
     }                                                                         \
   }                                                                           \
@@ -896,8 +897,7 @@ static void uv__fs_done(struct uv__work* w, int status) {
     req->result = -ECANCELED;
   }
 
-  if (req->cb != NULL)
-    req->cb(req);
+  req->cb(req);
 }
 
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -60,21 +60,21 @@
 
 #define INIT(type)                                                            \
   do {                                                                        \
-    uv__req_init((loop), (req), UV_FS);                                       \
-    (req)->fs_type = UV_FS_ ## type;                                          \
-    (req)->result = 0;                                                        \
-    (req)->ptr = NULL;                                                        \
-    (req)->loop = loop;                                                       \
-    (req)->path = NULL;                                                       \
-    (req)->new_path = NULL;                                                   \
-    (req)->cb = (cb);                                                         \
+    uv__req_init(loop, req, UV_FS);                                           \
+    req->fs_type = UV_FS_ ## type;                                            \
+    req->result = 0;                                                          \
+    req->ptr = NULL;                                                          \
+    req->loop = loop;                                                         \
+    req->path = NULL;                                                         \
+    req->new_path = NULL;                                                     \
+    req->cb = cb;                                                             \
   }                                                                           \
   while (0)
 
 #define PATH                                                                  \
   do {                                                                        \
-    (req)->path = uv__strdup(path);                                           \
-    if ((req)->path == NULL)                                                  \
+    req->path = uv__strdup(path);                                             \
+    if (req->path == NULL)                                                    \
       return -ENOMEM;                                                         \
   }                                                                           \
   while (0)
@@ -83,27 +83,27 @@
   do {                                                                        \
     size_t path_len;                                                          \
     size_t new_path_len;                                                      \
-    path_len = strlen((path)) + 1;                                            \
-    new_path_len = strlen((new_path)) + 1;                                    \
-    (req)->path = uv__malloc(path_len + new_path_len);                        \
-    if ((req)->path == NULL)                                                  \
+    path_len = strlen(path) + 1;                                              \
+    new_path_len = strlen(new_path) + 1;                                      \
+    req->path = uv__malloc(path_len + new_path_len);                          \
+    if (req->path == NULL)                                                    \
       return -ENOMEM;                                                         \
-    (req)->new_path = (req)->path + path_len;                                 \
-    memcpy((void*) (req)->path, (path), path_len);                            \
-    memcpy((void*) (req)->new_path, (new_path), new_path_len);                \
+    req->new_path = req->path + path_len;                                     \
+    memcpy((void*) req->path, path, path_len);                                \
+    memcpy((void*) req->new_path, new_path, new_path_len);                    \
   }                                                                           \
   while (0)
 
 #define POST                                                                  \
   do {                                                                        \
-    if ((cb) != NULL) {                                                       \
-      uv__work_submit((loop), &(req)->work_req, uv__fs_work, uv__fs_done);    \
+    if (cb != NULL) {                                                         \
+      uv__work_submit(loop, &req->work_req, uv__fs_work, uv__fs_done);        \
       return 0;                                                               \
     }                                                                         \
     else {                                                                    \
-      uv__fs_work(&(req)->work_req);                                          \
-      uv__fs_done(&(req)->work_req, 0);                                       \
-      return (req)->result;                                                   \
+      uv__fs_work(&req->work_req);                                            \
+      uv__fs_done(&req->work_req, 0);                                         \
+      return req->result;                                                     \
     }                                                                         \
   }                                                                           \
   while (0)

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -116,8 +116,8 @@ void uv_fs_init() {
 }
 
 
-INLINE static int fs__capture_path(uv_loop_t* loop, uv_fs_t* req,
-    const char* path, const char* new_path, const int copy_path) {
+INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
+    const char* new_path, const int copy_path) {
   char* buf;
   char* pos;
   ssize_t buf_sz = 0, path_len, pathw_len = 0, new_pathw_len = 0;
@@ -1762,8 +1762,7 @@ static void uv__fs_done(struct uv__work* w, int status) {
     req->result = UV_ECANCELED;
   }
 
-  if (req->cb != NULL)
-    req->cb(req);
+  req->cb(req);
 }
 
 
@@ -1792,7 +1791,7 @@ int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
 
   uv_fs_req_init(loop, req, UV_FS_OPEN, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -1902,7 +1901,7 @@ int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
   uv_fs_req_init(loop, req, UV_FS_UNLINK, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -1923,7 +1922,7 @@ int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
 
   uv_fs_req_init(loop, req, UV_FS_MKDIR, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -1946,7 +1945,7 @@ int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
 
   uv_fs_req_init(loop, req, UV_FS_MKDTEMP, cb);
 
-  err = fs__capture_path(loop, req, tpl, NULL, TRUE);
+  err = fs__capture_path(req, tpl, NULL, TRUE);
   if (err)
     return uv_translate_sys_error(err);
 
@@ -1965,7 +1964,7 @@ int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
 
   uv_fs_req_init(loop, req, UV_FS_RMDIR, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -1986,7 +1985,7 @@ int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
 
   uv_fs_req_init(loop, req, UV_FS_SCANDIR, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2009,7 +2008,7 @@ int uv_fs_link(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
   uv_fs_req_init(loop, req, UV_FS_LINK, cb);
 
-  err = fs__capture_path(loop, req, path, new_path, cb != NULL);
+  err = fs__capture_path(req, path, new_path, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2030,7 +2029,7 @@ int uv_fs_symlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
   uv_fs_req_init(loop, req, UV_FS_SYMLINK, cb);
 
-  err = fs__capture_path(loop, req, path, new_path, cb != NULL);
+  err = fs__capture_path(req, path, new_path, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2053,7 +2052,7 @@ int uv_fs_readlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
   uv_fs_req_init(loop, req, UV_FS_READLINK, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2074,7 +2073,7 @@ int uv_fs_chown(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_uid_t uid,
 
   uv_fs_req_init(loop, req, UV_FS_CHOWN, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2108,7 +2107,7 @@ int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
 
   uv_fs_req_init(loop, req, UV_FS_STAT, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2128,7 +2127,7 @@ int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
 
   uv_fs_req_init(loop, req, UV_FS_LSTAT, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2163,7 +2162,7 @@ int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, const char* path,
 
   uv_fs_req_init(loop, req, UV_FS_RENAME, cb);
 
-  err = fs__capture_path(loop, req, path, new_path, cb != NULL);
+  err = fs__capture_path(req, path, new_path, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2252,7 +2251,7 @@ int uv_fs_access(uv_loop_t* loop,
 
   uv_fs_req_init(loop, req, UV_FS_ACCESS, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err)
     return uv_translate_sys_error(err);
 
@@ -2274,7 +2273,7 @@ int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
 
   uv_fs_req_init(loop, req, UV_FS_CHMOD, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }
@@ -2314,7 +2313,7 @@ int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime,
 
   uv_fs_req_init(loop, req, UV_FS_UTIME, cb);
 
-  err = fs__capture_path(loop, req, path, NULL, cb != NULL);
+  err = fs__capture_path(req, path, NULL, cb != NULL);
   if (err) {
     return uv_translate_sys_error(err);
   }

--- a/test/benchmark-fs-stat.c
+++ b/test/benchmark-fs-stat.c
@@ -31,7 +31,7 @@
 
 #define sync_stat(req, path)                                                  \
   do {                                                                        \
-    uv_fs_stat(uv_default_loop(), (req), (path), NULL);                       \
+    uv_fs_stat(NULL, (req), (path), NULL);                                    \
     uv_fs_req_cleanup((req));                                                 \
   }                                                                           \
   while (0)

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -304,7 +304,7 @@ static int pipe_echo_start(char* pipeName) {
 #ifndef _WIN32
   {
     uv_fs_t req;
-    uv_fs_unlink(uv_default_loop(), &req, pipeName, NULL);
+    uv_fs_unlink(NULL, &req, pipeName, NULL);
     uv_fs_req_cleanup(&req);
   }
 #endif

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -267,14 +267,10 @@ int process_wait(process_info_t* vec, int n, int timeout) {
       kill(p->pid, SIGTERM);
     }
     retval = -2;
-
-    /* Wait for thread to finish. */
-    r = pthread_join(tid, NULL);
-    if (r) {
-      perror("pthread_join");
-      retval = -1;
-    }
   }
+
+  if (pthread_join(tid, NULL))
+    abort();
 
 terminate:
   close(args.pipe[0]);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -119,7 +119,7 @@ static void check_permission(const char* filename, unsigned int mode) {
   uv_fs_t req;
   uv_stat_t* s;
 
-  r = uv_fs_stat(uv_default_loop(), &req, filename, NULL);
+  r = uv_fs_stat(NULL, &req, filename, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
 
@@ -402,7 +402,7 @@ static void check_mkdtemp_result(uv_fs_t* req) {
   check_permission(req->path, 0700);
 
   /* Check if req->path is actually a directory */
-  r = uv_fs_stat(uv_default_loop(), &stat_req, req->path, NULL);
+  r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
   ASSERT(r == 0);
   ASSERT(((uv_stat_t*)stat_req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&stat_req);
@@ -521,7 +521,7 @@ TEST_IMPL(fs_file_noent) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, "does_not_exist", O_RDONLY, 0, NULL);
   ASSERT(r == UV_ENOENT);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -549,7 +549,7 @@ TEST_IMPL(fs_file_nametoolong) {
   memset(name, 'a', TOO_LONG_NAME_LENGTH);
   name[TOO_LONG_NAME_LENGTH] = 0;
 
-  r = uv_fs_open(loop, &req, name, O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, name, O_RDONLY, 0, NULL);
   ASSERT(r == UV_ENAMETOOLONG);
   ASSERT(req.result == UV_ENAMETOOLONG);
   uv_fs_req_cleanup(&req);
@@ -572,7 +572,7 @@ TEST_IMPL(fs_file_loop) {
   loop = uv_default_loop();
 
   unlink("test_symlink");
-  r = uv_fs_symlink(loop, &req, "test_symlink", "test_symlink", 0, NULL);
+  r = uv_fs_symlink(NULL, &req, "test_symlink", "test_symlink", 0, NULL);
 #ifdef _WIN32
   /*
    * Windows XP and Server 2003 don't support symlinks; we'll get UV_ENOTSUP.
@@ -585,7 +585,7 @@ TEST_IMPL(fs_file_loop) {
   ASSERT(r == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
   ASSERT(r == UV_ELOOP);
   ASSERT(req.result == UV_ELOOP);
   uv_fs_req_cleanup(&req);
@@ -730,63 +730,62 @@ TEST_IMPL(fs_file_sync) {
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_ftruncate(loop, &ftruncate_req, open_req1.result, 7, NULL);
+  r = uv_fs_ftruncate(NULL, &ftruncate_req, open_req1.result, 7, NULL);
   ASSERT(r == 0);
   ASSERT(ftruncate_req.result == 0);
   uv_fs_req_cleanup(&ftruncate_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", NULL);
+  r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
   ASSERT(r == 0);
   ASSERT(rename_req.result == 0);
   uv_fs_req_cleanup(&rename_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
-      NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, "test-bu") == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_unlink(loop, &unlink_req, "test_file2", NULL);
+  r = uv_fs_unlink(NULL, &unlink_req, "test_file2", NULL);
   ASSERT(r == 0);
   ASSERT(unlink_req.result == 0);
   uv_fs_req_cleanup(&unlink_req);
@@ -808,19 +807,19 @@ TEST_IMPL(fs_file_write_null_buffer) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(NULL, 0);
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r == 0);
   ASSERT(write_req.result == 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -850,19 +849,19 @@ TEST_IMPL(fs_async_dir) {
   ASSERT(mkdir_cb_count == 1);
 
   /* Create 2 files synchronously. */
-  r = uv_fs_open(loop, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -873,7 +872,7 @@ TEST_IMPL(fs_async_dir) {
   ASSERT(scandir_cb_count == 1);
 
   /* sync uv_fs_scandir */
-  r = uv_fs_scandir(loop, &scandir_req, "test_dir", 0, NULL);
+  r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
   ASSERT(r == 2);
   ASSERT(scandir_req.result == 2);
   ASSERT(scandir_req.ptr);
@@ -957,12 +956,12 @@ TEST_IMPL(fs_async_sendfile) {
   ASSERT(r == 0);
 
   /* Test starts here. */
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
-  r = uv_fs_open(loop, &open_req2, "test_file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req2.result >= 0);
@@ -975,10 +974,10 @@ TEST_IMPL(fs_async_sendfile) {
 
   ASSERT(sendfile_cb_count == 1);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
-  r = uv_fs_close(loop, &close_req, open_req2.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -1008,7 +1007,7 @@ TEST_IMPL(fs_mkdtemp) {
   ASSERT(mkdtemp_cb_count == 1);
 
   /* sync mkdtemp */
-  r = uv_fs_mkdtemp(loop, &mkdtemp_req2, path_template, NULL);
+  r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
   ASSERT(r == 0);
   check_mkdtemp_result(&mkdtemp_req2);
 
@@ -1040,7 +1039,7 @@ TEST_IMPL(fs_fstat) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1048,12 +1047,12 @@ TEST_IMPL(fs_fstat) {
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &req, file, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
   ASSERT(r == sizeof(test_buf));
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_fstat(loop, &req, file, NULL);
+  r = uv_fs_fstat(NULL, &req, file, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   s = req.ptr;
@@ -1130,7 +1129,7 @@ TEST_IMPL(fs_fstat) {
   ASSERT(fstat_cb_count == 1);
 
 
-  r = uv_fs_close(loop, &req, file, NULL);
+  r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1161,7 +1160,7 @@ TEST_IMPL(fs_access) {
   loop = uv_default_loop();
 
   /* File should not exist */
-  r = uv_fs_access(loop, &req, "test_file", F_OK, NULL);
+  r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
   ASSERT(r < 0);
   ASSERT(req.result < 0);
   uv_fs_req_cleanup(&req);
@@ -1174,7 +1173,7 @@ TEST_IMPL(fs_access) {
   access_cb_count = 0; /* reset for the next test */
 
   /* Create file */
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1182,7 +1181,7 @@ TEST_IMPL(fs_access) {
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
-  r = uv_fs_access(loop, &req, "test_file", F_OK, NULL);
+  r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1195,17 +1194,17 @@ TEST_IMPL(fs_access) {
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
-  r = uv_fs_close(loop, &req, file, NULL);
+  r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* Directory access */
-  r = uv_fs_mkdir(loop, &req, "test_dir", 0777, NULL);
+  r = uv_fs_mkdir(NULL, &req, "test_dir", 0777, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_access(loop, &req, "test_dir", W_OK, NULL);
+  r = uv_fs_access(NULL, &req, "test_dir", W_OK, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1235,7 +1234,7 @@ TEST_IMPL(fs_chmod) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1243,14 +1242,14 @@ TEST_IMPL(fs_chmod) {
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &req, file, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
   ASSERT(r == sizeof(test_buf));
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
 #ifndef _WIN32
   /* Make the file write-only */
-  r = uv_fs_chmod(loop, &req, "test_file", 0200, NULL);
+  r = uv_fs_chmod(NULL, &req, "test_file", 0200, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1259,7 +1258,7 @@ TEST_IMPL(fs_chmod) {
 #endif
 
   /* Make the file read-only */
-  r = uv_fs_chmod(loop, &req, "test_file", 0400, NULL);
+  r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1267,7 +1266,7 @@ TEST_IMPL(fs_chmod) {
   check_permission("test_file", 0400);
 
   /* Make the file read+write with sync uv_fs_fchmod */
-  r = uv_fs_fchmod(loop, &req, file, 0600, NULL);
+  r = uv_fs_fchmod(NULL, &req, file, 0600, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1333,7 +1332,7 @@ TEST_IMPL(fs_unlink_readonly) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop,
+  r = uv_fs_open(NULL,
                  &req,
                  "test_file",
                  O_RDWR | O_CREAT,
@@ -1345,7 +1344,7 @@ TEST_IMPL(fs_unlink_readonly) {
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &req, file, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
   ASSERT(r == sizeof(test_buf));
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
@@ -1353,7 +1352,7 @@ TEST_IMPL(fs_unlink_readonly) {
   close(file);
 
   /* Make the file read-only */
-  r = uv_fs_chmod(loop, &req, "test_file", 0400, NULL);
+  r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1361,7 +1360,7 @@ TEST_IMPL(fs_unlink_readonly) {
   check_permission("test_file", 0400);
 
   /* Try to unlink the file */
-  r = uv_fs_unlink(loop, &req, "test_file", NULL);
+  r = uv_fs_unlink(NULL, &req, "test_file", NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1373,7 +1372,7 @@ TEST_IMPL(fs_unlink_readonly) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   /* Cleanup. */
-  uv_fs_chmod(loop, &req, "test_file", 0600, NULL);
+  uv_fs_chmod(NULL, &req, "test_file", 0600, NULL);
   uv_fs_req_cleanup(&req);
   unlink("test_file");
 
@@ -1392,7 +1391,7 @@ TEST_IMPL(fs_chown) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1400,13 +1399,13 @@ TEST_IMPL(fs_chown) {
   uv_fs_req_cleanup(&req);
 
   /* sync chown */
-  r = uv_fs_chown(loop, &req, "test_file", -1, -1, NULL);
+  r = uv_fs_chown(NULL, &req, "test_file", -1, -1, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* sync fchown */
-  r = uv_fs_fchown(loop, &req, file, -1, -1, NULL);
+  r = uv_fs_fchown(NULL, &req, file, -1, -1, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
@@ -1458,7 +1457,7 @@ TEST_IMPL(fs_link) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1466,7 +1465,7 @@ TEST_IMPL(fs_link) {
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &req, file, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
   ASSERT(r == sizeof(test_buf));
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
@@ -1474,12 +1473,12 @@ TEST_IMPL(fs_link) {
   close(file);
 
   /* sync link */
-  r = uv_fs_link(loop, &req, "test_file", "test_file_link", NULL);
+  r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, "test_file_link", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   link = req.result;
@@ -1487,7 +1486,7 @@ TEST_IMPL(fs_link) {
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &req, link, &iov, 1, 0, NULL);
+  r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
@@ -1500,7 +1499,7 @@ TEST_IMPL(fs_link) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(link_cb_count == 1);
 
-  r = uv_fs_open(loop, &req, "test_file_link2", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   link = req.result;
@@ -1508,7 +1507,7 @@ TEST_IMPL(fs_link) {
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &req, link, &iov, 1, 0, NULL);
+  r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
@@ -1542,7 +1541,7 @@ TEST_IMPL(fs_readlink) {
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
-  ASSERT(UV_ENOENT == uv_fs_readlink(loop, &req, "no_such_file", NULL));
+  ASSERT(UV_ENOENT == uv_fs_readlink(NULL, &req, "no_such_file", NULL));
   ASSERT(req.ptr == NULL);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -1567,7 +1566,7 @@ TEST_IMPL(fs_symlink) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
@@ -1575,7 +1574,7 @@ TEST_IMPL(fs_symlink) {
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &req, file, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
   ASSERT(r == sizeof(test_buf));
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
@@ -1583,7 +1582,7 @@ TEST_IMPL(fs_symlink) {
   close(file);
 
   /* sync symlink */
-  r = uv_fs_symlink(loop, &req, "test_file", "test_file_symlink", 0, NULL);
+  r = uv_fs_symlink(NULL, &req, "test_file", "test_file_symlink", 0, NULL);
 #ifdef _WIN32
   if (r < 0) {
     if (r == UV_ENOTSUP) {
@@ -1605,7 +1604,7 @@ TEST_IMPL(fs_symlink) {
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, "test_file_symlink", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   link = req.result;
@@ -1613,14 +1612,14 @@ TEST_IMPL(fs_symlink) {
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &req, link, &iov, 1, 0, NULL);
+  r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
   close(link);
 
-  r = uv_fs_symlink(loop,
+  r = uv_fs_symlink(NULL,
                     &req,
                     "test_file_symlink",
                     "test_file_symlink_symlink",
@@ -1629,7 +1628,7 @@ TEST_IMPL(fs_symlink) {
   ASSERT(r == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_readlink(loop, &req, "test_file_symlink_symlink", NULL);
+  r = uv_fs_readlink(NULL, &req, "test_file_symlink_symlink", NULL);
   ASSERT(r == 0);
   ASSERT(strcmp(req.ptr, "test_file_symlink") == 0);
   uv_fs_req_cleanup(&req);
@@ -1645,7 +1644,7 @@ TEST_IMPL(fs_symlink) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(symlink_cb_count == 1);
 
-  r = uv_fs_open(loop, &req, "test_file_symlink2", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   link = req.result;
@@ -1653,14 +1652,14 @@ TEST_IMPL(fs_symlink) {
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &req, link, &iov, 1, 0, NULL);
+  r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
   close(link);
 
-  r = uv_fs_symlink(loop,
+  r = uv_fs_symlink(NULL,
                     &req,
                     "test_file_symlink2",
                     "test_file_symlink2_symlink",
@@ -1706,7 +1705,7 @@ TEST_IMPL(fs_symlink_dir) {
 
   loop = uv_default_loop();
 
-  uv_fs_mkdir(loop, &req, "test_dir", 0777, NULL);
+  uv_fs_mkdir(NULL, &req, "test_dir", 0777, NULL);
   uv_fs_req_cleanup(&req);
 
 #ifdef _WIN32
@@ -1723,18 +1722,18 @@ TEST_IMPL(fs_symlink_dir) {
   test_dir = "test_dir";
 #endif
 
-  r = uv_fs_symlink(loop, &req, test_dir, "test_dir_symlink",
+  r = uv_fs_symlink(NULL, &req, test_dir, "test_dir_symlink",
     UV_FS_SYMLINK_JUNCTION, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_stat(loop, &req, "test_dir_symlink", NULL);
+  r = uv_fs_stat(NULL, &req, "test_dir_symlink", NULL);
   ASSERT(r == 0);
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_lstat(loop, &req, "test_dir_symlink", NULL);
+  r = uv_fs_lstat(NULL, &req, "test_dir_symlink", NULL);
   ASSERT(r == 0);
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFLNK);
 #ifdef _WIN32
@@ -1744,7 +1743,7 @@ TEST_IMPL(fs_symlink_dir) {
 #endif
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_readlink(loop, &req, "test_dir_symlink", NULL);
+  r = uv_fs_readlink(NULL, &req, "test_dir_symlink", NULL);
   ASSERT(r == 0);
 #ifdef _WIN32
   ASSERT(strcmp(req.ptr, test_dir + 4) == 0);
@@ -1753,23 +1752,23 @@ TEST_IMPL(fs_symlink_dir) {
 #endif
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_scandir(loop, &scandir_req, "test_dir_symlink", 0, NULL);
+  r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
   ASSERT(r == 2);
   ASSERT(scandir_req.result == 2);
   ASSERT(scandir_req.ptr);
@@ -1785,15 +1784,15 @@ TEST_IMPL(fs_symlink_dir) {
   ASSERT(!scandir_req.ptr);
 
   /* unlink will remove the directory symlink */
-  r = uv_fs_unlink(loop, &req, "test_dir_symlink", NULL);
+  r = uv_fs_unlink(NULL, &req, "test_dir_symlink", NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_scandir(loop, &scandir_req, "test_dir_symlink", 0, NULL);
+  r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
   ASSERT(r == UV_ENOENT);
   uv_fs_req_cleanup(&scandir_req);
 
-  r = uv_fs_scandir(loop, &scandir_req, "test_dir", 0, NULL);
+  r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
   ASSERT(r == 2);
   ASSERT(scandir_req.result == 2);
   ASSERT(scandir_req.ptr);
@@ -1830,8 +1829,7 @@ TEST_IMPL(fs_utime) {
   /* Setup. */
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(loop, &req, path, O_RDWR | O_CREAT,
-      S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   uv_fs_req_cleanup(&req);
@@ -1839,12 +1837,12 @@ TEST_IMPL(fs_utime) {
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
-  r = uv_fs_utime(loop, &req, path, atime, mtime, NULL);
+  r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_stat(loop, &req, path, NULL);
+  r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   check_utime(path, atime, mtime);
@@ -1875,26 +1873,26 @@ TEST_IMPL(fs_stat_root) {
   int r;
   uv_loop_t* loop = uv_default_loop();
 
-  r = uv_fs_stat(loop, &stat_req, "\\", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
   ASSERT(r == 0);
 
-  r = uv_fs_stat(loop, &stat_req, "..\\..\\..\\..\\..\\..\\..", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "..\\..\\..\\..\\..\\..\\..", NULL);
   ASSERT(r == 0);
 
-  r = uv_fs_stat(loop, &stat_req, "..", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "..", NULL);
   ASSERT(r == 0);
 
-  r = uv_fs_stat(loop, &stat_req, "..\\", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "..\\", NULL);
   ASSERT(r == 0);
 
   /* stats the current directory on c: */
-  r = uv_fs_stat(loop, &stat_req, "c:", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "c:", NULL);
   ASSERT(r == 0);
 
-  r = uv_fs_stat(loop, &stat_req, "c:\\", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "c:\\", NULL);
   ASSERT(r == 0);
 
-  r = uv_fs_stat(loop, &stat_req, "\\\\?\\C:\\", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "\\\\?\\C:\\", NULL);
   ASSERT(r == 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -1915,8 +1913,7 @@ TEST_IMPL(fs_futime) {
   /* Setup. */
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(loop, &req, path, O_RDWR | O_CREAT,
-      S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   uv_fs_req_cleanup(&req);
@@ -1924,18 +1921,18 @@ TEST_IMPL(fs_futime) {
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
-  r = uv_fs_open(loop, &req, path, O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   file = req.result; /* FIXME probably not how it's supposed to be used */
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_futime(loop, &req, file, atime, mtime, NULL);
+  r = uv_fs_futime(NULL, &req, file, atime, mtime, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_stat(loop, &req, path, NULL);
+  r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   check_utime(path, atime, mtime);
@@ -1968,7 +1965,7 @@ TEST_IMPL(fs_stat_missing_path) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_stat(loop, &req, "non_existent_file", NULL);
+  r = uv_fs_stat(NULL, &req, "non_existent_file", NULL);
   ASSERT(r == UV_ENOENT);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -1987,13 +1984,13 @@ TEST_IMPL(fs_scandir_empty_dir) {
   path = "./empty_dir/";
   loop = uv_default_loop();
 
-  uv_fs_mkdir(loop, &req, path, 0777, NULL);
+  uv_fs_mkdir(NULL, &req, path, 0777, NULL);
   uv_fs_req_cleanup(&req);
 
   /* Fill the req to ensure that required fields are cleaned up */
   memset(&req, 0xdb, sizeof(req));
 
-  r = uv_fs_scandir(loop, &req, path, 0, NULL);
+  r = uv_fs_scandir(NULL, &req, path, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
   ASSERT(req.ptr == NULL);
@@ -2007,7 +2004,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
-  uv_fs_rmdir(loop, &req, path, NULL);
+  uv_fs_rmdir(NULL, &req, path, NULL);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY();
@@ -2022,7 +2019,7 @@ TEST_IMPL(fs_scandir_file) {
   path = "test/fixtures/empty_file";
   loop = uv_default_loop();
 
-  r = uv_fs_scandir(loop, &scandir_req, path, 0, NULL);
+  r = uv_fs_scandir(NULL, &scandir_req, path, 0, NULL);
   ASSERT(r == UV_ENOTDIR);
   uv_fs_req_cleanup(&scandir_req);
 
@@ -2046,14 +2043,14 @@ TEST_IMPL(fs_open_dir) {
   path = ".";
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &req, path, O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
   ASSERT(req.ptr == NULL);
   file = r;
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_close(loop, &req, file, NULL);
+  r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);
 
   r = uv_fs_open(loop, &req, path, O_RDONLY, 0, open_cb_simple);
@@ -2076,47 +2073,46 @@ TEST_IMPL(fs_file_open_append) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDWR | O_APPEND, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | O_APPEND, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDONLY, S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
-      NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   printf("read = %d\n", r);
   ASSERT(r == 26);
   ASSERT(read_req.result == 26);
@@ -2125,7 +2121,7 @@ TEST_IMPL(fs_file_open_append) {
                 sizeof("test-buffer\n\0test-buffer\n\0") - 1) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2147,54 +2143,53 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", NULL);
+  r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
   ASSERT(r == 0);
   ASSERT(rename_req.result == 0);
   uv_fs_req_cleanup(&rename_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
-      NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2216,44 +2211,44 @@ TEST_IMPL(fs_read_file_eof) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1,
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  read_req.result, NULL);
   ASSERT(r == 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2275,7 +2270,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
@@ -2283,17 +2278,17 @@ TEST_IMPL(fs_write_multiple_bufs) {
 
   iovs[0] = uv_buf_init(test_buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(test_buf2, sizeof(test_buf2));
-  r = uv_fs_write(loop, &write_req, open_req1.result, iovs, 2, 0, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, iovs, 2, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
   uv_fs_req_cleanup(&open_req1);
@@ -2303,7 +2298,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
   /* Read the strings back to separate buffers. */
   iovs[0] = uv_buf_init(buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
-  r = uv_fs_read(loop, &read_req, open_req1.result, iovs, 2, 0, NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, 2, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
@@ -2311,13 +2306,13 @@ TEST_IMPL(fs_write_multiple_bufs) {
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1,
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  read_req.result, NULL);
   ASSERT(r == 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2345,7 +2340,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   iovs = malloc(sizeof(*iovs) * iovcount);
   ASSERT(iovs != NULL);
 
-  r = uv_fs_open(loop,
+  r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
                  O_RDWR | O_CREAT,
@@ -2358,7 +2353,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   for (index = 0; index < iovcount; ++index)
     iovs[index] = uv_buf_init(test_buf, sizeof(test_buf));
 
-  r = uv_fs_write(loop,
+  r = uv_fs_write(NULL,
                   &write_req,
                   open_req1.result,
                   iovs,
@@ -2377,7 +2372,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
                               sizeof(test_buf));
 
-  r = uv_fs_read(loop, &read_req, open_req1.result, iovs, iovcount, 0, NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, iovcount, 0, NULL);
   ASSERT(r >= 0);
   ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
 
@@ -2390,7 +2385,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   free(buffer);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop,
+  r = uv_fs_read(NULL,
                  &read_req,
                  open_req1.result,
                  &iov,
@@ -2401,7 +2396,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2433,7 +2428,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   iovs = malloc(sizeof(*iovs) * iovcount);
   ASSERT(iovs != NULL);
 
-  r = uv_fs_open(loop,
+  r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
                  O_RDWR | O_CREAT,
@@ -2444,7 +2439,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(filler, filler_len);
-  r = uv_fs_write(loop, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT(r == filler_len);
   ASSERT(write_req.result == filler_len);
   uv_fs_req_cleanup(&write_req);
@@ -2453,7 +2448,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   for (index = 0; index < iovcount; ++index)
     iovs[index] = uv_buf_init(test_buf, sizeof(test_buf));
 
-  r = uv_fs_write(loop,
+  r = uv_fs_write(NULL,
                   &write_req,
                   open_req1.result,
                   iovs,
@@ -2472,7 +2467,8 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
                               sizeof(test_buf));
 
-  r = uv_fs_read(loop, &read_req, open_req1.result, iovs, iovcount, offset, NULL);
+  r = uv_fs_read(NULL, &read_req, open_req1.result,
+                 iovs, iovcount, offset, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result == sizeof(test_buf) * iovcount);
 
@@ -2484,14 +2480,14 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   uv_fs_req_cleanup(&read_req);
   free(buffer);
 
-  r = uv_fs_stat(loop, &stat_req, "test_file", NULL);
+  r = uv_fs_stat(NULL, &stat_req, "test_file", NULL);
   ASSERT(r == 0);
   ASSERT((int64_t)((uv_stat_t*)stat_req.ptr)->st_size ==
          offset + (int64_t)(iovcount * sizeof(test_buf)));
   uv_fs_req_cleanup(&stat_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop,
+  r = uv_fs_read(NULL,
                  &read_req,
                  open_req1.result,
                  &iov,
@@ -2502,7 +2498,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(loop, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -277,7 +277,7 @@ TEST_IMPL(spawn_stdout_to_file) {
 
   init_process_options("spawn_helper2", exit_cb);
 
-  r = uv_fs_open(uv_default_loop(), &fs_req, "stdout_file", O_CREAT | O_RDWR,
+  r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
   ASSERT(r != -1);
   uv_fs_req_cleanup(&fs_req);
@@ -300,11 +300,11 @@ TEST_IMPL(spawn_stdout_to_file) {
   ASSERT(close_cb_called == 1);
 
   buf = uv_buf_init(output, sizeof(output));
-  r = uv_fs_read(uv_default_loop(), &fs_req, file, &buf, 1, 0, NULL);
+  r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
   ASSERT(r == 12);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(uv_default_loop(), &fs_req, file, NULL);
+  r = uv_fs_close(NULL, &fs_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -331,7 +331,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
 
   init_process_options("spawn_helper6", exit_cb);
 
-  r = uv_fs_open(uv_default_loop(), &fs_req, "stdout_file", O_CREAT | O_RDWR,
+  r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
   ASSERT(r != -1);
   uv_fs_req_cleanup(&fs_req);
@@ -356,11 +356,11 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   ASSERT(close_cb_called == 1);
 
   buf = uv_buf_init(output, sizeof(output));
-  r = uv_fs_read(uv_default_loop(), &fs_req, file, &buf, 1, 0, NULL);
+  r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
   ASSERT(r == 27);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(uv_default_loop(), &fs_req, file, NULL);
+  r = uv_fs_close(NULL, &fs_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -389,7 +389,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   init_process_options("spawn_helper6", exit_cb);
 
   /* Replace stderr with our file */
-  r = uv_fs_open(uv_default_loop(),
+  r = uv_fs_open(NULL,
                  &fs_req,
                  "stdout_file",
                  O_CREAT | O_RDWR,
@@ -418,11 +418,11 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   ASSERT(close_cb_called == 1);
 
   buf = uv_buf_init(output, sizeof(output));
-  r = uv_fs_read(uv_default_loop(), &fs_req, file, &buf, 1, 0, NULL);
+  r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
   ASSERT(r == 27);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(uv_default_loop(), &fs_req, file, NULL);
+  r = uv_fs_close(NULL, &fs_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -456,7 +456,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   init_process_options("spawn_helper6", exit_cb);
 
   /* open 'stdout_file' and replace STDOUT_FILENO with it */
-  r = uv_fs_open(uv_default_loop(),
+  r = uv_fs_open(NULL,
                  &fs_req,
                  "stdout_file",
                  O_CREAT | O_RDWR,
@@ -468,7 +468,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   ASSERT(stdout_file != -1);
 
   /* open 'stderr_file' and replace STDERR_FILENO with it */
-  r = uv_fs_open(uv_default_loop(), &fs_req, "stderr_file", O_CREAT | O_RDWR,
+  r = uv_fs_open(NULL, &fs_req, "stderr_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
   ASSERT(r != -1);
   uv_fs_req_cleanup(&fs_req);
@@ -497,11 +497,11 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   buf = uv_buf_init(output, sizeof(output));
 
   /* check the content of stdout_file */
-  r = uv_fs_read(uv_default_loop(), &fs_req, stdout_file, &buf, 1, 0, NULL);
+  r = uv_fs_read(NULL, &fs_req, stdout_file, &buf, 1, 0, NULL);
   ASSERT(r >= 15);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(uv_default_loop(), &fs_req, stdout_file, NULL);
+  r = uv_fs_close(NULL, &fs_req, stdout_file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -509,11 +509,11 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   ASSERT(strncmp("hello errworld\n", output, 15) == 0);
 
   /* check the content of stderr_file */
-  r = uv_fs_read(uv_default_loop(), &fs_req, stderr_file, &buf, 1, 0, NULL);
+  r = uv_fs_read(NULL, &fs_req, stderr_file, &buf, 1, 0, NULL);
   ASSERT(r >= 12);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(uv_default_loop(), &fs_req, stderr_file, NULL);
+  r = uv_fs_close(NULL, &fs_req, stderr_file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -1399,7 +1399,7 @@ TEST_IMPL(spawn_fs_open) {
   uv_buf_t buf;
   uv_stdio_container_t stdio[1];
 
-  fd = uv_fs_open(uv_default_loop(), &fs_req, "/dev/null", O_RDWR, 0, NULL);
+  fd = uv_fs_open(NULL, &fs_req, "/dev/null", O_RDWR, 0, NULL);
   ASSERT(fd >= 0);
   uv_fs_req_cleanup(&fs_req);
 
@@ -1418,7 +1418,7 @@ TEST_IMPL(spawn_fs_open) {
   ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb));
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == uv_fs_close(uv_default_loop(), &fs_req, fd, NULL));
+  ASSERT(0 == uv_fs_close(NULL, &fs_req, fd, NULL));
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2);  /* One for `in`, one for process */


### PR DESCRIPTION
For synchronous file operation requests (ones without a callback), there
is no need to make a copy of the arguments because they don't outlive
the scope of the function call.

R=@saghul

CI: https://jenkins-iojs.nodesource.com/view/libuv/job/libuv+any-pr+multi/128/