### PR TITLE
Windows: Avoid EBADF on second accept

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -802,6 +802,7 @@ static void uv_pipe_queue_accept(uv_loop_t* loop, uv_pipe_t* handle,
       return;
     }
 
+    handle->handle = INVALID_HANDLE_VALUE;
     if (uv_set_pipe_handle(loop, handle, req->pipeHandle, -1, 0)) {
       CloseHandle(req->pipeHandle);
       req->pipeHandle = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
I'm not sure if this is the right fix, but it makes the bug go away.

https://github.com/libuv/libuv/issues/485

...if the handle->handle != INVALID_HANDLE_VALUE, does the handle->handle need to be closed?