### PR TITLE
freebsd: obtain true uptime through clock_gettime()

### DIFF
--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -223,17 +223,13 @@ error:
 
 
 int uv_uptime(double* uptime) {
-  time_t now;
-  struct timeval info;
-  size_t size = sizeof(info);
-  static int which[] = {CTL_KERN, KERN_BOOTTIME};
-
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  int r;
+  struct timespec sp;
+  r = clock_gettime(CLOCK_MONOTONIC, &sp);
+  if (r)
     return -errno;
 
-  now = time(NULL);
-
-  *uptime = (double)(now - info.tv_sec);
+  *uptime = sp.tv_sec;
   return 0;
 }
 


### PR DESCRIPTION
Obtain true uptime through clock_gettime() instead of subtracting 'bootime' from 'now'.
Talking about in nodejs/node#2573, and freebsd has updated
freebsd/freebsd@74d3dde

