### PR TITLE
Disable pwritev/preadv syscall

### DIFF
--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -207,26 +207,6 @@
 # endif
 #endif /* __NR_utimensat */
 
-#ifndef __NR_preadv
-# if defined(__x86_64__)
-#  define __NR_preadv 295
-# elif defined(__i386__)
-#  define __NR_preadv 333
-# elif defined(__arm__)
-#  define __NR_preadv (UV_SYSCALL_BASE + 361)
-# endif
-#endif /* __NR_preadv */
-
-#ifndef __NR_pwritev
-# if defined(__x86_64__)
-#  define __NR_pwritev 296
-# elif defined(__i386__)
-#  define __NR_pwritev 334
-# elif defined(__arm__)
-#  define __NR_pwritev (UV_SYSCALL_BASE + 362)
-# endif
-#endif /* __NR_pwritev */
-
 #ifndef __NR_dup3
 # if defined(__x86_64__)
 #  define __NR_dup3 292
@@ -438,24 +418,6 @@ int uv__utimesat(int dirfd,
 {
 #if defined(__NR_utimensat)
   return syscall(__NR_utimensat, dirfd, path, times, flags);
-#else
-  return errno = ENOSYS, -1;
-#endif
-}
-
-
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
-#if defined(__NR_preadv)
-  return syscall(__NR_preadv, fd, iov, iovcnt, offset);
-#else
-  return errno = ENOSYS, -1;
-#endif
-}
-
-
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
-#if defined(__NR_pwritev)
-  return syscall(__NR_pwritev, fd, iov, iovcnt, offset);
 #else
   return errno = ENOSYS, -1;
 #endif

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -151,8 +151,6 @@ int uv__utimesat(int dirfd,
                  const char* path,
                  const struct timespec times[2],
                  int flags);
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
 int uv__dup3(int oldfd, int newfd, int flags);
 
 #endif /* UV_LINUX_SYSCALL_H_ */


### PR DESCRIPTION
So I figured out that the syscalls for ppc and mips have 'Architecture specific requirements' as described in: http://man7.org/linux/man-pages/man2/syscall.2.html#NOTES
It's because the 64bit offset, doesn't fit in a 32 bit register.

The libuv syscall specific implementation came with: joyent/libuv/pull/1103 It was stated that, at that time some architecture specific preadv and pwritev implementations were emulated by glibc. I agree we don't want emulated preadv/pwritev because it can hurt performance.

At first I tried (several) fixes to solve this problem, but in hindsight I think libuv should leave the Architecture specific implementations to the implementing c library.

So, for now, I propose to disable the syscalls for preadv/pwritev.

Although disabling the current preadv/pwritev syscalls does fix #473, I would really like to know if I'm on the right track here.
If so I am willing to provide an (direct syscall) implementation for just those architectures that emulate preadv/pwritev.