### PR TITLE
Correct a typo by replacing uv_request_t by uv_req_t

### DIFF
--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -25,7 +25,7 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
-.. c:member:: void* uv_request_t.data
+.. c:member:: void* uv_req_t.data
 
     Space for user-defined arbitrary data. libuv does not use this field.
 


### PR DESCRIPTION
Tend to believe that `uv_request_t` should be `uv_req_t`. 
Please ignore if I have mistaken.