### PR TITLE
unix: fix error check when closing process pipe fd

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -226,13 +226,14 @@ static int uv__process_open_stream(uv_stdio_container_t* container,
                                    int pipefds[2],
                                    int writable) {
   int flags;
+  int err;
 
   if (!(container->flags & UV_CREATE_PIPE) || pipefds[0] < 0)
     return 0;
 
-  if (uv__close(pipefds[1]))
-    if (errno != EINTR && errno != EINPROGRESS)
-      abort();
+  err = uv__close(pipefds[1]);
+  if (err != 0 && err != -EINPROGRESS)
+    abort();
 
   pipefds[1] = -1;
   uv__nonblock(pipefds[0], 1);


### PR DESCRIPTION
uv__close() does not set errno, it returns the error.  It also never
returns EINTR, it always maps it to EINPROGRESS.

R=@saghul