### PR TITLE
threadpool: fix initialization of idle_threads

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -134,7 +134,9 @@ UV_DESTRUCTOR(static void cleanup(void)) {
 
   threads = NULL;
   nthreads = 0;
+  idle_threads = 0;
   initialized = 0;
+
 }
 #endif
 
@@ -160,6 +162,8 @@ static void init_once(void) {
       threads = default_threads;
     }
   }
+
+  idle_threads = 0;
 
   if (uv_cond_init(&cond))
     abort();


### PR DESCRIPTION
In some platforms,  without initialization , value is random.
Here, may cause thread blocked.  :)
@bnoordhuis @saghul