### PR TITLE
win: fix unsavory rwlock fallback implementation

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -250,8 +250,16 @@ typedef union {
   /* windows.h. */
   SRWLOCK srwlock_;
   struct {
-    uv_mutex_t read_mutex_;
-    uv_mutex_t write_mutex_;
+    union {
+      CRITICAL_SECTION cs;
+      /* TODO: remove me in v2.x. */
+      uv_mutex_t unused;
+    } read_lock_;
+    union {
+      HANDLE sem;
+      /* TODO: remove me in v2.x. */
+      uv_mutex_t unused;
+    } write_lock_;
     unsigned int num_readers_;
   } fallback_;
 } uv_rwlock_t;


### PR DESCRIPTION
Before this patch an uv_mutex_t (backed by a critical section) could be
released by a tread different from the thread that acquired it, which is
not allowed. This is fixed by using a semaphore instead.

BUG: https://github.com/libuv/libuv/issues/515
REF: https://github.com/nodejs/node/pull/2723

R=@bnoordhuis
R=@saghul