### PR TITLE
win: fix unsavory rwlock fallback implementation

### DIFF
--- a/include/uv-private/uv-win.h
+++ b/include/uv-private/uv-win.h
@@ -239,8 +239,16 @@ typedef union {
   /* windows.h. */
   SRWLOCK srwlock_;
   struct {
-    uv_mutex_t read_mutex_;
-    uv_mutex_t write_mutex_;
+    union {
+      CRITICAL_SECTION cs;
+      /* TODO: remove me in v2.x. */
+      uv_mutex_t unused;
+    } read_lock_;
+    union {
+      HANDLE sem;
+      /* TODO: remove me in v2.x. */
+      uv_mutex_t unused;
+    } write_lock_;
     unsigned int num_readers_;
   } fallback_;
 } uv_rwlock_t;


### PR DESCRIPTION
Before this patch an uv_mutex_t (backed by a critical section) could be
released by a tread different from the thread that acquired it, which is
not allowed. This is fixed by using a semaphore instead.

Note that the affected code paths were used on Windows XP and Windows
Server 2003 only.

This is a back-port of commit 3eb6764 from the v1.x branch.

Fixes: https://github.com/libuv/libuv/issues/515

R=@piscisaureus @saghul

CI: https://ci.nodejs.org/view/libuv/job/libuv+any-pr+multi/147/