### PR TITLE
win: Use an external snpritnf hook

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -55,11 +55,7 @@ static int inet_ntop4(const unsigned char *src, char *dst, size_t size) {
   char tmp[UV__INET_ADDRSTRLEN];
   int l;
 
-#ifndef _WIN32
   l = snprintf(tmp, sizeof(tmp), fmt, src[0], src[1], src[2], src[3]);
-#else
-  l = _snprintf(tmp, sizeof(tmp), fmt, src[0], src[1], src[2], src[3]);
-#endif
   if (l <= 0 || (size_t) l >= size) {
     return UV_ENOSPC;
   }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -141,11 +141,7 @@ static const char* uv__unknown_err_code(int err) {
   char buf[32];
   char* copy;
 
-#ifndef _WIN32
   snprintf(buf, sizeof(buf), "Unknown system error %d", err);
-#else
-  _snprintf(buf, sizeof(buf), "Unknown system error %d", err);
-#endif
   copy = uv__strdup(buf);
 
   return copy != NULL ? copy : "Unknown system error";

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -41,6 +41,10 @@
 #include "tree.h"
 #include "queue.h"
 
+#if !defined(snprintf) && defined(_MSC_VER) && _MSC_VER < 1900
+extern int snprintf(char*, size_t, const char*, ...);
+#endif
+
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 #define container_of(ptr, type, member) \

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -85,7 +85,7 @@ static void eof_timer_close_cb(uv_handle_t* handle);
 
 
 static void uv_unique_pipe_name(char* ptr, char* name, size_t size) {
-  _snprintf(name, size, "\\\\?\\pipe\\uv\\%p-%u", ptr, GetCurrentProcessId());
+  snprintf(name, size, "\\\\?\\pipe\\uv\\%p-%u", ptr, GetCurrentProcessId());
 }
 
 

--- a/src/win/snprintf.c
+++ b/src/win/snprintf.c
@@ -1,4 +1,4 @@
-/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+/* Copyright the libuv project contributors. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -19,21 +19,23 @@
  * IN THE SOFTWARE.
  */
 
-/* Don't complain about write(), fileno() etc. being deprecated. */
-#pragma warning(disable : 4996)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 
-
-#include <winsock2.h>
-#include <windows.h>
 #include <stdio.h>
+#include <stdarg.h>
 
-#if !defined(snprintf) && defined(_MSC_VER) && _MSC_VER < 1900
-extern int snprintf(char*, size_t, const char*, ...);
+/* Emulate snprintf() on MSVC<2015, _snprintf() doesn't zero-terminate the buffer
+ * on overflow...
+ */ 
+int snprintf(char* buf, size_t len, const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+
+  int n = _vscprintf(fmt, ap);
+  vsnprintf_s(buf, len, _TRUNCATE, fmt, ap);
+
+  va_end(ap);
+  return n; 
+} 
+
 #endif
-
-typedef struct {
-  HANDLE process;
-  HANDLE stdio_in;
-  HANDLE stdio_out;
-  char *name;
-} process_info_t;

--- a/test/task.h
+++ b/test/task.h
@@ -174,40 +174,8 @@ enum test_status {
 
 #endif
 
-
-#if defined _WIN32 && ! defined __GNUC__
-
-#include <stdarg.h>
-
-/* Define inline for MSVC<2015 */
-# if defined(_MSC_VER) && _MSC_VER < 1900
-#  define inline __inline
-# endif
-
-# if defined(_MSC_VER) && _MSC_VER < 1900
-/* Emulate snprintf() on MSVC<2015, _snprintf() doesn't zero-terminate the buffer
- * on overflow...
- */
-inline int snprintf(char* buf, size_t len, const char* fmt, ...) {
-  va_list ap;
-  int n;
-
-  va_start(ap, fmt);
-  n = _vsprintf_p(buf, len, fmt, ap);
-  va_end(ap);
-
-  /* It's a sad fact of life that no one ever checks the return value of
-   * snprintf(). Zero-terminating the buffer hopefully reduces the risk
-   * of gaping security holes.
-   */
-  if (n < 0)
-    if (len > 0)
-      buf[0] = '\0';
-
-  return n;
-}
-# endif
-
+#if !defined(snprintf) && defined(_MSC_VER) && _MSC_VER < 1900
+extern int snprintf(char*, size_t, const char*, ...);
 #endif
 
 #if defined(__clang__) ||                                \

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -960,11 +960,11 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   options.stdio_count = 2;
 
   /* Create a pipe that'll cause a collision. */
-  _snprintf(name,
-            sizeof(name),
-            "\\\\.\\pipe\\uv\\%p-%d",
-            &out,
-            GetCurrentProcessId());
+  snprintf(name,
+           sizeof(name),
+           "\\\\.\\pipe\\uv\\%p-%d",
+           &out,
+           GetCurrentProcessId());
   pipe_handle = CreateNamedPipeA(name,
                                 PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
                                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,

--- a/uv.gyp
+++ b/uv.gyp
@@ -104,6 +104,13 @@
             'src/win/winsock.c',
             'src/win/winsock.h',
           ],
+          'conditions': [
+            ['MSVS_VERSION < "2015"', {
+              'sources': [
+                'src/win/snprintf.c'
+              ]
+            }]
+          ],
           'link_settings': {
             'libraries': [
               '-ladvapi32',


### PR DESCRIPTION
* For VS2013 and below, it will compile and additional file `src/win/snprintf.c`, which contains the fallback implementation. The function is included with `extern` in other files while required. 

* In uv.gyp, `snprintf.c` is included in sources conditionally; only for VS2013 and below.

* Note that I have also guarded it with condition inside the `snprintf.c` file, so if any consumer/downstream is not using `libuv/uv.gyp` but their own build system (say CMake), this will still prevent them redefining snprintf for VS2015 even if they add `/src/win/snprintf.c` in to-be-compiled sources unconditionally.

Discussion: https://github.com/libuv/libuv/pull/487#issuecomment-141643603.

/cc: @saghul, @equalsraf 