### PR TITLE
unix: consolidate rwlock tryrdlock trywrlock errors

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -162,10 +162,13 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
   int err;
 
   err = pthread_rwlock_tryrdlock(rwlock);
-  if (err && err != EBUSY && err != EAGAIN)
-    abort();
+  if (err) {
+    if (err != EBUSY && err != EAGAIN)
+      abort();
+    return -EBUSY;
+  }
 
-  return -err;
+  return 0;
 }
 
 
@@ -185,10 +188,13 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
   int err;
 
   err = pthread_rwlock_trywrlock(rwlock);
-  if (err && err != EBUSY && err != EAGAIN)
-    abort();
+  if (err) {
+    if (err != EBUSY && err != EAGAIN)
+      abort();
+    return -EBUSY;
+  }
 
-  return -err;
+  return 0;
 }
 
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -124,14 +124,14 @@ void uv_mutex_lock(uv_mutex_t* mutex) {
 int uv_mutex_trylock(uv_mutex_t* mutex) {
   int err;
 
-  /* FIXME(bnoordhuis) EAGAIN means recursive lock limit reached. Arguably
-   * a bug, should probably abort rather than return -EAGAIN.
-   */
   err = pthread_mutex_trylock(mutex);
-  if (err && err != EBUSY && err != EAGAIN)
-    abort();
+  if (err) {
+    if (err != EBUSY && err != EAGAIN)
+      abort();
+    return -EBUSY;
+  }
 
-  return -err;
+  return 0;
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -232,7 +232,7 @@ int uv_mutex_trylock(uv_mutex_t* mutex) {
   if (TryEnterCriticalSection(mutex))
     return 0;
   else
-    return UV_EAGAIN;
+    return UV_EBUSY;
 }
 
 


### PR DESCRIPTION
Fold EAGAIN and EBUSY into EBUSY. This makes it consistent across all
Unix platforms and Windows.

Refs: https://github.com/libuv/libuv/pull/525

R=@bnoordhuis