### PR TITLE
unix: fix memory leak in uv_interface_addresses

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -256,8 +256,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   }
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -373,8 +373,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   }
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -814,8 +814,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     return 0;
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -298,8 +298,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
 
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -313,8 +313,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
 
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -693,8 +693,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   }
 
   *addresses = uv__malloc(*count * sizeof(**addresses));
-  if (!(*addresses))
+  if (!(*addresses)) {
+    freeifaddrs(addrs);
     return -ENOMEM;
+  }
 
   address = *addresses;
 


### PR DESCRIPTION
 include `darwin`, `freebsd`,`openbsd`,`sunos`,`netbsd`, `linux`.