### PR TITLE
unix: return EBUSY instead of EDEADLK in uv_rwlock_try*

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -163,7 +163,7 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
 
   err = pthread_rwlock_tryrdlock(rwlock);
   if (err) {
-    if (err != EBUSY && err != EAGAIN)
+    if (err != EBUSY && err != EAGAIN && err != EDEADLK)
       abort();
     return -EBUSY;
   }
@@ -189,7 +189,7 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
 
   err = pthread_rwlock_trywrlock(rwlock);
   if (err) {
-    if (err != EBUSY && err != EAGAIN)
+    if (err != EBUSY && err != EAGAIN && err != EDEADLK)
       abort();
     return -EBUSY;
   }


### PR DESCRIPTION
Make the implementation consistent with Linux and Windows. Linux only
gives EDEADLK for the non-try variants, while OSX and other BSDs do.

Fixes: https://github.com/libuv/libuv/issues/544

R=@bnoordhuis