### PR TITLE
build: remove unused 'component' GYP option

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -4,7 +4,6 @@
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture
     'uv_library%': 'static_library', # allow override to 'shared_library' for DLL/.so builds
-    'component%': 'static_library',  # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
   },
 

--- a/gyp_uv.py
+++ b/gyp_uv.py
@@ -83,9 +83,6 @@ if __name__ == '__main__':
   if not any(a.startswith('-Duv_library=') for a in args):
     args.append('-Duv_library=static_library')
 
-  if not any(a.startswith('-Dcomponent=') for a in args):
-    args.append('-Dcomponent=static_library')
-
   # Some platforms (OpenBSD for example) don't have multiprocessing.synchronize
   # so gyp must be run with --no-parallel
   if not gyp_parallel_support:


### PR DESCRIPTION
R=@bnoordhuis

AFAIS this is only used by Chrome, in order to build each component as a shared or static library. They seem to use shared for development to make linking faster, and release builds are all statically linked. We don't need this here, do we?