### PR TITLE
win: do not read more from stream than available

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1633,7 +1633,7 @@ void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle,
 
       if (ReadFile(handle->handle,
                    buf.base,
-                   buf.len,
+                   min(buf.len, avail),
                    &bytes,
                    NULL)) {
         /* Successful read */

--- a/test/runner.c
+++ b/test/runner.c
@@ -211,6 +211,7 @@ int run_test(const char* test,
   /* Clean up stale socket from previous run. */
   remove(TEST_PIPENAME);
   remove(TEST_PIPENAME_2);
+  remove(TEST_PIPENAME_3);
 #endif
 
   /* If it's a helper the user asks for, start it directly. */

--- a/test/task.h
+++ b/test/task.h
@@ -50,9 +50,11 @@
 #ifdef _WIN32
 # define TEST_PIPENAME "\\\\?\\pipe\\uv-test"
 # define TEST_PIPENAME_2 "\\\\?\\pipe\\uv-test2"
+# define TEST_PIPENAME_3 "\\\\?\\pipe\\uv-test3"
 #else
 # define TEST_PIPENAME "/tmp/uv-test-sock"
 # define TEST_PIPENAME_2 "/tmp/uv-test-sock2"
+# define TEST_PIPENAME_3 "/tmp/uv-test-sock3"
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
On Windows the pipe implementation could read more from a stream than
was available and it would create an assertion failure.  This change
will make it so we read the minimum of the available data or the length
of the data.

To test this, I took the existing ipc_send_recv_tcp test and updated it
to do two writes and two read on each side of the pipe since that was the
reproduction recipe used by the reporter.  This approach reproduced the
issue on Windows and the committed fix resolved the issue.

Fixes #505