### PR TITLE
win: fix c compiler error

### DIFF
--- a/src/win/snprintf.c
+++ b/src/win/snprintf.c
@@ -28,10 +28,11 @@
  * on overflow...
  */
 int snprintf(char* buf, size_t len, const char* fmt, ...) {
+  int n;
   va_list ap;
   va_start(ap, fmt);
 
-  int n = _vscprintf(fmt, ap);
+  n = _vscprintf(fmt, ap);
   vsnprintf_s(buf, len, _TRUNCATE, fmt, ap);
 
   va_end(ap);


### PR DESCRIPTION
`int` to be declared at beginning of function scope to satisfy c compiler.