### PR TITLE
unix: use QUEUE_MOVE when iterating over lists

### DIFF
--- a/src/queue.h
+++ b/src/queue.h
@@ -66,6 +66,17 @@ typedef void *QUEUE[2];
   }                                                                           \
   while (0)
 
+#define QUEUE_MOVE(h, n)                                                      \
+  do {                                                                        \
+    if (QUEUE_EMPTY(h))                                                       \
+      QUEUE_INIT(n);                                                          \
+    else {                                                                    \
+      QUEUE* q = QUEUE_HEAD(h);                                               \
+      QUEUE_SPLIT(h, q, n);                                                   \
+    }                                                                         \
+  }                                                                           \
+  while (0)
+
 #define QUEUE_INSERT_HEAD(h, q)                                               \
   do {                                                                        \
     QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \

--- a/src/queue.h
+++ b/src/queue.h
@@ -30,6 +30,9 @@ typedef void *QUEUE[2];
 #define QUEUE_DATA(ptr, type, field)                                          \
   ((type *) ((char *) (ptr) - offsetof(type, field)))
 
+/* Important note: mutating the list while QUEUE_FOREACH is
+ * iterating over its elements results in undefined behavior.
+ */
 #define QUEUE_FOREACH(q, h)                                                   \
   for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -223,13 +223,8 @@ void uv__work_done(uv_async_t* handle) {
   int err;
 
   loop = container_of(handle, uv_loop_t, wq_async);
-  QUEUE_INIT(&wq);
-
   uv_mutex_lock(&loop->wq_mutex);
-  if (!QUEUE_EMPTY(&loop->wq)) {
-    q = QUEUE_HEAD(&loop->wq);
-    QUEUE_SPLIT(&loop->wq, q, &wq);
-  }
+  QUEUE_MOVE(&loop->wq, &wq);
   uv_mutex_unlock(&loop->wq_mutex);
 
   while (!QUEUE_EMPTY(&wq)) {

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -721,9 +721,7 @@ static int uv__run_pending(uv_loop_t* loop) {
   if (QUEUE_EMPTY(&loop->pending_queue))
     return 0;
 
-  QUEUE_INIT(&pq);
-  q = QUEUE_HEAD(&loop->pending_queue);
-  QUEUE_SPLIT(&loop->pending_queue, q, &pq);
+  QUEUE_MOVE(&loop->pending_queue, &pq);
 
   while (!QUEUE_EMPTY(&pq)) {
     q = QUEUE_HEAD(&pq);

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -47,9 +47,14 @@
                                                                               \
   void uv__run_##name(uv_loop_t* loop) {                                      \
     uv_##name##_t* h;                                                         \
+    QUEUE queue;                                                              \
     QUEUE* q;                                                                 \
-    QUEUE_FOREACH(q, &loop->name##_handles) {                                 \
+    QUEUE_MOVE(&loop->name##_handles, &queue);                                \
+    while (!QUEUE_EMPTY(&queue)) {                                            \
+      q = QUEUE_HEAD(&queue);                                                 \
       h = QUEUE_DATA(q, uv_##name##_t, queue);                                \
+      QUEUE_REMOVE(q);                                                        \
+      QUEUE_INSERT_TAIL(&loop->name##_handles, q);                            \
       h->name##_cb(h);                                                        \
     }                                                                         \
   }                                                                           \

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -234,6 +234,8 @@ void uv__signal_loop_cleanup(uv_loop_t* loop) {
   /* Stop all the signal watchers that are still attached to this loop. This
    * ensures that the (shared) signal tree doesn't contain any invalid entries
    * entries, and that signal handlers are removed when appropriate.
+   * It's safe to use QUEUE_FOREACH here because the handles and the handle
+   * queue are not modified by uv__signal_stop().
    */
   QUEUE_FOREACH(q, &loop->handle_queue) {
     uv_handle_t* handle = QUEUE_DATA(q, uv_handle_t, handle_queue);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -779,9 +779,9 @@ start:
 
   if (req->send_handle) {
     struct msghdr msg;
-    char scratch[64];
     struct cmsghdr *cmsg;
     int fd_to_send = uv__handle_fd((uv_handle_t*) req->send_handle);
+    char scratch[64] = {0};
 
     assert(fd_to_send >= 0);
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -337,11 +337,18 @@ int uv_udp_recv_stop(uv_udp_t* handle) {
 
 
 void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
+  QUEUE queue;
   QUEUE* q;
   uv_handle_t* h;
 
-  QUEUE_FOREACH(q, &loop->handle_queue) {
+  QUEUE_MOVE(&loop->handle_queue, &queue);
+  while (!QUEUE_EMPTY(&queue)) {
+    q = QUEUE_HEAD(&queue);
     h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+
+    QUEUE_REMOVE(q);
+    QUEUE_INSERT_TAIL(&loop->handle_queue, q);
+
     if (h->flags & UV__HANDLE_INTERNAL) continue;
     walk_cb(h, arg);
   }


### PR DESCRIPTION
 Replace uses of QUEUE_FOREACH when the list can get modified while
iterating over it, in particular when a callback is made into the
user's code.  This should fix a number of spurious failures that
people have been reporting.

R=@saghul or @piscisaureus

@indutny There are two QUEUE_FOREACH statements in src/unix/fsevents.c.  They _look_ safe to me (as in: the list isn't mutated concurrently) but can you confirm?