### PR TITLE
unix: use ngx_queue_move when iterating over lists

### DIFF
--- a/include/uv-private/ngx-queue.h
+++ b/include/uv-private/ngx-queue.h
@@ -131,6 +131,9 @@ struct ngx_queue_s {
     ((type *) ((unsigned char *) q - offsetof(type, link)))
 
 
+/* Important note: mutating the list while ngx_queue_foreach is
+ * iterating over its elements results in undefined behavior.
+ */
 #define ngx_queue_foreach(q, h)                                               \
     for ((q) = ngx_queue_head(h);                                             \
          (q) != ngx_queue_sentinel(h) && !ngx_queue_empty(h);                 \

--- a/include/uv-private/ngx-queue.h
+++ b/include/uv-private/ngx-queue.h
@@ -106,6 +106,17 @@ struct ngx_queue_s {
   while (0)
 
 
+#define ngx_queue_move(h, n)                                                  \
+  do {                                                                        \
+    if (ngx_queue_empty(h))                                                   \
+      ngx_queue_init(n);                                                      \
+    else {                                                                    \
+      ngx_queue_t* q = ngx_queue_head(h);                                     \
+      ngx_queue_split(h, q, n);                                               \
+    }                                                                         \
+  }                                                                           \
+  while (0)
+
 #define ngx_queue_add(h, n)                                                   \
   do {                                                                        \
     (h)->prev->next = (n)->next;                                              \

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -55,11 +55,7 @@ struct uv__fsevents_event_s {
       ngx_queue_t split_head;                                                 \
       uv__fsevents_event_t* event;                                            \
       uv_mutex_lock(&(handle)->cf_mutex);                                     \
-      ngx_queue_init(&split_head);                                            \
-      if (!ngx_queue_empty(&(handle)->cf_events)) {                           \
-        ngx_queue_t* split_pos = ngx_queue_next(&(handle)->cf_events);        \
-        ngx_queue_split(&(handle)->cf_events, split_pos, &split_head);        \
-      }                                                                       \
+      ngx_queue_move(&(handle)->cf_events, &split_head);                      \
       uv_mutex_unlock(&(handle)->cf_mutex);                                   \
       while (!ngx_queue_empty(&split_head)) {                                 \
         curr = ngx_queue_head(&split_head);                                   \

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -48,9 +48,14 @@
                                                                               \
   void uv__run_##name(uv_loop_t* loop) {                                      \
     uv_##name##_t* h;                                                         \
+    ngx_queue_t queue;                                                        \
     ngx_queue_t* q;                                                           \
-    ngx_queue_foreach(q, &loop->name##_handles) {                             \
+    ngx_queue_move(&loop->name##_handles, &queue);                            \
+    while (!ngx_queue_empty(&queue)) {                                        \
+      q = ngx_queue_head(&queue);                                             \
       h = ngx_queue_data(q, uv_##name##_t, queue);                            \
+      ngx_queue_remove(q);                                                    \
+      ngx_queue_insert_tail(&loop->name##_handles, q);                        \
       h->name##_cb(h, 0);                                                     \
     }                                                                         \
   }                                                                           \

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -231,6 +231,8 @@ void uv__signal_loop_cleanup(uv_loop_t* loop) {
   /* Stop all the signal watchers that are still attached to this loop. This
    * ensures that the (shared) signal tree doesn't contain any invalid entries
    * entries, and that signal handlers are removed when appropriate.
+   * It's safe to use QUEUE_FOREACH here because the handles and the handle
+   * queue are not modified by uv__signal_stop().
    */
   ngx_queue_foreach(q, &loop->handle_queue) {
     uv_handle_t* handle = ngx_queue_data(q, uv_handle_t, handle_queue);

--- a/src/unix/threadpool.c
+++ b/src/unix/threadpool.c
@@ -202,13 +202,8 @@ void uv__work_done(uv_async_t* handle, int status) {
   int err;
 
   loop = container_of(handle, uv_loop_t, wq_async);
-  ngx_queue_init(&wq);
-
   uv_mutex_lock(&loop->wq_mutex);
-  if (!ngx_queue_empty(&loop->wq)) {
-    q = ngx_queue_head(&loop->wq);
-    ngx_queue_split(&loop->wq, q, &wq);
-  }
+  ngx_queue_move(&loop->wq, &wq);
   uv_mutex_unlock(&loop->wq_mutex);
 
   while (!ngx_queue_empty(&wq)) {


### PR DESCRIPTION
Replace uses of ngx_queue_foreach when the list can get modified while
iterating over it, in particular when a callback is made into the
user's code.  This should fix a number of spurious failures that
people have been reporting.

This is a backport of commit 442b8a5 from the v1.x branch.

R=@saghul?  At your leisure.