### PR TITLE
unix: only undo fs req registration in async mode

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1067,7 +1067,8 @@ int uv_fs_mkdtemp(uv_loop_t* loop,
   INIT(MKDTEMP);
   req->path = uv__strdup(tpl);
   if (req->path == NULL) {
-    uv__req_unregister(loop, req);
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return -ENOMEM;
   }
   POST;
@@ -1106,7 +1107,8 @@ int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
     req->bufs = uv__malloc(nbufs * sizeof(*bufs));
 
   if (req->bufs == NULL) {
-    uv__req_unregister(loop, req);
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return -ENOMEM;
   }
 
@@ -1233,7 +1235,8 @@ int uv_fs_write(uv_loop_t* loop,
     req->bufs = uv__malloc(nbufs * sizeof(*bufs));
 
   if (req->bufs == NULL) {
-    uv__req_unregister(loop, req);
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return -ENOMEM;
   }
 


### PR DESCRIPTION
Commit 0199955 ("fs: undo uv__req_init when uv__malloc failed")
mistakingly unregisters the requests unconditionally in a few places,
resulting in memory corruption when it hasn't been registered first.

Fixes: #543

R=@saghul

I redid the fix from the first commit in the second one as a macro.
Input on what you think is the cleanest approach appreciated.

CI: https://ci.nodejs.org/view/libuv/job/libuv+any-pr+multi/161/