### PR TITLE
Make work with Solaris Studio.

### DIFF
--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -18,6 +18,11 @@
 
 #include "internal.h"  /* UV_UNUSED */
 
+#if defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+#include <atomic.h>
+#define __sync_val_compare_and_swap(p, o, n) atomic_cas_ptr(p, o, n)
+#endif
+
 UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval));
 UV_UNUSED(static long cmpxchgl(long* ptr, long oldval, long newval));
 UV_UNUSED(static void cpu_relax(void));


### PR DESCRIPTION
The atomics that are in place of a lack of x86 cmpxchg are a GCC specific
intrinsic.  When compiling for Solaris on a SPARC platform with a non-gcc
compiler, this prevents a successful build.  This commit will rely on a
Solaris Studio specific preprocessor macro to redefine the GCC intrinsic name
to be the Solaris Studio one instead.