### PR TITLE
Fixed comment warning

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -208,7 +208,7 @@ static void uv_tty_capture_initial_style(CONSOLE_SCREEN_BUFFER_INFO* info) {
   static int style_captured = 0;
 
   /* Only do this once.
-  /* Assumption: Caller has acquired uv_tty_output_lock. */
+     Assumption: Caller has acquired uv_tty_output_lock. */
   if (style_captured)
     return;
 


### PR DESCRIPTION
Error I got in my project using libuv :

../../../../../3rdparty/libuv/src/win/tty.c: In function 'uv_tty_capture_initial_style':
../../../../../3rdparty/libuv/src/win/tty.c:211:3: error: "/*" within comment [-Werror=comment]
   /* Assumption: Caller has acquired uv_tty_output_lock. */
 