### PR TITLE
test: fix fs_event_watch_file_currentdir flakiness

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -487,7 +487,7 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
   r = uv_timer_init(loop, &timer);
   ASSERT(r == 0);
 
-  r = uv_timer_start(&timer, timer_cb_touch, 1, 0);
+  r = uv_timer_start(&timer, timer_cb_touch, 10, 0);
   ASSERT(r == 0);
 
   ASSERT(timer_cb_touch_called == 0);


### PR DESCRIPTION
In FreeBSD 10.2 the test sometimes times out because the "touch file" timer
fires before the "watch file" event has been registered in the kqueue.
Increasing the timeout value seems to fix the issue.