### PR TITLE
Change getaddrinfo_fail to use fully qualified domain name.

### DIFF
--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -83,10 +83,11 @@ static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle,
 TEST_IMPL(getaddrinfo_fail) {
   uv_getaddrinfo_t req;
 
+  /* Use a FQDN by ending in a period */
   ASSERT(0 == uv_getaddrinfo(uv_default_loop(),
                              &req,
                              getaddrinfo_fail_cb,
-                             "xyzzy.xyzzy.xyzzy",
+                             "xyzzy.xyzzy.xyzzy.",
                              NULL,
                              NULL));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
@@ -100,10 +101,11 @@ TEST_IMPL(getaddrinfo_fail) {
 TEST_IMPL(getaddrinfo_fail_sync) {
   uv_getaddrinfo_t req;
 
+  /* Use a FQDN by ending in a period */
   ASSERT(0 > uv_getaddrinfo(uv_default_loop(),
                             &req,
                             NULL,
-                            "xyzzy.xyzzy.xyzzy",
+                            "xyzzy.xyzzy.xyzzy.",
                             NULL,
                             NULL));
   uv_freeaddrinfo(req.addrinfo);


### PR DESCRIPTION
For the getaddrinfo_fail test cases you want to use a fully qualified
domain name so that in network configurations that have a search domain
the test will still fail.

To create a fully qualified domain add a period at the end, see
http://www.dns-sd.org/trailingdotsindomainnames.html for an explanation.