### PR TITLE
clarify the error relaying of EADDRINUSE for uv_tcp_bind

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -77,9 +77,9 @@ API
 
     When the port is already taken, the error is relayed and you can expect to see an 
     ``UV_EADDRINUSE`` error from function such as :c:func:`uv_listen` or 
-    :c:func:`uv_tcp_connect as :c:func:`.That is, a successful call to this function 
-    does not guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect` 
-    will succeed as well.
+    :c:func:`uv_tcp_connect`. That is, a successful call to this function does not 
+    guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect` will succeed 
+    as well.
 
     `flags` can contain ``UV_TCP_IPV6ONLY``, in which case dual-stack support
     is disabled and only IPv6 is used.

--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -75,10 +75,10 @@ API
     Bind the handle to an address and port. `addr` should point to an
     initialized ``struct sockaddr_in`` or ``struct sockaddr_in6``.
 
-    When the port is already taken, you can expect to see an ``UV_EADDRINUSE``
-    error from either :c:func:`uv_tcp_bind`, :c:func:`uv_listen` or
-    :c:func:`uv_tcp_connect`. That is, a successful call to this function does
-    not guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect`
+    When the port is already taken, the error is relayed and you can expect to see an 
+    ``UV_EADDRINUSE`` error from function such as :c:func:`uv_listen` or 
+    :c:func:`uv_tcp_connect as :c:func:`.That is, a successful call to this function 
+    does not guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect` 
     will succeed as well.
 
     `flags` can contain ``UV_TCP_IPV6ONLY``, in which case dual-stack support

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -156,6 +156,9 @@ int uv__tcp_connect(uv_connect_t* req,
   if (err)
     return err;
 
+  if (handle->delayed_error)
+    return handle->delayed_error;
+
   handle->delayed_error = 0;
 
   do


### PR DESCRIPTION
doc is updated to give the proper behaviour