### PR TITLE
doc: clarify deferring of EADDRINUSE error by uv_tcp_bind

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -75,11 +75,11 @@ API
     Bind the handle to an address and port. `addr` should point to an
     initialized ``struct sockaddr_in`` or ``struct sockaddr_in6``.
 
-    When the port is already taken, you can expect to see an ``UV_EADDRINUSE``
-    error from either :c:func:`uv_tcp_bind`, :c:func:`uv_listen` or
-    :c:func:`uv_tcp_connect`. That is, a successful call to this function does
-    not guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect`
-    will succeed as well.
+    When the port is already taken, the error is deferred and you can expect to see an 
+    ``UV_EADDRINUSE`` error from functions such as :c:func:`uv_listen` or 
+    :c:func:`uv_tcp_connect`. That is, a successful call to this function does not 
+    guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect` will succeed 
+    as well.
 
     `flags` can contain ``UV_TCP_IPV6ONLY``, in which case dual-stack support
     is disabled and only IPv6 is used.


### PR DESCRIPTION
EADDRINUSE is not returned by uv_tcp_bind. It is being deffered until call to other functions like uv_tcp_connect and uv_listen. Hence removing uv_tcp_bind from list of functions which does return EADDRINUSE.
