### PR TITLE
darwin: abort() if (un)locking fs mutex fails

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -630,7 +630,9 @@ static ssize_t uv__fs_write(uv_fs_t* req) {
    */
 #if defined(__APPLE__)
   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-  pthread_mutex_lock(&lock);
+
+  if (pthread_mutex_lock(&lock))
+    abort();
 #endif
 
   if (req->off < 0) {
@@ -687,7 +689,8 @@ static ssize_t uv__fs_write(uv_fs_t* req) {
 
 done:
 #if defined(__APPLE__)
-  pthread_mutex_unlock(&lock);
+  if (pthread_mutex_unlock(&lock))
+    abort();
 #endif
 
   return r;


### PR DESCRIPTION
The pthread_mutex_lock() and pthread_mutex_unlock() calls logically
cannot fail in uv__fs_write() but let's check the return value anyway:
cosmic rays and memory corruption do happen.

R=@saghul - for when you're back.