### PR TITLE
unix: delay signal handling until after normal i/o

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -118,6 +118,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   uv__io_t* w;
   uint64_t base;
   uint64_t diff;
+  int have_signals;
   int nevents;
   int count;
   int nfds;
@@ -225,6 +226,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       goto update_timeout;
     }
 
+    have_signals = 0;
     nevents = 0;
 
     assert(loop->watchers != NULL);
@@ -255,12 +257,25 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;
       }
 
-      w->cb(loop, w, pe->revents);
+      /* Run signal watchers last.  This also affects child process watchers
+       * because those are implemented in terms of signal watchers.
+       */
+      if (w == &loop->signal_io_watcher)
+        have_signals = 1;
+      else
+        w->cb(loop, w, pe->revents);
+
       nevents++;
     }
 
+    if (have_signals != 0)
+      loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;
+
+    if (have_signals != 0)
+      return;  /* Event loop should cycle now so don't poll again. */
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -78,6 +78,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t set;
   uint64_t base;
   uint64_t diff;
+  int have_signals;
   int filter;
   int fflags;
   int count;
@@ -192,6 +193,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       goto update_timeout;
     }
 
+    have_signals = 0;
     nevents = 0;
 
     assert(loop->watchers != NULL);
@@ -265,11 +267,25 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (revents == 0)
         continue;
 
-      w->cb(loop, w, revents);
+      /* Run signal watchers last.  This also affects child process watchers
+       * because those are implemented in terms of signal watchers.
+       */
+      if (w == &loop->signal_io_watcher)
+        have_signals = 1;
+      else
+        w->cb(loop, w, revents);
+
       nevents++;
     }
+
+    if (have_signals != 0)
+      loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;
+
+    if (have_signals != 0)
+      return;  /* Event loop should cycle now so don't poll again. */
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -140,6 +140,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   unsigned int nfds;
   unsigned int i;
   int saved_errno;
+  int have_signals;
   int nevents;
   int count;
   int err;
@@ -230,6 +231,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       return;
     }
 
+    have_signals = 0;
     nevents = 0;
 
     assert(loop->watchers != NULL);
@@ -252,7 +254,14 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (w == NULL)
         continue;
 
-      w->cb(loop, w, pe->portev_events);
+      /* Run signal watchers last.  This also affects child process watchers
+       * because those are implemented in terms of signal watchers.
+       */
+      if (w == &loop->signal_io_watcher)
+        have_signals = 1;
+      else
+        w->cb(loop, w, pe->portev_events);
+
       nevents++;
 
       if (w != loop->watchers[fd])
@@ -262,8 +271,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (w->pevents != 0 && QUEUE_EMPTY(&w->watcher_queue))
         QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
     }
+
+    if (have_signals != 0)
+      loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;
+
+    if (have_signals != 0)
+      return;  /* Event loop should cycle now so don't poll again. */
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {


### PR DESCRIPTION
It was reported that some node.js tests fail on AIX because the exit
event sometimes comes before the final stdio output of a child process.

Work around that by deferring the signal watcher that is used for
process management until after the dispatch of regular i/o watchers.

Fixes: https://github.com/libuv/libuv/issues/610

R=@saghul.  The duplication is galling, we should do something about that in v2.

[I'll update with a CI link once ci.nodejs.org is back up.]