### PR TITLE
win: set error when failed to close fd

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -533,7 +533,12 @@ void fs__close(uv_fs_t* req) {
   else
     result = 0;
 
-  SET_REQ_RESULT(req, result);
+  if (result == -1) {
+    assert(errno == EBADF);
+    SET_REQ_UV_ERROR(req, UV_EBADF, ERROR_INVALID_HANDLE);
+  } else {
+    req->result = 0;
+  }
 }
 
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -533,6 +533,9 @@ void fs__close(uv_fs_t* req) {
   else
     result = 0;
 
+  /* _close doesn't set _doserrno on failure, but it does always set errno
+   * to EBADF on failure.
+   */
   if (result == -1) {
     assert(errno == EBADF);
     SET_REQ_UV_ERROR(req, UV_EBADF, ERROR_INVALID_HANDLE);


### PR DESCRIPTION
_close doesn't set _doserrno on failure, but it does always set errno to EBADF on failure.

This fixes https://github.com/nodejs/node/issues/3718.

cc @piscisaureus @bnoordhuis