### PR TITLE
include: add stdio.h to uv.h

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -48,6 +48,7 @@ extern "C" {
 #include "uv-errno.h"
 #include "uv-version.h"
 #include <stddef.h>
+#include <stdio.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1600
 # include "stdint-msvc2008.h"


### PR DESCRIPTION
Fixes a compilation problem in some platforms (notably OSX) after
6490c50.

R=@bnoordhuis