### PR TITLE
QUEUE- and Unix-backend-related improvements, bugfixes, and tests. Version 4

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include \
 include_HEADERS=include/uv.h
 
 uvincludedir = $(includedir)/uv
-uvinclude_HEADERS=include/uv/errno.h include/uv/threadpool.h include/uv/version.h
+uvinclude_HEADERS=include/uv/errno.h include/uv/threadpool.h include/uv/version.h include/uv/queue.h
 
 CLEANFILES =
 

--- a/checksparse.sh
+++ b/checksparse.sh
@@ -26,6 +26,7 @@ SPARSE_FLAGS=${SPARSE_FLAGS:-"
 "}
 
 SOURCES="
+include/uv/queue.h
 include/uv/tree.h
 include/uv/unix.h
 include/uv.h

--- a/include/uv.h
+++ b/include/uv.h
@@ -47,6 +47,7 @@ extern "C" {
 
 #include "uv/errno.h"
 #include "uv/version.h"
+#include "uv/queue.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -375,7 +376,7 @@ UV_EXTERN const char* uv_err_name(int err);
   /* read-only */                                                             \
   uv_req_type type;                                                           \
   /* private */                                                               \
-  void* active_queue[2];                                                      \
+  QUEUE active_queue;                                                         \
   void* reserved[4];                                                          \
   UV_REQ_PRIVATE_FIELDS                                                       \
 
@@ -409,7 +410,7 @@ struct uv_shutdown_s {
   uv_handle_type type;                                                        \
   /* private */                                                               \
   uv_close_cb close_cb;                                                       \
-  void* handle_queue[2];                                                      \
+  QUEUE handle_queue;                                                         \
   UV_HANDLE_PRIVATE_FIELDS                                                    \
 
 /* The abstract base class of all handles. */
@@ -1596,8 +1597,8 @@ struct uv_loop_s {
   void* data;
   /* Loop reference counting. */
   unsigned int active_handles;
-  void* handle_queue[2];
-  void* active_reqs[2];
+  QUEUE handle_queue;
+  QUEUE active_reqs;
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
   void* reserved[4];

--- a/include/uv/linux.h
+++ b/include/uv/linux.h
@@ -28,7 +28,7 @@
   int inotify_fd;                                                             \
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
-  void* watchers[2];                                                          \
+  QUEUE watchers;                                                             \
   int wd;                                                                     \
 
 #endif /* UV_LINUX_H */

--- a/include/uv/queue.h
+++ b/include/uv/queue.h
@@ -1,0 +1,30 @@
+/* Copyright The libuv project and contributors. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef UV_QUEUE_H_
+#define UV_QUEUE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct QUEUE { struct QUEUE *next, *prev; };
+typedef struct QUEUE QUEUE;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UV_QUEUE_H_ */

--- a/include/uv/threadpool.h
+++ b/include/uv/threadpool.h
@@ -27,11 +27,13 @@
 #ifndef UV_THREADPOOL_H_
 #define UV_THREADPOOL_H_
 
+#include "uv/queue.h"
+
 struct uv__work {
   void (*work)(struct uv__work *w);
   void (*done)(struct uv__work *w, int status);
   struct uv_loop_s* loop;
-  void* wq[2];
+  QUEUE wq;
 };
 
 #endif /* UV_THREADPOOL_H_ */

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -203,7 +203,7 @@ typedef struct {
   uv_mutex_t wq_mutex;                                                        \
   uv_async_t wq_async;                                                        \
   uv_rwlock_t cloexec_lock;                                                   \
-  uv_handle_t* closing_handles;                                               \
+  QUEUE closing_handles;                                                      \
   QUEUE process_handles;                                                      \
   QUEUE prepare_handles;                                                      \
   QUEUE check_handles;                                                        \
@@ -253,7 +253,7 @@ typedef struct {
   uv_buf_t bufsml[4];                                                         \
 
 #define UV_HANDLE_PRIVATE_FIELDS                                              \
-  uv_handle_t* next_closing;                                                  \
+  QUEUE closing_queue;                                                        \
   unsigned int flags;                                                         \
 
 #define UV_STREAM_PRIVATE_FIELDS                                              \

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -92,8 +92,8 @@ typedef struct uv__io_s uv__io_t;
 
 struct uv__io_s {
   uv__io_cb cb;
-  void* pending_queue[2];
-  void* watcher_queue[2];
+  QUEUE pending_queue;
+  QUEUE watcher_queue;
   unsigned int pevents; /* Pending event mask i.e. mask at next tick. */
   unsigned int events;  /* Current event mask. */
   int fd;
@@ -194,21 +194,21 @@ typedef struct {
 #define UV_LOOP_PRIVATE_FIELDS                                                \
   unsigned long flags;                                                        \
   int backend_fd;                                                             \
-  void* pending_queue[2];                                                     \
-  void* watcher_queue[2];                                                     \
+  QUEUE pending_queue;                                                        \
+  QUEUE watcher_queue;                                                        \
   uv__io_t** watchers;                                                        \
   unsigned int nwatchers;                                                     \
   unsigned int nfds;                                                          \
-  void* wq[2];                                                                \
+  QUEUE wq;                                                                   \
   uv_mutex_t wq_mutex;                                                        \
   uv_async_t wq_async;                                                        \
   uv_rwlock_t cloexec_lock;                                                   \
   uv_handle_t* closing_handles;                                               \
-  void* process_handles[2];                                                   \
-  void* prepare_handles[2];                                                   \
-  void* check_handles[2];                                                     \
-  void* idle_handles[2];                                                      \
-  void* async_handles[2];                                                     \
+  QUEUE process_handles;                                                      \
+  QUEUE prepare_handles;                                                      \
+  QUEUE check_handles;                                                        \
+  QUEUE idle_handles;                                                         \
+  QUEUE async_handles;                                                        \
   void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
   uv__io_t async_io_watcher;                                                  \
   int async_wfd;                                                              \
@@ -231,7 +231,7 @@ typedef struct {
 #define UV_PRIVATE_REQ_TYPES /* empty */
 
 #define UV_WRITE_PRIVATE_FIELDS                                               \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
   unsigned int write_index;                                                   \
   uv_buf_t* bufs;                                                             \
   unsigned int nbufs;                                                         \
@@ -239,12 +239,12 @@ typedef struct {
   uv_buf_t bufsml[4];                                                         \
 
 #define UV_CONNECT_PRIVATE_FIELDS                                             \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
 
 #define UV_SHUTDOWN_PRIVATE_FIELDS /* empty */
 
 #define UV_UDP_SEND_PRIVATE_FIELDS                                            \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
   struct sockaddr_storage addr;                                               \
   unsigned int nbufs;                                                         \
   uv_buf_t* bufs;                                                             \
@@ -260,8 +260,8 @@ typedef struct {
   uv_connect_t *connect_req;                                                  \
   uv_shutdown_t *shutdown_req;                                                \
   uv__io_t io_watcher;                                                        \
-  void* write_queue[2];                                                       \
-  void* write_completed_queue[2];                                             \
+  QUEUE write_queue;                                                          \
+  QUEUE write_completed_queue;                                                \
   uv_connection_cb connection_cb;                                             \
   int delayed_error;                                                          \
   int accepted_fd;                                                            \
@@ -274,8 +274,8 @@ typedef struct {
   uv_alloc_cb alloc_cb;                                                       \
   uv_udp_recv_cb recv_cb;                                                     \
   uv__io_t io_watcher;                                                        \
-  void* write_queue[2];                                                       \
-  void* write_completed_queue[2];                                             \
+  QUEUE write_queue;                                                          \
+  QUEUE write_completed_queue;                                                \
 
 #define UV_PIPE_PRIVATE_FIELDS                                                \
   const char* pipe_fname; /* strdup'ed */
@@ -285,19 +285,19 @@ typedef struct {
 
 #define UV_PREPARE_PRIVATE_FIELDS                                             \
   uv_prepare_cb prepare_cb;                                                   \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
 
 #define UV_CHECK_PRIVATE_FIELDS                                               \
   uv_check_cb check_cb;                                                       \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
 
 #define UV_IDLE_PRIVATE_FIELDS                                                \
   uv_idle_cb idle_cb;                                                         \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
 
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   uv_async_cb async_cb;                                                       \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
   int pending;                                                                \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
@@ -326,7 +326,7 @@ typedef struct {
   int retcode;
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
-  void* queue[2];                                                             \
+  QUEUE queue;                                                                \
   int status;                                                                 \
 
 #define UV_FS_PRIVATE_FIELDS                                                  \

--- a/src/queue.h
+++ b/src/queue.h
@@ -30,73 +30,61 @@
 #define QUEUE_FOREACH(q, h)                                                   \
   for ((q) = (h)->next; (q) != (h); (q) = (q)->next)
 
-#define QUEUE_EMPTY(q)                                                        \
-  ((q) == (q)->next)
+static inline int QUEUE_EMPTY(const QUEUE *q) {
+  return q == q->next;
+}
 
-#define QUEUE_HEAD(q)                                                         \
-  ((q)->next)
+static inline QUEUE *QUEUE_HEAD(QUEUE *q) {
+  return q->next;
+}
 
-#define QUEUE_INIT(q)                                                         \
-  do {                                                                        \
-    (q)->next = (q);                                                          \
-    (q)->prev = (q);                                                          \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_INIT(QUEUE *q) {
+  q->next = q;
+  q->prev = q;
+}
 
-#define QUEUE_ADD(h, n)                                                       \
-  do {                                                                        \
-    (h)->prev->next = (n)->next;                                              \
-    (n)->next->prev = (h)->prev;                                              \
-    (h)->prev = (n)->prev;                                                    \
-    (h)->prev->next = (h);                                                    \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_ADD(QUEUE *h, QUEUE *n) {
+  h->prev->next = n->next;
+  n->next->prev = h->prev;
+  h->prev = n->prev;
+  h->prev->next = h;
+}
 
-#define QUEUE_SPLIT(h, q, n)                                                  \
-  do {                                                                        \
-    (n)->prev = (h)->prev;                                                    \
-    (n)->prev->next = (n);                                                    \
-    (n)->next = (q);                                                          \
-    (h)->prev = (q)->prev;                                                    \
-    (h)->prev->next = (h);                                                    \
-    (q)->prev = (n);                                                          \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_SPLIT(QUEUE *h, QUEUE *q, QUEUE *n) {
+  n->prev = h->prev;
+  n->prev->next = n;
+  n->next = q;
+  h->prev = q->prev;
+  h->prev->next = h;
+  q->prev = n;
+}
 
-#define QUEUE_MOVE(h, n)                                                      \
-  do {                                                                        \
-    if (QUEUE_EMPTY(h))                                                       \
-      QUEUE_INIT(n);                                                          \
-    else {                                                                    \
-      QUEUE* q = QUEUE_HEAD(h);                                               \
-      QUEUE_SPLIT(h, q, n);                                                   \
-    }                                                                         \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_MOVE(QUEUE *h, QUEUE *n) {
+  if (QUEUE_EMPTY(h))
+    QUEUE_INIT(n);
+  else {
+    QUEUE* q = QUEUE_HEAD(h);
+    QUEUE_SPLIT(h, q, n);
+  }
+}
 
-#define QUEUE_INSERT_HEAD(h, q)                                               \
-  do {                                                                        \
-    (q)->next = (h)->next;                                                    \
-    (q)->prev = (h);                                                          \
-    (q)->next->prev = (q);                                                    \
-    (h)->next = (q);                                                          \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_INSERT_HEAD(QUEUE *h, QUEUE *q) {
+  q->next = h->next;
+  q->prev = h;
+  q->next->prev = q;
+  h->next = q;
+}
 
-#define QUEUE_INSERT_TAIL(h, q)                                               \
-  do {                                                                        \
-    (q)->next = (h);                                                          \
-    (q)->prev = (h)->prev;                                                    \
-    (q)->prev->next = (q);                                                    \
-    (h)->prev = (q);                                                          \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_INSERT_TAIL(QUEUE *h, QUEUE *q) {
+  q->next = h;
+  q->prev = h->prev;
+  q->prev->next = q;
+  h->prev = q;
+}
 
-#define QUEUE_REMOVE(q)                                                       \
-  do {                                                                        \
-    (q)->prev->next = (q)->next;                                              \
-    (q)->next->prev = (q)->prev;                                              \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_REMOVE(QUEUE *q) {
+  q->prev->next = q->next;
+  q->next->prev = q->prev;
+}
 
 #endif /* QUEUE_H_ */

--- a/src/queue.h
+++ b/src/queue.h
@@ -30,6 +30,16 @@
 #define QUEUE_FOREACH(q, h)                                                   \
   for ((q) = (h)->next; (q) != (h); (q) = (q)->next)
 
+/* Removing an element from the queue, while iterating over it,
+ * should be done using QUEUE_REMOVE_SAFE() in conjunction with
+ * QUEUE_FOREACH_SAFE() sharing the same n.
+ * It's still not safe to remove the head though.
+ */
+#define QUEUE_FOREACH_SAFE(q, n, h)                                           \
+  for ((q) = (h)->next, (n) = (q)->next;                                      \
+       (q) != (h);                                                            \
+       (q) = (n), (n) = (n)->next)
+
 static inline int QUEUE_EMPTY(const QUEUE *q) {
   return q == q->next;
 }
@@ -85,6 +95,17 @@ static inline void QUEUE_INSERT_TAIL(QUEUE *h, QUEUE *q) {
 static inline void QUEUE_REMOVE(QUEUE *q) {
   q->prev->next = q->next;
   q->next->prev = q->prev;
+}
+
+/* Should be used to remove an element from the queue, while iterating over it,
+ * in conjunction with QUEUE_FOREACH_SAFE() sharing the same n.
+ * It's still not safe to remove the head though.
+ */
+static inline void QUEUE_REMOVE_SAFE(QUEUE *q, QUEUE **n) {
+  if ((*n) == q) {
+    *n = (*n)->next;
+  }
+  QUEUE_REMOVE(q);
 }
 
 #endif /* QUEUE_H_ */

--- a/src/queue.h
+++ b/src/queue.h
@@ -62,6 +62,10 @@ static inline void QUEUE_INIT(QUEUE *q) {
   q->prev = q;
 }
 
+static inline void QUEUE_DESTROY(QUEUE *q) {
+  QUEUE_POISON(q);
+}
+
 static inline void QUEUE_ADD(QUEUE *h, QUEUE *n) {
   h->prev->next = n->next;
   n->next->prev = h->prev;

--- a/src/queue.h
+++ b/src/queue.h
@@ -18,13 +18,7 @@
 
 #include <stddef.h>
 
-typedef void *QUEUE[2];
-
-/* Private macros. */
-#define QUEUE_NEXT(q)       (*(QUEUE **) &((*(q))[0]))
-#define QUEUE_PREV(q)       (*(QUEUE **) &((*(q))[1]))
-#define QUEUE_PREV_NEXT(q)  (QUEUE_NEXT(QUEUE_PREV(q)))
-#define QUEUE_NEXT_PREV(q)  (QUEUE_PREV(QUEUE_NEXT(q)))
+#include "uv/queue.h"
 
 /* Public macros. */
 #define QUEUE_DATA(ptr, type, field)                                          \
@@ -34,38 +28,38 @@ typedef void *QUEUE[2];
  * iterating over its elements results in undefined behavior.
  */
 #define QUEUE_FOREACH(q, h)                                                   \
-  for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))
+  for ((q) = (h)->next; (q) != (h); (q) = (q)->next)
 
 #define QUEUE_EMPTY(q)                                                        \
-  ((const QUEUE *) (q) == (const QUEUE *) QUEUE_NEXT(q))
+  ((q) == (q)->next)
 
 #define QUEUE_HEAD(q)                                                         \
-  (QUEUE_NEXT(q))
+  ((q)->next)
 
 #define QUEUE_INIT(q)                                                         \
   do {                                                                        \
-    QUEUE_NEXT(q) = (q);                                                      \
-    QUEUE_PREV(q) = (q);                                                      \
+    (q)->next = (q);                                                          \
+    (q)->prev = (q);                                                          \
   }                                                                           \
   while (0)
 
 #define QUEUE_ADD(h, n)                                                       \
   do {                                                                        \
-    QUEUE_PREV_NEXT(h) = QUEUE_NEXT(n);                                       \
-    QUEUE_NEXT_PREV(n) = QUEUE_PREV(h);                                       \
-    QUEUE_PREV(h) = QUEUE_PREV(n);                                            \
-    QUEUE_PREV_NEXT(h) = (h);                                                 \
+    (h)->prev->next = (n)->next;                                              \
+    (n)->next->prev = (h)->prev;                                              \
+    (h)->prev = (n)->prev;                                                    \
+    (h)->prev->next = (h);                                                    \
   }                                                                           \
   while (0)
 
 #define QUEUE_SPLIT(h, q, n)                                                  \
   do {                                                                        \
-    QUEUE_PREV(n) = QUEUE_PREV(h);                                            \
-    QUEUE_PREV_NEXT(n) = (n);                                                 \
-    QUEUE_NEXT(n) = (q);                                                      \
-    QUEUE_PREV(h) = QUEUE_PREV(q);                                            \
-    QUEUE_PREV_NEXT(h) = (h);                                                 \
-    QUEUE_PREV(q) = (n);                                                      \
+    (n)->prev = (h)->prev;                                                    \
+    (n)->prev->next = (n);                                                    \
+    (n)->next = (q);                                                          \
+    (h)->prev = (q)->prev;                                                    \
+    (h)->prev->next = (h);                                                    \
+    (q)->prev = (n);                                                          \
   }                                                                           \
   while (0)
 
@@ -82,26 +76,26 @@ typedef void *QUEUE[2];
 
 #define QUEUE_INSERT_HEAD(h, q)                                               \
   do {                                                                        \
-    QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \
-    QUEUE_PREV(q) = (h);                                                      \
-    QUEUE_NEXT_PREV(q) = (q);                                                 \
-    QUEUE_NEXT(h) = (q);                                                      \
+    (q)->next = (h)->next;                                                    \
+    (q)->prev = (h);                                                          \
+    (q)->next->prev = (q);                                                    \
+    (h)->next = (q);                                                          \
   }                                                                           \
   while (0)
 
 #define QUEUE_INSERT_TAIL(h, q)                                               \
   do {                                                                        \
-    QUEUE_NEXT(q) = (h);                                                      \
-    QUEUE_PREV(q) = QUEUE_PREV(h);                                            \
-    QUEUE_PREV_NEXT(q) = (q);                                                 \
-    QUEUE_PREV(h) = (q);                                                      \
+    (q)->next = (h);                                                          \
+    (q)->prev = (h)->prev;                                                    \
+    (q)->prev->next = (q);                                                    \
+    (h)->prev = (q);                                                          \
   }                                                                           \
   while (0)
 
 #define QUEUE_REMOVE(q)                                                       \
   do {                                                                        \
-    QUEUE_PREV_NEXT(q) = QUEUE_NEXT(q);                                       \
-    QUEUE_NEXT_PREV(q) = QUEUE_PREV(q);                                       \
+    (q)->prev->next = (q)->next;                                              \
+    (q)->next->prev = (q)->prev;                                              \
   }                                                                           \
   while (0)
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -20,6 +20,15 @@
 
 #include "uv/queue.h"
 
+/* Private macros. */
+#define QUEUE_POISON_NEXT   (void*)0x101
+#define QUEUE_POISON_PREV   (void*)0x102
+
+static inline void QUEUE_POISON(QUEUE *q) {
+  q->next = QUEUE_POISON_NEXT;
+  q->prev = QUEUE_POISON_PREV;
+}
+
 /* Public macros. */
 #define QUEUE_DATA(ptr, type, field)                                          \
   ((type *) ((char *) (ptr) - offsetof(type, field)))
@@ -58,6 +67,7 @@ static inline void QUEUE_ADD(QUEUE *h, QUEUE *n) {
   n->next->prev = h->prev;
   h->prev = n->prev;
   h->prev->next = h;
+  QUEUE_POISON(n);
 }
 
 static inline void QUEUE_SPLIT(QUEUE *h, QUEUE *q, QUEUE *n) {
@@ -95,6 +105,7 @@ static inline void QUEUE_INSERT_TAIL(QUEUE *h, QUEUE *q) {
 static inline void QUEUE_REMOVE(QUEUE *q) {
   q->prev->next = q->next;
   q->next->prev = q->prev;
+  QUEUE_POISON(q);
 }
 
 /* Should be used to remove an element from the queue, while iterating over it,

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -216,8 +216,7 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
 void uv__make_close_pending(uv_handle_t* handle) {
   assert(handle->flags & UV_CLOSING);
   assert(!(handle->flags & UV_CLOSED));
-  handle->next_closing = handle->loop->closing_handles;
-  handle->loop->closing_handles = handle;
+  QUEUE_INSERT_HEAD(&handle->loop->closing_handles, &handle->closing_queue);
 }
 
 int uv__getiovmax(void) {
@@ -289,16 +288,18 @@ static void uv__finish_close(uv_handle_t* handle) {
 
 
 static void uv__run_closing_handles(uv_loop_t* loop) {
-  uv_handle_t* p;
-  uv_handle_t* q;
+  QUEUE h;
+  QUEUE *q;
+  QUEUE *n;
 
-  p = loop->closing_handles;
-  loop->closing_handles = NULL;
+  /* first, hide the queue from others while we work on it */
+  QUEUE_INIT(&h);
+  QUEUE_ADD(&h, &loop->closing_handles);
+  QUEUE_INIT(&loop->closing_handles);
 
-  while (p) {
-    q = p->next_closing;
-    uv__finish_close(p);
-    p = q;
+  QUEUE_FOREACH_SAFE(q, n, &h) {
+    uv_handle_t *handle = QUEUE_DATA(q, uv_handle_t, closing_queue);
+    uv__finish_close(handle);
   }
 }
 
@@ -326,7 +327,7 @@ int uv_backend_timeout(const uv_loop_t* loop) {
   if (!QUEUE_EMPTY(&loop->pending_queue))
     return 0;
 
-  if (loop->closing_handles)
+  if (!QUEUE_EMPTY(&loop->closing_handles))
     return 0;
 
   return uv__next_timeout(loop);
@@ -336,7 +337,7 @@ int uv_backend_timeout(const uv_loop_t* loop) {
 static int uv__loop_alive(const uv_loop_t* loop) {
   return uv__has_active_handles(loop) ||
          uv__has_active_reqs(loop) ||
-         loop->closing_handles != NULL;
+         !QUEUE_EMPTY(&loop->closing_handles);
 }
 
 

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -437,7 +437,7 @@ static void uv__fsevents_reschedule(uv_fs_event_t* handle,
 
     q = &state->fsevent_handles;
     for (; i < path_count; i++) {
-      q = QUEUE_NEXT(q);
+      q = q->next;
       assert(q != &state->fsevent_handles);
       curr = QUEUE_DATA(q, uv_fs_event_t, cf_member);
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -51,7 +51,7 @@ int uv_loop_init(uv_loop_t* loop) {
   QUEUE_INIT(&loop->pending_queue);
   QUEUE_INIT(&loop->watcher_queue);
 
-  loop->closing_handles = NULL;
+  QUEUE_INIT(&loop->closing_handles);
   uv__update_time(loop);
   loop->async_io_watcher.fd = -1;
   loop->async_wfd = -1;

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -74,7 +74,7 @@ static void uv__chld(uv_signal_t* handle, int signum) {
   q = QUEUE_HEAD(h);
   while (q != h) {
     process = QUEUE_DATA(q, uv_process_t, queue);
-    q = QUEUE_NEXT(q);
+    q = q->next;
 
     do
       pid = waitpid(process->pid, &status, WNOHANG);
@@ -98,7 +98,7 @@ static void uv__chld(uv_signal_t* handle, int signum) {
   q = QUEUE_HEAD(h);
   while (q != h) {
     process = QUEUE_DATA(q, uv_process_t, queue);
-    q = QUEUE_NEXT(q);
+    q = q->next;
 
     QUEUE_REMOVE(&process->queue);
     QUEUE_INIT(&process->queue);

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -63,18 +63,15 @@ static void uv__chld(uv_signal_t* handle, int signum) {
   pid_t pid;
   QUEUE pending;
   QUEUE* q;
-  QUEUE* h;
+  QUEUE* n;
 
   assert(signum == SIGCHLD);
 
   QUEUE_INIT(&pending);
   loop = handle->loop;
 
-  h = &loop->process_handles;
-  q = QUEUE_HEAD(h);
-  while (q != h) {
+  QUEUE_FOREACH_SAFE(q, n, &loop->process_handles) {
     process = QUEUE_DATA(q, uv_process_t, queue);
-    q = q->next;
 
     do
       pid = waitpid(process->pid, &status, WNOHANG);
@@ -94,11 +91,8 @@ static void uv__chld(uv_signal_t* handle, int signum) {
     QUEUE_INSERT_TAIL(&pending, &process->queue);
   }
 
-  h = &pending;
-  q = QUEUE_HEAD(h);
-  while (q != h) {
+  QUEUE_FOREACH_SAFE(q, n, &pending) {
     process = QUEUE_DATA(q, uv_process_t, queue);
-    q = q->next;
 
     QUEUE_REMOVE(&process->queue);
     QUEUE_INIT(&process->queue);

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -202,7 +202,7 @@ void uv__fs_scandir_cleanup(uv_fs_t* req);
 #if defined(_WIN32)
 # define uv__handle_platform_init(h)
 #else
-# define uv__handle_platform_init(h) ((h)->next_closing = NULL)
+# define uv__handle_platform_init(h) QUEUE_INIT(&(h)->closing_queue)
 #endif
 
 #define uv__handle_init(loop_, h, type_)                                      \

--- a/uv.gyp
+++ b/uv.gyp
@@ -66,6 +66,7 @@
         'include/uv.h',
         'include/uv/tree.h',
         'include/uv/errno.h',
+        'include/uv/queue.h',
         'include/uv/threadpool.h',
         'include/uv/version.h',
         'src/fs-poll.c',


### PR DESCRIPTION
This is an improved version of #577, which instead of exposing the whole queue.h to a user and making it a part of the public API, exposes only the absolutely necessary part of queue.h (`struct QUEUE` declaration).
This pull request also incorporates comments raised as part of review request #577.
Everything else is identical to #577.

I didn't force-push new changesets to #577 as this would wipe many comments there because they are tied to particular changesets.
