### PR TITLE
unix: fix assertion failure in linux-inotify.c; add a corresponding test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,6 +200,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-poll-closesocket.c \
                          test/test-poll.c \
                          test/test-process-title.c \
+                         test/test-queue-foreach-delete.c \
                          test/test-ref.c \
                          test/test-run-nowait.c \
                          test/test-run-once.c \

--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -35,6 +35,7 @@
 struct watcher_list {
   RB_ENTRY(watcher_list) entry;
   QUEUE watchers;
+  int iterating;
   char* path;
   int wd;
 };
@@ -113,6 +114,15 @@ static struct watcher_list* find_watcher(uv_loop_t* loop, int wd) {
   return RB_FIND(watcher_root, CAST(&loop->inotify_watchers), &w);
 }
 
+static void maybe_free_watcher_list(struct watcher_list* w, uv_loop_t* loop) {
+  /* if the watcher_list->watchers is being iterated over, we can't free it. */
+  if ((!w->iterating) && QUEUE_EMPTY(&w->watchers)) {
+    /* No watchers left for this path. Clean up. */
+    RB_REMOVE(watcher_root, CAST(&loop->inotify_watchers), w);
+    uv__inotify_rm_watch(loop->inotify_fd, w->wd);
+    uv__free(w);
+  }
+}
 
 static void uv__inotify_read(uv_loop_t* loop,
                              uv__io_t* dummy,
@@ -160,6 +170,18 @@ static void uv__inotify_read(uv_loop_t* loop,
        */
       path = e->len ? (const char*) (e + 1) : uv__basename_r(w->path);
 
+      /* We're about to iterate over the queue and call user's callbacks.
+       * What can go wrong?
+       * A callback could call uv_fs_event_stop()
+       * and the queue can change under our feet.
+       * So, we use QUEUE_MOVE() trick to safely iterate over the queue.
+       * And we don't free the watcher_list until we're done iterating.
+       */
+      /* first,
+       * tell uv_fs_event_stop() (that could be called from a user's callback)
+       * not to free watcher_list.
+       */
+      w->iterating = 1;
       QUEUE_MOVE(&w->watchers, &queue);
       while (!QUEUE_EMPTY(&queue)) {
         q = QUEUE_HEAD(&queue);
@@ -170,6 +192,9 @@ static void uv__inotify_read(uv_loop_t* loop,
 
         h->cb(h, path, events, 0);
       }
+      /* done iterating, time to free empty watcher_list */
+      w->iterating = 0;
+      maybe_free_watcher_list(w, loop);
     }
   }
 }
@@ -221,6 +246,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   w->wd = wd;
   w->path = strcpy((char*)(w + 1), path);
   QUEUE_INIT(&w->watchers);
+  w->iterating = 0;
   RB_INSERT(watcher_root, CAST(&handle->loop->inotify_watchers), w);
 
 no_insert:
@@ -248,12 +274,7 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
   uv__handle_stop(handle);
   QUEUE_REMOVE(&handle->watchers);
 
-  if (QUEUE_EMPTY(&w->watchers)) {
-    /* No watchers left for this path. Clean up. */
-    RB_REMOVE(watcher_root, CAST(&handle->loop->inotify_watchers), w);
-    uv__inotify_rm_watch(handle->loop->inotify_fd, w->wd);
-    uv__free(w);
-  }
+  maybe_free_watcher_list(w, handle->loop);
 
   return 0;
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -336,6 +336,7 @@ HELPER_DECLARE (tcp6_echo_server)
 HELPER_DECLARE (udp4_echo_server)
 HELPER_DECLARE (pipe_echo_server)
 
+TEST_DECLARE   (queue_foreach_delete)
 
 TASK_LIST_START
   TEST_ENTRY_CUSTOM (platform_output, 0, 1, 5000)
@@ -718,6 +719,9 @@ TASK_LIST_START
   TEST_ENTRY  (dlerror)
   TEST_ENTRY  (ip4_addr)
   TEST_ENTRY  (ip6_addr_link_local)
+
+  TEST_ENTRY  (queue_foreach_delete)
+
 #if 0
   /* These are for testing the test runner. */
   TEST_ENTRY  (fail_always)

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -1,0 +1,233 @@
+/* Copyright The libuv project and contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <string.h>
+
+#ifdef __linux__
+
+/*
+ * The idea behind the test is as follows.
+ * Certain handle types are stored in a queue internally.
+ * Extra care should be taken for removal of a handle from the queue while iterating over the queue.
+ * (i.e., QUEUE_REMOVE() called within QUEUE_FOREACH())
+ * This usually happens when someone closes or stops a handle from within its callback.
+ * So we need to check that we haven't screwed the queue on close/stop.
+ * To do so we do the following (for each handle type):
+ *  1. Create and start 3 handles (#0, #1, and #2).
+ *
+ *     The queue after the start() calls:
+ *     ..=> [queue head] <=> [handle] <=> [handle #1] <=> [handle] <=..
+ *
+ *  2. Trigger handles to fire (for uv_idle_t, uv_prepare_t, and uv_check_t there is nothing to do).
+ *
+ *  3. In the callback for the first-executed handle (#0 or #2 depending on handle type)
+ *     stop the handle and the next one (#1).
+ *     (for uv_idle_t, uv_prepare_t, and uv_check_t callbacks are executed in the reverse order as they are start()'ed,
+ *     so callback for handle #2 will be called first)
+ *
+ *     The queue after the stop() calls:
+ *                                correct foreach "next"  |
+ *                                                       \/
+ *     ..=> [queue head] <==============================> [handle] <=..
+ *          [          ] <-  [handle] <=> [handle #1]  -> [      ]
+ *                                       /\
+ *                  wrong foreach "next"  |
+ *
+ *  4. The callback for handle #1 shouldn't be called because the handle #1 is stopped in the previous step.
+ *     However, if QUEUE_REMOVE() is not handled properly within QUEUE_FOREACH(), the callback _will_ be called.
+ */
+
+static const unsigned first_handle_number_idle     = 2;
+static const unsigned first_handle_number_prepare  = 2;
+static const unsigned first_handle_number_check    = 2;
+static const unsigned first_handle_number_async    = 0;
+static const unsigned first_handle_number_fs_event = 0;
+
+
+#define DEFINE_GLOBALS_AND_CBS(name)                                          \
+  static uv_##name##_t (name)[3];                                             \
+  static unsigned name##_cb_calls[3];                                         \
+                                                                              \
+  static void name##2_cb(uv_##name##_t* handle) {                             \
+    ASSERT(handle == &(name)[2]);                                             \
+    if (first_handle_number_##name == 2) {                                    \
+      uv_close((uv_handle_t*)&(name)[2], NULL);                               \
+      uv_close((uv_handle_t*)&(name)[1], NULL);                               \
+    }                                                                         \
+    name##_cb_calls[2]++;                                                     \
+  }                                                                           \
+                                                                              \
+  static void name##1_cb(uv_##name##_t* handle) {                             \
+    ASSERT(handle == &(name)[1]);                                             \
+    ASSERT(0 && "Shouldn't be called" && (&name[0]));                         \
+  }                                                                           \
+                                                                              \
+  static void name##0_cb(uv_##name##_t* handle) {                             \
+    ASSERT(handle == &(name)[0]);                                             \
+    if (first_handle_number_##name == 0) {                                    \
+      uv_close((uv_handle_t*)&(name)[0], NULL);                               \
+      uv_close((uv_handle_t*)&(name)[1], NULL);                               \
+    }                                                                         \
+    name##_cb_calls[0]++;                                                     \
+  }                                                                           \
+                                                                              \
+  static const uv_##name##_cb name##_cbs[] = {                                \
+    (uv_##name##_cb)name##0_cb,                                               \
+    (uv_##name##_cb)name##1_cb,                                               \
+    (uv_##name##_cb)name##2_cb,                                               \
+  };
+
+#define INIT_AND_START(name, loop)                                            \
+  do {                                                                        \
+    size_t i;                                                                 \
+    for (i = 0; i < ARRAY_SIZE(name); i++) {                                  \
+      int r;                                                                  \
+      r = uv_##name##_init((loop), &(name)[i]);                               \
+      ASSERT(r == 0);                                                         \
+                                                                              \
+      r = uv_##name##_start(&(name)[i], name##_cbs[i]);                       \
+      ASSERT(r == 0);                                                         \
+    }                                                                         \
+  } while (0)
+
+#define END_ASSERTS(name)                                                     \
+  do {                                                                        \
+    ASSERT(name##_cb_calls[0] == 1);                                          \
+    ASSERT(name##_cb_calls[1] == 0);                                          \
+    ASSERT(name##_cb_calls[2] == 1);                                          \
+  } while (0)
+
+DEFINE_GLOBALS_AND_CBS(idle)
+DEFINE_GLOBALS_AND_CBS(prepare)
+DEFINE_GLOBALS_AND_CBS(check)
+DEFINE_GLOBALS_AND_CBS(async)
+DEFINE_GLOBALS_AND_CBS(fs_event)
+
+static const char watched_dir[] = ".";
+
+static void init_asyncs(uv_loop_t* loop) {
+  size_t i;
+  for (i = 0; i < ARRAY_SIZE(async); i++) {
+    int r;
+    r = uv_async_init(loop, &async[i], async_cbs[i]);
+    ASSERT(r == 0);
+  }
+}
+
+static void init_and_start_fs_events(uv_loop_t* loop) {
+  size_t i;
+  for (i = 0; i < ARRAY_SIZE(fs_event); i++) {
+    int r;
+    r = uv_fs_event_init(loop, &fs_event[i]);
+    ASSERT(r == 0);
+
+    r = uv_fs_event_start(&fs_event[i], (uv_fs_event_cb)fs_event_cbs[i], watched_dir, 0);
+    ASSERT(r == 0);
+  }
+}
+
+
+static unsigned helper_timer_cb_calls;
+
+static void helper_timer_cb(uv_timer_t* thandle) {
+  size_t i;
+  int r;
+  uv_fs_t fs_req;
+  /* fire all asyncs */
+  for (i = 0; i < ARRAY_SIZE(async); i++) {
+    r = uv_async_send(&async[i]);
+    ASSERT(r == 0);
+  }
+
+  /* fire all fs_events */
+  r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
+  ASSERT(r == 0);
+  ASSERT(fs_req.result == 0);
+  ASSERT(fs_req.fs_type == UV_FS_UTIME);
+  ASSERT(strcmp(fs_req.path, watched_dir) == 0);
+  uv_fs_req_cleanup(&fs_req);
+
+  helper_timer_cb_calls++;
+}
+
+
+TEST_IMPL(queue_foreach_delete) {
+  uv_timer_t timer;
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+
+  INIT_AND_START(idle,    loop);
+  INIT_AND_START(prepare, loop);
+  INIT_AND_START(check,   loop);
+  init_asyncs(loop);
+  init_and_start_fs_events(loop);
+
+  /* helper timer to trigger async and fs_event callbacks */
+  r = uv_timer_init(loop, &timer);
+  ASSERT(r == 0);
+
+  r = uv_timer_start(&timer, helper_timer_cb, 0, 0);
+  ASSERT(r == 0);
+
+  /* mainloop */
+  r = uv_run(loop, UV_RUN_NOWAIT);
+  ASSERT(r == 1);
+
+  END_ASSERTS(idle);
+  END_ASSERTS(prepare);
+  END_ASSERTS(check);
+  END_ASSERTS(async);
+  END_ASSERTS(fs_event);
+
+  ASSERT(helper_timer_cb_calls == 1);
+
+  MAKE_VALGRIND_HAPPY();
+
+  return 0;
+}
+
+#else /* __linux__ */
+/* the test in its current form fails on non-Linux platforms:
+ * OSX:
+ *   Assertion failed in ../test/test-queue-foreach-delete.c on line 201: fs_event_cb_calls[0] == 1
+ * SmartOS:
+ *   Assertion failed in test/test-queue-foreach-delete.c on line 201: fs_event_cb_calls[2] == 1
+ * Windows:
+ *   Assertion failed in test\test-queue-foreach-delete.c on line 200: async_cb_calls[0] == 1
+ * FreeBSD:
+ *   Assertion failed in test/test-queue-foreach-delete.c on line 201: fs_event_cb_calls[0] == 1
+ *
+ * The test is very sensitive to differences in actual implementations.
+ * Although it tests different things, it's main purpose now is to test fs_event's linux-inofity.c,
+ * which is Linux-specific.
+ * So make the whole test Linux-specific for now.
+ *
+ * TODO: make the test work on at least all Unix platforms.
+ */
+TEST_IMPL(queue_foreach_delete) {
+  RETURN_SKIP("Linux only test");
+}
+#endif /* __linux__ */

--- a/uv.gyp
+++ b/uv.gyp
@@ -347,6 +347,7 @@
         'test/test-poll-close-doesnt-corrupt-stack.c',
         'test/test-poll-closesocket.c',
         'test/test-process-title.c',
+        'test/test-queue-foreach-delete.c',
         'test/test-ref.c',
         'test/test-run-nowait.c',
         'test/test-run-once.c',


### PR DESCRIPTION
@saghul asked to post these changes separately from #620 (and #577 before), so that they can be included into 1.8.0 release without other larger changes introduced in those pull requests.

After QUEUE_MOVE() change in 442b8a5a848e1589520a4d4fd175d7e9aa084c44 linux-inotify.c started to assert under certain conditions.
Revert QUEUE_MOVE() change for linux-inotify.c and apply QUEUE_FOREACH_SAFE()/QUEUE_REMOVE_SAFE() approach to it instead.
Add a corresponding test-case (this is a bigger test-case that also checks that QUEUE_MOVE() works fine for other handle types).

Note, that GitHub shows commits in a wrong order (ordered by commit date).
The actual order is the following: cd623378ea0d534dac1d4383a6c11284ba5404e1 (test), c09cc1a9af6fa66c01a482b6c9193affe3ddd91a (revert), d9975c5959c6850dabf195f036d9a02259812dbd (new macros), 41645a80311972a3b06394966c242b985ef52d5d (linux-inotify.c fix).