### PR TITLE
test: fix several compilation warnings

### DIFF
--- a/test/test-get-loadavg.c
+++ b/test/test-get-loadavg.c
@@ -24,10 +24,9 @@
 
 TEST_IMPL(get_loadavg) {
 
-  double avg[3];
+  double avg[3] = {-1, -1, -1};
   uv_loadavg(avg);
 
-  ASSERT(avg != NULL);
   ASSERT(avg[0] >= 0);
   ASSERT(avg[1] >= 0);
   ASSERT(avg[2] >= 0);

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -73,8 +73,8 @@ TEST_IMPL(getnameinfo_basic_ip4_sync) {
                              NULL,
                              (const struct sockaddr*)&addr4,
                              0));
-  ASSERT(req.host != NULL);
-  ASSERT(req.service != NULL);
+  ASSERT(req.host[0] != '\0');
+  ASSERT(req.service[0] != '\0');
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
```
test/test-get-loadavg.c:30:14: warning: comparison of array 'avg' not
equal to a null pointer is always true [-Wtautological-pointer-compare]

test/test-getnameinfo.c:76:18: warning: comparison of array 'req.host'
not equal to a null pointer is always true
[-Wtautological-pointer-compare]

test/test-getnameinfo.c:77:18: warning: comparison of array
'req.service' not equal to a null pointer is always true
[-Wtautological-pointer-compare]
```

R=@bnoordhuis
