### PR TITLE
win: map ERROR_BAD_PATHNAME to UV_ENOENT

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -129,6 +129,7 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_NETWORK_UNREACHABLE:         return UV_ENETUNREACH;
     case WSAENETUNREACH:                    return UV_ENETUNREACH;
     case WSAENOBUFS:                        return UV_ENOBUFS;
+    case ERROR_BAD_PATHNAME:                return UV_ENOENT;
     case ERROR_DIRECTORY:                   return UV_ENOENT;
     case ERROR_FILE_NOT_FOUND:              return UV_ENOENT;
     case ERROR_INVALID_NAME:                return UV_ENOENT;


### PR DESCRIPTION
e.g. when trying to call `uv_fs_stat` on `"Z:\\:\\a"` for a network drive `Z:`

Not sure where to test this. Do any of the tests currently deal with Windows network drives? Here was my reduced test program that could trigger this error code:
```
#include "uv.h"
#include "stdio.h"
uv_fs_t stat_req;
int main() {
    int r = uv_fs_stat(uv_default_loop(), &stat_req, "Z:\\:\\a", NULL);
    if (r) {
        fprintf(stderr, "Error return from uv_fs_stat: %d.\n", r);
        return -1;
    }
    uv_fs_req_cleanup(&stat_req);
    return 0;
}
```
Though if `Z:` is not a currently mapped network drive, then it'll give `ERROR_PATH_NOT_FOUND`.

edit: x-ref https://github.com/joyent/libuv/issues/390