### PR TITLE
test: fix test/test-tty.c for AIX

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -153,11 +153,14 @@ TEST_IMPL(tty_file) {
     ASSERT(0 == close(fd));
   }
 
+/* Bug on AIX where '/dev/random' returns 1 from isatty() */
+#ifndef _AIX
   fd = open("/dev/random", O_RDONLY);
   if (fd != -1) {
     ASSERT(UV_EINVAL == uv_tty_init(&loop, &tty, fd, 1));
     ASSERT(0 == close(fd));
   }
+#endif /* _AIX */
 
   fd = open("/dev/zero", O_RDONLY);
   if (fd != -1) {


### PR DESCRIPTION
'/dev/random' causes 'isatty()' to return 1 on AIX[1]. This causes
an issue where 'dev/tty' is opened (hard coded in
src/unix/tty.c:uv_tty_init). Tried to replace the hardcoded value with
what is returned by 'ttyname()' but on AIX all that is returned is
'/dev/'.

[1]http://goo.gl/wGa7mf