### PR TITLE
linux,fs: remove preadv/pwritev syscall wrappers

### DIFF
--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -207,26 +207,6 @@
 # endif
 #endif /* __NR_utimensat */
 
-#ifndef __NR_preadv
-# if defined(__x86_64__)
-#  define __NR_preadv 295
-# elif defined(__i386__)
-#  define __NR_preadv 333
-# elif defined(__arm__)
-#  define __NR_preadv (UV_SYSCALL_BASE + 361)
-# endif
-#endif /* __NR_preadv */
-
-#ifndef __NR_pwritev
-# if defined(__x86_64__)
-#  define __NR_pwritev 296
-# elif defined(__i386__)
-#  define __NR_pwritev 334
-# elif defined(__arm__)
-#  define __NR_pwritev (UV_SYSCALL_BASE + 362)
-# endif
-#endif /* __NR_pwritev */
-
 #ifndef __NR_dup3
 # if defined(__x86_64__)
 #  define __NR_dup3 292

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -151,8 +151,6 @@ int uv__utimesat(int dirfd,
                  const char* path,
                  const struct timespec times[2],
                  int flags);
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
 int uv__dup3(int oldfd, int newfd, int flags);
 
 #endif /* UV_LINUX_SYSCALL_H_ */


### PR DESCRIPTION
This is an alternate fix to #498. Credits go to @bwijen.

Use an 64bit offset and therefore have 'Architecture specific requirements' as
described in:
http://man7.org/linux/man-pages/man2/syscall.2.html#NOTES

Refs: https://github.com/libuv/libuv/pull/498
Fixes: https://github.com/libuv/libuv/issues/473

R=@bnoordhuis