### PR TITLE
test,freebsd: select correct localhost ipv4

### DIFF
--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -363,7 +363,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   unsigned int i;
   double time;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &listen_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &listen_addr));
   loop = uv_default_loop();
 
   servers = calloc(num_servers, sizeof(servers[0]));

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -183,7 +183,7 @@ static void pinger_new(void) {
   int r;
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &client_addr));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   pinger->state = 0;
   pinger->pongs = 0;

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -202,7 +202,7 @@ static void tcp_make_connect(conn_rec* p) {
   r = uv_tcp_init(loop, (uv_tcp_t*)&p->stream);
   ASSERT(r == 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_connect(&tp->conn_req,
                      (uv_tcp_t*) &p->stream,

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -425,7 +425,7 @@ static void tcp_pump(int n) {
 
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &connect_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &connect_addr));
 
   /* Start making connections */
   maybe_connect_some();

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -112,7 +112,7 @@ BENCHMARK_IMPL(tcp_write_batch) {
   }
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_client);
   ASSERT(r == 0);

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -187,7 +187,7 @@ static int pummel(unsigned int n_senders,
 
   for (i = 0; i < n_senders; i++) {
     struct sender_state* s = senders + i;
-    ASSERT(0 == uv_ip4_addr("127.0.0.1",
+    ASSERT(0 == uv_ip4_addr(localhost_ipv4(),
                             BASE_PORT + (i % n_receivers),
                             &s->addr));
     ASSERT(0 == uv_udp_init(loop, &s->udp_handle));

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -103,7 +103,7 @@ HELPER_IMPL(tcp4_blackhole_server) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_server);
   ASSERT(r == 0);

--- a/test/task.h
+++ b/test/task.h
@@ -215,4 +215,21 @@ UNUSED static int can_ipv6(void) {
   return supported;
 }
 
+
+/* Helper function to get the localhost ipv4 address. It defaults to 127.0.0.1
+ * except in FreeBSD, that uses the value of the LOCALHOST environment variable,
+ * if present. The reason is that the FreeBSD buildbots in the libuv CI set that
+ * variable to their localhost ipv4 address.
+ */
+UNUSED static const char* localhost_ipv4() {
+#ifdef __FreeBSD__
+  const char* addr = getenv("LOCALHOST");
+  if (addr) {
+    return addr;
+  }
+#endif
+
+  return "127.0.0.1";
+}
+
 #endif /* TASK_H_ */

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -172,7 +172,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 TEST_IMPL(callback_stack) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   if (uv_tcp_init(uv_default_loop(), &client)) {
     FATAL("uv_tcp_init failed");

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -92,7 +92,7 @@ static void connection_fail(uv_connect_cb connect_cb) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &client_addr));
 
   /* There should be no servers listening on this port. */
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
 
   /* Try to connect to the server and do NUM_PINGS ping-pongs. */
   r = uv_tcp_init(uv_default_loop(), &tcp);

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -155,7 +155,7 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   ASSERT(client != NULL);
   ASSERT(connect_req != NULL);
 

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -52,7 +52,7 @@ TEST_IMPL(emfile) {
   }
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   ASSERT(0 == uv_tcp_init(loop, &server_handle));
   ASSERT(0 == uv_tcp_init(loop, &client_handle));
   ASSERT(0 == uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -25,8 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
-static const char* address_ip4 = "127.0.0.1";
 static const char* address_ip6 = "::1";
 static const int port = 80;
 
@@ -48,7 +46,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
 TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
-  r = uv_ip4_addr(address_ip4, port, &addr4);
+  r = uv_ip4_addr(localhost_ipv4(), port, &addr4);
   ASSERT(r == 0);
 
   r = uv_getnameinfo(uv_default_loop(),
@@ -66,7 +64,7 @@ TEST_IMPL(getnameinfo_basic_ip4) {
 
 
 TEST_IMPL(getnameinfo_basic_ip4_sync) {
-  ASSERT(0 == uv_ip4_addr(address_ip4, port, &addr4));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), port, &addr4));
 
   ASSERT(0 == uv_getnameinfo(uv_default_loop(),
                              &req,

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -130,13 +130,16 @@ static void on_connection(uv_stream_t* server, int status) {
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(handle, &sockname, &namelen);
   ASSERT(r == 0);
-  check_sockname(&sockname, "127.0.0.1", server_port, "accepted socket");
+  check_sockname(&sockname, localhost_ipv4(), server_port, "accepted socket");
   getsocknamecount++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername(handle, &peername, &namelen);
   ASSERT(r == 0);
-  check_sockname(&peername, "127.0.0.1", connect_port, "accepted socket peer");
+  check_sockname(&peername,
+                 localhost_ipv4(),
+                 connect_port,
+                 "accepted socket peer");
   getpeernamecount++;
 
   r = uv_read_start((uv_stream_t*)handle, alloc, after_read);
@@ -153,13 +156,16 @@ static void on_connect(uv_connect_t* req, int status) {
   namelen = sizeof sockname;
   r = uv_tcp_getsockname((uv_tcp_t*) req->handle, &sockname, &namelen);
   ASSERT(r == 0);
-  check_sockname(&sockname, "127.0.0.1", 0, "connected socket");
+  check_sockname(&sockname, localhost_ipv4(), 0, "connected socket");
   getsocknamecount++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername((uv_tcp_t*) req->handle, &peername, &namelen);
   ASSERT(r == 0);
-  check_sockname(&peername, "127.0.0.1", server_port, "connected socket peer");
+  check_sockname(&peername,
+                 localhost_ipv4(),
+                 server_port,
+                 "connected socket peer");
   getpeernamecount++;
 
   uv_close((uv_handle_t*)&tcp, NULL);
@@ -213,7 +219,7 @@ static void tcp_connector(void) {
   struct sockaddr sockname;
   int r, namelen;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", server_port, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), server_port, &server_addr));
 
   r = uv_tcp_init(loop, &tcp);
   tcp.data = &connect_req;
@@ -311,7 +317,7 @@ static void udp_sender(void) {
   ASSERT(!r);
 
   buf = uv_buf_init("PING", 4);
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", server_port, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), server_port, &server_addr));
 
   r = uv_udp_send(&send_req,
                   &udp,

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -56,7 +56,7 @@ TEST_IMPL(handle_fileno) {
   uv_loop_t* loop;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_idle_init(loop, &idle);
   ASSERT(r == 0);

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -30,7 +30,7 @@ TEST_IMPL(ip4_addr) {
 
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   ASSERT(0 == uv_ip4_addr("255.255.255.255", TEST_PORT, &addr));
   ASSERT(UV_EINVAL == uv_ip4_addr("255.255.255*000", TEST_PORT, &addr));
   ASSERT(UV_EINVAL == uv_ip4_addr("255.255.255.256", TEST_PORT, &addr));
@@ -38,7 +38,7 @@ TEST_IMPL(ip4_addr) {
   ASSERT(UV_EINVAL == uv_ip4_addr("255", TEST_PORT, &addr));
 
   /* for broken address family */
-  ASSERT(UV_EAFNOSUPPORT == uv_inet_pton(42, "127.0.0.1",
+  ASSERT(UV_EAFNOSUPPORT == uv_inet_pton(42, localhost_ipv4(),
     &addr.sin_addr.s_addr));
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -188,7 +188,7 @@ static int run_ipc_send_recv_tcp(int inprocess) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   ctx.expected_type = UV_TCP;
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -125,7 +125,7 @@ static void make_many_connections(void) {
     r = uv_tcp_init(uv_default_loop(), &conn->conn);
     ASSERT(r == 0);
 
-    ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+    ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
     r = uv_tcp_connect(&conn->conn_req,
                        (uv_tcp_t*) &conn->conn,
@@ -711,7 +711,7 @@ int ipc_helper_tcp_connection(void) {
   r = uv_tcp_init(uv_default_loop(), &conn.conn);
   ASSERT(r == 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_connect(&conn.conn_req,
                      (uv_tcp_t*) &conn.conn,

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -78,7 +78,7 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   ASSERT(connect_req != NULL);
 
   r = uv_tcp_init(uv_default_loop(), &client);

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -96,7 +96,7 @@ TEST_IMPL(osx_select_many_fds) {
 
   TEST_FILE_LIMIT(ARRAY_SIZE(tcps) + 100);
 
-  r = uv_ip4_addr("127.0.0.1", 0, &addr);
+  r = uv_ip4_addr(localhost_ipv4(), 0, &addr);
   ASSERT(r == 0);
 
   for (i = 0; i < ARRAY_SIZE(tcps); i++) {

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -185,7 +185,7 @@ static void tcp_pinger_new(void) {
   struct sockaddr_in server_addr;
   pinger_t *pinger;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   ASSERT(pinger != NULL);
   pinger->state = 0;

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -86,7 +86,7 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   r = ioctlsocket(sock, FIONBIO, &on);
   ASSERT(r == 0);
 
-  r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+  r = uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr);
   ASSERT(r == 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -67,7 +67,7 @@ TEST_IMPL(poll_closesocket) {
   r = ioctlsocket(sock, FIONBIO, &on);
   ASSERT(r == 0);
 
-  r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+  r = uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr);
   ASSERT(r == 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -480,7 +480,7 @@ static void start_server(void) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   sock = create_bound_socket(addr);
   context = create_server_context(sock);
 
@@ -499,7 +499,7 @@ static void start_client(void) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &addr));
 
   sock = create_bound_socket(addr);

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -256,7 +256,7 @@ TEST_IMPL(tcp_ref2b) {
 TEST_IMPL(tcp_ref3) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -275,7 +275,7 @@ TEST_IMPL(tcp_ref3) {
 TEST_IMPL(tcp_ref4) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -306,7 +306,7 @@ TEST_IMPL(udp_ref) {
 TEST_IMPL(udp_ref2) {
   struct sockaddr_in addr;
   uv_udp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_bind(&h, (const struct sockaddr*) &addr, 0);
   uv_udp_recv_start(&h, (uv_alloc_cb)fail_cb, (uv_udp_recv_cb)fail_cb);
@@ -324,7 +324,7 @@ TEST_IMPL(udp_ref3) {
   uv_udp_send_t req;
   uv_udp_t h;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_send(&req,
               &h,

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -69,7 +69,7 @@ TEST_IMPL(shutdown_close_tcp) {
   uv_tcp_t h;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &h);
   ASSERT(r == 0);
   r = uv_tcp_connect(&connect_req,

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -156,7 +156,7 @@ TEST_IMPL(shutdown_eof) {
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
   r = uv_tcp_init(uv_default_loop(), &tcp);
   ASSERT(!r);
 

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -63,7 +63,7 @@ TEST_IMPL(shutdown_twice) {
 
   uv_connect_t connect_req;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &h);

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -56,7 +56,7 @@ static void check_buffer_size(uv_handle_t* handle) {
 TEST_IMPL(socket_buffer_size) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   ASSERT(0 == uv_tcp_init(uv_default_loop(), &tcp));
   ASSERT(0 == uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0));

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -173,7 +173,7 @@ TEST_IMPL(tcp_bind_localhost_ok) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT(r == 0);
@@ -190,7 +190,7 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT(r == 0);

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -156,7 +156,7 @@ TEST_IMPL(tcp_close_accept) {
    */
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   ASSERT(0 == uv_tcp_init(loop, &tcp_server));
   ASSERT(0 == uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0));

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -80,7 +80,7 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
   ASSERT(r == 0);
@@ -104,7 +104,7 @@ TEST_IMPL(tcp_close) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   loop = uv_default_loop();
 

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -68,7 +68,7 @@ TEST_IMPL(tcp_connect_error_after_write) {
   return 0; /* windows slackers... */
 #endif
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   buf = uv_buf_init("TEST", 4);
 
   r = uv_tcp_init(uv_default_loop(), &conn);

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -78,7 +78,7 @@ static void tcp_connector(uv_loop_t* loop, uv_tcp_t* client, uv_connect_t* req) 
   struct sockaddr_in server_addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &server_addr));
 
   r = uv_tcp_init(loop, client);
   ASSERT(r == 0);
@@ -98,7 +98,7 @@ TEST_IMPL(tcp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET);
   ASSERT(r == 0);
@@ -139,7 +139,7 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   uv_os_fd_t fd;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET6);
   ASSERT(r == 0);

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -101,7 +101,7 @@ TEST_IMPL(tcp_oob) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   loop = uv_default_loop();
 
   ASSERT(0 == uv_tcp_init(loop, &server_handle));

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -164,7 +164,7 @@ TEST_IMPL(tcp_open) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   startup();
   sock = create_tcp_socket();

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -62,7 +62,7 @@ TEST_IMPL(tcp_read_stop) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT(0 == uv_tcp_init(uv_default_loop(), &tcp_handle));
   ASSERT(0 == uv_tcp_connect(&connect_req,

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -106,7 +106,7 @@ TEST_IMPL(tcp_shutdown_after_write) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -114,7 +114,7 @@ TEST_IMPL(tcp_try_write) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
   ASSERT(0 == uv_tcp_connect(&connect_req,

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -88,7 +88,7 @@ TEST_IMPL(tcp_unexpected_read) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   loop = uv_default_loop();
 
   ASSERT(0 == uv_timer_init(loop, &timer_handle));

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -44,7 +44,7 @@ static void connect_cb(uv_connect_t *req, int status) {
 
 TEST_IMPL(tcp_write_after_connect) {
   struct sockaddr_in sa;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &sa));
   ASSERT(0 == uv_loop_init(&loop));
   ASSERT(0 == uv_tcp_init(&loop, &tcp_client));
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -93,7 +93,7 @@ TEST_IMPL(tcp_write_fail) {
   uv_tcp_t client;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -110,7 +110,7 @@ TEST_IMPL(tcp_write_queue_order) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
   ASSERT(0 == uv_tcp_connect(&connect_req,

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -107,7 +107,7 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   loop = uv_default_loop();
   ASSERT(loop != NULL);

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -145,7 +145,7 @@ TEST_IMPL(tcp_writealot) {
   uv_tcp_t client;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   send_buffer = calloc(1, TOTAL_BYTES);
   ASSERT(send_buffer != NULL);

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -217,7 +217,7 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   uv_loop_t* loop;
   int r;
 
-  r = uv_ip4_addr("127.0.0.1", 80, &addr4);
+  r = uv_ip4_addr(localhost_ipv4(), 80, &addr4);
   ASSERT(r == 0);
 
   INIT_CANCEL_INFO(&ci, reqs);

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -38,7 +38,7 @@ TEST_IMPL(udp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET);
   ASSERT(r == 0);
@@ -79,7 +79,7 @@ TEST_IMPL(udp_create_early_bad_bind) {
   uv_os_fd_t fd;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET6);
   ASSERT(r == 0);

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -68,7 +68,7 @@ TEST_IMPL(udp_dgram_too_big) {
   ASSERT(r == 0);
 
   buf = uv_buf_init(dgram, sizeof dgram);
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_send(&req_,
                   &handle_,

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -134,7 +134,7 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
   ASSERT(r == 0);
 
   buf = uv_buf_init("PING", 4);
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_send(&req_,
                   &client,

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -102,7 +102,7 @@ TEST_IMPL(udp_multicast_join) {
   uv_buf_t buf;
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
   ASSERT(r == 0);

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -140,7 +140,7 @@ TEST_IMPL(udp_open) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -176,7 +176,7 @@ TEST_IMPL(udp_send_and_recv) {
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
   ASSERT(r == 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -112,7 +112,7 @@ TEST_IMPL(udp_send_immediate) {
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
   ASSERT(r == 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -99,8 +99,8 @@ TEST_IMPL(udp_send_unreachable) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT_2, &addr2));
 
   r = uv_timer_init( uv_default_loop(), &timer );
   ASSERT(r == 0);

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -105,7 +105,7 @@ TEST_IMPL(udp_try_send) {
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
   ASSERT(r == 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -67,7 +67,7 @@ TEST_IMPL(watcher_cross_stop) {
 
   TEST_FILE_LIMIT(ARRAY_SIZE(sockets) + 32);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_ip4_addr(localhost_ipv4(), TEST_PORT, &addr));
   memset(big_string, 'A', sizeof(big_string));
   buf = uv_buf_init(big_string, sizeof(big_string));
 


### PR DESCRIPTION
Add a new localhost_ipv4() function to retrieve the correct localhost
address to be used by the tests. For FreeBSD, use the environment
variable LOCALHOST if it is set, otherwise, use 127.0.0.1. This will
help running the tests correctly in the libuv CI.