### PR TITLE
win: work around sharepoint scandir bug

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -901,7 +901,15 @@ void fs__scandir(uv_fs_t* req) {
       /* Compute the length of the filename in WCHARs. */
       wchar_len = info->FileNameLength / sizeof info->FileName[0];
 
-      /* Skip over '.' and '..' entries. */
+      /* Skip over '.' and '..' entries.  It has been reported that
+       * the SharePoint driver includes the terminating zero byte in
+       * the filename length.  Strip those first.
+       */
+      while (wchar_len > 0 && info->FileName[wchar_len - 1] == L'\0')
+        wchar_len -= 1;
+
+      if (wchar_len == 0)
+        continue;
       if (wchar_len == 1 && info->FileName[0] == L'.')
         continue;
       if (wchar_len == 2 && info->FileName[0] == L'.' &&


### PR DESCRIPTION
It has been reported that for SharePoint connections mapped as a drive,
uv_fs_scandir() returns "." and ".." entries when the expectation is
that they should be filtered out.

After some investigation it looks like the driver returns ".\0" and
"..\0" for those entries, that is, it includes the zero byte in the
filename length.  Rewrite the filter to catch those entries as well.

Fixes: https://github.com/nodejs/node/issues/4002

R=@piscisaureus

Maybe a better fix is:
```c
if (wchar_len > 0 && info->FileName[wchar_len - 1] == L'\0'))
  wchar_len -= 1;
```
Thoughts?

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/195/