### PR TITLE
linux,fs: fix calling p{read,write}v with a 64bit offset

### DIFF
--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -444,18 +444,18 @@ int uv__utimesat(int dirfd,
 }
 
 
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, int64_t offset) {
 #if defined(__NR_preadv)
-  return syscall(__NR_preadv, fd, iov, iovcnt, offset);
+  return syscall(__NR_preadv, fd, iov, iovcnt, (long)offset, (long)(offset >> 32));
 #else
   return errno = ENOSYS, -1;
 #endif
 }
 
 
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, int64_t offset) {
 #if defined(__NR_pwritev)
-  return syscall(__NR_pwritev, fd, iov, iovcnt, offset);
+  return syscall(__NR_pwritev, fd, iov, iovcnt, (long)offset, (long)(offset >> 32));
 #else
   return errno = ENOSYS, -1;
 #endif

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -151,8 +151,8 @@ int uv__utimesat(int dirfd,
                  const char* path,
                  const struct timespec times[2],
                  int flags);
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
+ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, int64_t offset);
+ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, int64_t offset);
 int uv__dup3(int oldfd, int newfd, int flags);
 
 #endif /* UV_LINUX_SYSCALL_H_ */


### PR DESCRIPTION
According to [0] we need to pass it in 2 32bit registers. Fix
inspired by the musl libc implementation [1].

[0]: http://man7.org/linux/man-pages/man2/syscall.2.html#NOTES
[1]: http://git.musl-libc.org/cgit/musl/tree/src/unistd/preadv.c

R=@bnoordhuis
CI: https://ci.nodejs.org/job/libuv+any-pr+multi/204/