### PR TITLE
win: fix path for removed and renamed fs events

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -115,7 +115,11 @@ static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_RENAME);
+  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(strcmp(filename, "file1") == 0);
+  #else
   ASSERT(filename == NULL || strcmp(filename, "file1") == 0);
+  #endif
   ASSERT(0 == uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }
@@ -178,8 +182,12 @@ static void fs_event_cb_dir_multi_file(uv_fs_event_t* handle,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE || UV_RENAME);
+  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(strncmp(filename, file_prefix, sizeof(file_prefix) - 1) == 0);
+  #else
   ASSERT(filename == NULL ||
          strncmp(filename, file_prefix, sizeof(file_prefix) - 1) == 0);
+  #endif
 
   if (fs_event_created + fs_event_removed == fs_event_file_count) {
     /* Once we've processed all create events, delete all files */
@@ -250,8 +258,16 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE || UV_RENAME);
+  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(strncmp(filename,
+                 file_prefix_in_subdir,
+                 sizeof(file_prefix_in_subdir) - 1) == 0);
+  #else
   ASSERT(filename == NULL ||
-         strncmp(filename, file_prefix_in_subdir, sizeof(file_prefix_in_subdir) - 1) == 0);
+         strncmp(filename,
+                 file_prefix_in_subdir,
+                 sizeof(file_prefix_in_subdir) - 1) == 0);
+  #endif
 
   if (fs_event_created + fs_event_removed == fs_event_file_count) {
     /* Once we've processed all create events, delete all files */
@@ -270,7 +286,11 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE);
+  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(strcmp(filename, "file2") == 0);
+  #else
   ASSERT(filename == NULL || strcmp(filename, "file2") == 0);
+  #endif
   ASSERT(0 == uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }
@@ -293,7 +313,11 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE);
+  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(strcmp(filename, "watch_file") == 0);
+  #else
   ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
+  #endif
 
   /* Regression test for SunOS: touch should generate just one event. */
   {


### PR DESCRIPTION
This fixes https://github.com/libuv/libuv/issues/634

Previous behavior on Windows was to set the path to NULL for removed and renamed fs events. This was because the path provided by ReadDirectoryChangesW might (in rare cases) be an 8.3 short name which could then no longer be converted to a long name after the path had been removed or renamed. This meant that the user had to detect which path was actually deleted or renamed and required the user to rescan the entire watched subtree, taking several seconds or more for large subtrees.

However, ReadDirectoryChangesW is publicly documented to emit 8.3 short names if the original handle for the changed path was opened using an 8.3 short name, and libuv may already emit 8.3 short names for other events if the path cannot be explicitly resolved to a long name.

There was a suggestion in a previous pull request that before fixing something like this, we should first convert all long form paths to 8.3 short names for consistency sake but that would surely be overkill and surprising behavior. Even for removed and renamed events, the path provided by ReadDirectoryChangesW is usually in long form. It is only in short form if that was the form used by the application which originated the change.

This commit fixes the path for removed and renamed fs events, and does not set the path to NULL, even if the path might be an 8.3 short name. This makes it possible for the user to do a partial scan of the subtree, restricting the scan to paths which match the long form or 8.3 short name (even if some of these are false positive matches). This means that deletes and renames can now be detected accurately on Windows within a few milliseconds.

This already has positive test coverage at https://github.com/joyent/libuv/blob/v1.x/test/test-fs-event.c#L117, and the NULL check there should probably only be removed by someone more familiar with the rest of the api. The documentation already allows for NULL paths and this might not be the last remaining cause of them.