### PR TITLE
fsevents: use fsevents for file watching too

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -375,9 +375,12 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   if (fstat(fd, &statbuf))
     goto fallback;
-  /* FSEvents works only with directories */
+
+#ifndef MAC_OS_X_VERSION_10_7
+  /* FSEvents works only with directories before 10.7 */
   if (!(statbuf.st_mode & S_IFDIR))
     goto fallback;
+#endif
 
   /* The fallback fd is no longer needed */
   uv__close(fd);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -295,13 +295,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   ASSERT(events == UV_CHANGE);
   ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
 
-  /* Regression test for SunOS: touch should generate just one event. */
-  {
-    static uv_timer_t timer;
-    uv_timer_init(handle->loop, &timer);
-    timer.data = handle;
-    uv_timer_start(&timer, timer_cb_close_handle, 250, 0);
-  }
+  uv_close((uv_handle_t*) handle, close_cb);
 }
 
 static void timer_cb_file(uv_timer_t* handle) {


### PR DESCRIPTION
This prevents opening a fd for each file being watched on OS X 10.7+.
It fails back to using kqueue on anything < 10.7.

Ref: https://github.com/libuv/libuv/issues/387
