### PR TITLE
src: remove non ascii character

### DIFF
--- a/src/unix/android-ifaddrs.c
+++ b/src/unix/android-ifaddrs.c
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2013, Kenneth MacKay
-Copyright (c) 2014, Emergya (Cloud4all, FP7/2007-2013 grant agreement n° 289016)
+Copyright (c) 2014, Emergya (Cloud4all, FP7/2007-2013 grant agreement #289016)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
src/unix/android-ifaddrs.c contained a weird character in its header comment. I don't know if this is valid UTF-8 or not, but [this](https://github.com/edlund/amalgamate) python tool could not process it otherwise (despite being unicode-ready).