### PR TITLE
Fix support for uClibc-ng

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -39,7 +39,7 @@
 #define HAVE_IFADDRS_H 1
 
 #ifdef __UCLIBC__
-# if __UCLIBC_MAJOR__ < 0 || __UCLIBC_MINOR__ < 9 || __UCLIBC_SUBLEVEL__ < 32
+# if __UCLIBC_MAJOR__ < 0 && __UCLIBC_MINOR__ < 9 && __UCLIBC_SUBLEVEL__ < 32
 #  undef HAVE_IFADDRS_H
 # endif
 #endif


### PR DESCRIPTION
uClibc-ng is currently at v1.0.9.  The patch corrects the uClibc
version test so that HAVE_IFADDRS_H is defined for uClibc versions
after v0.9.32.
