### PR TITLE
unix: report errors for unpollable fds

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -91,6 +91,24 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
 }
 
 
+int uv__io_check_fd(uv_loop_t* loop, int fd) {
+  struct poll_ctl pc;
+
+  pc.events = POLLIN;
+  pc.cmd = PS_MOD;  /* Equivalent to PS_ADD if the fd is not in the pollset. */
+  pc.fd = fd;
+
+  if (pollset_ctl(loop->backend_fd, &pc, 1))
+    return -errno;
+
+  pc.cmd = PS_DELETE;
+  if (pollset_ctl(loop->backend_fd, &pc, 1))
+    abort();
+
+  return 0;
+}
+
+
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct pollfd events[1024];
   struct pollfd pqry;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -180,6 +180,7 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 void uv__io_close(uv_loop_t* loop, uv__io_t* w);
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w);
 int uv__io_active(const uv__io_t* w, unsigned int events);
+int uv__io_check_fd(uv_loop_t* loop, int fd);
 void uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
 
 /* async */

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -48,6 +48,24 @@ int uv__kqueue_init(uv_loop_t* loop) {
 }
 
 
+int uv__io_check_fd(uv_loop_t* loop, int fd) {
+  struct kevent ev;
+  int rc;
+
+  rc = 0;
+  EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
+  if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
+    rc = -errno;
+
+  EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
+  if (rc == 0)
+    if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
+      abort();
+
+  return rc;
+}
+
+
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct kevent events[1024];
   struct kevent* ev;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -53,6 +53,10 @@ static void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
   int err;
 
+  err = uv__io_check_fd(loop, fd);
+  if (err)
+    return err;
+
   err = uv__nonblock(fd, 1);
   if (err)
     return err;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -116,6 +116,17 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 }
 
 
+int uv__io_check_fd(uv_loop_t* loop, int fd) {
+  if (port_associate(loop->backend_fd, PORT_SOURCE_FD, fd, POLLIN, 0))
+    return -errno;
+
+  if (port_dissociate(loop->backend_fd, PORT_SOURCE_FD, fd))
+    abort();
+
+  return 0;
+}
+
+
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct port_event events[1024];
   struct port_event* pe;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -305,6 +305,7 @@ TEST_DECLARE   (dlerror)
 TEST_DECLARE   (poll_duplex)
 TEST_DECLARE   (poll_unidirectional)
 TEST_DECLARE   (poll_close)
+TEST_DECLARE   (poll_bad_fdtype)
 
 TEST_DECLARE   (ip4_addr)
 TEST_DECLARE   (ip6_addr_link_local)
@@ -608,6 +609,7 @@ TASK_LIST_START
   TEST_ENTRY  (poll_duplex)
   TEST_ENTRY  (poll_unidirectional)
   TEST_ENTRY  (poll_close)
+  TEST_ENTRY  (poll_bad_fdtype)
 
   TEST_ENTRY  (socket_buffer_size)
 


### PR DESCRIPTION
Libuv would abort() when trying to watch a file descriptor that is
not compatible with epoll-style polling; file descriptors referring
to on-disk files fall into this category.

File descriptors that libuv creates itself are not an issue but
external ones that come in through the uv_poll_init() API are.

Starting with this commit, when the file descriptor is rejected by
the underlying system call, an error is propagated to the uv__io_cb
callback, and from there to the uv_poll_cb callback.

Fixes: https://github.com/libuv/libuv/issues/658

R=@saghul

I verified that the tests pass on Linux and OS X.  I speculate Windows is going to fail because `uv_poll_init()` seems to return an error directly when the file descriptor is incompatible.

We can perhaps emulate that on Unices by registering file descriptors early but that is probably a more invasive change.  Thoughts?

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/217/