### PR TITLE
uv__fs_buf_iter: don't nullify req->bufs on EINTR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,6 +151,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-default-loop-close.c \
                          test/test-delayed-accept.c \
                          test/test-dlerror.c \
+                         test/test-eintr-handling.c \
                          test/test-embed.c \
                          test/test-emfile.c \
                          test/test-error.c \

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -858,9 +858,14 @@ static ssize_t uv__fs_buf_iter(uv_fs_t* req, uv__fs_buf_iter_processor process) 
     total += result;
   }
 
+  if (errno == EINTR && total == -1)
+    return total;
+
   if (bufs != req->bufsml)
     uv__free(bufs);
+
   req->bufs = NULL;
+  req->nbufs = 0;
 
   return total;
 }

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -1,0 +1,93 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef _WIN32
+
+TEST_IMPL(pipe_set_non_blocking) {
+  RETURN_SKIP("Test not implemented on Windows.");
+}
+
+#else  /* !_WIN32 */
+
+#include <unistd.h>
+
+static uv_loop_t* loop;
+static uv_fs_t read_req;
+static uv_buf_t iov;
+
+static char buf[32];
+static char test_buf[] = "test-buffer\n";
+int pipe_fds[2];
+
+struct thread_ctx {
+  uv_barrier_t barrier;
+  int fd;
+};
+
+static void thread_main(void* arg) {
+  int nwritten;
+  ASSERT(0 == kill(getpid(), SIGUSR1));
+
+  do {
+      nwritten = write(pipe_fds[1], test_buf, sizeof(test_buf));
+  } while (nwritten == -1 && errno == EINTR);
+
+  ASSERT(nwritten == sizeof(test_buf));
+}
+
+static void sig_func(uv_signal_t* handle, int signum) {
+  uv_signal_stop(handle);
+}
+
+TEST_IMPL(eintr_handling) {
+  struct thread_ctx ctx;
+  uv_thread_t thread;
+  uv_signal_t signal;
+  int nread;
+
+  iov = uv_buf_init(buf, sizeof(buf));
+  loop = uv_default_loop();
+
+  ASSERT(0 == uv_signal_init(loop, &signal));
+  ASSERT(0 == uv_signal_start(&signal, sig_func, SIGUSR1));
+
+  ASSERT(0 == pipe(pipe_fds));
+  ASSERT(0 == uv_thread_create(&thread, thread_main, &ctx));
+
+  nread = uv_fs_read(loop, &read_req, pipe_fds[0], &iov, 1, -1, NULL);
+
+  ASSERT(nread == sizeof(test_buf));
+  ASSERT(0 == strcmp(buf, test_buf));
+
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+
+  ASSERT(0 == close(pipe_fds[0]));
+  ASSERT(0 == close(pipe_fds[1]));
+  uv_close((uv_handle_t*) &signal, NULL);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+#endif  /* !_WIN32 */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -192,6 +192,7 @@ TEST_DECLARE   (active)
 TEST_DECLARE   (embed)
 TEST_DECLARE   (async)
 TEST_DECLARE   (async_null_cb)
+TEST_DECLARE   (eintr_handling)
 TEST_DECLARE   (get_currentexe)
 TEST_DECLARE   (process_title)
 TEST_DECLARE   (cwd_and_chdir)
@@ -568,6 +569,7 @@ TASK_LIST_START
 
   TEST_ENTRY  (async)
   TEST_ENTRY  (async_null_cb)
+  TEST_ENTRY  (eintr_handling)
 
   TEST_ENTRY  (get_currentexe)
 

--- a/uv.gyp
+++ b/uv.gyp
@@ -300,6 +300,7 @@
         'test/test-cwd-and-chdir.c',
         'test/test-default-loop-close.c',
         'test/test-delayed-accept.c',
+        'test/test-eintr-handling.c',
         'test/test-error.c',
         'test/test-embed.c',
         'test/test-emfile.c',


### PR DESCRIPTION
uv__fs_buf_iter currently sets req->bufs to NULL
after it is done, but if the operation fails with EINTR
then it will be retried, at which point it expects
the bufs to not be NULL, causing a seg fault as in
https://github.com/nodejs/node/issues/4291.

uv__fs_buf_iter should not set req->bufs to NULL
if the operation fails with EINTR.

Also, when it sets req->bufs to NULL, it should set
req->nbufs to 0 as well, so we don't have the messy
situation of a positive nbufs with no actual bufs.


I should have liked nothing better than to include a unit test with this change, but I know of no way to trigger EINTRs without the elaborate setup outlined in https://github.com/nodejs/node/issues/4291, which requires resizing the terminal window, an operation with no allegory in a unit test scenario. Suggestions welcome!