### PR TITLE
test,unix: fix logic error in test runner

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -226,7 +226,7 @@ int process_wait(process_info_t* vec, int n, int timeout) {
   tv = timebase;
   for (;;) {
     /* Check that gettimeofday() doesn't jump back in time. */
-    assert(tv.tv_sec == timebase.tv_sec ||
+    assert(tv.tv_sec > timebase.tv_sec ||
            (tv.tv_sec == timebase.tv_sec && tv.tv_usec >= timebase.tv_usec));
 
     elapsed_ms =


### PR DESCRIPTION
Fix the logic that guards against the system clock jumping back in time.

Fixes: https://github.com/libuv/libuv/issues/667

R=@saghul

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/224/