### PR TITLE
unix: don't null-terminate buffer on uv_os_homedir

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1035,12 +1035,12 @@ int uv_os_homedir(char* buffer, size_t* size) {
   if (buf != NULL) {
     len = strlen(buf);
 
-    if (len >= *size) {
+    if (len > *size) {
       *size = len;
       return -ENOBUFS;
     }
 
-    memcpy(buffer, buf, len + 1);
+    memcpy(buffer, buf, len);
     *size = len;
 
     return 0;
@@ -1090,13 +1090,13 @@ int uv_os_homedir(char* buffer, size_t* size) {
 
   len = strlen(pw.pw_dir);
 
-  if (len >= *size) {
+  if (len > *size) {
     *size = len;
     uv__free(buf);
     return -ENOBUFS;
   }
 
-  memcpy(buffer, pw.pw_dir, len + 1);
+  memcpy(buffer, pw.pw_dir, len);
   *size = len;
   uv__free(buf);
 

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -17,9 +17,7 @@ TEST_IMPL(homedir) {
   ASSERT(strlen(homedir) == 0);
   r = uv_os_homedir(homedir, &len);
   ASSERT(r == 0);
-  ASSERT(strlen(homedir) == len);
   ASSERT(len > 0);
-  ASSERT(homedir[len] == '\0');
 
   if (len > 1) {
     last = homedir[len - 1];


### PR DESCRIPTION
For consistency with other functions returning paths this way.

Still WIP (need to check the Windows side) but wanted to discuss it. 
R=@bnoordhuis /cc @cjihrig 