### PR TITLE
test,win: fix compilation with shared lib

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -418,7 +418,8 @@
         [ 'OS=="win"', {
           'sources': [
             'test/runner-win.c',
-            'test/runner-win.h'
+            'test/runner-win.h',
+            'src/win/snprintf.c',
           ],
           'libraries': [ '-lws2_32' ]
         }, { # POSIX
@@ -486,6 +487,7 @@
           'sources': [
             'test/runner-win.c',
             'test/runner-win.h',
+            'src/win/snprintf.c',
           ],
           'libraries': [ '-lws2_32' ]
         }, { # POSIX


### PR DESCRIPTION
Tests were failing to link because of undefined snprintf symbol with
VS < 2015 and using shared library.

snprintf is implemented in libuv in src/win/snprintf.c when compiling
with VS < 2015, so this commit add src/win/snprintf.c to test sources
to make snprintf available in tests.

Fixes: #676 
