### PR TITLE
test: fix race condition in pipe-close-stdout

### DIFF
--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -53,6 +53,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
   int pid;
   int fd[2];
   int status;
+  char buf;
   uv_pipe_t stdin_pipe;
 
   r = pipe(fd);
@@ -64,6 +65,8 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
      * The write side will be closed by the parent process.
     */
     close(fd[1]);
+    /* block until write end of pipe is closed */
+    read(fd[0], &buf, 1);
     close(0);
     r = dup(fd[0]);
     ASSERT(r != -1);


### PR DESCRIPTION
If the child process reaches uv_run before the parent has closed the
write end of the pipe the test fails with the following output:

Assertion failed in test/test-pipe-close-stdout-read-stdin.c
on line 86: uv_run(uv_default_loop(), UV_RUN_NOWAIT) == 0
Assertion failed in test/test-pipe-close-stdout-read-stdin.c
on line 97: WIFEXITED(status) && WEXITSTATUS(status) == 0

This is mainly seen on AIX, but does not mean that it can not occur on
linux. This change causes the child process to be blocked until the
write end of the pipe is properly closed. See 'man 7 pipe'[0] for
more detail.

[0]http://linux.die.net/man/7/pipe