### PR TITLE
test: fix threadpool_multiple_event_loops for AIX

### DIFF
--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -123,12 +123,17 @@ static void do_work(void* arg) {
     getaddrinfo_do(req);
   }
 
+/* Disable fs work on AIX as there are known issues.
+ * See: Readme.md AIX Notes
+ */
+#ifndef _AIX
   for (i = 0; i < ARRAY_SIZE(fs_reqs); i++) {
     struct fs_req* req = fs_reqs + i;
     req->counter = 16;
     req->loop = loop;
     fs_do(req);
   }
+#endif
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);


### PR DESCRIPTION
Disabled the filesystem portion of the test as there are known issues
with AIX and its fs. This particular test was failing with a timeout.