### PR TITLE
unix, win: consistently null-terminate buffers

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -265,8 +265,9 @@ API
     `uv_os_homedir()` first checks the `HOME` environment variable using
     :man:`getenv(3)`. If `HOME` is not set, :man:`getpwuid_r(3)` is called. The
     user's home directory is stored in `buffer`. When `uv_os_homedir()` is
-    called, `size` indicates the maximum size of `buffer`. On success or
-    `UV_ENOBUFS` failure, `size` is set to the string length of `buffer`.
+    called, `size` indicates the maximum size of `buffer`. On success `size` is set
+    to the string length of `buffer`. On `UV_ENOBUFS` failure `size` is set to the
+    required length for `buffer`, including the null byte.
 
     .. warning::
         `uv_os_homedir()` is not thread safe.
@@ -281,8 +282,9 @@ API
     If none of these are found, the path `"/tmp"` is used, or, on Android,
     `"/data/local/tmp"` is used. The temp directory is stored in `buffer`. When
     `uv_os_tmpdir()` is called, `size` indicates the maximum size of `buffer`.
-    On success or `UV_ENOBUFS` failure, `size` is set to the string length of
-    `buffer` (which does not include the terminating null).
+    On success `size` is set to the string length of `buffer` (which does not
+    include the terminating null). On `UV_ENOBUFS` failure `size` is set to the
+    required length for `buffer`, including the null byte.
 
     .. warning::
         `uv_os_tmpdir()` is not thread safe.

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -138,13 +138,14 @@ int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buffer, size_t* size) {
   assert(ctx != NULL);
 
   required_len = strlen(ctx->path);
-  if (required_len > *size) {
+  if (required_len >= *size) {
     *size = required_len;
     return UV_ENOBUFS;
   }
 
   memcpy(buffer, ctx->path, required_len);
   *size = required_len;
+  buffer[required_len] = '\0';
 
   return 0;
 }

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -139,7 +139,7 @@ int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buffer, size_t* size) {
 
   required_len = strlen(ctx->path);
   if (required_len >= *size) {
-    *size = required_len;
+    *size = required_len + 1;
     return UV_ENOBUFS;
   }
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1036,7 +1036,7 @@ int uv_os_homedir(char* buffer, size_t* size) {
     len = strlen(buf);
 
     if (len >= *size) {
-      *size = len;
+      *size = len + 1;
       return -ENOBUFS;
     }
 
@@ -1091,7 +1091,7 @@ int uv_os_homedir(char* buffer, size_t* size) {
   len = strlen(pw.pw_dir);
 
   if (len >= *size) {
-    *size = len;
+    *size = len + 1;
     uv__free(buf);
     return -ENOBUFS;
   }
@@ -1138,7 +1138,7 @@ return_buffer:
   len = strlen(buf);
 
   if (len >= *size) {
-    *size = len;
+    *size = len + 1;
     return -ENOBUFS;
   }
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -235,7 +235,7 @@ static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
 
 
   if (addrlen >= *size) {
-    *size = addrlen;
+    *size = addrlen + 1;
     return UV_ENOBUFS;
   }
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -234,13 +234,17 @@ static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
     addrlen = strlen(sa.sun_path);
 
 
-  if (addrlen > *size) {
+  if (addrlen >= *size) {
     *size = addrlen;
     return UV_ENOBUFS;
   }
 
   memcpy(buffer, sa.sun_path, addrlen);
   *size = addrlen;
+
+  /* only null-terminate if it's not an abstract socket */
+  if (buffer[0] != '\0')
+    buffer[addrlen] = '\0';
 
   return 0;
 }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -452,7 +452,7 @@ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
 
   required_len = strlen(handle->path);
   if (required_len >= *size) {
-    *size = required_len;
+    *size = required_len + 1;
     return UV_ENOBUFS;
   }
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -451,13 +451,14 @@ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
   }
 
   required_len = strlen(handle->path);
-  if (required_len > *size) {
+  if (required_len >= *size) {
     *size = required_len;
     return UV_ENOBUFS;
   }
 
   memcpy(buffer, handle->path, required_len);
   *size = required_len;
+  buffer[required_len] = '\0';
 
   return 0;
 }

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2040,7 +2040,7 @@ static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size)
     goto error;
   } else if (pipe_prefix_len + addrlen >= *size) {
     /* "\\\\.\\pipe" + name */
-    *size = pipe_prefix_len + addrlen;
+    *size = pipe_prefix_len + addrlen + 1;
     err = UV_ENOBUFS;
     goto error;
   }

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2038,7 +2038,7 @@ static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size)
     *size = 0;
     err = uv_translate_sys_error(GetLastError());
     goto error;
-  } else if (pipe_prefix_len + addrlen > *size) {
+  } else if (pipe_prefix_len + addrlen >= *size) {
     /* "\\\\.\\pipe" + name */
     *size = pipe_prefix_len + addrlen;
     err = UV_ENOBUFS;
@@ -2062,6 +2062,7 @@ static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size)
 
   addrlen += pipe_prefix_len;
   *size = addrlen;
+  buffer[addrlen] = '\0';
 
   err = 0;
   goto cleanup;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -210,7 +210,7 @@ int uv_cwd(char* buffer, size_t* size) {
   if (r == 0) {
     return uv_translate_sys_error(GetLastError());
   } else if (r > (int) *size) {
-    *size = r -1;
+    *size = r;
     return UV_ENOBUFS;
   }
 
@@ -1218,7 +1218,7 @@ convert_buffer:
   if (bufsize == 0) {
     return uv_translate_sys_error(GetLastError());
   } else if (bufsize > *size) {
-    *size = bufsize - 1;
+    *size = bufsize;
     return UV_ENOBUFS;
   }
 
@@ -1263,7 +1263,7 @@ int uv_os_tmpdir(char* buffer, size_t* size) {
   if (bufsize == 0) {
     return uv_translate_sys_error(GetLastError());
   } else if (bufsize > *size) {
-    *size = bufsize - 1;
+    *size = bufsize;
     return UV_ENOBUFS;
   }
 

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -819,6 +819,7 @@ TEST_IMPL(fs_event_getpath) {
   r = uv_fs_event_getpath(&fs_event, buf, &len);
   ASSERT(r == 0);
   ASSERT(buf[len - 1] != 0);
+  ASSERT(buf[len] == '\0');
   ASSERT(memcmp(buf, "watch_dir", len) == 0);
   r = uv_fs_event_stop(&fs_event);
   ASSERT(r == 0);

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -173,6 +173,7 @@ TEST_IMPL(fs_poll_getpath) {
   len = sizeof buf;
   ASSERT(0 == uv_fs_poll_getpath(&poll_handle, buf, &len));
   ASSERT(buf[len - 1] != 0);
+  ASSERT(buf[len] == '\0');
   ASSERT(0 == memcmp(buf, FIXTURE, len));
 
   uv_close((uv_handle_t*) &poll_handle, close_cb);

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -114,6 +114,7 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT(r == 0);
 
   ASSERT(buf[len - 1] != 0);
+  ASSERT(buf[len] == '\0');
   ASSERT(memcmp(buf, TEST_PIPENAME, len) == 0);
 
   len = sizeof buf;


### PR DESCRIPTION
libuv has multiple functions which return buffers. Make them consistent
with the following rules: the returned size *does not* include the null
byte, but the buffer *is* null terminated.

There is only one exception to the above: Linux abstract sockets,
because null bytes are not used as string terminators in those.

Refs: https://github.com/libuv/libuv/pull/674

R=@bnoordhuis, @sam-github, @cjihrig 
CI: https://ci.nodejs.org/job/libuv+any-pr+multi/233/