### PR TITLE
ios: Fixes undefined PTHREAD_STACK_MIN

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -29,6 +29,8 @@
 #include <sys/time.h>
 #include <sys/resource.h>  /* getrlimit() */
 
+#include <limits.h>
+
 #undef NANOSEC
 #define NANOSEC ((uint64_t) 1e9)
 


### PR DESCRIPTION
When I compile last commit for my ios project, it says that `PTHREAD_STACK_MIN` is undefined. It's actually defined in `limits.h` so I add the header to the file.