### PR TITLE
turn the cl_send down  as the sv_send

### DIFF
--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -94,7 +94,9 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
-
+  
+  uv_close((uv_handle_t*) handle, close_cb);
+  
   r = uv_udp_recv_start(req->handle, alloc_cb, cl_recv_cb);
   ASSERT(r == 0);
 


### PR DESCRIPTION
When the send is completed, you should turn it off, just as you did in the sv_send_cb()