### PR TITLE
osx: fixed a preprocessor condition that relied on '__FreeBSD__' to be defined, which broke the build on Darwin.

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -435,7 +435,7 @@ int uv__accept(int sockfd) {
   assert(sockfd >= 0);
 
   while (1) {
-#if defined(__linux__) || __FreeBSD__ >= 10
+#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD__ >= 10)
     static int no_accept4;
 
     if (no_accept4)


### PR DESCRIPTION
This trivial fix makes sure `__FreeBSD__` is not used if not defined.