### PR TITLE
linux: fix compilation with musl

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -52,7 +52,7 @@
 # endif
 # include <sys/socket.h>
 # include <net/ethernet.h>
-# include <linux/if_packet.h>
+# include <netpacket/packet.h>
 #endif /* HAVE_IFADDRS_H */
 
 /* Available from 2.6.32 onwards. */


### PR DESCRIPTION
Not sure I'm on the right track here... When attempting to compile libuv + the tests with musl I get a compilation error:

~~~~
../src/unix/linux-core.c:55:30: fatal error: linux/if_packet.h: No such file or directory
compilation terminated.
~~~~

I'm compiling the thing with the musl-gcc wrapper as follows:

~~~~
export CC=musl-gcc
export LINK=musl-gcc
export CFLAGS=-static
./gyp_uv.py
...
~~~~

This PR compiles on musl and non-musl.

R=@bnoordhuis