### PR TITLE
test: fix deadlocks in uv_cond_wait

### DIFF
--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -27,29 +27,23 @@
 
 typedef struct worker_config {
   uv_mutex_t mutex;
-  uv_cond_t cond_1, cond_2;
+  uv_cond_t cond;
   int signal_delay, wait_delay;
   int use_broadcast;
   volatile int posted_1, posted_2;
-  void (*signal_cond)(struct worker_config* c,
-                      uv_cond_t* cond,
-                      volatile int* flag);
-  void (*wait_cond)(struct worker_config* c,
-                    uv_cond_t* cond,
-                    const volatile int* flag);
+  void (*signal_cond)(struct worker_config* c, volatile int* flag);
+  void (*wait_cond)(struct worker_config* c, const volatile int* flag);
 } worker_config;
 
 
 static void worker(void* arg) {
   worker_config* c = arg;
-  c->signal_cond(c, &c->cond_1, &c->posted_1);
-  c->wait_cond(c, &c->cond_2, &c->posted_2);
+  c->signal_cond(c, &c->posted_1);
+  c->wait_cond(c, &c->posted_2);
 }
 
 
-static void condvar_signal(worker_config* c,
-                           uv_cond_t* cond,
-                           volatile int* flag) {
+static void condvar_signal(worker_config* c, volatile int* flag) {
   if (c->signal_delay)
     uv_sleep(c->signal_delay);
 
@@ -57,21 +51,19 @@ static void condvar_signal(worker_config* c,
   ASSERT(*flag == 0);
   *flag = 1;
   if (c->use_broadcast)
-    uv_cond_broadcast(cond);
+    uv_cond_broadcast(&c->cond);
   else
-    uv_cond_signal(cond);
+    uv_cond_signal(&c->cond);
   uv_mutex_unlock(&c->mutex);
 }
 
 
-static void condvar_wait(worker_config* c,
-                         uv_cond_t* cond,
-                         const volatile int* flag) {
+static void condvar_wait(worker_config* c, const volatile int* flag) {
   uv_mutex_lock(&c->mutex);
   if (c->wait_delay)
     uv_sleep(c->wait_delay);
   while (*flag == 0) {
-    uv_cond_wait(cond, &c->mutex);
+    uv_cond_wait(&c->cond, &c->mutex);
   }
   ASSERT(*flag == 1);
   uv_mutex_unlock(&c->mutex);
@@ -87,18 +79,16 @@ TEST_IMPL(condvar_1) {
   wc.signal_cond = condvar_signal;
   wc.wait_cond = condvar_wait;
 
-  ASSERT(0 == uv_cond_init(&wc.cond_1));
-  ASSERT(0 == uv_cond_init(&wc.cond_2));
+  ASSERT(0 == uv_cond_init(&wc.cond));
   ASSERT(0 == uv_mutex_init(&wc.mutex));
   ASSERT(0 == uv_thread_create(&thread, worker, &wc));
 
-  wc.wait_cond(&wc, &wc.cond_1, &wc.posted_1);
-  wc.signal_cond(&wc, &wc.cond_2, &wc.posted_2);
+  wc.wait_cond(&wc, &wc.posted_1);
+  wc.signal_cond(&wc, &wc.posted_2);
 
   ASSERT(0 == uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
-  uv_cond_destroy(&wc.cond_1);
-  uv_cond_destroy(&wc.cond_2);
+  uv_cond_destroy(&wc.cond);
 
   return 0;
 }
@@ -113,33 +103,29 @@ TEST_IMPL(condvar_2) {
   wc.signal_cond = condvar_signal;
   wc.wait_cond = condvar_wait;
 
-  ASSERT(0 == uv_cond_init(&wc.cond_1));
-  ASSERT(0 == uv_cond_init(&wc.cond_2));
+  ASSERT(0 == uv_cond_init(&wc.cond));
   ASSERT(0 == uv_mutex_init(&wc.mutex));
   ASSERT(0 == uv_thread_create(&thread, worker, &wc));
 
-  wc.wait_cond(&wc, &wc.cond_1, &wc.posted_1);
-  wc.signal_cond(&wc, &wc.cond_2, &wc.posted_2);
+  wc.wait_cond(&wc, &wc.posted_1);
+  wc.signal_cond(&wc, &wc.posted_2);
 
   ASSERT(0 == uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
-  uv_cond_destroy(&wc.cond_1);
-  uv_cond_destroy(&wc.cond_2);
+  uv_cond_destroy(&wc.cond);
 
   return 0;
 }
 
 
-static void condvar_timedwait(worker_config* c,
-                              uv_cond_t* cond,
-                              const volatile int* flag) {
+static void condvar_timedwait(worker_config* c, const volatile int* flag) {
   int r;
 
   uv_mutex_lock(&c->mutex);
   if (c->wait_delay)
     uv_sleep(c->wait_delay);
   while (*flag == 0) {
-    r = uv_cond_timedwait(cond, &c->mutex, (uint64_t)(150 * 1e6));
+    r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(150 * 1e6));
     ASSERT(r == 0);
   }
   uv_mutex_unlock(&c->mutex);
@@ -155,18 +141,16 @@ TEST_IMPL(condvar_3) {
   wc.signal_cond = condvar_signal;
   wc.wait_cond = condvar_timedwait;
 
-  ASSERT(0 == uv_cond_init(&wc.cond_1));
-  ASSERT(0 == uv_cond_init(&wc.cond_2));
+  ASSERT(0 == uv_cond_init(&wc.cond));
   ASSERT(0 == uv_mutex_init(&wc.mutex));
   ASSERT(0 == uv_thread_create(&thread, worker, &wc));
 
-  wc.wait_cond(&wc, &wc.cond_1, &wc.posted_1);
-  wc.signal_cond(&wc, &wc.cond_2, &wc.posted_2);
+  wc.wait_cond(&wc, &wc.posted_1);
+  wc.signal_cond(&wc, &wc.posted_2);
 
   ASSERT(0 == uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
-  uv_cond_destroy(&wc.cond_1);
-  uv_cond_destroy(&wc.cond_2);
+  uv_cond_destroy(&wc.cond);
 
   return 0;
 }
@@ -181,18 +165,16 @@ TEST_IMPL(condvar_4) {
   wc.signal_cond = condvar_signal;
   wc.wait_cond = condvar_timedwait;
 
-  ASSERT(0 == uv_cond_init(&wc.cond_1));
-  ASSERT(0 == uv_cond_init(&wc.cond_2));
+  ASSERT(0 == uv_cond_init(&wc.cond));
   ASSERT(0 == uv_mutex_init(&wc.mutex));
   ASSERT(0 == uv_thread_create(&thread, worker, &wc));
 
-  wc.wait_cond(&wc, &wc.cond_1, &wc.posted_1);
-  wc.signal_cond(&wc, &wc.cond_2, &wc.posted_2);
+  wc.wait_cond(&wc, &wc.posted_1);
+  wc.signal_cond(&wc, &wc.posted_2);
 
   ASSERT(0 == uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
-  uv_cond_destroy(&wc.cond_1);
-  uv_cond_destroy(&wc.cond_2);
+  uv_cond_destroy(&wc.cond);
 
   return 0;
 }
@@ -208,18 +190,16 @@ TEST_IMPL(condvar_5) {
   wc.signal_cond = condvar_signal;
   wc.wait_cond = condvar_wait;
 
-  ASSERT(0 == uv_cond_init(&wc.cond_1));
-  ASSERT(0 == uv_cond_init(&wc.cond_2));
+  ASSERT(0 == uv_cond_init(&wc.cond));
   ASSERT(0 == uv_mutex_init(&wc.mutex));
   ASSERT(0 == uv_thread_create(&thread, worker, &wc));
 
-  wc.wait_cond(&wc, &wc.cond_1, &wc.posted_1);
-  wc.signal_cond(&wc, &wc.cond_2, &wc.posted_2);
+  wc.wait_cond(&wc, &wc.posted_1);
+  wc.signal_cond(&wc, &wc.posted_2);
 
   ASSERT(0 == uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
-  uv_cond_destroy(&wc.cond_1);
-  uv_cond_destroy(&wc.cond_2);
+  uv_cond_destroy(&wc.cond);
 
   return 0;
 }

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -28,9 +28,11 @@
 typedef struct worker_config {
   uv_mutex_t mutex;
   uv_cond_t cond;
-  int signal_delay, wait_delay;
+  int signal_delay;
+  int wait_delay;
   int use_broadcast;
-  volatile int posted_1, posted_2;
+  volatile int posted_1;
+  volatile int posted_2;
   void (*signal_cond)(struct worker_config* c, volatile int* flag);
   void (*wait_cond)(struct worker_config* c, const volatile int* flag);
 } worker_config;


### PR DESCRIPTION
Calling uv_cond_wait without uv_cond_signal/uv_cond_broadcast may
cause deadlock. This commit avoids this situation as well as tests
these functions.

Fixes: #712