### PR TITLE
linux-core: universal cpu count

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -552,6 +552,29 @@ int uv_uptime(double* uptime) {
 }
 
 
+int uv_cpu_num() {
+  unsigned int num;
+  char buf[1024];
+  FILE* fp;
+
+  fp = fopen("/proc/stat", "r");
+  if (fp == NULL)
+    return -errno;
+
+  if (!fgets(buf, sizeof(buf), fp))
+    abort();
+
+  num = 0;
+  while (fgets(buf, sizeof(buf), fp)) {
+    if (strncmp(buf, "cpu", 3))
+      break;
+    num++;
+  }
+  fclose(fp);
+  return num;
+}
+
+
 int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   unsigned int numcpus;
   uv_cpu_info_t* ci;
@@ -560,7 +583,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *cpu_infos = NULL;
   *count = 0;
 
-  numcpus = sysconf(_SC_NPROCESSORS_ONLN);
+  numcpus = uv_cpu_num();
   assert(numcpus != (unsigned int) -1);
   assert(numcpus != 0);
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -552,7 +552,7 @@ int uv_uptime(double* uptime) {
 }
 
 
-int uv_cpu_num() {
+static int uv__cpu_num() {
   unsigned int num;
   char buf[1024];
   FILE* fp;
@@ -583,7 +583,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *cpu_infos = NULL;
   *count = 0;
 
-  numcpus = uv_cpu_num();
+  numcpus = uv__cpu_num();
   assert(numcpus != (unsigned int) -1);
   assert(numcpus != 0);
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -552,7 +552,7 @@ int uv_uptime(double* uptime) {
 }
 
 
-static int uv__cpu_num() {
+static int uv__cpu_num(unsigned int* numcpus) {
   unsigned int num;
   char buf[1024];
   FILE* fp;
@@ -571,7 +571,8 @@ static int uv__cpu_num() {
     num++;
   }
   fclose(fp);
-  return num;
+  *numcpus = num;
+  return 0;
 }
 
 
@@ -583,7 +584,11 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *cpu_infos = NULL;
   *count = 0;
 
-  numcpus = uv__cpu_num();
+  err = uv__cpu_num(&numcpus);
+  if (err) {
+    numcpus = sysconf(_SC_NPROCESSORS_ONLN);
+  }
+
   assert(numcpus != (unsigned int) -1);
   assert(numcpus != 0);
 


### PR DESCRIPTION
When libuv is running inside container - eg. lxc container, cpu number
is not obvious. Linux control groups (cgroups) may limit numer of cpus.

As a result of different number cpu cores inside container and
outside container, libuv is crashing.

sysconf(_SC_NPROCESSORS_ONLN) - returns num of host cpus (eg. 32)
`/proc/stat` - sees only cpus limited by cgroups (eg. 4)

When libuv is trying to operate at both numbers and they're different
it's crashing with current test:

run-tests: ../src/unix/linux-core.c:766: read_times: Assertion `num ==
numcpus' failed.

My patch counts number of cpus based on `/proc/stat` it's already
used in other place - eg. function read_times. With that patch tests are
working inside and outside container.