### PR TITLE
test: fix threadpool_multiple_event_loops for PPC

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -722,7 +722,13 @@ TASK_LIST_START
   TEST_ENTRY  (fs_read_write_null_arguments)
   TEST_ENTRY  (threadpool_queue_work_simple)
   TEST_ENTRY  (threadpool_queue_work_einval)
+#if  defined(__PPC__) || defined(__PPC64__) /* For linux PPC and AIX */
+  /* pthread_join takes a while, especially on AIX.
+   * Therefore being gratuitous with timeout */
+  TEST_ENTRY_CUSTOM  (threadpool_multiple_event_loops, 0, 0, 120000)
+#else
   TEST_ENTRY  (threadpool_multiple_event_loops)
+#endif
   TEST_ENTRY  (threadpool_cancel_getaddrinfo)
   TEST_ENTRY  (threadpool_cancel_getnameinfo)
   TEST_ENTRY  (threadpool_cancel_work)

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -123,17 +123,12 @@ static void do_work(void* arg) {
     getaddrinfo_do(req);
   }
 
-/* Disable fs work on AIX as there are known issues.
- * See: Readme.md AIX Notes
- */
-#ifndef _AIX
   for (i = 0; i < ARRAY_SIZE(fs_reqs); i++) {
     struct fs_req* req = fs_reqs + i;
     req->counter = 16;
     req->loop = loop;
     fs_do(req);
   }
-#endif
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);


### PR DESCRIPTION
On PPC (linux and AIX) uv_thread_join (which is just a call to
pthread_join) takes quite a while. Increased the timeout of this
specific test on PPC so that there is ample time for all threads to join
back. The fs_do and getaddrinfo_do calls do not take up much time.

Also removing the ifdef for AIX around fs_do since it did nothing.

This should fix https://github.com/libuv/libuv/issues/687

From a run on the community machine:
```
[imran@node-ci-be libuv]$ make check
make  test/run-tests
make[1]: Entering directory `/home/imran/libuv'
  CC       test/test_run_tests-run-tests.o
  CCLD     test/run-tests
make[1]: Leaving directory `/home/imran/libuv'
make  check-TESTS
make[1]: Entering directory `/home/imran/libuv'
[%   0|+   0|-   0|T   0|S   0]: platform_output
Output from process `platform_output`:
uv_get_process_title: /home/imran/libuv/test/.libs/lt-run-tests
uv_cwd: /home/imran/libuv
uv_resident_set_memory: 2162688
uv_uptime: 1205986.000000
uv_getrusage:
  user: 0 sec 44 microsec
  system: 0 sec 162 microsec
uv_cpu_info:
  model: unknown
  speed: 0
  times.sys: 33331400
  times.user: 148390400
  times.idle: 11775118800
  times.irq: 1529100
  times.nice: 4100
  model: unknown
  speed: 0
  times.sys: 30043200
  times.user: 131771600
  times.idle: 11808101300
  times.irq: 1014600
  times.nice: 11300
  model: unknown
  speed: 0
  times.sys: 28187800
  times.user: 143528300
  times.idle: 11803955900
  times.irq: 1149100
  times.nice: 1600
  model: unknown
  speed: 0
  times.sys: 31647300
  times.user: 129339200
  times.idle: 11808075300
  times.irq: 825900
  times.nice: 12700
uv_interface_addresses:
  name: lo
  internal: 1
  physical address: 00:00:00:00:00:00
  address: 127.0.0.1
  netmask: 255.0.0.0
  name: eth0
  internal: 0
  physical address: fa:16:3e:72:73:1a
  address: 192.168.60.29
  netmask: 255.255.252.0
  name: lo
  internal: 1
  physical address: 00:00:00:00:00:00
  address: ::1
  netmask: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
  name: eth0
  internal: 0
  physical address: fa:16:3e:72:73:1a
  address: fe80::f816:3eff:fe72:731a
  netmask: ffff:ffff:ffff:ffff::
=============================================================
[%  86|+ 245|-   0|T   0|S   0]: fs_event_watch_dir_recursive
`fs_event_watch_dir_recursive` skipped
Output from process `fs_event_watch_dir_recursive`:
Recursive directory watching not supported on this platform.
=============================================================
[%  96|+ 273|-   0|T   0|S   1]: thread_stack_size
`thread_stack_size` skipped
Output from process `thread_stack_size`:
OSX only test
=============================================================
[% 100|+ 282|-   0|T   0|S   2]: Done.
PASS: test/run-tests
=============
1 test passed
=============
make[1]: Leaving directory `/home/imran/libuv'
[imran@node-ci-be libuv]
```