### PR TITLE
build: compile -D_THREAD_SAFE on AIX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -282,7 +282,7 @@ endif
 
 
 if AIX
-libuv_la_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT
+libuv_la_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT -D_THREAD_SAFE
 include_HEADERS += include/uv-aix.h
 libuv_la_SOURCES += src/unix/aix.c
 endif

--- a/uv.gyp
+++ b/uv.gyp
@@ -241,6 +241,7 @@
             '_ALL_SOURCE',
             '_XOPEN_SOURCE=500',
             '_LINUX_SOURCE_COMPAT',
+            '_THREAD_SAFE',
           ],
           'link_settings': {
             'libraries': [


### PR DESCRIPTION
This enables thread safe errno on AIX and causes the following tests to
pass:
ipc_send_recv_pipe_inprocess
ipc_send_recv_tcp_inprocess
fs_poll
fs_file_noent
fs_file_nametoolong
fs_file_loop
fs_chown
fs_readlink
fs_realpath
fs_scandir_file