### PR TITLE
fs: fix mkdtemp on AIX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -273,7 +273,7 @@ test_run_tests_SOURCES += test/runner-unix.c \
 endif
 
 if AIX
-test_run_tests_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT
+test_run_tests_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=700 -D_LINUX_SOURCE_COMPAT
 endif
 
 if SUNOS
@@ -282,7 +282,7 @@ endif
 
 
 if AIX
-libuv_la_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT -D_THREAD_SAFE
+libuv_la_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=700 -D_LINUX_SOURCE_COMPAT -D_THREAD_SAFE
 include_HEADERS += include/uv-aix.h
 libuv_la_SOURCES += src/unix/aix.c
 endif

--- a/uv.gyp
+++ b/uv.gyp
@@ -239,7 +239,7 @@
           'sources': [ 'src/unix/aix.c' ],
           'defines': [
             '_ALL_SOURCE',
-            '_XOPEN_SOURCE=500',
+            '_XOPEN_SOURCE=700',
             '_LINUX_SOURCE_COMPAT',
             '_THREAD_SAFE',
           ],
@@ -248,6 +248,15 @@
               '-lperfstat',
             ],
           },
+        }],
+        [ 'OS=="aix"', {
+          'sources': [ 'src/unix/fs.c' ],
+          'defines': [
+            '_ALL_SOURCE',
+            '_XOPEN_SOURCE=700',
+            '_LINUX_SOURCE_COMPAT',
+            '_THREAD_SAFE',
+          ],
         }],
         [ 'OS=="freebsd" or OS=="dragonflybsd"', {
           'sources': [ 'src/unix/freebsd.c' ],
@@ -434,7 +443,7 @@
         [ 'OS=="aix"', {     # make test-fs.c compile, needs _POSIX_C_SOURCE
           'defines': [
             '_ALL_SOURCE',
-            '_XOPEN_SOURCE=500',
+            '_XOPEN_SOURCE=700',
           ],
         }],
         ['uv_library=="shared_library"', {


### PR DESCRIPTION
AIX 6.1 adds supports for mkdtemp only if `_XOPEN_SOURCE >= 700`,
according to Michael Haubenwallner.

See: https://sourceware.org/bugzilla/show_bug.cgi?id=13558