### PR TITLE
unix,linux: set close-on-exec on file handles

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -427,6 +427,22 @@ int uv__socket(int domain, int type, int protocol) {
   return sockfd;
 }
 
+/* get a file pointer to a file in read-only and close-on-exec mode */
+FILE* uv__open_file(const char* path) {
+  int fd;
+  FILE* fp;
+
+  fd = uv__open_cloexec(path, O_RDONLY);
+  if (fd == -1)
+    return NULL;
+
+   fp = fdopen(fd, "r");
+   if (fp == NULL)
+     uv__close(fd);
+
+   return fp;
+}
+
 
 int uv__accept(int sockfd) {
   int peerfd;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -28,6 +28,7 @@
 #include <stdlib.h> /* abort */
 #include <string.h> /* strrchr */
 #include <fcntl.h>  /* O_CLOEXEC, may be */
+#include <stdio.h>
 
 #if defined(__STRICT_ANSI__)
 # define inline __inline
@@ -246,6 +247,8 @@ void uv__timer_close(uv_timer_t* handle);
 void uv__udp_close(uv_udp_t* handle);
 void uv__udp_finish_close(uv_udp_t* handle);
 uv_handle_type uv__handle_type(int fd);
+FILE* uv__open_file(const char* path);
+
 
 #if defined(__APPLE__)
 int uv___stream_fd(const uv_stream_t* handle);

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -575,18 +575,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   unsigned int numcpus;
   uv_cpu_info_t* ci;
   int err;
-  int statfile_fd;
   FILE* statfile_fp;
 
   *cpu_infos = NULL;
   *count = 0;
 
-  err = uv__open_cloexec("/proc/stat", O_RDONLY);
-  if (err < 0)
-    return err;
-  statfile_fd = err;
-
-  statfile_fp = fdopen(statfile_fd, "r");
+  statfile_fp = uv__open_file("/proc/stat");
   if (statfile_fp == NULL)
     return -errno;
 
@@ -666,7 +660,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
     defined(__i386__) || \
     defined(__mips__) || \
     defined(__x86_64__)
-  fp = fopen("/proc/cpuinfo", "r");
+  fp = uv__open_file("/proc/cpuinfo");
   if (fp == NULL)
     return -errno;
 
@@ -813,7 +807,7 @@ static unsigned long read_cpufreq(unsigned int cpunum) {
            "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq",
            cpunum);
 
-  fp = fopen(buf, "r");
+  fp = uv__open_file(buf);
   if (fp == NULL)
     return 0;
 


### PR DESCRIPTION
This PR removes calls to `fopen` in `src/linux-core.c` and replaces them with the function `uv__open_file` added here as well. The purpose of this is to make sure all open file handles have close-on-exec set.

Described further in #736 opened by @bnoordhuis.

Tested on OS X 10.11.2 and Linux 4.4.1-2 both on x86_64

Some considerations:
1: `UV__O_CLOEXEC` is probably not defined for some platforms, I will have to wait for CI to see
2: `uv__open_file` currently always opens files as read-only. This could be changed but would require parsing mode string to get `open(2)` flags, and is not currently necessary.
3: `CONTRIBUTING.md` states that declarations for unix-specific code go in `include/uv-unix.h`. However I saw no function declarations in that file and noticed that other functions in `src/unix/core.c` were declared in `uv-common.h` so I did that as well, perhaps that is a mistake.