### PR TITLE
test: reduce timeout in tcp_close_while_connecting

### DIFF
--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -72,7 +72,7 @@ TEST_IMPL(tcp_close_while_connecting) {
     RETURN_SKIP("Network unreachable.");
   ASSERT(r == 0);
   ASSERT(0 == uv_timer_init(loop, &timer1_handle));
-  ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 50, 0));
+  ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
   ASSERT(0 == uv_timer_init(loop, &timer2_handle));
   ASSERT(0 == uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));


### PR DESCRIPTION
Somtimes (once every 10 runs or so) the socket would 'connect' before
'uv_close' was called. This caused EHOSTUNREACH to be set for SO_ERROR
instead of ECANCELED.