### PR TITLE
unix: compile error in Android using bionic

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -749,13 +749,13 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_gen = src->st_gen;
 #elif defined(__ANDROID__)
   dst->st_atim.tv_sec = src->st_atime;
-  dst->st_atim.tv_nsec = src->st_atime_nsec;
+  dst->st_atim.tv_nsec = src->st_atimensec;
   dst->st_mtim.tv_sec = src->st_mtime;
-  dst->st_mtim.tv_nsec = src->st_mtime_nsec;
+  dst->st_mtim.tv_nsec = src->st_mtimensec;
   dst->st_ctim.tv_sec = src->st_ctime;
-  dst->st_ctim.tv_nsec = src->st_ctime_nsec;
+  dst->st_ctim.tv_nsec = src->st_ctimensec;
   dst->st_birthtim.tv_sec = src->st_ctime;
-  dst->st_birthtim.tv_nsec = src->st_ctime_nsec;
+  dst->st_birthtim.tv_nsec = src->st_ctimensec;
   dst->st_flags = 0;
   dst->st_gen = 0;
 #elif !defined(_AIX) && (       \


### PR DESCRIPTION
When compiling with bionic, st_atime_nsec (and the other nsec members)
cannot be found.
In order to compile uv with both NDK and bionic, tv_nsec should be
accessed from st_atimensec (and the others nsec members).
See "Compatibility with glibc" in stat.h from bionic.

Signed-off-by: Robert Chiras <robert.chiras@intel.com>

Note: I found this compilation error when trying to build node (which uses libuv), using Brillo build system. I included node in the Brillo tree, generated Android make files, and compiled the node target.