### PR TITLE
linux: call fclose(), fix fdopen() memory leak

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -606,7 +606,9 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     rewind(statfile_fp);
     err = read_times(statfile_fp, numcpus, ci);
 
-  uv__close(statfile_fd);
+  if (fclose(statfile_fp))
+    if (errno != EINTR && errno != EINPROGRESS)
+      abort();
 
   if (err) {
     uv_free_cpu_info(ci, numcpus);


### PR DESCRIPTION
Commit 6798876 ("linux: fix cpu count") switched the /proc/stat parser
to fdopen().  Use fclose() to close the file descriptor to avoid leaking
resources associated with the FILE struct.

R=@saghul

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/268/