### PR TITLE
unix: fix uv__handle_type for AIX

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -946,13 +946,13 @@ static void uv__write_callbacks(uv_stream_t* stream) {
 
 uv_handle_type uv__handle_type(int fd) {
   struct sockaddr_storage ss;
-  socklen_t len;
+  socklen_t sslen, len;
   int type;
 
   memset(&ss, 0, sizeof(ss));
-  len = sizeof(ss);
+  sslen = sizeof(ss);
 
-  if (getsockname(fd, (struct sockaddr*)&ss, &len))
+  if (getsockname(fd, (struct sockaddr*)&ss, &sslen))
     return UV_UNKNOWN_HANDLE;
 
   len = sizeof type;
@@ -961,6 +961,14 @@ uv_handle_type uv__handle_type(int fd) {
     return UV_UNKNOWN_HANDLE;
 
   if (type == SOCK_STREAM) {
+#if defined(_AIX)
+    /* on AIX the getsockname call returns an empty sa structure
+     * for sockets of type AF_UNIX.  For all other types it will
+     * return a properly filled in structure.
+     */
+    if (sslen == 0)
+      return UV_NAMED_PIPE;
+#endif
     switch (ss.ss_family) {
       case AF_UNIX:
         return UV_NAMED_PIPE;


### PR DESCRIPTION
'getsockname' does not handle UNIX domain sockets on AIX[1], it does not
fail but simply returns an empty structure with length 0.
If 'getsockname' does not fail (i.e. does not return -1) and the length
is 0 we know, on AIX, that the type is AF_UNIX.

This fixes test pipe_sendmsg

[1]https://goo.gl/ozqcmS