### PR TITLE
[linux-core] remove redundant call to rewind()

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -602,10 +602,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     return -ENOMEM;
 
   err = read_models(numcpus, ci);
-  if (err == 0) {
-    rewind(statfile_fp);
+  if (err == 0)
     err = read_times(statfile_fp, numcpus, ci);
-  }
 
   if (fclose(statfile_fp))
     if (errno != EINTR && errno != EINPROGRESS)


### PR DESCRIPTION
is already called in the beginning of read_times()