### PR TITLE
unix: use open(2) with O_CLOEXEC on OS X

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -53,6 +53,9 @@
 # include <mach-o/dyld.h> /* _NSGetExecutablePath */
 # include <sys/filio.h>
 # include <sys/ioctl.h>
+# if defined(O_CLOEXEC)
+#  define UV__O_CLOEXEC O_CLOEXEC
+# endif
 #endif
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
@@ -930,8 +933,7 @@ int uv__open_cloexec(const char* path, int flags) {
   int err;
   int fd;
 
-#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD__ >= 9) || \
-    defined(__DragonFly__)
+#if defined(UV__O_CLOEXEC)
   static int no_cloexec;
 
   if (!no_cloexec) {


### PR DESCRIPTION
On OS X the implementation of `uv__open_cloexec` was falling back to calling `open` and manually setting close-on-exec despite the `O_CLOEXEC` flag being available since 10.7