### PR TITLE
Fixed crash on client closing

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -876,7 +876,7 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     QUEUE_REMOVE(&w->watcher_queue);
     QUEUE_INIT(&w->watcher_queue);
 
-    if (loop->watchers[w->fd] != NULL) {
+    if (loop->watchers[w->fd] == w && loop->nfds > 0) {
       assert(loop->watchers[w->fd] == w);
       assert(loop->nfds > 0);
       loop->watchers[w->fd] = NULL;


### PR DESCRIPTION
1.  I start a server never write back to client.
2. Open chrome and access http://0.0.0.0, chrome will wait for response
which my server won’t send.
3. Tap stop button on chrome. My server crashes.

This fixed the problem