### PR TITLE
linux: fix error checking in uv__open_file

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -433,7 +433,7 @@ FILE* uv__open_file(const char* path) {
   FILE* fp;
 
   fd = uv__open_cloexec(path, O_RDONLY);
-  if (fd == -1)
+  if (fd < 0)
     return NULL;
 
    fp = fdopen(fd, "r");


### PR DESCRIPTION
uv__open_cloexec returns either the fd or a libuv error, which is -errno
on Unix, not -1.

R=@libuv/collaborators 