### PR TITLE
test: up the test test limit, exit earlier in write-queue-order test

### DIFF
--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -26,7 +26,7 @@
 #include "uv.h"
 #include "task.h"
 
-#define MAX_REQ_COUNT 100000
+#define MAX_REQ_COUNT 100
 
 static int req_count = 0;
 
@@ -127,6 +127,7 @@ static void start_server(void) {
 TEST_IMPL(tcp_write_queue_order) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
+  int buffer_size = 16 * 1024;
 
   start_server();
 
@@ -137,6 +138,7 @@ TEST_IMPL(tcp_write_queue_order) {
                              &client,
                              (struct sockaddr*) &addr,
                              connect_cb));
+  ASSERT(0 == uv_send_buffer_size(&client, &buffer_size));
 
   ASSERT(0 == uv_timer_init(uv_default_loop(), &timer));
   ASSERT(0 == uv_timer_start(&timer, timer_cb, 100, 0));


### PR DESCRIPTION
The test now uses a bigger upper limit so users with big socket
buffer size settings still hit the limit, but we stop sooner.
It counts how many requests it can write without hitting the send
buffer limit of the socket, then it writes the same amount on top
of it. This should ensure that there will be some write requests
cancelled.

Fixes #764