### PR TITLE
unix: retry ioctl(TIOCGWINSZ) on EINTR

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -185,8 +185,13 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
 
 int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
   struct winsize ws;
+  int err;
 
-  if (ioctl(uv__stream_fd(tty), TIOCGWINSZ, &ws))
+  do
+    err = ioctl(uv__stream_fd(tty), TIOCGWINSZ, &ws);
+  while (err == -1 && errno == EINTR);
+
+  if (err == -1)
     return -errno;
 
   *width = ws.ws_col;


### PR DESCRIPTION
Some platforms (notably Solaris) can fail in this ioctl() if interrupted
by a signal.  Retry the system call when that happens.

Fixes: https://github.com/nodejs/node/issues/5737