### PR TITLE
unix: fix ahafs implementation for AIX

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -524,7 +524,7 @@ static int uv__makedir_p(const char *dir) {
     if (*p == '/') {
       *p = 0;
       err = mkdir(tmp, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-      if(err != 0)
+      if (err != 0 && errno != EEXIST)
         return err;
       *p = '/';
     }
@@ -743,7 +743,7 @@ static void uv__ahafs_event(uv_loop_t* loop, uv__io_t* event_watch, unsigned int
    */
   bytes = pread(event_watch->fd, result_data, RDWR_BUF_SIZE, 0);
 
-  assert((bytes <= 0) && "uv__ahafs_event - Error reading monitor file");
+  assert((bytes >= 0) && "uv__ahafs_event - Error reading monitor file");
 
   /* Parse the data */
   if(bytes > 0)

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -725,17 +725,10 @@ static void uv__ahafs_event(uv_loop_t* loop, uv__io_t* event_watch, unsigned int
   int bytes, rc = 0;
   uv_fs_event_t* handle;
   int events = 0;
-  int  i = 0;
   char fname[PATH_MAX];
   char *p;
 
   handle = container_of(event_watch, uv_fs_event_t, event_watcher);
-
-  /* Clean all the buffers*/
-  for(i = 0; i < PATH_MAX; i++) {
-    fname[i] = 0;
-  }
-  i = 0;
 
   /* At this point, we assume that polling has been done on the
    * file descriptor, so we can just read the AHAFS event occurrence
@@ -749,35 +742,27 @@ static void uv__ahafs_event(uv_loop_t* loop, uv__io_t* event_watch, unsigned int
   if(bytes > 0)
     rc = uv__parse_data(result_data, &events, handle);
 
+  /* Unrecoverable error */
+  if (rc == -1)
+    return;
+
   /* For directory changes, the name of the files that triggered the change
    * are never absolute pathnames
    */
   if (uv__path_is_a_directory(handle->path) == 0) {
     p = handle->dir_filename;
-    while(*p != NULL){
-      fname[i]= *p;
-      i++;
-      p++;
-    }
   } else {
-    /* For file changes, figure out whether filename is absolute or not */
-    if (handle->path[0] == '/') {
-      p = strrchr(handle->path, '/');
+    p = strrchr(handle->path, '/');
+    if (p == NULL)
+      p = handle->path;
+    else
       p++;
-
-      while(*p != NULL) {
-        fname[i]= *p;
-        i++;
-        p++;
-      }
-    }
   }
+  strncpy(fname, p, sizeof(fname) - 1);
+  /* Just in case */
+  fname[sizeof(fname) - 1] = '\0';
 
-  /* Unrecoverable error */
-  if (rc == -1)
-    return;
-  else /* Call the actual JavaScript callback function */
-    handle->cb(handle, (const char*)&fname, events, 0);
+  handle->cb(handle, fname, events, 0);
 }
 #endif
 
@@ -857,7 +842,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   /* Setup/Initialize all the libuv routines */
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__ahafs_event, fd);
-  handle->path = uv__strdup((const char*)&absolute_path);
+  handle->path = uv__strdup(filename);
   handle->cb = cb;
 
   uv__io_start(handle->loop, &handle->event_watcher, UV__POLLIN);


### PR DESCRIPTION
uv__makedir_p was not processing all directories in passed string. Now
if a directory already exists (EEXIST) it simply moves onto the next
directory in the provided string.

Fixed bogus assert in uv__ahafs_event

This fixes a bunch of tests issue https://github.com/libuv/libuv/issues/719 (not all unfortunately! still working on it).

This requires ahafs to be mounted using the following command(as root)

```
mount -v ahafs /aha /aha
```

Here's what test output looks like with the change and ahafs mounted

```
=============================================================
[%  58|+ 165|-   0|T   0|S   0]: process_title
`process_title` skipped
Output from process `process_title`:
uv_(get|set)_process_title is not implemented.
=============================================================
[%  75|+ 212|-   0|T   0|S   1]: emfile
`emfile` failed: exit code 393222
Output from process `emfile`:
Assertion failed in test/test-emfile.c on line 104: 0 == status
=============================================================
[%  83|+ 234|-   1|T   0|S   1]: fs_futime
`fs_futime` failed: exit code 393222
Output from process `fs_futime`:
Assertion failed in test/test-fs.c on line 2062: r == 0
=============================================================
[%  86|+ 242|-   2|T   0|S   1]: fs_event_watch_dir_recursive
`fs_event_watch_dir_recursive` skipped
Output from process `fs_event_watch_dir_recursive`:
Recursive directory watching not supported on this platform.
=============================================================
[%  89|+ 249|-   2|T   0|S   2]: fs_event_close_in_callback
`fs_event_close_in_callback` failed: timeout
Output from process `fs_event_close_in_callback`: (no output)
=============================================================
[%  90|+ 251|-   3|T   0|S   2]: fs_event_getpath
`fs_event_getpath` failed: exit code 393222
Output from process `fs_event_getpath`:
Assertion failed in test/test-fs-event.c on line 823: memcmp(buf, "watch_dir", len) == 0
=============================================================
[%  96|+ 268|-   4|T   0|S   2]: thread_stack_size
`thread_stack_size` skipped
Output from process `thread_stack_size`:
OSX only test
=============================================================
[% 100|+ 277|-   4|T   0|S   3]: Done.
FAIL: test/run-tests
======================================================
```

Note ```emfile``` and ```fs_futime``` are not fs watch related failures (looking into those seperately)