### PR TITLE
aix: fix 'POLLRDHUP undeclared' build error

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -102,7 +102,6 @@
 # define UV__POLLOUT    POLLOUT
 # define UV__POLLERR    POLLERR
 # define UV__POLLHUP    POLLHUP
-# define UV__POLLRDHUP  POLLRDHUP
 #endif
 
 #ifndef UV__POLLIN
@@ -122,7 +121,11 @@
 #endif
 
 #ifndef UV__POLLRDHUP
-# define UV__POLLRDHUP  0x200
+# ifdef POLLRDHUP
+#  define UV__POLLRDHUP POLLRDHUP
+# else
+#  define UV__POLLRDHUP 0x200
+# endif
 #endif
 
 #if !defined(O_CLOEXEC) && defined(__FreeBSD__)


### PR DESCRIPTION
AIX doesn't have POLLRDHUP.  Fixes the following compile-time error:

    src/unix/core.c: In function 'uv__io_start':
    src/unix/core.c:831:40: error: 'POLLRDHUP' undeclared
    assert(0 == (events & ~(UV__POLLIN | UV__POLLOUT | UV__POLLRDHUP)));

Fixes: https://github.com/libuv/libuv/issues/783

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/295/