### PR TITLE
util: extends uv_getrusage by majflt on NT and other NT counters

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1045,6 +1045,21 @@ typedef struct {
    uint64_t ru_nsignals;  /* signals received */
    uint64_t ru_nvcsw;     /* voluntary context switches */
    uint64_t ru_nivcsw;    /* involuntary context switches */
+
+   uint64_t ru_committotal; /* pages max. currently committed */
+   uint64_t ru_commitlimit; /* pages max. that can be committed */
+   uint64_t ru_commitpeak; /*  pages max. that were simultaneously */
+   uint64_t ru_physicaltotal; /* actual physical memory, in pages */
+   uint64_t ru_physicalavailable; /* phys. memory available, in pages */
+   uint64_t ru_systemcache; /* system cache memory */
+   uint64_t ru_kerneltotal; /* mem. in kernel pools, in pages */
+   uint64_t ru_kernelpaged; /* mem. in the paged kernel pool, in pages */
+   uint64_t ru_kernelnonpaged; /* mem. in the nonpaged kernel pool, in pages */
+   uint64_t ru_pageSize; /* size of a page, in bytes */
+
+   uint64_t ru_handlecount; /* open handles */
+   uint64_t ru_processcount; /* number of processes */
+   uint64_t ru_threadcount; /* number of threads */
 } uv_rusage_t;
 
 UV_EXTERN int uv_getrusage(uv_rusage_t* rusage);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -60,6 +60,7 @@ TEST_IMPL(platform_output) {
   ASSERT(rusage.ru_utime.tv_usec >= 0);
   ASSERT(rusage.ru_stime.tv_sec >= 0);
   ASSERT(rusage.ru_stime.tv_usec >= 0);
+  ASSERT(rusage.ru_majflt >= 0);
   printf("uv_getrusage:\n");
   printf("  user: %llu sec %llu microsec\n",
          (unsigned long long) rusage.ru_utime.tv_sec,


### PR DESCRIPTION
**From the commit message**
> This extension for the win part of uv_getrusage() adds the
win equivalent of hard page faults to the available properties.
>
> Since there are also similar counters in GetPerformanceInfo() that
are not as easily accessible in posix sytems, it is supposedly
beneficial to add them to  the overall API, while overcoming unices
shortcomings. Note: getrusage() implementation is very different
on unices also.
> 
> In consequence uv_rusage_t increaes in size.

**Motivation**
Pending PRs in `node` core will likely expose `getrusage()` to `js`. While doing research I was seeing that `NT` implementation lags behind values. Efforts to harmonize this API through the OSes will likely fail, since even the unices differ to much. In consequence I was plainly adding available properties to the API.

My global goal though is to increase performance observability in `node` in the `io` and in general in the C/C++ parts.

**A Word of Warning**
Since this is my first serious C contribution (C is hobby for me up until now), please take this with care. If this is nonsense in the idea as well as the implementation (especially casting shenanigans), I am happy to close this quick. 
Also test were flaky in unrelated parts of the library. This also increased my insecurity.

Happy if this moves forward though :smile: 