### PR TITLE
test: use %ld for printing uid/gid

### DIFF
--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -127,8 +127,8 @@ TEST_IMPL(platform_output) {
   ASSERT(err == 0);
 
   printf("uv_os_get_passwd:\n");
-  printf("  euid: %d\n", pwd.uid);
-  printf("  gid: %d\n", pwd.gid);
+  printf("  euid: %ld\n", pwd.uid);
+  printf("  gid: %ld\n", pwd.gid);
   printf("  username: %s\n", pwd.username);
   printf("  shell: %s\n", pwd.shell);
   printf("  home directory: %s\n", pwd.homedir);


### PR DESCRIPTION
The uid and gid fields in uv_passwd_t are of type long so use %ld for
printing them.  Fixes two -Wformat compiler warnings.

CI: https://ci.nodejs.org/job/libuv+any-pr+multi/302/