### PR TITLE
test: fix tcp_close_accept flakiness on SmartOS

### DIFF
--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -84,8 +84,8 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   uv_loop_t* loop;
   unsigned int i;
 
-  /* Only first stream should receive read events */
-  ASSERT(stream == (uv_stream_t*) &tcp_incoming[0]);
+  ASSERT((stream == (uv_stream_t*) &tcp_incoming[0]) ||
+         (stream == (uv_stream_t*) &tcp_incoming[1]));
   ASSERT(0 == uv_read_stop(stream));
   ASSERT(1 == nread);
 


### PR DESCRIPTION
This test is failing from time to time on `SmartOS` because
the last connection sometimes succeeds. To avoid it, close
the server before attemping the connection.

Fixes: https://github.com/libuv/libuv/issues/799