### PR TITLE
unix: remove outdated comment

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -200,9 +200,6 @@ out:
   if (err)
     uv__io_feed(handle->loop, &handle->io_watcher);
 
-  /* Mimic the Windows pipe implementation, always
-   * return 0 and let the callback handle errors.
-   */
 }
 
 


### PR DESCRIPTION
Since this comment was written the function has changed from `int` to `void`, making the comment nonsensical and confusing.