### PR TITLE
util: adds maxrss, pagefault nt equivalents to uv_getrusage

### DIFF
--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -61,6 +61,8 @@ TEST_IMPL(platform_output) {
   ASSERT(rusage.ru_utime.tv_usec >= 0);
   ASSERT(rusage.ru_stime.tv_sec >= 0);
   ASSERT(rusage.ru_stime.tv_usec >= 0);
+  ASSERT(rusage.ru_majflt >= 0);
+  ASSERT(rusage.ru_maxrss >= 0);
   printf("uv_getrusage:\n");
   printf("  user: %llu sec %llu microsec\n",
          (unsigned long long) rusage.ru_utime.tv_sec,
@@ -68,6 +70,8 @@ TEST_IMPL(platform_output) {
   printf("  system: %llu sec %llu microsec\n",
          (unsigned long long) rusage.ru_stime.tv_sec,
          (unsigned long long) rusage.ru_stime.tv_usec);
+  printf("  page faults: %llu\n", rusage.ru_majflt);
+  printf("  maximum resident set size: %llu\n", rusage.ru_maxrss);
 
   err = uv_cpu_info(&cpus, &count);
   ASSERT(err == 0);


### PR DESCRIPTION
Ref: #787 

As discussed in the above PR, this fills missing parameters to `uv_getrusage` without breaking ABI.

NOTE: unix and nt semantics for the added parameters differ. Users
Just should be aware of this, since it can be reagarded as natural
due to obvious differences between the platforms.