### PR TITLE
unix: implement uv__fs_futime for AIX 7.1

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -205,6 +205,13 @@ skip:
 # else
   return futimes(req->file, tv);
 # endif
+#elif defined(_AIX71)
+  struct timespec ts[2];
+  ts[0].tv_sec  = req->atime;
+  ts[0].tv_nsec = (unsigned long)(req->atime * 1000000) % 1000000 * 1000;
+  ts[1].tv_sec  = req->mtime;
+  ts[1].tv_nsec = (unsigned long)(req->mtime * 1000000) % 1000000 * 1000;
+  return futimens(req->file, ts);
 #else
   errno = ENOSYS;
   return -1;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2033,6 +2033,9 @@ TEST_IMPL(fs_stat_root) {
 
 
 TEST_IMPL(fs_futime) {
+#if defined(_AIX) && !defined(_AIX71)
+  RETURN_SKIP("futime is not implemented for AIX versions below 7.1");
+#else
   utime_check_t checkme;
   const char* path = "test_file";
   double atime;
@@ -2087,6 +2090,7 @@ TEST_IMPL(fs_futime) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
+#endif
 }
 
 


### PR DESCRIPTION
'futimens' is only only implemented on AIX 7.1
Other functions like 'utimes' and 'utimes' are merely stub funtions
that return ENOSYS on AIX 6.1 and below.

Skip test fs_futime for AIX versions below 7.1