### PR TITLE
test: handle root home directories

### DIFF
--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -45,9 +45,15 @@ TEST_IMPL(get_passwd) {
   ASSERT(len > 0);
 
 #ifdef _WIN32
-  ASSERT(pwd.homedir[len - 1] != '\\');
+  if (len == 3 && pwd.homedir[1] == ':')
+    ASSERT(pwd.homedir[2] == '\\');
+  else
+    ASSERT(pwd.homedir[len - 1] != '\\');
 #else
-  ASSERT(pwd.homedir[len - 1] != '/');
+  if (len == 1)
+    ASSERT(pwd.homedir[0] == '/');
+  else
+    ASSERT(pwd.homedir[len - 1] != '/');
 #endif
 
 #ifdef _WIN32

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -29,7 +29,6 @@
 TEST_IMPL(homedir) {
   char homedir[PATHMAX];
   size_t len;
-  char last;
   int r;
 
   /* Test the normal case */
@@ -42,14 +41,17 @@ TEST_IMPL(homedir) {
   ASSERT(len > 0);
   ASSERT(homedir[len] == '\0');
 
-  if (len > 1) {
-    last = homedir[len - 1];
 #ifdef _WIN32
-    ASSERT(last != '\\');
+  if (len == 3 && homedir[1] == ':')
+    ASSERT(homedir[2] == '\\');
+  else
+    ASSERT(homedir[len - 1] != '\\');
 #else
-    ASSERT(last != '/');
+  if (len == 1)
+    ASSERT(homedir[0] == '/');
+  else
+    ASSERT(homedir[len - 1] != '/');
 #endif
-  }
 
   /* Test the case where the buffer is too small */
   len = SMALLPATH;


### PR DESCRIPTION
Currently, the tests assert that the home directory doesn't end in a slash. However, if the home directory is `/` or something like `C:\`, then this assertion is incorrect. This commit adds special handling for these cases.

Fixes #812