### PR TITLE
test: skip early bind tests if no IPv6 is supported

### DIFF
--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -139,6 +139,9 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   uv_os_fd_t fd;
   int r;
 
+  if (!can_ipv6())
+    RETURN_SKIP("IPv6 not supported");
+
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET6);

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -79,6 +79,9 @@ TEST_IMPL(udp_create_early_bad_bind) {
   uv_os_fd_t fd;
   int r;
 
+  if (!can_ipv6())
+    RETURN_SKIP("IPv6 not supported");
+
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET6);


### PR DESCRIPTION
I detected this on one of the Raspberry Pi bots.

CI: https://ci.nodejs.org/job/libuv-test-commit/19/

R=@libuv/collaborators 