### PR TITLE
build: define WIN32_LEAN_AND_MEAN on mingw

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ if WINNT
 
 include_HEADERS += include/uv-win.h include/tree.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/win \
+               -DWIN32_LEAN_AND_MEAN \
                -D_WIN32_WINNT=0x0600
 LIBS += -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
 libuv_la_SOURCES += src/win/async.c \

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -20,6 +20,7 @@ CFLAGS += -Wall \
           -Iinclude \
           -Isrc \
           -Isrc/win \
+          -DWIN32_LEAN_AND_MEAN \
           -D_WIN32_WINNT=0x0600
 
 INCLUDES = include/stdint-msvc2008.h \


### PR DESCRIPTION
This commit partially reverts 60db5b5a1bb446e4b8a6d15ce277d5f7987bf07a by defining `WIN32_LEAN_AND_MEAN` on mingw. Fixes #820.