### PR TITLE
win: uv_dlopen fix for long file names

### DIFF
--- a/test/test-dlopen.c
+++ b/test/test-dlopen.c
@@ -1,0 +1,82 @@
+#include "uv.h"
+#include "task.h"
+#include <string.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#define MAX_DIR_NAME_LENGTH 247
+#define BUFFER_SIZE 1024
+
+TEST_IMPL(dlopen) {
+#ifdef _WIN32
+  const char* system_dll = "\\ntdll.dll";
+  char system_dll_filename[BUFFER_SIZE];
+  char temporary_folder_short[BUFFER_SIZE];
+  char temporary_folder[BUFFER_SIZE];
+  unsigned temporary_folder_length;
+  char temporary_filename[BUFFER_SIZE];
+  unsigned temporary_filename_length;
+  char temporary_filename_long[BUFFER_SIZE + 4] = "\\\\?\\";
+  uv_lib_t lib;
+  int open_result;
+
+  /* Get system DLL full filename */
+  if (!GetSystemDirectoryA(system_dll_filename, BUFFER_SIZE))
+    abort();
+  strncat(system_dll_filename, system_dll, 
+          BUFFER_SIZE - strlen(system_dll_filename));
+
+  /* Create a temporary folder just within MAX_PATH length limits*/
+  if (!GetTempPathA(MAX_PATH, temporary_folder_short))
+    abort();
+  temporary_folder_length = GetLongPathNameA(temporary_folder_short,
+                                             temporary_folder,
+                                             BUFFER_SIZE);
+  if (temporary_folder_length == 0)
+    abort();
+  while (temporary_folder_length < MAX_DIR_NAME_LENGTH) {
+    temporary_folder[temporary_folder_length++] = '0';
+  }
+  temporary_folder[temporary_folder_length] = '\0';
+  if (!CreateDirectoryA(temporary_folder, NULL) 
+      && GetLastError() != ERROR_ALREADY_EXISTS) {
+    abort();
+  }
+
+  /* Copy system DLL to new location, but lengthen the name so it is
+     over MAX_PATH in length. Symlink won't work here. */
+  strcpy(temporary_filename, temporary_folder);
+  temporary_filename_length = temporary_folder_length;
+  temporary_filename[temporary_filename_length++] = '\\';
+  while (temporary_filename_length < MAX_PATH + 1) {
+    temporary_filename[temporary_filename_length++] = '0';
+  }
+  temporary_filename[temporary_filename_length] = '\0';
+  /* Add +1 to skip \ from system_dll beginning */
+  strncat(temporary_filename, system_dll + 1,
+          BUFFER_SIZE - temporary_filename_length);
+  strncat(temporary_filename_long, temporary_filename, BUFFER_SIZE);
+  DeleteFileA(temporary_filename_long);
+  if (!CopyFileA(system_dll_filename, temporary_filename_long, TRUE))
+    abort();
+
+  /* Open DLL with very long filename */
+  open_result = uv_dlopen(temporary_filename_long, &lib);
+  if (open_result == 0)
+    uv_dlclose(&lib);
+
+  /* Clean up */
+  DeleteFileA(temporary_filename_long);
+  RemoveDirectoryA(temporary_folder);
+
+  /* Test if we succeeded */
+  ASSERT(open_result == 0);
+  return 0;
+
+#else
+  RETURN_SKIP("Windows only test");
+#endif	
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -307,6 +307,9 @@ TEST_DECLARE   (thread_rwlock_trylock)
 TEST_DECLARE   (thread_create)
 TEST_DECLARE   (thread_equal)
 TEST_DECLARE   (dlerror)
+#ifdef _WIN32
+TEST_DECLARE   (dlopen)
+#endif
 TEST_DECLARE   (poll_duplex)
 TEST_DECLARE   (poll_unidirectional)
 TEST_DECLARE   (poll_close)
@@ -748,6 +751,9 @@ TASK_LIST_START
   TEST_ENTRY  (thread_create)
   TEST_ENTRY  (thread_equal)
   TEST_ENTRY  (dlerror)
+#ifdef _WIN32
+  TEST_ENTRY  (dlopen)
+#endif
   TEST_ENTRY  (ip4_addr)
   TEST_ENTRY  (ip6_addr_link_local)
 

--- a/uv.gyp
+++ b/uv.gyp
@@ -110,6 +110,7 @@
               '-ladvapi32',
               '-liphlpapi',
               '-lpsapi',
+              '-lrpcrt4',
               '-lshell32',
               '-luserenv',
               '-lws2_32'
@@ -404,6 +405,7 @@
         'test/test-udp-multicast-join.c',
         'test/test-udp-multicast-join6.c',
         'test/test-dlerror.c',
+        'test/test-dlopen.c',
         'test/test-udp-multicast-ttl.c',
         'test/test-ip4-addr.c',
         'test/test-ip6-addr.c',


### PR DESCRIPTION
Some Windows versions will fail to open DLLs when filename is longer
than MAX_PATH. Create a symlink with shorter name and retry loading
library.

Fixes: https://github.com/nodejs/node/issues/3667