### PR TITLE
test: fix fs_event_watch_file_current_dir for AIX

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -511,7 +511,7 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
   r = uv_timer_init(loop, &timer);
   ASSERT(r == 0);
 
-  r = uv_timer_start(&timer, timer_cb_touch, 10, 0);
+  r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
   ASSERT(r == 0);
 
   ASSERT(timer_cb_touch_called == 0);


### PR DESCRIPTION
Tested on community machine, no longer fails ( was 5 failures before )

```
=============================================================
[% 100|+ 278|-   4|T   0|S   4]: Done.
FAIL: test/run-tests
======================================================
1 of 1 test failed
Please report to https://github.com/libuv/libuv/issues
======================================================
gmake[1]: *** [check-TESTS] Error 1
gmake[1]: Leaving directory `/home/imran/libuv'
gmake: *** [check-am] Error 2
imran@sovma188 ~/libuv
```