### PR TITLE
android: fixes errno comparison crash android < 4.4

### DIFF
--- a/src/unix/pthread-fixes.c
+++ b/src/unix/pthread-fixes.c
@@ -39,19 +39,23 @@
 
 int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset) {
   static int workaround;
+  int err;
 
   if (workaround) {
     return sigprocmask(how, set, oset);
-  } else if (pthread_sigmask(how, set, oset)) {
-    if (errno == EINVAL && sigprocmask(how, set, oset) == 0) {
-      workaround = 1;
-      return 0;
-    } else {
-      return -1;
-    }
   } else {
-    return 0;
+    err = pthread_sigmask(how, set, oset);
+    if (err) {
+      if (err == EINVAL && sigprocmask(how, set, oset) == 0) {
+        workaround = 1;
+        return 0;
+      } else {
+        return -1;
+      }
+    }
   }
+
+  return 0;
 }
 
 /*Android doesn't provide pthread_barrier_t for now.*/


### PR DESCRIPTION
Originally intended workaround is especially needed for Android <4.4.
However it fails to compare errno collected from pthread_sigmask.

This was fixed primarily in JXcore. See issue: https://github.com/jxcore/jxcore-cordova/issues/55