### PR TITLE
include: suppress pedantic warnings

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -27,6 +27,12 @@
 extern "C" {
 #endif
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpragmas"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #ifdef _WIN32
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
@@ -1488,6 +1494,10 @@ struct uv_loop_s {
 #undef UV_SIGNAL_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_PLATFORM_FIELDS
+
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds `GCC diagnostic` pragmas to `uv.h` to ignore
`-pedantic` warnings (only for GCC, of course).
This allows GCC users to keep compiling their code with
the `-pedantic` flag, even when including `uv.h`.