### PR TITLE
set MinGW LIBS in configure.ac, not in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,6 @@ include_HEADERS += include/uv-win.h include/tree.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/win \
                -DWIN32_LEAN_AND_MEAN \
                -D_WIN32_WINNT=0x0600
-LIBS += -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
 libuv_la_SOURCES += src/win/async.c \
                     src/win/atomicops-inl.h \
                     src/win/core.c \

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,9 @@ AM_CONDITIONAL([NETBSD],   [AS_CASE([$host_os],[netbsd*],       [true], [false])
 AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
+AS_CASE([$host_os],[mingw*], [
+    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv"
+])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
 AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])


### PR DESCRIPTION
Fix libuv.pc on MinGW.

Previous version generates libuv.pc with LIBS = "-lpthread" instead of "-lpthread -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv" on MinGW.

Previous version generates the following Makefile.am:

    am__append_4 = -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
    ...
    LIBS = -lpthread  $(am__append_4)

and the following configure.ac:

    AS_IF([test "x$PKG_CONFIG" != "x"], [
        AC_CONFIG_FILES([libuv.pc])
    ])
    AC_CONFIG_FILES([Makefile])

Therefore, Makefile is generated after libuv.pc. Variables from Makefile don't affect config.status and libuv.pc.

Tony Theodore proposed to set LIBS in configure.ac instead of Makefile.am and created this patch.

See also https://github.com/mxe/mxe/pull/1291