### PR TITLE
Error out when REAL_PATH is undefined on a system

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h> /* PATH_MAX */
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -390,7 +391,7 @@ static ssize_t uv__fs_pathmax_size(const char* path) {
 #if defined(PATH_MAX)
     return PATH_MAX;
 #else
-    return 4096;
+#error "PATH_MAX undefined in the current platform"
 #endif
   }
 


### PR DESCRIPTION
Currently when PATH_MAX is undefined realpath will default to using 4096.
There is a potential stack overflow attack that can be mitigated by having
PATH_MAX defined. This change conservatively errors if a system does not
have PATH_MAX defined.

This change also comes with a new header specifically for freeBSD
to ensure that PATH_MAX will be available on that platform.

ref: http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
ref: https://github.com/nodejs/node/issues/2680#issuecomment-213521708
ref: https://github.com/isaacs/node-glob/pull/259#issuecomment-213367860