### PR TITLE
build: always compile with -fvisibility=hidden

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -1,6 +1,5 @@
 {
   'variables': {
-    'visibility%': 'hidden',         # V8's visibility setting
     'target_arch%': 'ia32',          # set v8's target architecture
     'host_arch%': 'ia32',            # set v8's host architecture
     'uv_library%': 'static_library', # allow override to 'shared_library' for DLL/.so builds
@@ -156,9 +155,6 @@
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],
-          [ 'visibility=="hidden"', {
-            'cflags': [ '-fvisibility=hidden' ],
-          }],
         ],
       }],
       ['OS=="mac"', {
@@ -170,9 +166,6 @@
           'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
           'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
-          # GCC_INLINES_ARE_PRIVATE_EXTERN maps to -fvisibility-inlines-hidden
-          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
-          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',      # -fvisibility=hidden
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
           'USE_HEADERMAP': 'NO',

--- a/uv.gyp
+++ b/uv.gyp
@@ -17,6 +17,7 @@
       }],
     ],
     'xcode_settings': {
+      'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
       'WARNING_CFLAGS': [ '-Wall', '-Wextra', '-Wno-unused-parameter' ],
       'OTHER_CFLAGS': [ '-g', '--std=gnu89', '-pedantic' ],
     }
@@ -117,6 +118,7 @@
           },
         }, { # Not Windows i.e. POSIX
           'cflags': [
+            '-fvisibility=hidden',
             '-g',
             '--std=gnu89',
             '-pedantic',


### PR DESCRIPTION
The 'visibility%' gyp variable was designed as an override mechanism for
old (<=3.4) versions of gcc that don't know about -fvisibility=hidden.

It turns out it's fairly easy for embedders to muck up the define, as
witnessed by the fact that node.js is currently leaking internal libuv
symbols due to not properly setting 'visibility%'.

While that could be fixed by tweaking node.js, because we don't support
gcc 3.4 anymore and haven't for a long time, making -fvisibility=hidden
the default here seems all around easier.

CI: https://ci.nodejs.org/job/libuv-test-commit/38/