### PR TITLE
Define _KMEMUSER to get symbols that are hidden on newer NetBSD versi…

### DIFF
--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -18,6 +18,9 @@
  * IN THE SOFTWARE.
  */
 
+/* needs kernel internal types */
+#define _KMEMUSER 1
+
 #include "uv.h"
 #include "internal.h"
 


### PR DESCRIPTION
…ons.

See https://github.com/mamedev/mame/pull/852