### PR TITLE
win: support sub-second precision in uv_fs_futimes()

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -94,7 +94,7 @@
 
 #define TIME_T_TO_FILETIME(time, filetime_ptr)                              \
   do {                                                                      \
-    uint64_t bigtime = ((uint64_t) ((time) * 10000000LL)) +                 \
+    uint64_t bigtime = ((uint64_t) ((time) * 10000000ULL)) +                \
                                   116444736000000000ULL;                    \
     (filetime_ptr)->dwLowDateTime = bigtime & 0xFFFFFFFF;                   \
     (filetime_ptr)->dwHighDateTime = bigtime >> 32;                         \

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -94,7 +94,7 @@
 
 #define TIME_T_TO_FILETIME(time, filetime_ptr)                              \
   do {                                                                      \
-    uint64_t bigtime = ((int64_t) (time) * 10000000LL) +                    \
+    uint64_t bigtime = ((uint64_t) ((time) * 10000000LL)) +                 \
                                   116444736000000000ULL;                    \
     (filetime_ptr)->dwLowDateTime = bigtime & 0xFFFFFFFF;                   \
     (filetime_ptr)->dwHighDateTime = bigtime >> 32;                         \
@@ -1429,8 +1429,8 @@ static void fs__fchmod(uv_fs_t* req) {
 INLINE static int fs__utime_handle(HANDLE handle, double atime, double mtime) {
   FILETIME filetime_a, filetime_m;
 
-  TIME_T_TO_FILETIME((time_t) atime, &filetime_a);
-  TIME_T_TO_FILETIME((time_t) mtime, &filetime_m);
+  TIME_T_TO_FILETIME(atime, &filetime_a);
+  TIME_T_TO_FILETIME(mtime, &filetime_m);
 
   if (!SetFileTime(handle, NULL, &filetime_a, &filetime_m)) {
     return -1;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -662,8 +662,8 @@ static void check_utime(const char* path, double atime, double mtime) {
   ASSERT(req.result == 0);
   s = &req.statbuf;
 
-  ASSERT(s->st_atim.tv_sec  == atime);
-  ASSERT(s->st_mtim.tv_sec  == mtime);
+  ASSERT(s->st_atim.tv_sec + (s->st_atim.tv_nsec / 1000000000.0) == atime);
+  ASSERT(s->st_mtim.tv_sec + (s->st_mtim.tv_nsec / 1000000000.0) == mtime);
 
   uv_fs_req_cleanup(&req);
 }
@@ -1968,6 +1968,13 @@ TEST_IMPL(fs_utime) {
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
+  // Test sub-second timestamps only on Windows (assuming NTFS). Some other
+  // platforms support sub-second timestamps, but that support is filesystem-
+  // dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+#ifdef _WIN32
+  mtime += 0.444;            /* 1982-09-10 11:22:33.444 */
+#endif
+
   r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
@@ -2054,6 +2061,13 @@ TEST_IMPL(fs_futime) {
   close(r);
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
+
+  // Test sub-second timestamps only on Windows (assuming NTFS). Some other
+  // platforms support sub-second timestamps, but that support is filesystem-
+  // dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+#ifdef _WIN32
+  mtime += 0.444;            /* 1982-09-10 11:22:33.444 */
+#endif
 
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
   ASSERT(r >= 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1968,9 +1968,11 @@ TEST_IMPL(fs_utime) {
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
-  // Test sub-second timestamps only on Windows (assuming NTFS). Some other
-  // platforms support sub-second timestamps, but that support is filesystem-
-  // dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+  /*
+   * Test sub-second timestamps only on Windows (assuming NTFS). Some other
+   * platforms support sub-second timestamps, but that support is filesystem-
+   * dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+   */
 #ifdef _WIN32
   mtime += 0.444;            /* 1982-09-10 11:22:33.444 */
 #endif
@@ -2062,9 +2064,11 @@ TEST_IMPL(fs_futime) {
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
-  // Test sub-second timestamps only on Windows (assuming NTFS). Some other
-  // platforms support sub-second timestamps, but that support is filesystem-
-  // dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+  /*
+   * Test sub-second timestamps only on Windows (assuming NTFS). Some other
+   * platforms support sub-second timestamps, but that support is filesystem-
+   * dependent. Notably OS X (HFS Plus) does NOT support sub-second timestamps.
+   */
 #ifdef _WIN32
   mtime += 0.444;            /* 1982-09-10 11:22:33.444 */
 #endif


### PR DESCRIPTION
This fixes #800 and updates the utimes and futimes test
cases to verify sub-second last-modified times on Windows.