### PR TITLE
test: fix -Wformat warnings in platform test

### DIFF
--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -70,8 +70,9 @@ TEST_IMPL(platform_output) {
   printf("  system: %llu sec %llu microsec\n",
          (unsigned long long) rusage.ru_stime.tv_sec,
          (unsigned long long) rusage.ru_stime.tv_usec);
-  printf("  page faults: %llu\n", rusage.ru_majflt);
-  printf("  maximum resident set size: %llu\n", rusage.ru_maxrss);
+  printf("  page faults: %llu\n", (unsigned long long) rusage.ru_majflt);
+  printf("  maximum resident set size: %llu\n",
+         (unsigned long long) rusage.ru_maxrss);
 
   err = uv_cpu_info(&cpus, &count);
   ASSERT(err == 0);


### PR DESCRIPTION
Cast the `ru_majflt` and `ru_maxrss` field to `unsigned long long` when
printing them with `"%llu"`.

Warnings introduced in commit 6f17a61 ("win: add maxrss, pagefaults to
uv_getrusage()".)

CI: https://ci.nodejs.org/job/libuv-test-commit/39/