### PR TITLE
test: fix POLLHDRUP related failures for AIX

### DIFF
--- a/docs/src/poll.rst
+++ b/docs/src/poll.rst
@@ -31,6 +31,8 @@ closed immediately after a call to :c:func:`uv_poll_stop` or :c:func:`uv_close`.
     On windows only sockets can be polled with poll handles. On Unix any file
     descriptor that would be accepted by :man:`poll(2)` can be used.
 
+.. note::
+    On AIX, watching for disconnection is not supported.
 
 Data types
 ----------
@@ -100,6 +102,10 @@ API
     .. note::
         Calling :c:func:`uv_poll_start` on a handle that is already active is fine. Doing so
         will update the events mask that is being watched for.
+
+    .. note::
+        Though UV_DISCONNECT can be set, it is unsupported on AIX and as such will not be set
+        on the `events` field in the callback.
 
     .. versionchanged:: 1.9.0 Added the UV_DISCONNECT event.
 


### PR DESCRIPTION
`POLLHDRUP` is not implemented on AIX. Therefore `UV_DISCONNECT` will
never be set on `events`. This causes the socket to never be closed and
the tests to be stuck inside `pollset_poll` indefinitely, resulting in a
timeout.
This fixes the following tests:
poll_duplex
poll_unidirectional

Updated docs to let end users know that `UV_DISCONNECT` can be set, but
is unsupported on AIX.

Fixes: https://github.com/libuv/libuv/issues/844