### PR TITLE
win: clarify fsevents handling code

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -349,7 +349,8 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
   FILE_NOTIFY_INFORMATION* file_info;
   int err, sizew, size;
   char* filename = NULL;
-  WCHAR* filenamew, *long_filenamew = NULL;
+  WCHAR* filenamew = NULL;
+  WCHAR* long_filenamew = NULL;
   DWORD offset = 0;
 
   assert(req->type == UV_FS_EVENT_REQ);
@@ -374,6 +375,7 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
       do {
         file_info = (FILE_NOTIFY_INFORMATION*)((char*)file_info + offset);
         assert(!filename);
+        assert(!filenamew);
         assert(!long_filenamew);
 
         /*
@@ -438,14 +440,17 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
                 uv__free(long_filenamew);
                 long_filenamew = filenamew;
                 sizew = -1;
+              } else {
+                /* We couldn't get the long filename, use the one reported. */
+                filenamew = file_info->FileName;
+                sizew = file_info->FileNameLength / sizeof(WCHAR);
               }
-            }
-            /*
-             * Removed or renamed events cannot be resolved to the long form.
-             * We therefore use the name given by ReadDirectoryChangesW.
-             * This may be the long form or the 8.3 short name in some cases.
-             */
-            if (!long_filenamew) {
+            } else {
+              /*
+               * Removed or renamed events cannot be resolved to the long form.
+               * We therefore use the name given by ReadDirectoryChangesW.
+               * This may be the long form or the 8.3 short name in some cases.
+               */
               filenamew = file_info->FileName;
               sizew = file_info->FileNameLength / sizeof(WCHAR);
             }
@@ -455,36 +460,34 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
             sizew = -1;
           }
 
-          if (filenamew) {
-            /* Convert the filename to utf8. */
+          /* Convert the filename to utf8. */
+          size = WideCharToMultiByte(CP_UTF8,
+                                     0,
+                                     filenamew,
+                                     sizew,
+                                     NULL,
+                                     0,
+                                     NULL,
+                                     NULL);
+          if (size) {
+            filename = (char*)uv__malloc(size + 1);
+            if (!filename) {
+              uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+            }
+
             size = WideCharToMultiByte(CP_UTF8,
                                        0,
                                        filenamew,
                                        sizew,
-                                       NULL,
-                                       0,
+                                       filename,
+                                       size,
                                        NULL,
                                        NULL);
             if (size) {
-              filename = (char*)uv__malloc(size + 1);
-              if (!filename) {
-                uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
-              }
-
-              size = WideCharToMultiByte(CP_UTF8,
-                                         0,
-                                         filenamew,
-                                         sizew,
-                                         filename,
-                                         size,
-                                         NULL,
-                                         NULL);
-              if (size) {
-                filename[size] = '\0';
-              } else {
-                uv__free(filename);
-                filename = NULL;
-              }
+              filename[size] = '\0';
+            } else {
+              uv__free(filename);
+              filename = NULL;
             }
           }
 
@@ -505,6 +508,7 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
           filename = NULL;
           uv__free(long_filenamew);
           long_filenamew = NULL;
+          filenamew = NULL;
         }
 
         offset = file_info->NextEntryOffset;


### PR DESCRIPTION
The code for handling fs events is quite complex, this commits tries to
make it easier to follow.

First, there are 2 cases in which we use the name of the file straight
from the event (when watching a directory):

- if we cannot create the long path
- if the file got renamed or removed

So separate this logically, even if the code we need is the same.

Second, one way or anothwer we will always have some filename to report,
so remove an unnecessary if.

Third, nullify filenamew, to avoid having a dangling pointer, should the
code change.