### PR TITLE
win,tty: fix read stop in line mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [
-    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv"
+    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
 ])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -483,7 +483,8 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   union {                                                                     \
     struct {                                                                  \
       /* Used for readable TTY handles */                                     \
-      HANDLE read_line_handle;                                                \
+      /* TODO: remove me in v2.x. */                                          \
+      HANDLE unused_;                                                         \
       uv_buf_t read_line_buffer;                                              \
       HANDLE read_raw_wait;                                                   \
       /* Fields used for translating win keystrokes into vt100 characters */  \

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -83,6 +83,7 @@ extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 #define UV_HANDLE_ZERO_READ                     0x00080000
 #define UV_HANDLE_EMULATE_IOCP                  0x00100000
 #define UV_HANDLE_BLOCKING_WRITES               0x00200000
+#define UV_HANDLE_CANCELLATION_PENDING          0x00400000
 
 /* Used by uv_tcp_t and uv_udp_t handles */
 #define UV_HANDLE_IPV6                          0x01000000

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -43,6 +43,9 @@ TEST_DECLARE   (semaphore_1)
 TEST_DECLARE   (semaphore_2)
 TEST_DECLARE   (semaphore_3)
 TEST_DECLARE   (tty)
+#ifdef _WIN32
+TEST_DECLARE   (tty_raw)
+#endif
 TEST_DECLARE   (tty_file)
 TEST_DECLARE   (tty_pty)
 TEST_DECLARE   (stdio_over_pipes)
@@ -387,6 +390,9 @@ TASK_LIST_START
 #endif
   TEST_ENTRY  (pipe_set_non_blocking)
   TEST_ENTRY  (tty)
+#ifdef _WIN32
+  TEST_ENTRY  (tty_raw)
+#endif
   TEST_ENTRY  (tty_file)
   TEST_ENTRY  (tty_pty)
   TEST_ENTRY  (stdio_over_pipes)

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -146,6 +146,75 @@ TEST_IMPL(tty) {
 }
 
 
+#ifdef _WIN32
+static void tty_raw_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+  buf->base = malloc(size);
+  buf->len = size;
+}
+
+static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
+  if (nread > 0) {
+    ASSERT(nread  == 1);
+    ASSERT(buf->base[0] == ' ');
+    uv_close((uv_handle_t*) tty_in, NULL);
+  } else {
+    ASSERT(nread == 0);
+  }
+}
+
+TEST_IMPL(tty_raw) {
+  int r;
+  int ttyin_fd;
+  uv_tty_t tty_in;
+  uv_loop_t* loop = uv_default_loop();
+  HANDLE handle;
+  INPUT_RECORD record;
+  DWORD written;
+
+  /* Make sure we have an FD that refers to a tty */
+  handle = CreateFileA("conin$",
+                       GENERIC_READ | GENERIC_WRITE,
+                       FILE_SHARE_READ | FILE_SHARE_WRITE,
+                       NULL,
+                       OPEN_EXISTING,
+                       FILE_ATTRIBUTE_NORMAL,
+                       NULL);
+  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
+  ASSERT(ttyin_fd >= 0);
+  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+
+  r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
+  ASSERT(r == 0);
+
+  r = uv_read_start((uv_stream_t*)&tty_in, tty_raw_alloc, tty_raw_read);
+  ASSERT(r == 0);
+
+  /* Give uv_tty_line_read_thread time to block on ReadConsoleW */
+  Sleep(100);
+
+  /* Turn on raw mode. */
+  r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
+  ASSERT(r == 0);
+
+  /* Write ' ' that should be read in raw mode */
+  record.EventType = KEY_EVENT;
+  record.Event.KeyEvent.bKeyDown = TRUE;
+  record.Event.KeyEvent.wRepeatCount = 1;
+  record.Event.KeyEvent.wVirtualKeyCode = VK_SPACE;
+  record.Event.KeyEvent.wVirtualScanCode = MapVirtualKeyW(VK_SPACE, MAPVK_VK_TO_VSC);
+  record.Event.KeyEvent.uChar.UnicodeChar = L' ';
+  record.Event.KeyEvent.dwControlKeyState = 0;
+  WriteConsoleInputW(handle, &record, 1, &written);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+#endif
+
+
 TEST_IMPL(tty_file) {
 #ifndef _WIN32
   uv_loop_t loop;

--- a/uv.gyp
+++ b/uv.gyp
@@ -112,6 +112,7 @@
               '-liphlpapi',
               '-lpsapi',
               '-lshell32',
+              '-luser32',
               '-luserenv',
               '-lws2_32'
             ],


### PR DESCRIPTION
Closing the handle does not make `ReadConsoleW` exit reliably on Windows 7 and above. Thus, after switching from line to raw mode, keypresses were held until enter was pressed. This has caused a number of issues in node: https://github.com/nodejs/node/issues/2504 , https://github.com/nodejs/node/issues/2996, https://github.com/nodejs/node/issues/5384 , https://github.com/nodejs/node/issues/5821 , https://github.com/nodejs/node/issues/5940 .

This fix makes `ReadConsoleW` exit by writing a return keypress to its input buffer, similar to what was already done for raw mode. The second commit removes the duplicate handle that was used to close the console before. The third commit restores the cursor position to where it was before writing the enter, because `ReadConsoleW` echoes the newline in the screen.

This PR includes a test that switches the console to raw mode and uses `WriteConsoleInputW` to test reading in raw mode. I do not know of a unix equivalent to `WriteConsoleInputW`, so the test is for Windows only. In this test, switching to raw mode is done after a 100 ms sleep, to allow `uv_tty_line_read_thread` to reach [`ReadConsoleW`](https://github.com/libuv/libuv/blob/e397caa3a6a139fff2fed06e0223ee92582fa2d2/src/win/tty.c#L422).

The added `User32` library is necessary for [`MapVirtualKeyW`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646306).

Fixes: libuv/libuv#852

cc @saghul @piscisaureus 
