### PR TITLE
gitignore: ignore VS temporary database files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.pyc
 *.sdf
 *.suo
+.vs/
+*.VC.db
+*.VC.opendb
 core
 vgcore.*
 .buildstamp


### PR DESCRIPTION
Visual Studio 2015 uses a new database engine, creating temporary files that should be ignored.

For libuv specifically, these files are:

```
uv.VC.VC.opendb
uv.VC.db
```

The `uv.VC.db` is the database, and `uv.VC.VC.opendb` is a lock file that is created only when VS is open.

The `.vs` folder will be the new place for temporary files, but VS is moving the files progressively: https://visualstudio.uservoice.com/forums/121579-visual-studio/suggestions/6079923-store-project-related-information-in-vs-folder-to