### PR TITLE
unix: use system allocator for scandir()

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -370,9 +370,10 @@ out:
   if (dents != NULL) {
     int i;
 
+    /* Memory was allocated using the system allocator, so use free() here. */
     for (i = 0; i < n; i++)
-      uv__free(dents[i]);
-    uv__free(dents);
+      free(dents[i]);
+    free(dents);
   }
   errno = saved_errno;
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -503,6 +503,9 @@ void uv__fs_scandir_cleanup(uv_fs_t* req) {
     (*nbufs)--;
   for (; *nbufs < (unsigned int) req->result; (*nbufs)++)
     uv__fs_scandir_free(dents[*nbufs]);
+
+  uv__fs_scandir_free(req->ptr);
+  req->ptr = NULL;
 }
 
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1878,8 +1878,12 @@ void uv_fs_req_cleanup(uv_fs_t* req) {
   if (req->flags & UV_FS_FREE_PATHS)
     uv__free(req->file.pathw);
 
-  if (req->flags & UV_FS_FREE_PTR)
-    uv__free(req->ptr);
+  if (req->flags & UV_FS_FREE_PTR) {
+    if (req->fs_type == UV_FS_SCANDIR && req->ptr != NULL)
+      uv__fs_scandir_cleanup(req);
+    else
+      uv__free(req->ptr);
+  }
 
   req->path = NULL;
   req->file.pathw = NULL;


### PR DESCRIPTION
On unix, `scandir()` uses the system allocator to allocate memory. This commit releases the memory with `free()` instead of `uv__free()`. `uv__free()` is still used on Windows, which uses `uv__malloc()` to
request the memory.

Closes #873 
R= @saghul 