### PR TITLE
unix: add uv_flush_sync

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -482,6 +482,7 @@ UV_EXTERN int uv_write2(uv_write_t* req,
 UV_EXTERN int uv_try_write(uv_stream_t* handle,
                            const uv_buf_t bufs[],
                            unsigned int nbufs);
+UV_EXTERN int uv_flush_sync(uv_stream_t* stream);
 
 /* uv_write_t is a subclass of uv_req_t. */
 struct uv_write_s {

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1625,6 +1625,21 @@ void uv__stream_close(uv_stream_t* handle) {
 }
 
 
+/* Have stream block and then synchronously flush queued writes.
+ * This function works without an event loop.
+ * Intended to be used just prior to exit().
+ * Returns 0 on success, non-zero on failure.
+ */
+int uv_flush_sync(uv_stream_t* stream) {
+  int rc = uv_stream_set_blocking(stream, 1);
+  if (rc == 0) {
+    uv__write(stream);
+    rc = (int)stream->write_queue_size;
+  }
+  return rc;
+}
+
+
 int uv_stream_set_blocking(uv_stream_t* handle, int blocking) {
   /* Don't need to check the file descriptor, uv__nonblock()
    * will fail with EBADF if it's not valid.


### PR DESCRIPTION
Required for https://github.com/nodejs/node/pull/6773

@saghul Assuming this has to also be implemented on windows (although node doesn't need it on windows..) what's the windows version of `uv__write`? Do I need to switch over the handle type and call multiple methods?

I'm also not sure what kind of docs note should go here?