### PR TITLE
win,build: fix compilation on ancient Windows systems

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -40,6 +40,9 @@
 #include "stream-inl.h"
 #include "req-inl.h"
 
+#ifndef InterlockedOr
+# define InterlockedOr _InterlockedOr
+#endif
 
 #define UNICODE_REPLACEMENT_CHARACTER (0xfffd)
 


### PR DESCRIPTION
Fixes build on Windows XP with Visual Studio 2008.

R=@orangemocha, @piscisaureus 