### PR TITLE
Fixup license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-libuv is part of the Node project: http://nodejs.org/
-libuv may be distributed alone under Node's license:
-
 ====
 
 Copyright Joyent, Inc. and other Node contributors. All rights reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,30 @@
+libuv is licensed for use as follows:
+
+====
+Copyright (c) 2015-present libuv project contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+====
+
+This license applies to parts of libuv originating from the
+https://github.com/joyent/libuv repository:
+
 ====
 
 Copyright Joyent, Inc. and other Node contributors. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Starting with version 1.0.0 libuv follows the [semantic versioning](http://semve
 scheme. The API change and backwards compatibility rules are those indicated by
 SemVer. libuv will keep a stable ABI across major releases.
 
+## Licensing
+
+libuv is licensed under the MIT license. Check the [LICENSE file](LICENSE).
+
 ## Community
 
  * [Mailing list](http://groups.google.com/group/libuv)


### PR DESCRIPTION
First of all: IANAL.

These changes basically reflect what we've been doing for a while.

As a follow-up, I'd like to remove all license boilerplate from the files replacing it with a "pointer" to the actual license. Example: https://github.com/openssl/openssl/commit/846e33c729311169d9c988ceba29484b3783f244

/cc @libuv/collaborators 