### PR TITLE
unix: ignore EINPROGRESS in uv__close

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -500,8 +500,8 @@ int uv__close_nocheckstdio(int fd) {
   rc = close(fd);
   if (rc == -1) {
     rc = -errno;
-    if (rc == -EINTR)
-      rc = -EINPROGRESS;  /* For platform/libc consistency. */
+    if (rc == -EINTR || rc == -EINPROGRESS)
+      rc = 0;    /* The close is in progress, not an error. */
     errno = saved_errno;
   }
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -251,7 +251,7 @@ static ssize_t uv__fs_open(uv_fs_t* req) {
    */
   if (r >= 0 && uv__cloexec(r, 1) != 0) {
     r = uv__close(r);
-    if (r != 0 && r != -EINPROGRESS)
+    if (r != 0)
       abort();
     r = -1;
   }

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -232,7 +232,7 @@ static int uv__process_open_stream(uv_stdio_container_t* container,
     return 0;
 
   err = uv__close(pipefds[1]);
-  if (err != 0 && err != -EINPROGRESS)
+  if (err != 0)
     abort();
 
   pipefds[1] = -1;


### PR DESCRIPTION
It's just an indicator that the operation will happen later, so return
success.

R= @bnoordhuis (you suggested this in some issue I can't remember)
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/58/