### PR TITLE
linux-core: Fix uv_get_total/free_memory() on uclibc.

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -484,12 +484,20 @@ int uv_exepath(char* buffer, size_t* size) {
 
 
 uint64_t uv_get_free_memory(void) {
-  return (uint64_t) sysconf(_SC_PAGESIZE) * sysconf(_SC_AVPHYS_PAGES);
+  struct sysinfo info;
+
+  if (sysinfo(&info) == 0)
+    return (uint64_t) info.freeram * info.mem_unit;
+  return 0;
 }
 
 
 uint64_t uv_get_total_memory(void) {
-  return (uint64_t) sysconf(_SC_PAGESIZE) * sysconf(_SC_PHYS_PAGES);
+  struct sysinfo info;
+
+  if (sysinfo(&info) == 0)
+    return (uint64_t) info.totalram * info.mem_unit;
+  return 0;
 }
 
 


### PR DESCRIPTION
The _SC_PHYS_PAGES and _SC_AVPHYS_PAGES are not POSIX sysconf values, so
the standart C libraries have no obligation to support it, even on
Linux.  Add a fallback by using the sysinfo() system call if
sysconf(_SC_PHYS_PAGES) returns -1 instead of reporting that the machine
has close to 16 exbibytes of memory.