### PR TITLE
test: silence build warnings on AIX

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -39,7 +39,7 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
-#elif __GNUC__ >= 4
+#elif __GNUC__ >= 4 && !defined(_AIX)
 # define UV_EXTERN __attribute__((visibility("default")))
 #else
 # define UV_EXTERN /* nothing */

--- a/uv.gyp
+++ b/uv.gyp
@@ -447,6 +447,7 @@
           'defines': [
             '_ALL_SOURCE',
             '_XOPEN_SOURCE=500',
+            '-D_LINUX_SOURCE_COMPAT',
           ],
         }],
         ['uv_library=="shared_library"', {


### PR DESCRIPTION
Also bring uv.gyp up to date with the same flags set in Makefile.am

As discussed in PR https://github.com/libuv/libuv/pull/893
Should I also add `-Wno-attribrutes` to `libuv_la_CFLAGS`? Would really make the compile a lot less verbose
CI Run: https://ci.nodejs.org/job/libuv-test-commit-aix/nodes=aix61-ppc64/69/console

