### PR TITLE
unix: wrap blocks in SAVE_ERRNO

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -491,19 +491,19 @@ skip:
 
 
 int uv__close_nocheckstdio(int fd) {
-  int saved_errno;
   int rc;
 
   assert(fd > -1);  /* Catch uninitialized io_watcher.fd bugs. */
 
-  saved_errno = errno;
-  rc = close(fd);
-  if (rc == -1) {
-    rc = -errno;
-    if (rc == -EINTR || rc == -EINPROGRESS)
-      rc = 0;    /* The close is in progress, not an error. */
-    errno = saved_errno;
-  }
+  SAVE_ERRNO(
+    rc = close(fd);
+
+    if (rc == -1) {
+      rc = -errno;
+      if (rc == -EINTR || rc == -EINPROGRESS)
+        rc = 0;    /* The close is in progress, not an error. */
+    }
+  );
 
   return rc;
 }

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -347,7 +347,6 @@ static int uv__fs_scandir_filter(const uv__dirent_t* dent) {
 
 static ssize_t uv__fs_scandir(uv_fs_t* req) {
   uv__dirent_t **dents;
-  int saved_errno;
   int n;
 
   dents = NULL;
@@ -366,16 +365,16 @@ static ssize_t uv__fs_scandir(uv_fs_t* req) {
   return n;
 
 out:
-  saved_errno = errno;
-  if (dents != NULL) {
-    int i;
+  SAVE_ERRNO(
+    if (dents != NULL) {
+      int i;
 
-    /* Memory was allocated using the system allocator, so use free() here. */
-    for (i = 0; i < n; i++)
-      free(dents[i]);
-    free(dents);
-  }
-  errno = saved_errno;
+      /* Memory was allocated using the system allocator, so use free() here. */
+      for (i = 0; i < n; i++)
+        free(dents[i]);
+      free(dents);
+    }
+  );
 
   req->ptr = NULL;
 


### PR DESCRIPTION
This commit wraps two code blocks with `SAVE_ERRNO()` and removes the manual caching of `errno`.