### PR TITLE
test: skip tty_pty test if pty is not available

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -262,14 +262,17 @@ TEST_IMPL(tty_file) {
 TEST_IMPL(tty_pty) {
 # if defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
     defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
-  int master_fd, slave_fd;
+  int master_fd, slave_fd, r;
   struct winsize w;
   uv_loop_t loop;
   uv_tty_t master_tty, slave_tty;
 
   ASSERT(0 == uv_loop_init(&loop));
 
-  ASSERT(0 == openpty(&master_fd, &slave_fd, NULL, NULL, &w));
+  r = openpty(&master_fd, &slave_fd, NULL, NULL, &w);
+  if (r != 0)
+    RETURN_SKIP("No pty available, skipping.");
+
   ASSERT(0 == uv_tty_init(&loop, &slave_tty, slave_fd, 0));
   ASSERT(0 == uv_tty_init(&loop, &master_tty, master_fd, 0));
   /* Check if the file descriptor was reopened. If it is,


### PR DESCRIPTION
Do not let `tty_pty` test fail if no terminals are available to `openpty()`.