### PR TITLE
unix: don't convert stat buffer when syscall fails

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -810,8 +810,11 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
 static int uv__fs_stat(const char *path, uv_stat_t *buf) {
   struct stat pbuf;
   int ret;
+
   ret = stat(path, &pbuf);
-  uv__to_stat(&pbuf, buf);
+  if (ret == 0)
+    uv__to_stat(&pbuf, buf);
+
   return ret;
 }
 
@@ -819,8 +822,11 @@ static int uv__fs_stat(const char *path, uv_stat_t *buf) {
 static int uv__fs_lstat(const char *path, uv_stat_t *buf) {
   struct stat pbuf;
   int ret;
+
   ret = lstat(path, &pbuf);
-  uv__to_stat(&pbuf, buf);
+  if (ret == 0)
+    uv__to_stat(&pbuf, buf);
+
   return ret;
 }
 
@@ -828,8 +834,11 @@ static int uv__fs_lstat(const char *path, uv_stat_t *buf) {
 static int uv__fs_fstat(int fd, uv_stat_t *buf) {
   struct stat pbuf;
   int ret;
+
   ret = fstat(fd, &pbuf);
-  uv__to_stat(&pbuf, buf);
+  if (ret == 0)
+    uv__to_stat(&pbuf, buf);
+
   return ret;
 }
 


### PR DESCRIPTION
Don't call uv__to_stat() when the stat/fstat/lstat system call fails;
the stack-allocated buffer contains only garbage in that case.

Not a very serious bug it's technically undefined behavior and it made
valgrind squawk.

Introduced in commit 499c7976 ("unix, windows: nanosecond resolution
for uv_fs_[fl]stat").

Alternatively, we could `memset(pbuf, 0, sizeof(pbuf))` before the system call.  Thoughts?

CI: https://ci.nodejs.org/job/libuv-test-commit/65/