### PR TITLE
win: compare entire filename in watch events

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -344,6 +344,22 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
 }
 
 
+static int file_info_cmp(WCHAR* str, WCHAR* file_name, int file_name_len) {
+  int str_len;
+
+  str_len = wcslen(str);
+
+  /*
+    Since we only care about equality, return early if the strings
+    aren't the same length
+  */
+  if (str_len != (file_name_len / sizeof(WCHAR)))
+    return -1;
+
+  return _wcsnicmp(str, file_name, str_len);
+}
+
+
 void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
     uv_fs_event_t* handle) {
   FILE_NOTIFY_INFORMATION* file_info;
@@ -383,10 +399,12 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
          * or if the filename filter matches.
          */
         if (handle->dirw ||
-          _wcsnicmp(handle->filew, file_info->FileName,
-            file_info->FileNameLength / sizeof(WCHAR)) == 0 ||
-          _wcsnicmp(handle->short_filew, file_info->FileName,
-            file_info->FileNameLength / sizeof(WCHAR)) == 0) {
+            file_info_cmp(handle->filew,
+                          file_info->FileName,
+                          file_info->FileNameLength) == 0 ||
+            file_info_cmp(handle->short_filew,
+                          file_info->FileName,
+                          file_info->FileNameLength) == 0) {
 
           if (handle->dirw) {
             /*

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -275,6 +275,7 @@ TEST_DECLARE   (fs_read_file_eof)
 TEST_DECLARE   (fs_event_watch_dir)
 TEST_DECLARE   (fs_event_watch_dir_recursive)
 TEST_DECLARE   (fs_event_watch_file)
+TEST_DECLARE   (fs_event_watch_file_exact_path)
 TEST_DECLARE   (fs_event_watch_file_twice)
 TEST_DECLARE   (fs_event_watch_file_current_dir)
 #ifdef _WIN32
@@ -724,6 +725,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_event_watch_dir)
   TEST_ENTRY  (fs_event_watch_dir_recursive)
   TEST_ENTRY  (fs_event_watch_file)
+  TEST_ENTRY  (fs_event_watch_file_exact_path)
   TEST_ENTRY  (fs_event_watch_file_twice)
   TEST_ENTRY  (fs_event_watch_file_current_dir)
 #ifdef _WIN32


### PR DESCRIPTION
This PR causes Window file watching events to compare the entire file path when filtering events. This fixes a bug where incomplete path comparisons would cause invalid events to be raised.

Refs: https://github.com/libuv/libuv/pull/682