### PR TITLE
src: adding uv_idle_start_nop function

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -754,6 +754,7 @@ struct uv_idle_s {
 
 UV_EXTERN int uv_idle_init(uv_loop_t*, uv_idle_t* idle);
 UV_EXTERN int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb);
+UV_EXTERN int uv_idle_start_nop(uv_idle_t* handle);
 UV_EXTERN int uv_idle_stop(uv_idle_t* idle);
 
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -647,3 +647,10 @@ void uv_loop_delete(uv_loop_t* loop) {
   if (loop != default_loop)
     uv__free(loop);
 }
+
+void uv__idle_nop_callback(uv_idle_t* handle) {
+}
+
+int uv_idle_start_nop(uv_idle_t* handle) {
+  return uv_idle_start(handle, uv__idle_nop_callback);
+}

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -97,3 +97,31 @@ TEST_IMPL(idle_starvation) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+TEST_IMPL(idle_start_nop_callback) {
+  int r;
+
+  r = uv_idle_init(uv_default_loop(), &idle_handle);
+  ASSERT(r == 0);
+  r = uv_idle_start_nop(&idle_handle);
+  ASSERT(r == 0);
+
+  r = uv_check_init(uv_default_loop(), &check_handle);
+  ASSERT(r == 0);
+  r = uv_check_start(&check_handle, check_cb);
+  ASSERT(r == 0);
+
+  r = uv_timer_init(uv_default_loop(), &timer_handle);
+  ASSERT(r == 0);
+  r = uv_timer_start(&timer_handle, timer_cb, 50, 0);
+  ASSERT(r == 0);
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(timer_cb_called == 1);
+  ASSERT(close_cb_called == 3);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -162,6 +162,7 @@ TEST_DECLARE   (timer_from_check)
 TEST_DECLARE   (timer_null_callback)
 TEST_DECLARE   (timer_early_check)
 TEST_DECLARE   (idle_starvation)
+TEST_DECLARE   (idle_start_nop_callback)
 TEST_DECLARE   (loop_handles)
 TEST_DECLARE   (get_loadavg)
 TEST_DECLARE   (walk_handles)
@@ -551,6 +552,7 @@ TASK_LIST_START
   TEST_ENTRY  (timer_early_check)
 
   TEST_ENTRY  (idle_starvation)
+  TEST_ENTRY  (idle_start_nop_callback)
 
   TEST_ENTRY  (ref)
   TEST_ENTRY  (idle_ref)


### PR DESCRIPTION
The motivation for this change came from a usecase in Node.js [1]
and the handling of setImmediate functions. These are implemented with
uv_check callbacks. Since checks are performed after polling for I/O,
if there are no idle handler or prepare handler (need to check this) then
the I/O polling would block as there would be nothing for the event loop
to process until there is an I/O event. But if there is an idle handler,
there is something for the event loop to do which will cause the poll
timeout to be zero and the event loop will not block on I/O.

The suggestion here is to add a new function that only takes a
uv_idle_t* and no callback. I first looked at adding using a no-operation
function if the passed in callback was null, but was concerned with
breaking existing functionality as currently if the callback is null
ENIVAL is returned by src/unix/loop-watcher.c and src/win/loop-watcher.c.

I'm was not sure if it would make sense to have no-operation callbacks
for prepare and check handlers too, but if it does the implementations of
these callbacks could probably be moved into loop-watcher.c.

Opening this pull request to get some feedback on what would be the
best way to proceed. Sorry about the long description, but wanted to
verify that my understanding is correct and nothing else.

[1]
https://github.com/nodejs/node/blob/db21266427c1228065dd0576cf59e47ce4485f4e/src/node.cc#L234-L237