### PR TITLE
tests: tcp_close_accept: close server before initiating new connection

### DIFF
--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -102,6 +102,9 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
       uv_close((uv_handle_t*) &tcp_incoming[i], close_cb);
   }
 
+  /* Close server, so no one will connect to it */
+  uv_close((uv_handle_t*) &tcp_server, close_cb);
+
   /* Create new fd that should be one of the closed incomings */
   ASSERT(0 == uv_tcp_init(loop, &tcp_check));
   ASSERT(0 == uv_tcp_connect(&tcp_check_req,
@@ -109,9 +112,6 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
                              (const struct sockaddr*) &addr,
                              connect_cb));
   ASSERT(0 == uv_read_start((uv_stream_t*) &tcp_check, alloc_cb, read_cb));
-
-  /* Close server, so no one will connect to it */
-  uv_close((uv_handle_t*) &tcp_server, close_cb);
 }
 
 static void connection_cb(uv_stream_t* server, int status) {


### PR DESCRIPTION
On line 107, a uv_tcp_connect call is made. The callback should return with an error because the server is subsequently closed. On linux, this indeed seems to happen. However, on certain platforms like zOS, the callback returns with success. This is because the server is only closed later on line 114.

So I propose to move line 114 above. This even obeys the test case description below. 

> When all clients will be accepted by server - we'll start reading from them and, on first client's first byte, will **close second client and server. After that, we'll immediately initiate new connection to server** using tcp_check handle (thus, reusing fd from second client).