### PR TITLE
unix: unneccessary use const qualifier in container_of

### DIFF
--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -31,8 +31,8 @@ static int timer_less_than(const struct heap_node* ha,
   const uv_timer_t* a;
   const uv_timer_t* b;
 
-  a = container_of(ha, const uv_timer_t, heap_node);
-  b = container_of(hb, const uv_timer_t, heap_node);
+  a = container_of(ha, uv_timer_t, heap_node);
+  b = container_of(hb, uv_timer_t, heap_node);
 
   if (a->timeout < b->timeout)
     return 1;
@@ -135,7 +135,7 @@ int uv__next_timeout(const uv_loop_t* loop) {
   if (heap_node == NULL)
     return -1; /* block indefinitely */
 
-  handle = container_of(heap_node, const uv_timer_t, heap_node);
+  handle = container_of(heap_node, uv_timer_t, heap_node);
   if (handle->timeout <= loop->time)
     return 0;
 


### PR DESCRIPTION
The type parameter in the "container_of(ptr, type, member)" macro which uses builtin "offsetof(type, member)" should not require cv qualifier. Also note that for some platforms, the "offsetof" builtin does not recognize the cv qualifier in the type.