### PR TITLE
unix: expand range of values for usleep 

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -378,5 +378,13 @@ void rewind_cursor(void) {
 
 /* Pause the calling thread for a number of milliseconds. */
 void uv_sleep(int msec) {
-  usleep(msec * 1000);
+  int sec;
+  int usec;
+
+  sec = msec / 1000;
+  usec = (msec % 1000) * 1000;
+  if(sec > 0)
+    sleep(sec);
+  if(usec > 0)
+    usleep(usec);
 }


### PR DESCRIPTION
uv_sleep uses usleep which can take integers in the range [0,1000000]. Avoid the using boundary parameters (e.g. 1000000) for portability reasons.