### PR TITLE
unix: preserve loop->data across loop init/done

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -28,11 +28,15 @@
 #include <unistd.h>
 
 int uv_loop_init(uv_loop_t* loop) {
+  void* saved_data;
   int err;
 
   uv__signal_global_once_init();
 
+  saved_data = loop->data;
   memset(loop, 0, sizeof(*loop));
+  loop->data = saved_data;
+
   heap_init((struct heap*) &loop->timer_heap);
   QUEUE_INIT(&loop->wq);
   QUEUE_INIT(&loop->active_reqs);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -613,6 +613,7 @@ uv_loop_t* uv_loop_new(void) {
 int uv_loop_close(uv_loop_t* loop) {
   QUEUE* q;
   uv_handle_t* h;
+  void* saved_data;
 
   if (!QUEUE_EMPTY(&(loop)->active_reqs))
     return UV_EBUSY;
@@ -626,7 +627,9 @@ int uv_loop_close(uv_loop_t* loop) {
   uv__loop_close(loop);
 
 #ifndef NDEBUG
+  saved_data = loop->data;
   memset(loop, -1, sizeof(*loop));
+  loop->data = saved_data;
 #endif
   if (loop == default_loop_ptr)
     default_loop_ptr = NULL;

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -34,7 +34,9 @@ TEST_IMPL(loop_close) {
   int r;
   uv_loop_t loop;
 
+  loop.data = &loop;
   ASSERT(0 == uv_loop_init(&loop));
+  ASSERT(loop.data == (void*) &loop);
 
   uv_timer_init(&loop, &timer_handle);
   uv_timer_start(&timer_handle, timer_cb, 100, 100);
@@ -47,7 +49,9 @@ TEST_IMPL(loop_close) {
   r = uv_run(&loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
+  ASSERT(loop.data == (void*) &loop);
   ASSERT(0 == uv_loop_close(&loop));
+  ASSERT(loop.data == (void*) &loop);
 
   return 0;
 }


### PR DESCRIPTION
Libuv leaves loop->data unchanged in uv_loop_init() and uv_loop_done()
on Windows but it clobbered it on UNIX platforms.  This commit fixes
that inconsistency.

CI: https://ci.nodejs.org/job/libuv-test-commit/74/