### PR TITLE
process: fix uv_stdio_container_t flags type

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -849,7 +849,7 @@ typedef enum {
 } uv_stdio_flags;
 
 typedef struct uv_stdio_container_s {
-  uv_stdio_flags flags;
+  unsigned int flags;
 
   union {
     uv_stream_t* stream;


### PR DESCRIPTION
In C++, does not correctly set the value of flags.

![2016-07-22 16-11-13](https://cloud.githubusercontent.com/assets/6904176/17050700/ee774d02-5026-11e6-8f70-824dcdc1cb67.png)

