### PR TITLE
 zos: use pthread helper functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -390,6 +390,8 @@ libuv_la_CFLAGS += -D_UNIX03_THREADS \
                    -qXPLINK \
                    -qFLOAT=IEEE
 libuv_la_LDFLAGS += -qXPLINK
+libuv_la_SOURCES += src/unix/pthread-fixes.c \
+                    src/unix/pthread-barrier.c
 endif
 
 if HAVE_PKG_CONFIG

--- a/uv.gyp
+++ b/uv.gyp
@@ -302,6 +302,12 @@
         ['uv_library=="shared_library"', {
           'defines': [ 'BUILDING_UV_SHARED=1' ]
         }],
+        ['OS=="zos"', {
+          'sources': [ 
+            'src/unix/pthread-fixes.c',
+            'src/unix/pthread-barrier.c'
+          ]
+        }],
       ]
     },
 


### PR DESCRIPTION
zOS does not implement some pthread_barrier functions. So we will use the provided helper functions in src/unix/pthread*. 