### PR TITLE
zos: implement uv__io_check_fd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -392,6 +392,7 @@ libuv_la_CFLAGS += -D_UNIX03_THREADS \
 libuv_la_LDFLAGS += -qXPLINK
 libuv_la_SOURCES += src/unix/pthread-fixes.c \
                     src/unix/pthread-barrier.c
+libuv_la_SOURCES += src/unix/os390.c
 endif
 
 if HAVE_PKG_CONFIG

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -1,0 +1,42 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+
+int uv__io_check_fd(uv_loop_t* loop, int fd) {
+  struct pollfd p[1];
+  int rv;
+
+  p[0].fd = fd;
+  p[0].events = POLLIN;
+
+  do
+    rv = poll(p, 1, 0);
+  while (rv == -1 && errno == EINTR);
+
+  if (rv == -1)
+    abort();
+
+  if (p[0].revents & POLLNVAL)
+    return -1;
+
+  return 0;
+}

--- a/uv.gyp
+++ b/uv.gyp
@@ -306,6 +306,7 @@
           'sources': [
             'src/unix/pthread-fixes.c',
             'src/unix/pthread-barrier.c'
+            'src/unix/os390.c'
           ]
         }],
       ]


### PR DESCRIPTION
This method uses the poll syscall to determine whether POLLNVAL is
flagged or not.