### PR TITLE
doc: add missing type UV_FS_REALPATH to enum uv_fs_type

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -91,7 +91,8 @@ Data types
             UV_FS_SYMLINK,
             UV_FS_READLINK,
             UV_FS_CHOWN,
-            UV_FS_FCHOWN
+            UV_FS_FCHOWN,
+            UV_FS_REALPATH
         } uv_fs_type;
 
 .. c:type:: uv_dirent_t


### PR DESCRIPTION
See the [documentation](http://docs.libuv.org/en/v1.x/fs.html).  
`UV_FS_REALPATH` is not part of `uv_fs_type` as it ought to be.