### PR TITLE
core: add reserved fields to uv_loop_t

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1465,6 +1465,7 @@ struct uv_loop_s {
   void* active_reqs[2];
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
+  void* reserved[4];
   UV_LOOP_PRIVATE_FIELDS
 };
 


### PR DESCRIPTION
Same as we do for uv_handle_t and uv_req_t, they may come useful if we
need to get creative to keep ABI compatibility.