### PR TITLE
win: fix compilation on mingw

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -54,6 +54,10 @@
 /* The number of nanoseconds in one second. */
 #define UV__NANOSEC 1000000000
 
+/* Max user name length, from iphlpapi.h */
+#ifndef UNLEN
+# define UNLEN 256
+#endif
 
 /* Cached copy of the process title, plus a mutex guarding it. */
 static char *process_title;


### PR DESCRIPTION
Libuv compilation fails under MinGW [(gist)](https://gist.github.com/bzoz/f669e84138d661690f722abfffee0975). This PR adds missing define for UNLEN from iphlpapi.h and [MSDN](https://msdn.microsoft.com/en-us/library/cc761107.aspx).