### PR TITLE
win: drop support for old MinGW versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Run:
 ## Supported Platforms
 
 Microsoft Windows operating systems since Windows Vista. It can be built
-with either Visual Studio 2015 or MinGW.
+with either Visual Studio 2015 or MinGW-w64.
 
 Linux using the GCC toolchain.
 

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -31,14 +31,6 @@ typedef intptr_t ssize_t;
 
 #include <winsock2.h>
 
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
-typedef struct pollfd {
-  SOCKET fd;
-  short  events;
-  short  revents;
-} WSAPOLLFD, *PWSAPOLLFD, *LPWSAPOLLFD;
-#endif
-
 #ifndef LOCALE_INVARIANT
 # define LOCALE_INVARIANT 0x007f
 #endif

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -25,9 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR)
 #include <crtdbg.h>
-#endif
 
 #include "uv.h"
 #include "internal.h"
@@ -42,7 +40,7 @@ static uv_loop_t* default_loop_ptr;
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 
 
-#if defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
+#if defined(_DEBUG)
 /* Our crt debug report handler allows us to temporarily disable asserts
  * just for the current thread.
  */
@@ -72,7 +70,7 @@ UV_THREAD_LOCAL int uv__crt_assert_enabled = FALSE;
 #endif
 
 
-#if !defined(__MINGW32__) || __MSVCRT_VERSION__ >= 0x800
+#if __MSVCRT_VERSION__ >= 0x800
 static void uv__crt_invalid_parameter_handler(const wchar_t* expression,
     const wchar_t* function, const wchar_t * file, unsigned int line,
     uintptr_t reserved) {
@@ -89,7 +87,7 @@ static void uv_init(void) {
   /* Tell the CRT to not exit the application when an invalid parameter is
    * passed. The main issue is that invalid FDs will trigger this behavior.
    */
-#if !defined(__MINGW32__) || __MSVCRT_VERSION__ >= 0x800
+#if __MSVCRT_VERSION__ >= 0x800
   _set_invalid_parameter_handler(uv__crt_invalid_parameter_handler);
 #endif
 
@@ -97,7 +95,7 @@ static void uv_init(void) {
    * functions (eg _get_osfhandle) raise an assert when called with invalid
    * FDs even though they return the proper error code in the release build.
    */
-#if defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
+#if defined(_DEBUG)
   _CrtSetReportHook(uv__crt_dbg_report_handler);
 #endif
 

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -45,30 +45,6 @@ int uv__getaddrinfo_translate_error(int sys_err) {
 }
 
 
-/*
- * MinGW is missing this
- */
-#if !defined(_MSC_VER) && !defined(__MINGW64_VERSION_MAJOR)
-  typedef struct addrinfoW {
-    int ai_flags;
-    int ai_family;
-    int ai_socktype;
-    int ai_protocol;
-    size_t ai_addrlen;
-    WCHAR* ai_canonname;
-    struct sockaddr* ai_addr;
-    struct addrinfoW* ai_next;
-  } ADDRINFOW, *PADDRINFOW;
-
-  DECLSPEC_IMPORT int WSAAPI GetAddrInfoW(const WCHAR* node,
-                                          const WCHAR* service,
-                                          const ADDRINFOW* hints,
-                                          PADDRINFOW* result);
-
-  DECLSPEC_IMPORT void WSAAPI FreeAddrInfoW(PADDRINFOW pAddrInfo);
-#endif
-
-
 /* adjust size value to be multiple of 4. Use to keep pointer aligned */
 /* Do we need different versions of this for different architectures? */
 #define ALIGNED_SIZE(X)     ((((X) + 3) >> 2) << 2)

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4118,9 +4118,6 @@ typedef const UNICODE_STRING *PCUNICODE_STRING;
 # define DEVICE_TYPE DWORD
 #endif
 
-/* MinGW already has a definition for REPARSE_DATA_BUFFER, but mingw-w64 does
- * not.
- */
 #if defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR)
   typedef struct _REPARSE_DATA_BUFFER {
     ULONG  ReparseTag;
@@ -4581,15 +4578,6 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
 
 #ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
 # define SYMBOLIC_LINK_FLAG_DIRECTORY 0x1
-#endif
-
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
-  typedef struct _OVERLAPPED_ENTRY {
-      ULONG_PTR lpCompletionKey;
-      LPOVERLAPPED lpOverlapped;
-      ULONG_PTR Internal;
-      DWORD dwNumberOfBytesTransferred;
-  } OVERLAPPED_ENTRY, *LPOVERLAPPED_ENTRY;
 #endif
 
 /* from wincon.h */

--- a/src/win/winsock.h
+++ b/src/win/winsock.h
@@ -146,45 +146,4 @@ typedef struct _AFD_RECV_INFO {
 #define IOCTL_AFD_POLL \
     _AFD_CONTROL_CODE(AFD_POLL, METHOD_BUFFERED)
 
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
-typedef struct _IP_ADAPTER_UNICAST_ADDRESS_XP {
-  /* FIXME: __C89_NAMELESS was removed */
-  /* __C89_NAMELESS */ union {
-    ULONGLONG Alignment;
-    /* __C89_NAMELESS */ struct {
-      ULONG Length;
-      DWORD Flags;
-    };
-  };
-  struct _IP_ADAPTER_UNICAST_ADDRESS_XP *Next;
-  SOCKET_ADDRESS Address;
-  IP_PREFIX_ORIGIN PrefixOrigin;
-  IP_SUFFIX_ORIGIN SuffixOrigin;
-  IP_DAD_STATE DadState;
-  ULONG ValidLifetime;
-  ULONG PreferredLifetime;
-  ULONG LeaseLifetime;
-} IP_ADAPTER_UNICAST_ADDRESS_XP,*PIP_ADAPTER_UNICAST_ADDRESS_XP;
-
-typedef struct _IP_ADAPTER_UNICAST_ADDRESS_LH {
-  union {
-    ULONGLONG Alignment;
-    struct {
-      ULONG Length;
-      DWORD Flags;
-    };
-  };
-  struct _IP_ADAPTER_UNICAST_ADDRESS_LH *Next;
-  SOCKET_ADDRESS Address;
-  IP_PREFIX_ORIGIN PrefixOrigin;
-  IP_SUFFIX_ORIGIN SuffixOrigin;
-  IP_DAD_STATE DadState;
-  ULONG ValidLifetime;
-  ULONG PreferredLifetime;
-  ULONG LeaseLifetime;
-  UINT8 OnLinkPrefixLength;
-} IP_ADAPTER_UNICAST_ADDRESS_LH,*PIP_ADAPTER_UNICAST_ADDRESS_LH;
-
-#endif
-
 #endif /* UV_WIN_WINSOCK_H_ */

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -24,9 +24,7 @@
 #include <malloc.h>
 #include <stdio.h>
 #include <process.h>
-#if !defined(__MINGW32__)
-# include <crtdbg.h>
-#endif
+#include <crtdbg.h>
 
 
 #include "task.h"
@@ -47,10 +45,8 @@ int platform_init(int argc, char **argv) {
   /* Disable the "application crashed" popup. */
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
       SEM_NOOPENFILEERRORBOX);
-#if !defined(__MINGW32__)
   _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
   _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
-#endif
 
   _setmode(0, _O_BINARY);
   _setmode(1, _O_BINARY);

--- a/test/runner-win.h
+++ b/test/runner-win.h
@@ -19,9 +19,11 @@
  * IN THE SOFTWARE.
  */
 
+
+#ifdef _MSC_VER
 /* Don't complain about write(), fileno() etc. being deprecated. */
 #pragma warning(disable : 4996)
-
+#endif
 
 #include <winsock2.h>
 #include <windows.h>

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1179,9 +1179,7 @@ TEST_IMPL(environment_creation) {
       }
     }
     if (prev) { /* verify sort order  */
-#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
-#endif
     }
     ASSERT(found); /* verify that we expected this variable */
   }


### PR DESCRIPTION
MinGW (from mingw.org) is really old, so stop pretending we support it.
Just support MinGW-w64, which works also works with 32bit Windows,
despite it's misleading name.
