### PR TITLE
test: fix android build error.

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -28,7 +28,7 @@
 #else /*  Unix */
 # include <fcntl.h>
 # include <unistd.h>
-# if defined(__linux__)
+# if defined(__linux__) && !defined(__ANDROID__)
 #  include <pty.h>
 # elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #  include <util.h>
@@ -260,7 +260,7 @@ TEST_IMPL(tty_file) {
 }
 
 TEST_IMPL(tty_pty) {
-# if defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
+# if defined(__linux__) && !defined(__ANDROID__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
     defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
   int master_fd, slave_fd, r;
   struct winsize w;


### PR DESCRIPTION
Do not compile 'tty_pty' test for android.