### PR TITLE
darwin: handle EINTR in /dev/tty workaround

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -291,7 +291,10 @@ int uv__stream_try_select(uv_stream_t* stream, int* fd) {
   timeout.tv_sec = 0;
   timeout.tv_nsec = 1;
 
-  ret = kevent(kq, filter, 1, events, 1, &timeout);
+  do
+    ret = kevent(kq, filter, 1, events, 1, &timeout);
+  while (ret == -1 && errno == EINTR);
+
   uv__close(kq);
 
   if (ret == -1)


### PR DESCRIPTION
On OS X, special files like /dev/null and /dev/tty don't work with
kqueue.  Libuv falls back to select() in that case but the initial
probe didn't handle EINTR.

Introduced in August 2012 in commit 731adaca ("unix: use select()
for specific fds on OS X"), this bug was only ten days away from
celebrating its fourth birthday.

CI: https://ci.nodejs.org/job/libuv-test-commit/88/