### PR TITLE
test: fix OOB buffer access

### DIFF
--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -231,7 +231,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
   len1 = sizeof buf1;
   r = uv_pipe_getsockname(&pipe_client, buf1, &len1);
   ASSERT(r == 0);
-  ASSERT(buf1[len1 - 1] != 0);
+  ASSERT(len1 == 0);  /* It's an annonymous pipe. */
 
   r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
   ASSERT(r == 0);
@@ -240,7 +240,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
   len2 = sizeof buf2;
   r = uv_pipe_getsockname(&pipe_client, buf2, &len2);
   ASSERT(r == 0);
-  ASSERT(buf2[len2 - 1] != 0);
+  ASSERT(len2 == 0);  /* It's an annonymous pipe. */
 
   r = uv_read_stop((uv_stream_t*)&pipe_client);
   ASSERT(r == 0);


### PR DESCRIPTION
The test uses an annonymous pipe, which means the returned length will
be 0.

Fixes: https://github.com/libuv/libuv/issues/376
Fixes: https://github.com/libuv/libuv/issues/529
Refs: https://github.com/libuv/libuv/issues/264