### PR TITLE
test: don't close CRT fd handed off to uv_pipe_t

### DIFF
--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -255,7 +255,6 @@ TEST_IMPL(pipe_getsockname_blocking) {
 
   ASSERT(pipe_close_cb_called == 1);
 
-  _close(readfd);
   CloseHandle(writeh);
 #endif
 


### PR DESCRIPTION
After 4ed29c2498408c99079f25bfc0c6aec5bfbf42c4 got fixed, when a CRT fd
is handed off to a pipe handle using uv_pipe_open libuv will close it
properly, so it's an error to do so ourselves.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit-windows/126/