### PR TITLE
Use '${prefix}' for pkg-config 'exec_prefix'

### DIFF
--- a/libuv.pc.in
+++ b/libuv.pc.in
@@ -1,5 +1,5 @@
 prefix=@prefix@
-exec_prefix=@prefix@
+exec_prefix=${prefix}
 libdir=@libdir@
 includedir=@includedir@
 


### PR DESCRIPTION
This follows common pkg-config configuration files and allows for certain
pkg-config overrides to work. For example, when cross-compiling it is common to
have to set a different pkg-config prefix through either '--define-prefix' or a
'PKG_CONFIG_LIBUV_PREFIX' environment variable. If the 'exec_prefix' is
hardcoded to '@prefix@' then it will not pick up those pkg-config overrides.