### PR TITLE
unix,win: fix indention in core sources

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -319,7 +319,7 @@ static int uv__loop_alive(const uv_loop_t* loop) {
 
 
 int uv_loop_alive(const uv_loop_t* loop) {
-    return uv__loop_alive(loop);
+  return uv__loop_alive(loop);
 }
 
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -474,7 +474,7 @@ static int uv__loop_alive(const uv_loop_t* loop) {
 
 
 int uv_loop_alive(const uv_loop_t* loop) {
-    return uv__loop_alive(loop);
+  return uv__loop_alive(loop);
 }
 
 


### PR DESCRIPTION
Just fixes the indentions inside the `uv_loop_alive` functions when reading source code :-)