### PR TITLE
test: make tcp_close_while_connecting more resilient

### DIFF
--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -37,7 +37,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT(status == UV_ECANCELED || status == 0);
   uv_timer_stop(&timer2_handle);
   connect_cb_called++;
 }


### PR DESCRIPTION
It's not impossible for the connect() to succeed before handle is fully
closed, so handle that case too.

Hopefully it fixes #1003 

R= @libuv/collaborators @jbergstroem 
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/97/