### PR TITLE
win: return IOCP HANDLE in uv_backend_fd

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -121,10 +121,10 @@ API
     Returns the size of the `uv_loop_t` structure. Useful for FFI binding
     writers who don't want to know the structure layout.
 
-.. c:function:: int uv_backend_fd(const uv_loop_t* loop)
+.. c:function:: uv_os_fd_t uv_backend_fd(const uv_loop_t* loop)
 
-    Get backend file descriptor. Only kqueue, epoll and event ports are
-    supported.
+    Get backend file descriptor. Returns the epoll / kqueue / event ports file
+    descriptor on Unix and the IOCP `HANDLE` on Windows.
 
     This can be used in conjunction with `uv_run(loop, UV_RUN_NOWAIT)` to
     poll in one thread and run the event loop's callbacks in another see
@@ -133,6 +133,9 @@ API
     .. note::
         Embedding a kqueue fd in another kqueue pollset doesn't work on all platforms. It's not
         an error to add the fd but it never generates events.
+
+    .. versionchanged:: 2.0.0: added support for Windows and changed return type
+        to ``uv_os_fd_t``.
 
 .. c:function:: int uv_backend_timeout(const uv_loop_t* loop)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -280,7 +280,7 @@ UV_EXTERN int uv_has_ref(const uv_handle_t*);
 UV_EXTERN void uv_update_time(uv_loop_t*);
 UV_EXTERN uint64_t uv_now(const uv_loop_t*);
 
-UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+UV_EXTERN uv_os_fd_t uv_backend_fd(const uv_loop_t*);
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -283,7 +283,7 @@ int uv_is_closing(const uv_handle_t* handle) {
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
+uv_os_fd_t uv_backend_fd(const uv_loop_t* loop) {
   return loop->backend_fd;
 }
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -264,8 +264,8 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
-  return -1;
+uv_os_fd_t uv_backend_fd(const uv_loop_t* loop) {
+  return loop->iocp;
 }
 
 


### PR DESCRIPTION
Change the return type from int to uv_os_fd_t so we can return an int on
Unix and a HANDLE on Windows.

Applications can use this to poll the libuv event loop from another
thread as is now possible on Unix.

The test implementation is based in what Electron does:
https://github.com/electron/electron/blob/master/atom/common/node_bindings_win.cc

Refs: https://github.com/libuv/libuv/issues/965

R=@libuv/collaborators and maybe @joaocgreis ?
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/103/