### PR TITLE
test: relax threadpool_cancel_single

### DIFF
--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -347,11 +347,8 @@ TEST_IMPL(threadpool_cancel_single) {
     ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   }
 
-  if (cancelled != 0) {
-    fputs("Failed to cancel a work req in 5,000 iterations, giving up.\n",
-          stderr);
-    return 1;
-  }
+  if (cancelled != 0)
+    RETURN_SKIP("Failed to cancel a work req in 5,000 iterations, giving up.");
 
   ASSERT(req.data == NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));


### PR DESCRIPTION
Sporadic failures have been seen on Windows, relax the test since it's
technically possible (though unlikely) that we can't cancel a single
request in 5000 iterations.

R= @libuv/collaborators 