### PR TITLE
unix: always define pthread barrier fallback pad

### DIFF
--- a/include/pthread-barrier.h
+++ b/include/pthread-barrier.h
@@ -39,7 +39,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   2 * sizeof(sem_t) + \
   2 * sizeof(unsigned int) - \
   sizeof(void *)
-#elif defined(__MVS__)
+#else
 # define UV_BARRIER_STRUCT_PADDING 0
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/1019

R = @libuv/collaborators 