### PR TITLE
fs: fix uv_fs_fstat on platforms using musl libc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -284,6 +284,10 @@ if AIX
 test_run_tests_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT
 endif
 
+if LINUX
+test_run_tests_CFLAGS += -D_GNU_SOURCE
+endif
+
 if SUNOS
 test_run_tests_CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=500
 endif

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -790,6 +790,7 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_flags = 0;
   dst->st_gen = 0;
 #elif !defined(_AIX) && (       \
+    defined(_GNU_SOURCE)     || \
     defined(_BSD_SOURCE)     || \
     defined(_SVID_SOURCE)    || \
     defined(_XOPEN_SOURCE)   || \

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1135,6 +1135,7 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_ctim.tv_sec == t.st_ctime);
   ASSERT(s->st_ctim.tv_nsec == 0);
 #elif defined(__sun) || \
+      defined(_GNU_SOURCE) || \
       defined(_BSD_SOURCE) || \
       defined(_SVID_SOURCE) || \
       defined(_XOPEN_SOURCE) || \


### PR DESCRIPTION
In `musl` libc, defining `_GNU_SOURCE` doesn't automatically define the
other feature definitions, causing that `uv_fs_fstat` would not fill the
`nsec` fields. For the same reason, compile the tests on linux with
`-D_GNU_SOURCE` so the `fs_fstat` tests passes on `musl` platforms.