### PR TITLE
test: fix tcp_close_while_connecting CI failures

### DIFF
--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -29,6 +29,7 @@ static uv_tcp_t tcp_handle;
 static int connect_cb_called;
 static int timer1_cb_called;
 static int close_cb_called;
+static int netunreach_errors;
 
 
 static void close_cb(uv_handle_t* handle) {
@@ -37,9 +38,15 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == UV_ECANCELED || status == 0);
+  /* The expected error is UV_ECANCELED but the test tries to connect to what
+   * is basically an arbitrary address in the expectation that no network path
+   * exists, so UV_ENETUNREACH is an equally plausible outcome.
+   */
+  ASSERT(status == UV_ECANCELED || status == UV_ENETUNREACH);
   uv_timer_stop(&timer2_handle);
   connect_cb_called++;
+  if (status == UV_ENETUNREACH)
+    netunreach_errors++;
 }
 
 
@@ -82,5 +89,9 @@ TEST_IMPL(tcp_close_while_connecting) {
   ASSERT(close_cb_called == 2);
 
   MAKE_VALGRIND_HAPPY();
+
+  if (netunreach_errors > 0)
+    RETURN_SKIP("Network unreachable.");
+
   return 0;
 }


### PR DESCRIPTION
The expected error is UV_ECANCELED but the test tries to connect to what
is basically an arbitrary address in the expectation that no network
path exists, so UV_ENETUNREACH is an equally plausible outcome.

This commit undoes the change from commit e994000 ("test: make
tcp_close_while_connecting more resilient") because I don't think
the connection ever actually succeeds.

Refs: https://github.com/libuv/libuv/pull/1005
CI: https://ci.nodejs.org/job/libuv-test-commit/131/