### PR TITLE
build,osx: fix warnings on tests compilation with gyp

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -470,6 +470,9 @@
             [ 'OS != "zos"', {
               'defines': [ '_GNU_SOURCE' ],
               'cflags': [ '-Wno-long-long' ],
+              'xcode_settings': {
+                'WARNING_CFLAGS': [ '-Wno-long-long' ]
+              }
             }],
           ]},
         ],


### PR DESCRIPTION
Add `-Wno-long-long` to `WARNING_CFLAGS`.