### PR TITLE
build: use -pthreads for tests with autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ libuv_la_SOURCES = src/fs-poll.c \
 if SUNOS
 # Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers
 # on other platforms complain that the argument is unused during compilation.
-libuv_la_CFLAGS += -pthread
+libuv_la_CFLAGS += -pthreads
 endif
 
 if WINNT
@@ -134,6 +134,13 @@ test_run_tests_CFLAGS =
 else
 test_run_tests_CFLAGS = -Wno-long-long
 endif
+
+if SUNOS
+# Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers
+# on other platforms complain that the argument is unused during compilation.
+test_run_tests_CFLAGS += -pthreads
+endif
+
 test_run_tests_LDFLAGS =
 test_run_tests_SOURCES = test/blackhole-server.c \
                          test/dns-server.c \


### PR DESCRIPTION
This prevents tests from using non-reentrant implementations of common
APIs (e.g `errno`) when using POSIX threads and building with autotools.
This is consistent with the way tests are builds when using gyp.

The problem was found when investigating tests failures on SmartOS for
one test added by https://github.com/libuv/libuv/pull/640. These
failures were due to that test using POSIX threads and also using a
non-reentrant errno global variable, instead of the reentrant `___errno`
function.