### PR TITLE
win,tty: fix uv_tty_set_mode race conditions

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -111,11 +111,10 @@ static int uv_tty_virtual_offset = -1;
 static int uv_tty_virtual_height = -1;
 static int uv_tty_virtual_width = -1;
 
-/* We use a semaphore rather than a mutex or critical section because in */
-/* some cases (uv__cancel_read_console) we need take the lock in the main */
-/* thread and release it in another thread. Using a semaphore ensures that */
-/* in such scenario the main thread will still block when trying to acquire */
-/* the lock. */
+/* We use a semaphore rather than a mutex or critical section because in some
+   cases (uv__cancel_read_console) we need take the lock in the main thread and
+   release it in another thread. Using a semaphore ensures that in such
+   scenario the main thread will still block when trying to acquire the lock. */
 static uv_sem_t uv_tty_output_lock;
 
 static HANDLE uv_tty_output_handle = INVALID_HANDLE_VALUE;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -111,7 +111,12 @@ static int uv_tty_virtual_offset = -1;
 static int uv_tty_virtual_height = -1;
 static int uv_tty_virtual_width = -1;
 
-static CRITICAL_SECTION uv_tty_output_lock;
+/* We use a semaphore rather than a mutex or critical section because in */
+/* some cases (uv__cancel_read_console) we need take the lock in the main */
+/* thread and release it in another thread. Using a semaphore ensures that */
+/* in such scenario the main thread will still block when trying to acquire */
+/* the lock. */
+static HANDLE uv_tty_output_lock;
 
 static HANDLE uv_tty_output_handle = INVALID_HANDLE_VALUE;
 
@@ -134,7 +139,9 @@ static uv_vtermstate_t uv__vterm_state = UV_UNCHECKED;
 static void uv__determine_vterm_state(HANDLE handle);
 
 void uv_console_init() {
-  InitializeCriticalSection(&uv_tty_output_lock);
+  uv_tty_output_lock = CreateSemaphoreW(NULL, 1, 1, NULL);
+  if (uv_tty_output_lock == NULL)
+    uv_fatal_error(GetLastError(), "CreateSemaphoreW");
 }
 
 
@@ -172,7 +179,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
 
     /* Obtain the the tty_output_lock because the virtual window state is */
     /* shared between all uv_tty_t handles. */
-    EnterCriticalSection(&uv_tty_output_lock);
+    WaitForSingleObject(uv_tty_output_lock, INFINITE);
 
     if (uv__vterm_state == UV_UNCHECKED)
       uv__determine_vterm_state(handle);
@@ -187,7 +194,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
 
     uv_tty_update_virtual_window(&screen_buffer_info);
 
-    LeaveCriticalSection(&uv_tty_output_lock);
+    ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
   }
 
 
@@ -315,10 +322,6 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
       return UV_EINVAL;
   }
 
-  if (!SetConsoleMode(tty->handle, flags)) {
-    return uv_translate_sys_error(GetLastError());
-  }
-
   /* If currently reading, stop, and restart reading. */
   if (tty->flags & UV_HANDLE_READING) {
     was_reading = 1;
@@ -331,6 +334,14 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   } else {
     was_reading = 0;
   }
+
+  WaitForSingleObject(uv_tty_output_lock, INFINITE);
+  if (!SetConsoleMode(tty->handle, flags)) {
+    err = uv_translate_sys_error(GetLastError());
+    ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
+    return err;
+  }
+  ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
 
   /* Update flag. */
   tty->flags &= ~UV_HANDLE_TTY_RAW;
@@ -361,9 +372,9 @@ int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
     return uv_translate_sys_error(GetLastError());
   }
 
-  EnterCriticalSection(&uv_tty_output_lock);
+  WaitForSingleObject(uv_tty_output_lock, INFINITE);
   uv_tty_update_virtual_window(&info);
-  LeaveCriticalSection(&uv_tty_output_lock);
+  ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
 
   *width = uv_tty_virtual_width;
   *height = uv_tty_virtual_height;
@@ -432,6 +443,7 @@ static DWORD CALLBACK uv_tty_line_read_thread(void* data) {
   DWORD chars, read_chars;
   LONG status;
   COORD pos;
+  BOOL read_console_success;
 
   assert(data);
 
@@ -461,11 +473,13 @@ static DWORD CALLBACK uv_tty_line_read_thread(void* data) {
     return 0;
   }
 
-  if (ReadConsoleW(handle->handle,
-                   (void*) utf16,
-                   chars,
-                   &read_chars,
-                   NULL)) {
+  read_console_success = ReadConsoleW(handle->handle,
+                                      (void*) utf16,
+                                      chars,
+                                      &read_chars,
+                                      NULL);
+
+  if (read_console_success) {
     read_bytes = WideCharToMultiByte(CP_UTF8,
                                      0,
                                      utf16,
@@ -480,33 +494,36 @@ static DWORD CALLBACK uv_tty_line_read_thread(void* data) {
     SET_REQ_ERROR(req, GetLastError());
   }
 
-  InterlockedExchange(&uv__read_console_status, COMPLETED);
+  status = InterlockedExchange(&uv__read_console_status, COMPLETED);
 
-  /* If we canceled the read by sending a VK_RETURN event, restore the screen
-     state to undo the visual effect of the VK_RETURN*/
-  if (InterlockedOr(&uv__restore_screen_state, 0)) {
-    HANDLE active_screen_buffer = CreateFileA("conout$",
+  if (status ==  TRAP_REQUESTED) {
+    /* If we canceled the read by sending a VK_RETURN event, restore the */
+    /* screen state to undo the visual effect of the VK_RETURN */
+    if (read_console_success && InterlockedOr(&uv__restore_screen_state, 0)) {
+      HANDLE active_screen_buffer;
+      active_screen_buffer = CreateFileA("conout$",
                                          GENERIC_READ | GENERIC_WRITE,
                                          FILE_SHARE_READ | FILE_SHARE_WRITE,
                                          NULL,
                                          OPEN_EXISTING,
                                          FILE_ATTRIBUTE_NORMAL,
                                          NULL);
-    if (active_screen_buffer != INVALID_HANDLE_VALUE) {
-      pos = uv__saved_screen_state.dwCursorPosition;
+      if (active_screen_buffer != INVALID_HANDLE_VALUE) {
+        pos = uv__saved_screen_state.dwCursorPosition;
 
-      /* If the cursor was at the bottom line of the screen buffer, the
-         VK_RETURN would have caused the buffer contents to scroll up by
-         one line. The right position to reset the cursor to is therefore one
-         line higher */
-      if (pos.Y == uv__saved_screen_state.dwSize.Y - 1)
-        pos.Y--;
+        /* If the cursor was at the bottom line of the screen buffer, the */
+        /* VK_RETURN would have caused the buffer contents to scroll up by */
+        /* one line. The right position to reset the cursor to is therefore */
+        /* one line higher */
+        if (pos.Y == uv__saved_screen_state.dwSize.Y - 1)
+          pos.Y--;
 
-      SetConsoleCursorPosition(active_screen_buffer, pos);
-      CloseHandle(active_screen_buffer);
+        SetConsoleCursorPosition(active_screen_buffer, pos);
+        CloseHandle(active_screen_buffer);
+      } 
     }
+    ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
   }
-
   POST_COMPLETION_FOR_REQ(loop, req);
   return 0;
 }
@@ -694,14 +711,14 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
       if (handle->tty.rd.last_input_record.EventType == WINDOW_BUFFER_SIZE_EVENT) {
         CONSOLE_SCREEN_BUFFER_INFO info;
 
-        EnterCriticalSection(&uv_tty_output_lock);
+        WaitForSingleObject(uv_tty_output_lock, INFINITE);
 
         if (uv_tty_output_handle != INVALID_HANDLE_VALUE &&
             GetConsoleScreenBufferInfo(uv_tty_output_handle, &info)) {
           uv_tty_update_virtual_window(&info);
         }
 
-        LeaveCriticalSection(&uv_tty_output_lock);
+        ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
 
         continue;
       }
@@ -1035,11 +1052,16 @@ static int uv__cancel_read_console(uv_tty_t* handle) {
 
   assert(!(handle->flags & UV_HANDLE_CANCELLATION_PENDING));
 
+  /* Hold the output lock during the cancellation, to ensure that further
+  /* writes don't interfere with the screen state. It will be the ReadConsole
+  /* thread's responsibility to release the lock. */
+  WaitForSingleObject(uv_tty_output_lock, INFINITE);
   status = InterlockedExchange(&uv__read_console_status, TRAP_REQUESTED);
   if (status != IN_PROGRESS) {
     /* Either we have managed to set a trap for the other thread before
        ReadConsole is called, or ReadConsole has returned because the user
        has pressed ENTER. In either case, there is nothing else to do. */
+    ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
     return 0;
   }
 
@@ -1624,7 +1646,7 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
   /* state. */
   *error = ERROR_SUCCESS;
 
-  EnterCriticalSection(&uv_tty_output_lock);
+  WaitForSingleObject(uv_tty_output_lock, INFINITE);
 
   for (i = 0; i < nbufs; i++) {
     uv_buf_t buf = bufs[i];
@@ -2061,7 +2083,7 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
   handle->tty.wr.previous_eol = previous_eol;
   handle->tty.wr.ansi_parser_state = ansi_parser_state;
 
-  LeaveCriticalSection(&uv_tty_output_lock);
+  ReleaseSemaphore(uv_tty_output_lock, 1, NULL);
 
   if (*error == STATUS_SUCCESS) {
     return 0;


### PR DESCRIPTION
Additional synchronization is needed to ensure that the program cannot modify the screen state while a line read is getting cancelled.

Also, we need to stop any pending reads before calling `SetConsoleMode`, or a call to `ReadConsole` could start while the console is still in raw mode.

We also switch to use a semaphore rather than a critical section because in some cases (`uv__cancel_read_console`) we need take the lock in the main thread and release it in another thread. Using a semaphore ensures that in such scenario the main thread will still block when trying to acquire  the lock

Credit: orangemocha - Alexis Campailla <orangemocha@nodejs.org>

Fixes: https://github.com/nodejs/node/issues/7837