### PR TITLE
loop-watcher: allow null cb

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-handle-fileno.c \
                          test/test-homedir.c \
                          test/test-hrtime.c \
+                         test/test-idle-null-cb.c \
                          test/test-idle.c \
                          test/test-ip4-addr.c \
                          test/test-ip6-addr.c \

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -31,7 +31,6 @@
                                                                               \
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
-    if (cb == NULL) return -EINVAL;                                           \
     QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \
@@ -55,7 +54,7 @@
       h = QUEUE_DATA(q, uv_##name##_t, queue);                                \
       QUEUE_REMOVE(q);                                                        \
       QUEUE_INSERT_TAIL(&loop->name##_handles, q);                            \
-      h->name##_cb(h);                                                        \
+      if (h->name##_cb != NULL) h->name##_cb(h);                              \
     }                                                                         \
   }                                                                           \
                                                                               \

--- a/test/test-idle-null-cb.c
+++ b/test/test-idle-null-cb.c
@@ -1,0 +1,47 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+
+static uv_idle_t idle_handle;
+static uv_check_t check_handle;
+
+TEST_IMPL(idle_starvation) {
+  int r;
+
+  r = uv_idle_init(uv_default_loop(), &idle_handle);
+  ASSERT(r == 0);
+  r = uv_idle_start(&idle_handle, nullptr);
+  ASSERT(r == 0);
+
+  r = uv_check_init(uv_default_loop(), &check_handle);
+  ASSERT(r == 0);
+  r = uv_check_start(&check_handle, nullptr);
+  ASSERT(r == 0);
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-idle-null-cb.c
+++ b/test/test-idle-null-cb.c
@@ -31,12 +31,12 @@ TEST_IMPL(idle_starvation) {
 
   r = uv_idle_init(uv_default_loop(), &idle_handle);
   ASSERT(r == 0);
-  r = uv_idle_start(&idle_handle, nullptr);
+  r = uv_idle_start(&idle_handle, NULL);
   ASSERT(r == 0);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
   ASSERT(r == 0);
-  r = uv_check_start(&check_handle, nullptr);
+  r = uv_check_start(&check_handle, NULL);
   ASSERT(r == 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/uv.gyp
+++ b/uv.gyp
@@ -351,6 +351,7 @@
         'test/test-handle-fileno.c',
         'test/test-homedir.c',
         'test/test-hrtime.c',
+        'test/test-idle-null-cb.c',
         'test/test-idle.c',
         'test/test-ip6-addr.c',
         'test/test-ipc.c',


### PR DESCRIPTION
This allows `uv_check/prepare/idle_start()` to accept a null cb.