### PR TITLE
win, test: fix fs_event_watch_dir_recursive

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -272,12 +272,14 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
                                                  const char* filename,
                                                  int events,
                                                  int status) {
+#ifdef _WIN32
   /* Each file created (or deleted) will cause this callback to be called twice
    * under Windows: once with the name of the file, and second time with the
    * name of the directory. We will ignore the callback for the directory
    * itself. */
   if (filename && strcmp(filename, file_prefix_in_subdir) == 0)
     return;
+#endif
   fs_event_cb_called++;
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -272,6 +272,12 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
                                                  const char* filename,
                                                  int events,
                                                  int status) {
+  /* Each file created (or deleted) will cause this callback to be called twice
+   * under Windows: once with the name of the file, and second time with the
+   * name of the directory. We will ignore the callback for the directory
+   * itself. */
+  if (filename && strcmp(filename, file_prefix_in_subdir) == 0)
+    return;
   fs_event_cb_called++;
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);


### PR DESCRIPTION
Under Windows `uv_fs_event_start` with `UV_FS_EVENT_RECURSIVE` will report new file creation and file deletion twice - once with the name of the file, and second time with the name of the directory itself. This will filter out callbacks with directory name, making observed callbacks count match expected values.

This test fails on Windows 10 and works most of the times on 2012 because of order of callbacks being called. In 2012 the test is flaky, when it passes it is because the callbacks for entire directory come after the ones for files. Under Windows 10, directory callback is called after each file modification.

Fixes: https://github.com/libuv/libuv/issues/1009