### PR TITLE
WIP: Windows: remove LSP support

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -397,7 +397,6 @@ typedef struct {
   SOCKET peer_socket;                                                         \
   AFD_POLL_INFO afd_poll_info_1;                                              \
   AFD_POLL_INFO afd_poll_info_2;                                              \
-  /* Used in fast and slow mode. */                                           \
   uv_req_t poll_req_1;                                                        \
   uv_req_t poll_req_2;                                                        \
   unsigned char submitted_events_1;                                           \

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -107,9 +107,6 @@ extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
 #define UV_HANDLE_TTY_SAVED_POSITION            0x04000000
 #define UV_HANDLE_TTY_SAVED_ATTRIBUTES          0x08000000
 
-/* Only used by uv_poll_t handles. */
-#define UV_HANDLE_POLL_SLOW                     0x02000000
-
 
 /*
  * Requests: see req-inl.h

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -359,10 +359,6 @@ int WSAAPI uv_wsarecvfrom_workaround(SOCKET socket, WSABUF* buffers,
 int WSAAPI uv_msafd_poll(SOCKET socket, AFD_POLL_INFO* info_in,
     AFD_POLL_INFO* info_out, OVERLAPPED* overlapped);
 
-/* Whether there are any non-IFS LSPs stacked on TCP */
-extern int uv_tcp_non_ifs_lsp_ipv4;
-extern int uv_tcp_non_ifs_lsp_ipv6;
-
 /* Ip address used to bind to any port at any interface */
 extern struct sockaddr_in uv_addr_ip4_any_;
 extern struct sockaddr_in6 uv_addr_ip6_any_;

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -26,10 +26,6 @@
 #include "internal.h"
 
 
-/* Whether there are any non-IFS LSPs stacked on TCP */
-int uv_tcp_non_ifs_lsp_ipv4;
-int uv_tcp_non_ifs_lsp_ipv6;
-
 /* Ip address used to bind to any port at any interface */
 struct sockaddr_in uv_addr_ip4_any_;
 struct sockaddr_in6 uv_addr_ip6_any_;
@@ -83,9 +79,6 @@ static int error_means_no_support(DWORD error) {
 void uv_winsock_init() {
   WSADATA wsa_data;
   int errorno;
-  SOCKET dummy;
-  WSAPROTOCOL_INFOW protocol_info;
-  int opt_len;
 
   /* Initialize winsock */
   errorno = WSAStartup(MAKEWORD(2, 2), &wsa_data);
@@ -100,52 +93,6 @@ void uv_winsock_init() {
 
   if (uv_ip6_addr("::", 0, &uv_addr_ip6_any_)) {
     abort();
-  }
-
-  /* Detect non-IFS LSPs */
-  dummy = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
-
-  if (dummy != INVALID_SOCKET) {
-    opt_len = (int) sizeof protocol_info;
-    if (getsockopt(dummy,
-                   SOL_SOCKET,
-                   SO_PROTOCOL_INFOW,
-                   (char*) &protocol_info,
-                   &opt_len) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "getsockopt");
-
-    if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
-      uv_tcp_non_ifs_lsp_ipv4 = 1;
-
-    if (closesocket(dummy) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "closesocket");
-
-  } else if (!error_means_no_support(WSAGetLastError())) {
-    /* Any error other than "socket type not supported" is fatal. */
-    uv_fatal_error(WSAGetLastError(), "socket");
-  }
-
-  /* Detect IPV6 support and non-IFS LSPs */
-  dummy = socket(AF_INET6, SOCK_STREAM, IPPROTO_IP);
-
-  if (dummy != INVALID_SOCKET) {
-    opt_len = (int) sizeof protocol_info;
-    if (getsockopt(dummy,
-                   SOL_SOCKET,
-                   SO_PROTOCOL_INFOW,
-                   (char*) &protocol_info,
-                   &opt_len) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "getsockopt");
-
-    if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
-      uv_tcp_non_ifs_lsp_ipv6 = 1;
-
-    if (closesocket(dummy) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "closesocket");
-
-  } else if (!error_means_no_support(WSAGetLastError())) {
-    /* Any error other than "socket type not supported" is fatal. */
-    uv_fatal_error(WSAGetLastError(), "socket");
   }
 }
 


### PR DESCRIPTION
I started to work on this a while ago but forgot about it, so I'm opening the PR so I don't forget again.

Current status: LSP support is removed.
What's left: Use WSASocket and pass the correct WSAPROTOCOL_INFO structure in order to select the correct AFD provider.

@libuv/collaborators @joaocgreis @joshgav please feel free to review the work so far.

> Showing with 97 additions and 404 deletions. 

Hell yeah!
