### PR TITLE
win, unix: extract common fields out of the loop fields.

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -313,7 +313,6 @@ typedef struct {
   unsigned int dispatched_signals;
 
 #define UV_FS_EVENT_PRIVATE_FIELDS                                            \
-  uv_fs_event_cb cb;                                                          \
   UV_PLATFORM_FS_EVENT_FIELDS                                                 \
 
 #endif /* UV_UNIX_H */

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -271,8 +271,6 @@ typedef struct {
   uv__io_t io_watcher;
 
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
-  uv_async_cb async_cb;                                                       \
-  void* queue[2];                                                             \
   int pending;                                                                \
 
 #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -288,13 +288,6 @@ typedef struct {
   void* queue[2];                                                             \
   int pending;                                                                \
 
-#define UV_TIMER_PRIVATE_FIELDS                                               \
-  uv_timer_cb timer_cb;                                                       \
-  void* heap_node[3];                                                         \
-  uint64_t timeout;                                                           \
-  uint64_t repeat;                                                            \
-  uint64_t start_id;
-
 #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
   struct uv__work work_req;                                                   \
   uv_getaddrinfo_cb cb;                                                       \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -237,7 +237,6 @@ typedef struct {
   unsigned int nbufs;                                                         \
   uv_buf_t* bufs;                                                             \
   ssize_t status;                                                             \
-  uv_udp_send_cb send_cb;                                                     \
   uv_buf_t bufsml[4];                                                         \
 
 #define UV_HANDLE_PRIVATE_FIELDS                                              \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -202,23 +202,10 @@ typedef struct {
   uv__io_t** watchers;                                                        \
   unsigned int nwatchers;                                                     \
   unsigned int nfds;                                                          \
-  void* wq[2];                                                                \
-  uv_mutex_t wq_mutex;                                                        \
-  uv_async_t wq_async;                                                        \
   uv_rwlock_t cloexec_lock;                                                   \
   uv_handle_t* closing_handles;                                               \
   void* process_handles[2];                                                   \
-  void* prepare_handles[2];                                                   \
-  void* check_handles[2];                                                     \
-  void* idle_handles[2];                                                      \
-  void* async_handles[2];                                                     \
   struct uv__async async_watcher;                                             \
-  struct {                                                                    \
-    void* min;                                                                \
-    unsigned int nelts;                                                       \
-  } timer_heap;                                                               \
-  uint64_t timer_counter;                                                     \
-  uint64_t time;                                                              \
   int signal_pipefd[2];                                                       \
   uv__io_t signal_io_watcher;                                                 \
   uv_signal_t child_watcher;                                                  \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -271,18 +271,6 @@ typedef struct {
 #define UV_POLL_PRIVATE_FIELDS                                                \
   uv__io_t io_watcher;
 
-#define UV_PREPARE_PRIVATE_FIELDS                                             \
-  uv_prepare_cb prepare_cb;                                                   \
-  void* queue[2];                                                             \
-
-#define UV_CHECK_PRIVATE_FIELDS                                               \
-  uv_check_cb check_cb;                                                       \
-  void* queue[2];                                                             \
-
-#define UV_IDLE_PRIVATE_FIELDS                                                \
-  uv_idle_cb idle_cb;                                                         \
-  void* queue[2];                                                             \
-
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   uv_async_cb async_cb;                                                       \
   void* queue[2];                                                             \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -285,15 +285,6 @@ typedef struct {
   struct addrinfo* addrinfo;                                                  \
   int retcode;
 
-#define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
-  struct uv__work work_req;                                                   \
-  uv_getnameinfo_cb getnameinfo_cb;                                           \
-  struct sockaddr_storage storage;                                            \
-  int flags;                                                                  \
-  char host[NI_MAXHOST];                                                      \
-  char service[NI_MAXSERV];                                                   \
-  int retcode;
-
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   void* queue[2];                                                             \
   int status;                                                                 \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -241,7 +241,6 @@ typedef struct {
 
 #define UV_HANDLE_PRIVATE_FIELDS                                              \
   uv_handle_t* next_closing;                                                  \
-  unsigned int flags;                                                         \
 
 #define UV_STREAM_PRIVATE_FIELDS                                              \
   uv_connect_t *connect_req;                                                  \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -273,13 +273,9 @@ typedef struct {
   int pending;                                                                \
 
 #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
-  struct uv__work work_req;                                                   \
-  uv_getaddrinfo_cb cb;                                                       \
   struct addrinfo* hints;                                                     \
   char* hostname;                                                             \
   char* service;                                                              \
-  struct addrinfo* addrinfo;                                                  \
-  int retcode;
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   void* queue[2];                                                             \

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -304,9 +304,6 @@ typedef struct {
   struct uv__work work_req;                                                   \
   uv_buf_t bufsml[4];                                                         \
 
-#define UV_WORK_PRIVATE_FIELDS                                                \
-  struct uv__work work_req;
-
 #define UV_TTY_PRIVATE_FIELDS                                                 \
   struct termios orig_termios;                                                \
   int mode;

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -390,8 +390,6 @@ typedef struct {
   unsigned char events;
 
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
-  void* queue[2];                                                             \
-  uv_async_cb async_cb;                                                       \
   LONG volatile async_sent;
 
 #define UV_HANDLE_PRIVATE_FIELDS                                              \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -446,7 +446,6 @@ typedef struct {
   } req;                                                                      \
   HANDLE dir_handle;                                                          \
   int req_pending;                                                            \
-  uv_fs_event_cb cb;                                                          \
   WCHAR* filew;                                                               \
   WCHAR* short_filew;                                                         \
   WCHAR* dirw;                                                                \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -394,7 +394,6 @@ typedef struct {
 
 #define UV_HANDLE_PRIVATE_FIELDS                                              \
   uv_handle_t* endgame_next;                                                  \
-  unsigned int flags;
 
 #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
   struct uv__work work_req;                                                   \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -411,15 +411,6 @@ typedef struct {
   struct addrinfo* addrinfo;                                                  \
   int retcode;
 
-#define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
-  struct uv__work work_req;                                                   \
-  uv_getnameinfo_cb getnameinfo_cb;                                           \
-  struct sockaddr_storage storage;                                            \
-  int flags;                                                                  \
-  char host[NI_MAXHOST];                                                      \
-  char service[NI_MAXSERV];                                                   \
-  int retcode;
-
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   struct uv_process_exit_s {                                                  \
     UV_REQ_FIELDS                                                             \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -447,9 +447,6 @@ typedef struct {
     } time;                                                                   \
   } fs;
 
-#define UV_WORK_PRIVATE_FIELDS                                                \
-  struct uv__work work_req;
-
 #define UV_FS_EVENT_PRIVATE_FIELDS                                            \
   struct uv_fs_event_req_s {                                                  \
     UV_REQ_FIELDS                                                             \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -394,18 +394,6 @@ typedef struct {
   uv_async_cb async_cb;                                                       \
   LONG volatile async_sent;
 
-#define UV_PREPARE_PRIVATE_FIELDS                                             \
-  void* queue[2];                                                             \
-  uv_prepare_cb prepare_cb;
-
-#define UV_CHECK_PRIVATE_FIELDS                                               \
-  void* queue[2];                                                             \
-  uv_check_cb check_cb;
-
-#define UV_IDLE_PRIVATE_FIELDS                                                \
-  void* queue[2];                                                             \
-  uv_idle_cb idle_cb;
-
 #define UV_HANDLE_PRIVATE_FIELDS                                              \
   uv_handle_t* endgame_next;                                                  \
   unsigned int flags;

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -389,13 +389,6 @@ typedef struct {
   unsigned char mask_events_2;                                                \
   unsigned char events;
 
-#define UV_TIMER_PRIVATE_FIELDS                                               \
-  uv_timer_cb timer_cb;                                                       \
-  void* heap_node[3];                                                         \
-  uint64_t timeout;                                                           \
-  uint64_t repeat;                                                            \
-  uint64_t start_id;
-
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   void* queue[2];                                                             \
   uv_async_cb async_cb;                                                       \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -198,33 +198,16 @@ typedef struct {
 #define UV_LOOP_PRIVATE_FIELDS                                                \
     /* The loop's I/O completion port */                                      \
   HANDLE iocp;                                                                \
-  /* The current time according to the event loop. in msecs. */               \
-  uint64_t time;                                                              \
   /* Tail of a single-linked circular queue of pending reqs. If the queue */  \
   /* is empty, tail_ is NULL. If there is only one item, */                   \
   /* tail_->next_req == tail_ */                                              \
   uv_req_t* pending_reqs_tail;                                                \
   /* Head of a single-linked list of closed handles */                        \
   uv_handle_t* endgame_handles;                                               \
-  /* Timers */                                                                \
-  struct {                                                                    \
-    void* min;                                                                \
-    unsigned int nelts;                                                       \
-  } timer_heap;                                                               \
-  uint64_t timer_counter;                                                     \
-  /* Lists of active loop (prepare / check / idle) watchers */                \
-  void* prepare_handles[2];                                                   \
-  void* check_handles[2];                                                     \
-  void* idle_handles[2];                                                      \
   /* This handle holds the peer sockets for the fast variant of uv_poll_t */  \
   SOCKET poll_peer_sockets[UV_MSAFD_PROVIDER_COUNT];                          \
-  /* Threadpool */                                                            \
-  void* wq[2];                                                                \
-  uv_mutex_t wq_mutex;                                                        \
-  uv_async_t wq_async;                                                        \
   /* Async handle */                                                          \
   struct uv_req_s async_req;                                                  \
-  void* async_handles[2];                                                     \
   /* Global queue of loops */                                                 \
   void* loops_queue[2];
 

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -396,8 +396,6 @@ typedef struct {
   uv_handle_t* endgame_next;                                                  \
 
 #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
-  struct uv__work work_req;                                                   \
-  uv_getaddrinfo_cb getaddrinfo_cb;                                           \
   void* alloc;                                                                \
   WCHAR* node;                                                                \
   WCHAR* service;                                                             \
@@ -405,8 +403,6 @@ typedef struct {
   /* later on to store the result of GetAddrInfoW. The final result will */   \
   /* be converted to struct addrinfo* and stored in the addrinfo field.  */   \
   struct addrinfoW* addrinfow;                                                \
-  struct addrinfo* addrinfo;                                                  \
-  int retcode;
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   struct uv_process_exit_s {                                                  \

--- a/include/uv.h
+++ b/include/uv.h
@@ -416,6 +416,18 @@ struct uv_shutdown_s {
   uint64_t repeat;                                                            \
   uint64_t start_id;
 
+#define UV_PREPARE_PRIVATE_FIELDS                                             \
+  uv_prepare_cb prepare_cb;                                                   \
+  void* queue[2];                                                             \
+
+#define UV_CHECK_PRIVATE_FIELDS                                               \
+  uv_check_cb check_cb;                                                       \
+  void* queue[2];                                                             \
+
+#define UV_IDLE_PRIVATE_FIELDS                                                \
+  uv_idle_cb idle_cb;                                                         \
+  void* queue[2];                                                             \
+
 /* The abstract base class of all handles. */
 struct uv_handle_s {
   UV_HANDLE_FIELDS

--- a/include/uv.h
+++ b/include/uv.h
@@ -1461,6 +1461,25 @@ struct uv_loop_s {
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
   void* reserved[4];
+  /* private fields that appear in both implementations */
+  /* Lists of active loop (async / prepare / check / idle) watchers */
+  void* async_handles[2];
+  void* prepare_handles[2];
+  void* check_handles[2];
+  void* idle_handles[2];
+  /* Timers */
+  struct {
+    void* min;
+    unsigned int nelts;
+  } timer_heap;
+  /* The current time according to the event loop. in msecs. */
+  uint64_t time;
+  uint64_t timer_counter;
+  /* Threadpool */
+  void* wq[2];
+  uv_mutex_t wq_mutex;
+  uv_async_t wq_async;
+
   UV_LOOP_PRIVATE_FIELDS
 };
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -428,6 +428,15 @@ struct uv_shutdown_s {
   uv_idle_cb idle_cb;                                                         \
   void* queue[2];                                                             \
 
+#define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
+  struct uv__work work_req;                                                   \
+  uv_getnameinfo_cb getnameinfo_cb;                                           \
+  struct sockaddr_storage storage;                                            \
+  int flags;                                                                  \
+  char host[NI_MAXHOST];                                                      \
+  char service[NI_MAXSERV];                                                   \
+  int retcode;
+
 /* The abstract base class of all handles. */
 struct uv_handle_s {
   UV_HANDLE_FIELDS

--- a/include/uv.h
+++ b/include/uv.h
@@ -827,6 +827,11 @@ struct uv_getaddrinfo_s {
   UV_REQ_FIELDS
   /* read-only */
   uv_loop_t* loop;
+  /* private */
+  struct uv__work work_req;
+  uv_getaddrinfo_cb getaddrinfo_cb;
+  int retcode;
+  struct addrinfo* addrinfo;
   /* struct addrinfo* addrinfo is marked as private, but it really isn't. */
   UV_GETADDRINFO_PRIVATE_FIELDS
 };

--- a/include/uv.h
+++ b/include/uv.h
@@ -407,6 +407,7 @@ struct uv_shutdown_s {
     int fd;                                                                   \
     void* reserved[4];                                                        \
   } u;                                                                        \
+  unsigned int flags;                                                         \
   UV_HANDLE_PRIVATE_FIELDS                                                    \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \

--- a/include/uv.h
+++ b/include/uv.h
@@ -409,6 +409,13 @@ struct uv_shutdown_s {
   } u;                                                                        \
   UV_HANDLE_PRIVATE_FIELDS                                                    \
 
+#define UV_TIMER_PRIVATE_FIELDS                                               \
+  uv_timer_cb timer_cb;                                                       \
+  void* heap_node[3];                                                         \
+  uint64_t timeout;                                                           \
+  uint64_t repeat;                                                            \
+  uint64_t start_id;
+
 /* The abstract base class of all handles. */
 struct uv_handle_s {
   UV_HANDLE_FIELDS

--- a/include/uv.h
+++ b/include/uv.h
@@ -1321,6 +1321,7 @@ struct uv_fs_event_s {
   UV_HANDLE_FIELDS
   /* private */
   char* path;
+  uv_fs_event_cb cb;
   UV_FS_EVENT_PRIVATE_FIELDS
 };
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -785,6 +785,8 @@ UV_EXTERN int uv_idle_stop(uv_idle_t* idle);
 
 struct uv_async_s {
   UV_HANDLE_FIELDS
+  uv_async_cb async_cb;
+  void* queue[2];
   UV_ASYNC_PRIVATE_FIELDS
 };
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -437,6 +437,9 @@ struct uv_shutdown_s {
   char service[NI_MAXSERV];                                                   \
   int retcode;
 
+#define UV_WORK_PRIVATE_FIELDS                                                \
+  struct uv__work work_req;
+
 /* The abstract base class of all handles. */
 struct uv_handle_s {
   UV_HANDLE_FIELDS

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -129,8 +129,8 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
     req->retcode = UV_EAI_CANCELED;
   }
 
-  if (req->cb)
-    req->cb(req, req->retcode, req->addrinfo);
+  if (req->getaddrinfo_cb)
+    req->getaddrinfo_cb(req, req->retcode, req->addrinfo);
 }
 
 
@@ -159,7 +159,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
 
   uv__req_init(loop, req, UV_GETADDRINFO);
   req->loop = loop;
-  req->cb = cb;
+  req->getaddrinfo_cb = cb;
   req->addrinfo = NULL;
   req->hints = NULL;
   req->service = NULL;

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -109,16 +109,16 @@ static void uv__udp_run_completed(uv_udp_t* handle) {
       uv__free(req->bufs);
     req->bufs = NULL;
 
-    if (req->send_cb == NULL)
+    if (req->cb == NULL)
       continue;
 
     /* req->status >= 0 == bytes written
      * req->status <  0 == errno
      */
     if (req->status >= 0)
-      req->send_cb(req, 0);
+      req->cb(req, 0);
     else
-      req->send_cb(req, req->status);
+      req->cb(req, req->status);
   }
 
   if (QUEUE_EMPTY(&handle->write_queue)) {
@@ -408,7 +408,7 @@ int uv__udp_send(uv_udp_send_t* req,
   uv__req_init(handle->loop, req, UV_UDP_SEND);
   assert(addrlen <= sizeof(req->addr));
   memcpy(&req->addr, addr, addrlen);
-  req->send_cb = send_cb;
+  req->cb = send_cb;
   req->handle = handle;
   req->nbufs = nbufs;
 


### PR DESCRIPTION
only -11 lines though in total.
