### PR TITLE
win: fix leaky fs request buffer

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -230,6 +230,7 @@ INLINE static void uv_fs_req_init(uv_loop_t* loop, uv_fs_t* req,
   req->ptr = NULL;
   req->path = NULL;
   req->cb = cb;
+  memset(&req->fs, 0, sizeof(req->fs));
 }
 
 
@@ -1893,9 +1894,13 @@ void uv_fs_req_cleanup(uv_fs_t* req) {
       uv__free(req->ptr);
   }
 
+  if (req->fs.info.bufs != req->fs.info.bufsml)
+    uv__free(req->fs.info.bufs);
+
   req->path = NULL;
   req->file.pathw = NULL;
   req->fs.info.new_pathw = NULL;
+  req->fs.info.bufs = NULL;
   req->ptr = NULL;
 
   req->flags |= UV_FS_CLEANEDUP;


### PR DESCRIPTION
This fixes https://github.com/libuv/libuv/issues/1069, https://github.com/nodejs/node/issues/7191

When a large number of buffers (>4) is passed into `uv_fs_read()` or
`uv_fs_write()`, a new buffer is dynamically allocated to hold a copy
of the request data. This change adds a flag to the request indicating
that it contains a dynamically-allocated buffer, and code in
`uv_fs_req_cleanup()` to free that buffer if the flag is present.