### PR TITLE
darwin: use clock_gettime in macOS 10.12

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -34,7 +34,11 @@
 #include <mach-o/dyld.h> /* _NSGetExecutablePath */
 #include <sys/resource.h>
 #include <sys/sysctl.h>
+#include <time.h>
 #include <unistd.h>  /* sysconf */
+
+#undef NANOSEC
+#define NANOSEC ((uint64_t) 1e9)
 
 
 int uv__platform_loop_init(uv_loop_t* loop) {
@@ -53,6 +57,11 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
 
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
+#ifdef MAC_OS_X_VERSION_10_12
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
+#else
   static mach_timebase_info_data_t info;
 
   if ((ACCESS_ONCE(uint32_t, info.numer) == 0 ||
@@ -61,6 +70,7 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
     abort();
 
   return mach_absolute_time() * info.numer / info.denom;
+#endif
 }
 
 


### PR DESCRIPTION
Looks like macOS Sierra has some nice additions :-)

Potential caveat: a binary compiled on 10.12 will not run on earlier systems.  Since we already have some OSX versions checks in place I thought that's ok.

R= @libuv/collaborators and explicit ping to the in-house OSX expert: @indutny 
