### PR TITLE
Allow custom read/write handlers in streams

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -250,6 +250,8 @@ typedef void* (*uv_malloc_func)(size_t size);
 typedef void* (*uv_realloc_func)(void* ptr, size_t size);
 typedef void* (*uv_calloc_func)(size_t count, size_t size);
 typedef void (*uv_free_func)(void* ptr);
+typedef int (*uv_write_func)(uv_write_t *req, uv_buf_t *buf);
+typedef int (*uv_read_func)(uv_stream_t *req, uv_buf_t *buf);
 
 UV_EXTERN int uv_replace_allocator(uv_malloc_func malloc_func,
                                    uv_realloc_func realloc_func,
@@ -445,6 +447,7 @@ UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
   size_t write_queue_size;                                                    \
   uv_alloc_cb alloc_cb;                                                       \
   uv_read_cb read_cb;                                                         \
+  uv_read_func read_func;                                                     \
   /* private */                                                               \
   UV_STREAM_PRIVATE_FIELDS
 
@@ -487,6 +490,7 @@ UV_EXTERN int uv_try_write(uv_stream_t* handle,
 struct uv_write_s {
   UV_REQ_FIELDS
   uv_write_cb cb;
+  uv_write_func write_func;
   uv_stream_t* send_handle;
   uv_stream_t* handle;
   UV_WRITE_PRIVATE_FIELDS


### PR DESCRIPTION
When working with e.g. mbedtls, all ssl necessary
calls can be added in the normal tcp workflow,
except reading and writing the tcp socket. To read
from mbedtls tcp sockets we need to call the
mbedtls_ssl_write and mbedtls_ssl_read functions,
instead of the regular read and write.

This commit allows a developer to override the
standard c read/write calls inside uv__read and
uv__write with custom implementations. For
writing a write_func was added to uv_write_t and
for reading a read_func was added to the
uv_stream_t.

----

At first, what do you think about the idea i propose here? I could add full mbedtls ssl socket support with just these changes in libuv.

Secondly, we need a place where we can initialize both `write_func` and `read_func` to `NULL` before calling `uv__read` and `uv__write` or else we are checking undefined variables. Any ideas on that?

Thirdly, if you like the idea i will again add documentation and tests.