### PR TITLE
 win: map ERROR_INVALID_NAME to UV_EINVAL

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -99,6 +99,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAEHOSTUNREACH:                   return UV_EHOSTUNREACH;
     case ERROR_INSUFFICIENT_BUFFER:         return UV_EINVAL;
     case ERROR_INVALID_DATA:                return UV_EINVAL;
+    case ERROR_INVALID_NAME:                return UV_EINVAL;
     case ERROR_INVALID_PARAMETER:           return UV_EINVAL;
     case ERROR_SYMLINK_NOT_SUPPORTED:       return UV_EINVAL;
     case WSAEINVAL:                         return UV_EINVAL;
@@ -132,7 +133,6 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_BAD_PATHNAME:                return UV_ENOENT;
     case ERROR_DIRECTORY:                   return UV_ENOENT;
     case ERROR_FILE_NOT_FOUND:              return UV_ENOENT;
-    case ERROR_INVALID_NAME:                return UV_ENOENT;
     case ERROR_INVALID_DRIVE:               return UV_ENOENT;
     case ERROR_INVALID_REPARSE_DATA:        return UV_ENOENT;
     case ERROR_MOD_NOT_FOUND:               return UV_ENOENT;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2645,3 +2645,18 @@ TEST_IMPL(fs_read_write_null_arguments) {
 
   return 0;
 }
+
+
+#ifdef _WIN32
+TEST_IMPL(fs_invalid_filename) {
+  uv_fs_t req;
+  int r;
+
+  r = uv_fs_open(NULL, &req, "foo??", O_RDONLY, 0, NULL);
+  ASSERT(r == UV_EINVAL);
+  ASSERT(req.result == UV_EINVAL);
+  uv_fs_req_cleanup(&req);
+
+  return 0;
+}
+#endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -297,6 +297,9 @@ TEST_DECLARE   (fs_open_dir)
 TEST_DECLARE   (fs_rename_to_existing_file)
 TEST_DECLARE   (fs_write_multiple_bufs)
 TEST_DECLARE   (fs_read_write_null_arguments)
+#ifdef _WIN32
+TEST_DECLARE   (fs_invalid_filename)
+#endif
 TEST_DECLARE   (fs_write_alotof_bufs)
 TEST_DECLARE   (fs_write_alotof_bufs_with_offset)
 TEST_DECLARE   (threadpool_queue_work_simple)
@@ -752,6 +755,9 @@ TASK_LIST_START
   TEST_ENTRY  (fs_write_alotof_bufs)
   TEST_ENTRY  (fs_write_alotof_bufs_with_offset)
   TEST_ENTRY  (fs_read_write_null_arguments)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_invalid_filename)
+#endif
   TEST_ENTRY  (threadpool_queue_work_simple)
   TEST_ENTRY  (threadpool_queue_work_einval)
 #if defined(__PPC__) || defined(__PPC64__)  /* For linux PPC and AIX */


### PR DESCRIPTION
E.g. when trying to create a file named "foo??".

See https://github.com/nodejs/node/issues/8987

---

Investigation results as asked by @piscisaureus:

``` cpp
#include <cstdio>
#include <cerrno>
#include <cstring>
#include <cerrno>
#include <iostream>

using namespace std;

int main()
{
  auto woo = fopen("foo??", "w");
  if (errno == EINVAL) {
    perror("EINVAL");
  } else {
    perror("somethign else??");
  }
}
```

Output when built with Visual Studio:

`EINVAL: Invalid argument`

Output when built with gcc in MSYS2:

`EINVAL: Invalid argument`
