### PR TITLE
test: Fix Compilation Error on some 32 Bit Linuxes

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2584,7 +2584,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   r = uv_fs_read(NULL, &read_req, open_req1.result,
                  iovs, iovcount, offset, NULL);
   ASSERT(r >= 0);
-  ASSERT(read_req.result == sizeof(test_buf) * iovcount);
+  ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
     ASSERT(strncmp(buffer + index * sizeof(test_buf),


### PR DESCRIPTION
On travis for some targets I've noticed libuv failing to compile because of a signed/unsigned mismatch in the `alotof_buffs_with_offset` test:

```
../test/test-fs.c: In function ‘run_test_fs_write_alotof_bufs_with_offset’:
../test/test-fs.c:2604:3: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
cc1: all warnings being treated as errors
make[2]: *** [/home/travis/build/munificent/wren/deps/libuv/out/Release/obj.target/run-tests/test/test-fs.o] Error 1
make[2]: Leaving directory `/home/travis/build/munificent/wren/deps/libuv/out'
make[1]: *** [build/libuv-32.a] Error 2
make[1]: Leaving directory `/home/travis/build/munificent/wren'
make: *** [ci] Error 2
```

Adding this cast should fix the issue, and makes the read assertion
match the write assertion from above.