### PR TITLE
 win: avoid undefined `DUMMYUNIONNAME` macro in winapi

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4145,7 +4145,7 @@ typedef const UNICODE_STRING *PCUNICODE_STRING;
       struct {
         UCHAR  DataBuffer[1];
       } GenericReparseBuffer;
-    } DUMMYUNIONNAME;
+    };
   } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 #endif
 
@@ -4153,7 +4153,7 @@ typedef struct _IO_STATUS_BLOCK {
   union {
     NTSTATUS Status;
     PVOID Pointer;
-  } DUMMYUNIONNAME;
+  };
   ULONG_PTR Information;
 } IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
 


### PR DESCRIPTION
Remove use of the `DUMMYUNIONNAME` macro from our definitions of internal winapi anonymous unions....

EDIT:

Our definitions of some internal winapi anonymous unions reference the `DUMMYUNIONNAME` macro.  This macro was added to `winternl.h` in Windows SDK v7.0a in combination with a conditional definition of `DUMMYUNIONNAME` to either **empty** or `u` depending on compiler support.  We support some compilers, such as VS 2008, whose windows headers do not define the `DUMMYUNIONNAME` macro.  Avoid using the undefined macro by defining one ourselves.  Avoid conflicts with windows headers that do define it (before or after our winapi.h is included) by renaming ours to `UV_DUMMYUNIONNAME`.

EDIT 2:

After discussion we decided to restore the original version above:

Remove use of the `DUMMYUNIONNAME` macro from our definitions of internal winapi anonymous unions.  This macro was added to `winternl.h` in Windows SDK v7.0a in combination with a conditional definition of `DUMMYUNIONNAME` to either empty or `u` depending on compiler support.  We support no compilers that do not have anonymous unions, but we do support compilers such as VS 2008 that complain about the presence of the `DUMMYUNIONNAME` identifier on an anonymous union because their winapi headers do not define the macro publicly.  Simply remove it.
