### PR TITLE
macOS: avoid including CoreServices header globally

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -52,7 +52,7 @@
 #endif /* _AIX */
 
 #if defined(__APPLE__) && !TARGET_OS_IPHONE
-# include <CoreServices/CoreServices.h>
+# include <AvailabilityMacros.h>
 #endif
 
 #if defined(__ANDROID__)


### PR DESCRIPTION
In `unix/internal.h` we include it only for `AvailabilityMacros.h`, so include that directly instead.  We already include `CoreServices` where needed in implementation files.

Apple documents a newer `Availability.h` for iOS and OS X >= 10.6, but our reason for including the above header is to detect old OS X versions.