### PR TITLE
win: remove unused static variables

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -35,10 +35,6 @@
 #include "handle-inl.h"
 #include "req-inl.h"
 
-
-static uv_loop_t default_loop_struct;
-static uv_loop_t* default_loop_ptr;
-
 /* uv_once initialization guards */
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -123,7 +123,7 @@ INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
     const char* new_path, const int copy_path) {
   char* buf;
   char* pos;
-  ssize_t buf_sz = 0, path_len, pathw_len = 0, new_pathw_len = 0;
+  ssize_t buf_sz = 0, path_len = 0, pathw_len = 0, new_pathw_len = 0;
 
   /* new_path can only be set if path is also set. */
   assert(new_path == NULL || path != NULL);


### PR DESCRIPTION
default_loop_struct and default_loop_ptr seem to have been overlooked
in commit 32747c7 ("win,unix: move loop functions which have identical
implementations".)

CI: https://ci.nodejs.org/job/libuv-test-commit/155/