### PR TITLE
Revert "unix,win: simplify calculating polling timeout"

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -301,13 +301,16 @@ int uv_backend_timeout(const uv_loop_t* loop) {
   if (loop->stop_flag != 0)
     return 0;
 
-  if (!uv_loop_alive(loop))
+  if (!uv__has_active_handles(loop) && !uv__has_active_reqs(loop))
     return 0;
 
   if (!QUEUE_EMPTY(&loop->idle_handles))
     return 0;
 
   if (!QUEUE_EMPTY(&loop->pending_queue))
+    return 0;
+
+  if (loop->closing_handles)
     return 0;
 
   return uv__next_timeout(loop);

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -336,10 +336,13 @@ int uv_backend_timeout(const uv_loop_t* loop) {
   if (loop->stop_flag != 0)
     return 0;
 
-  if (!uv_loop_alive(loop))
+  if (!uv__has_active_handles(loop) && !uv__has_active_reqs(loop))
     return 0;
 
   if (loop->pending_reqs_tail)
+    return 0;
+
+  if (loop->endgame_handles)
     return 0;
 
   if (loop->idle_handles)
@@ -460,8 +463,8 @@ static void uv_poll_ex(uv_loop_t* loop, DWORD timeout) {
 
 
 static int uv__loop_alive(const uv_loop_t* loop) {
-  return uv__has_active_handles(loop) ||
-         uv__has_active_reqs(loop) ||
+  return loop->active_handles > 0 ||
+         !QUEUE_EMPTY(&loop->active_reqs) ||
          loop->endgame_handles != NULL;
 }
 


### PR DESCRIPTION
This reverts commit a35308306fc9614407194fd294fdc130c98b53a5.

Sorry everyone. Looks like this had some edge case I had not foreseen.  Here is a CI for proof: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/160/

I'll take another look at this after I come back from vacation.

Ref: https://github.com/libuv/libuv/commit/a35308306fc9614407194fd294fdc130c98b53a5#commitcomment-19497483