### PR TITLE
Add new ifdef UV_STATICLIB in UV_EXTERN definition

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -27,7 +27,9 @@
 extern "C" {
 #endif
 
-#ifdef _WIN32
+#ifdef UV_STATICLIB
+# define UV_EXTERN /* nothing */
+#elif defined(_WIN32)
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
     /* Building shared library. */


### PR DESCRIPTION
When compiling the code with UV_STATICLIB definitions
the value of UV_EXTERN will be empty for all platforms

This fix refer to issue
inconsistently between windows and gnu for static lib (#1108)
