### PR TITLE
v2: remove suggested_size from alloc_cb

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -284,7 +284,6 @@ UV_EXTERN uv_os_fd_t uv_backend_fd(const uv_loop_t*);
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,
-                            size_t suggested_size,
                             uv_buf_t* buf);
 typedef void (*uv_read_cb)(uv_stream_t* stream,
                            ssize_t nread,

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1127,7 +1127,7 @@ static void uv__read(uv_stream_t* stream) {
     assert(stream->alloc_cb != NULL);
 
     buf = uv_buf_init(NULL, 0);
-    stream->alloc_cb((uv_handle_t*)stream, 64 * 1024, &buf);
+    stream->alloc_cb((uv_handle_t*)stream, &buf);
     if (buf.base == NULL || buf.len == 0) {
       /* User indicates it can't or won't handle the read. */
       stream->read_cb(stream, UV_ENOBUFS, &buf);

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -169,7 +169,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
 
   do {
     buf = uv_buf_init(NULL, 0);
-    handle->alloc_cb((uv_handle_t*) handle, 64 * 1024, &buf);
+    handle->alloc_cb((uv_handle_t*) handle, &buf);
     if (buf.base == NULL || buf.len == 0) {
       handle->recv_cb(handle, UV_ENOBUFS, &buf, NULL, 0);
       return;

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -974,7 +974,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
     /* Do nonblocking reads until the buffer is empty */
     while (handle->flags & UV_HANDLE_READING) {
       buf = uv_buf_init(NULL, 0);
-      handle->alloc_cb((uv_handle_t*) handle, 65536, &buf);
+      handle->alloc_cb((uv_handle_t*) handle, &buf);
       if (buf.base == NULL || buf.len == 0) {
         handle->read_cb((uv_stream_t*) handle, UV_ENOBUFS, &buf);
         break;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -532,7 +532,7 @@ static void uv_tty_queue_read_line(uv_loop_t* loop, uv_tty_t* handle) {
   memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
 
   handle->tty.rd.read_line_buffer = uv_buf_init(NULL, 0);
-  handle->alloc_cb((uv_handle_t*) handle, 8192, &handle->tty.rd.read_line_buffer);
+  handle->alloc_cb((uv_handle_t*) handle, &handle->tty.rd.read_line_buffer);
   if (handle->tty.rd.read_line_buffer.base == NULL ||
       handle->tty.rd.read_line_buffer.len == 0) {
     handle->read_cb((uv_stream_t*) handle,
@@ -858,7 +858,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
         /* Allocate a buffer if needed */
         if (buf_used == 0) {
           buf = uv_buf_init(NULL, 0);
-          handle->alloc_cb((uv_handle_t*) handle, 1024, &buf);
+          handle->alloc_cb((uv_handle_t*) handle, &buf);
           if (buf.base == NULL || buf.len == 0) {
             handle->read_cb((uv_stream_t*) handle, UV_ENOBUFS, &buf);
             goto out;

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -87,14 +87,12 @@ static void ipc_read_cb(uv_stream_t* handle,
                         ssize_t nread,
                         const uv_buf_t* buf);
 static void ipc_alloc_cb(uv_handle_t* handle,
-                         size_t suggested_size,
                          uv_buf_t* buf);
 
 static void sv_async_cb(uv_async_t* handle);
 static void sv_connection_cb(uv_stream_t* server_handle, int status);
 static void sv_read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf);
 static void sv_alloc_cb(uv_handle_t* handle,
-                        size_t suggested_size,
                         uv_buf_t* buf);
 
 static void cl_connect_cb(uv_connect_t* req, int status);
@@ -161,7 +159,6 @@ static void ipc_connect_cb(uv_connect_t* req, int status) {
 
 
 static void ipc_alloc_cb(uv_handle_t* handle,
-                         size_t suggested_size,
                          uv_buf_t* buf) {
   struct ipc_client_ctx* ctx;
   ctx = container_of(handle, struct ipc_client_ctx, ipc_pipe);
@@ -307,7 +304,6 @@ static void sv_connection_cb(uv_stream_t* server_handle, int status) {
 
 
 static void sv_alloc_cb(uv_handle_t* handle,
-                        size_t suggested_size,
                         uv_buf_t* buf) {
   static char slab[32];
   buf->base = slab;

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -75,14 +75,13 @@ static uint64_t start; /* in ms  */
 static int closed_streams;
 static int conns_failed;
 
-static void alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf);
 static void connect_cb(uv_connect_t* conn_req, int status);
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
 static void close_cb(uv_handle_t* handle);
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   buf->base = slab;

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -74,7 +74,6 @@ static void exit_cb(uv_process_t* process,
 
 
 static void on_alloc(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   buf->base = output + output_used;
   buf->len = OUTPUT_SIZE - output_used;

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -60,10 +60,8 @@ static int exiting;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -33,7 +33,7 @@ typedef struct {
 static uv_tcp_t tcp_server;
 
 static void connection_cb(uv_stream_t* stream, int status);
-static void alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf);
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
 static void shutdown_cb(uv_shutdown_t* req, int status);
 static void close_cb(uv_handle_t* handle);
@@ -61,7 +61,6 @@ static void connection_cb(uv_stream_t* stream, int status) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   buf->base = slab;

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -45,9 +45,10 @@ static int bytes_received = 0;
 static int shutdown_cb_called = 0;
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
-  buf->len = size;
-  buf->base = malloc(size);
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);
   ASSERT(buf->base != NULL);
 }
 
@@ -71,7 +72,6 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   ASSERT(nested == 0 && "read_cb must be called from a fresh stack");
 
   printf("Read. nread == %d\n", (int)nread);
-  free(buf->base);
 
   if (nread == 0) {
     return;

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -28,7 +28,7 @@
 
 static unsigned int read_cb_called;
 
-static void alloc_cb(uv_handle_t *handle, size_t size, uv_buf_t *buf) {
+static void alloc_cb(uv_handle_t *handle, uv_buf_t *buf) {
   static char slab[1];
   buf->base = slab;
   buf->len = sizeof(slab);

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -30,9 +30,10 @@ static int close_cb_called = 0;
 static int connect_cb_called = 0;
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
-  buf->base = malloc(size);
-  buf->len = size;
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);
 }
 
 
@@ -117,10 +118,6 @@ static void start_server(void) {
 
 static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   /* The server will not send anything, it should close gracefully. */
-
-  if (buf->base) {
-    free(buf->base);
-  }
 
   if (nread >= 0) {
     ASSERT(nread == 0);

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -42,9 +42,10 @@ static uv_udp_t udpServer;
 static uv_udp_send_t send_req;
 
 
-static void alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
-  buf->base = malloc(suggested_size);
-  buf->len = suggested_size;
+static void alloc(uv_handle_t* handle, uv_buf_t* buf) {
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);
 }
 
 
@@ -65,10 +66,6 @@ static void after_read(uv_stream_t* handle,
                        const uv_buf_t* buf) {
   uv_shutdown_t* req;
   int r;
-
-  if (buf->base) {
-    free(buf->base);
-  }
 
   req = (uv_shutdown_t*) malloc(sizeof *req);
   r = uv_shutdown(req, handle, after_shutdown);
@@ -245,7 +242,6 @@ static void udp_recv(uv_udp_t* handle,
   int r;
 
   ASSERT(nread >= 0);
-  free(buf->base);
 
   if (nread == 0) {
     return;

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -74,7 +74,6 @@ static int write2_cb_called;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   /* we're not actually reading anything so a small buffer is okay */
   static char slab[8];

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -30,7 +30,7 @@
 static int read_count;
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
   static char slab[1024];
   buf->base = slab;
   buf->len = sizeof(slab);

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -48,10 +48,10 @@ typedef struct {
 } pinger_t;
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
-  buf->base = malloc(size);
-  buf->len = size;
-}
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);}
 
 
 static void pinger_on_close(uv_handle_t* handle) {
@@ -102,7 +102,6 @@ static void pinger_read_cb(uv_stream_t* stream,
     ASSERT(nread == UV_EOF);
 
     puts("got EOF");
-    free(buf->base);
 
     uv_close((uv_handle_t*)(&pinger->stream.tcp), pinger_on_close);
 
@@ -127,8 +126,6 @@ static void pinger_read_cb(uv_stream_t* stream,
       break;
     }
   }
-
-  free(buf->base);
 }
 
 

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -29,7 +29,7 @@
 #include "uv.h"
 #include "task.h"
 
-void alloc_buffer(uv_handle_t *handle, size_t suggested_size, uv_buf_t* buf)
+void alloc_buffer(uv_handle_t *handle, uv_buf_t* buf)
 {
   static char buffer[1024];
 

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -62,7 +62,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
   static char base[1];
 
   buf->base = base;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -110,7 +110,6 @@ static void detach_failure_cb(uv_process_t* process,
 }
 
 static void on_alloc(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   buf->base = output + output_used;
   buf->len = OUTPUT_SIZE - output_used;

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -74,7 +74,6 @@ static void init_process_options(char* test, uv_exit_cb exit_cb) {
 
 
 static void on_alloc(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   buf->base = output + output_used;
   buf->len = OUTPUT_SIZE - output_used;
@@ -168,8 +167,6 @@ static void on_pipe_read(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   ASSERT(memcmp("hello world\n", buf->base, nread) == 0);
   on_pipe_read_called++;
 
-  free(buf->base);
-
   uv_close((uv_handle_t*)&stdin_pipe, close_cb);
   uv_close((uv_handle_t*)&stdout_pipe, close_cb);
 }
@@ -182,10 +179,10 @@ static void after_pipe_write(uv_write_t* req, int status) {
 
 
 static void on_read_alloc(uv_handle_t* handle,
-                          size_t suggested_size,
                           uv_buf_t* buf) {
-  buf->base = malloc(suggested_size);
-  buf->len = suggested_size;
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);
 }
 
 

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -78,7 +78,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(0 == uv_write(&write_reqs[i], outgoing, &buf, 1, write_cb));
 }
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
   static char slab[1];
   buf->base = slab;
   buf->len = sizeof(slab);

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -37,7 +37,6 @@ static int ticks;
 static const int kMaxTicks = 10;
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char storage[1024];
   *buf = uv_buf_init(storage, sizeof(storage));

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -83,10 +83,8 @@ static void close_socket(uv_os_sock_t sock) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -50,7 +50,6 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[64];
   buf->base = slab;

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -67,7 +67,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 }
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
   static char base[1024];
 
   buf->base = base;

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -48,7 +48,6 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   ASSERT(0 && "alloc_cb should not have been called");
 }

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -30,7 +30,7 @@ static void connection_cb(uv_stream_t* server, int status);
 static void connect_cb(uv_connect_t* req, int status);
 static void write_cb(uv_write_t* req, int status);
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
-static void alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf);
 
 static uv_tcp_t tcp_server;
 static uv_tcp_t tcp_client;
@@ -66,7 +66,6 @@ static void connection_cb(uv_stream_t* server, int status) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[1024];
   buf->base = slab;

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -50,9 +50,10 @@ static uv_shutdown_t shutdown_req;
 static uv_write_t write_reqs[WRITES];
 
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
-  buf->base = malloc(size);
-  buf->len = size;
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
+  static char slab[1024];
+  buf->base = slab;
+  buf->len = sizeof(slab);
 }
 
 
@@ -92,8 +93,6 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     printf("GOT EOF\n");
     uv_close((uv_handle_t*)tcp, close_cb);
   }
-
-  free(buf->base);
 }
 
 

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -42,7 +42,6 @@ static int close_cb_called;
 
 
 static void sv_alloc_cb(uv_handle_t* handle,
-                        size_t suggested_size,
                         uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
@@ -52,7 +51,6 @@ static void sv_alloc_cb(uv_handle_t* handle,
 
 
 static void cl_alloc_cb(uv_handle_t* handle,
-                        size_t suggested_size,
                         uv_buf_t* buf) {
   /* Do nothing, recv_cb should be called with UV_ENOBUFS. */
 }

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -61,7 +61,6 @@ static int can_ipv6_ipv4_dual() {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -39,11 +39,9 @@ static int sv_send_cb_called;
 static int close_cb_called;
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -40,11 +40,9 @@ static int sv_send_cb_called;
 static int close_cb_called;
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -79,10 +79,8 @@ static void close_socket(uv_os_sock_t sock) {
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -42,11 +42,9 @@ static int close_cb_called;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -38,11 +38,9 @@ static int close_cb_called;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -40,11 +40,9 @@ static int timer_cb_called;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
   alloc_cb_called++;

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -48,11 +48,9 @@ static int close_cb_called;
 
 
 static void alloc_cb(uv_handle_t* handle,
-                     size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -33,7 +33,7 @@ static unsigned int recv_cb_called;
 static unsigned int send_cb_called;
 static unsigned int close_cb_called;
 
-static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+static void alloc_cb(uv_handle_t* handle, uv_buf_t* buf) {
   buf->base = slab;
   buf->len = sizeof(slab);
 }


### PR DESCRIPTION
This PR is opened for issue #1025. It removes the parameter from the
`typedef`in the the allocation callback and subsequent implementations.

It has been relatively underused, and users are able to allocate 
as much data as they want. The suggested size is now contained 
in the documentation for users to have a good default to go to.
