### PR TITLE
win: include filename in dlopen error message

### DIFF
--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -42,11 +42,13 @@ TEST_IMPL(dlerror) {
 
   msg = uv_dlerror(&lib);
   ASSERT(msg != NULL);
+  ASSERT(strstr(msg, path) != NULL);
   ASSERT(strstr(msg, dlerror_no_error) == NULL);
 
   /* Should return the same error twice in a row. */
   msg = uv_dlerror(&lib);
   ASSERT(msg != NULL);
+  ASSERT(strstr(msg, path) != NULL);
   ASSERT(strstr(msg, dlerror_no_error) == NULL);
 
   uv_dlclose(&lib);


### PR DESCRIPTION
Should hopefully make the dreaded "%1 is not a valid Win32 application"
error message a thing of the past.

CI: https://ci.nodejs.org/job/libuv-test-commit/162/