### PR TITLE
win: add missing break statement

### DIFF
--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -372,6 +372,7 @@ int uv__stdio_create(uv_loop_t* loop,
 
           case FILE_TYPE_PIPE:
             CHILD_STDIO_CRT_FLAGS(buffer, i) = FOPEN | FPIPE;
+            break;
 
           case FILE_TYPE_CHAR:
           case FILE_TYPE_REMOTE:


### PR DESCRIPTION
Add a missing `break` statement referenced in https://github.com/libuv/libuv/issues/1119#issuecomment-258118534.

R= @bnoordhuis 