### PR TITLE
windows: added fcntl.h to uv-win.h

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -49,6 +49,7 @@ typedef struct pollfd {
 
 #include <process.h>
 #include <signal.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1600


### PR DESCRIPTION
As mentioned in #1127 `uv-win.h` does not include `fcntl.h` and `_O_CREAT`, `_O_RDRW` and the others are not available.
Users must include explicitly the header. On the other side, `uv-unix.h` includes it and `O_CREAT`, `O_RDRW` and the others are accessible.
I'd include the header also in `uv-win.h` for consistency.