### PR TITLE
doc: fixed wrong man page link for uv_fs_lstat

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -223,7 +223,7 @@ API
 .. c:function:: int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
 .. c:function:: int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
-    Equivalent to :man:`stat(2)`, :man:`fstat(2)` and :man:`fstat(2)` respectively.
+    Equivalent to :man:`stat(2)`, :man:`fstat(2)` and :man:`lstat(2)` respectively.
 
 .. c:function:: int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, const char* path, const char* new_path, uv_fs_cb cb)
 


### PR DESCRIPTION
The link of `lstat` is wrong, probably a _copy-and-paste_ of the one of `fstat`. Fixed