### PR TITLE
win: remove short-circuiting in tty

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -984,14 +984,6 @@ int uv_tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
     return 0;
   }
 
-  /* Maybe the user stopped reading half-way while processing key events. */
-  /* Short-circuit if this could be the case. */
-  if (handle->tty.rd.last_key_len > 0) {
-    SET_REQ_SUCCESS(&handle->read_req);
-    uv_insert_pending_req(handle->loop, (uv_req_t*) &handle->read_req);
-    return 0;
-  }
-
   uv_tty_queue_read(loop, handle);
 
   return 0;


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/9690#issuecomment-261714872

I couldn't figure out the purpose of this code, and the commit message (622eb99113b28222a8ca149447350d0762f540ef) doesn't help much either. So I tried removing it. It fixes the Node.js issue, and the tests in both libuv and Node.js still pass!