### PR TITLE
win: remove dead code related to BACKUP_SEMANTICS

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -403,7 +403,6 @@ void fs__open(uv_fs_t* req) {
   switch (flags & (_O_RDONLY | _O_WRONLY | _O_RDWR)) {
   case _O_RDONLY:
     access = FILE_GENERIC_READ;
-    attributes |= FILE_FLAG_BACKUP_SEMANTICS;
     break;
   case _O_WRONLY:
     access = FILE_GENERIC_WRITE;
@@ -418,7 +417,6 @@ void fs__open(uv_fs_t* req) {
   if (flags & _O_APPEND) {
     access &= ~FILE_WRITE_DATA;
     access |= FILE_APPEND_DATA;
-    attributes &= ~FILE_FLAG_BACKUP_SEMANTICS;
   }
 
   /*


### PR DESCRIPTION
Remove several conditionals which appear to carefully set or clear
FILE_FLAG_BACKUP_SEMANTICS, since FILE_FLAG_BACKUP_SEMANTICS is
unconditionally ORed into the attributes before CreateFileW() is called.