### PR TITLE
unix: Remove FD from epoll in uv_poll_stop.

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -88,6 +88,9 @@ static void uv__poll_stop(uv_poll_t* handle) {
               &handle->io_watcher,
               POLLIN | POLLOUT | UV__POLLRDHUP);
   uv__handle_stop(handle);
+
+  /* Remove stale events for this file descriptor */
+  uv__platform_invalidate_fd(handle->loop, ((uv__io_t*) &handle)->fd);
 }
 
 


### PR DESCRIPTION
This PR makes `uv_poll_stop` to invalidate the FD, i.e. remove it from epoll/kqueue (**not close**, the FD stays open and the end user really controls it).

This PR addresses https://github.com/MagicStack/uvloop/issues/61 and https://github.com/libuv/libuv/issues/1148.