### PR TITLE
win: map ERROR_ELEVATION_REQUIRED to UV_EACCES

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -71,6 +71,7 @@ int uv_translate_sys_error(int sys_errno) {
   switch (sys_errno) {
     case ERROR_NOACCESS:                    return UV_EACCES;
     case WSAEACCES:                         return UV_EACCES;
+    case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
     case ERROR_ADDRESS_ALREADY_ASSOCIATED:  return UV_EADDRINUSE;
     case WSAEADDRINUSE:                     return UV_EADDRINUSE;
     case WSAEADDRNOTAVAIL:                  return UV_EADDRNOTAVAIL;

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -53,6 +53,7 @@ TEST_IMPL(error_message) {
 TEST_IMPL(sys_error) {
 #if defined(_WIN32)
   ASSERT(uv_translate_sys_error(ERROR_NOACCESS) == UV_EACCES);
+  ASSERT(uv_translate_sys_error(ERROR_ELEVATION_REQUIRED) == UV_EACCES);
   ASSERT(uv_translate_sys_error(WSAEADDRINUSE) == UV_EADDRINUSE);
   ASSERT(uv_translate_sys_error(ERROR_BAD_PIPE) == UV_EPIPE);
 #else


### PR DESCRIPTION
uv_spawn() on Windows will fail with ERROR_ELEVATION_REQUIRED (740) if
attempting to run an application that requires elevation.

~~Add a Windows test that calls uv_spawn() with a helper .exe that
requires elevated permissions. Test should either run successfully if
run with Administrator privileges or fail with the mapped error.~~

Refs: https://github.com/nodejs/node/issues/9464