### PR TITLE
sunos: fix SUNOS_NO_IFADDRS build

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -695,6 +695,11 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   uv__free(cpu_infos);
 }
 
+#ifdef SUNOS_NO_IFADDRS
+int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
+  return -ENOSYS;
+}
+#else  /* SUNOS_NO_IFADDRS */
 /*
  * Inspired By:
  * https://blogs.oracle.com/paulie/entry/retrieving_mac_address_in_solaris
@@ -742,9 +747,6 @@ static int uv__set_phys_addr(uv_interface_address_t* address,
 }
 
 int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-#ifdef SUNOS_NO_IFADDRS
-  return -ENOSYS;
-#else
   uv_interface_address_t* address;
   struct ifaddrs* addrs;
   struct ifaddrs* ent;
@@ -805,9 +807,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   freeifaddrs(addrs);
 
   return 0;
-#endif  /* SUNOS_NO_IFADDRS */
 }
-
+#endif  /* SUNOS_NO_IFADDRS */
 
 void uv_free_interface_addresses(uv_interface_address_t* addresses,
   int count) {


### PR DESCRIPTION
Don't compile uv__set_phys_addr() if SUNOS_NO_IFADDRS is defined,
it has been reported to break the build on Solaris 10.

Bug introduced in commit d75e334 ("sunos: set phys_addr of
interface_address using ARP") from last June.

Fixes: https://github.com/nodejs/node/issues/9856
CI: https://ci.nodejs.org/job/libuv-test-commit/184/