### PR TITLE
fs: re-enable watch facility in AIX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -316,7 +316,11 @@ test_run_tests_CFLAGS += -D_UNIX03_THREADS \
 endif
 
 if AIX
-libuv_la_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT -D_THREAD_SAFE
+libuv_la_CFLAGS += -D_ALL_SOURCE \
+                   -D_XOPEN_SOURCE=500 \
+                   -D_LINUX_SOURCE_COMPAT \
+                   -D_THREAD_SAFE \
+                   -DHAVE_SYS_AHAFS_EVPRODS_H
 include_HEADERS += include/uv-aix.h
 libuv_la_SOURCES += src/unix/aix.c
 endif

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -753,6 +753,13 @@ static void uv__ahafs_event(uv_loop_t* loop, uv__io_t* event_watch, unsigned int
 
   assert((bytes >= 0) && "uv__ahafs_event - Error reading monitor file");
 
+  /* In file / directory move cases, AIX Event infrastructure
+   * produces a second event with no data.
+   * Ignore it and return gracefully.
+   */
+  if(bytes == 0)
+    return;
+
   /* Parse the data */
   if(bytes > 0)
     rc = uv__parse_data(result_data, &events, handle);

--- a/uv.gyp
+++ b/uv.gyp
@@ -275,6 +275,7 @@
             '_XOPEN_SOURCE=500',
             '_LINUX_SOURCE_COMPAT',
             '_THREAD_SAFE',
+            'HAVE_SYS_AHAFS_EVPRODS_H',
           ],
           'link_settings': {
             'libraries': [


### PR DESCRIPTION

Reference: [5085](https://github.com/nodejs/node/issues/5085) and [10085](https://github.com/nodejs/node/issues/10085)

On AIX, watch feature depends on AHAFS based Event infrastructure.
While in principle the watch use case is same across platforms, there
are subtle differences in the way AIX deals with this, with few
behavioral changes (external).

This commit opens up the AIX code for watch feature which was masked
under a macro HAVE_SYS_AHAFS_EVPRODS_H