### PR TITLE
win, tty: make sure uv_insert_pending_req is called once

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -1004,6 +1004,9 @@ int uv_tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
   if (handle->tty.rd.last_key_len > 0) {
     SET_REQ_SUCCESS(&handle->read_req);
     uv_insert_pending_req(handle->loop, (uv_req_t*) &handle->read_req);
+    /* Make sure no attempt is made to insert it again until it's handled. */
+    handle->flags |= UV_HANDLE_READ_PENDING;
+    handle->reqs_pending++;
     return 0;
   }
 


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/9690#issuecomment-261714872

An actual fix this time.

This seems to be the cleanest way to prevent `uv_tty_read_start` from calling `uv_insert_pending_req` twice. Judging from the usage of the `UV_HANDLE_READ_PENDING` flag, this shouldn't cause any issues, but I might be missing something. (FWIW, pasting now works correctly and all tests pass)