### PR TITLE
LEP-0005 implementation – remove uv_file

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -161,7 +161,7 @@ API
     Cleanup request. Must be called after a request is finished to deallocate
     any memory libuv might have allocated.
 
-.. c:function:: int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
+.. c:function:: int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb)
 
     Equivalent to :man:`close(2)`.
 
@@ -174,7 +174,7 @@ API
         in binary mode. Because of this the O_BINARY and O_TEXT flags are not
         supported.
 
-.. c:function:: int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
+.. c:function:: int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`preadv(2)`.
 
@@ -182,7 +182,7 @@ API
 
     Equivalent to :man:`unlink(2)`.
 
-.. c:function:: int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
+.. c:function:: int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`pwritev(2)`.
 
@@ -220,7 +220,7 @@ API
         ext3 and ext4 at the time of this writing), check the :man:`getdents(2)` man page.
 
 .. c:function:: int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
-.. c:function:: int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
+.. c:function:: int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb)
 .. c:function:: int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
     Equivalent to :man:`stat(2)`, :man:`fstat(2)` and :man:`lstat(2)` respectively.
@@ -229,19 +229,19 @@ API
 
     Equivalent to :man:`rename(2)`.
 
-.. c:function:: int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
+.. c:function:: int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb)
 
     Equivalent to :man:`fsync(2)`.
 
-.. c:function:: int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
+.. c:function:: int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb)
 
     Equivalent to :man:`fdatasync(2)`.
 
-.. c:function:: int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_file file, int64_t offset, uv_fs_cb cb)
+.. c:function:: int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`ftruncate(2)`.
 
-.. c:function:: int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_file out_fd, uv_file in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
+.. c:function:: int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t out_fd, uv_os_fd_t in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
 
     Limited equivalent to :man:`sendfile(2)`.
 
@@ -250,12 +250,12 @@ API
     Equivalent to :man:`access(2)` on Unix. Windows uses ``GetFileAttributesW()``.
 
 .. c:function:: int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode, uv_fs_cb cb)
-.. c:function:: int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_file file, int mode, uv_fs_cb cb)
+.. c:function:: int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, int mode, uv_fs_cb cb)
 
     Equivalent to :man:`chmod(2)` and :man:`fchmod(2)` respectively.
 
 .. c:function:: int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime, double mtime, uv_fs_cb cb)
-.. c:function:: int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_file file, double atime, double mtime, uv_fs_cb cb)
+.. c:function:: int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, double atime, double mtime, uv_fs_cb cb)
 
     Equivalent to :man:`utime(2)` and :man:`futime(2)` respectively.
 
@@ -312,7 +312,7 @@ API
     .. versionadded:: 1.8.0
 
 .. c:function:: int uv_fs_chown(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
-.. c:function:: int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
+.. c:function:: int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
 
     Equivalent to :man:`chown(2)` and :man:`fchown(2)` respectively.
 
@@ -320,3 +320,19 @@ API
         These functions are not implemented on Windows.
 
 .. seealso:: The :c:type:`uv_req_t` API functions also apply.
+
+Helper functions
+----------------
+
+.. c:function:: uv_os_fd_t uv_convert_fd_to_handle(int fd)
+
+   Destructively converts a file descriptor in the C runtime
+   to the OS-dependent handle.
+   Upon return, the input ``fd`` parameter is invalid and closed.
+
+.. c:function:: uv_os_fd_t uv_get_osfhandle(int fd)
+
+   For a file descriptor in the C runtime, get the OS-dependent handle.
+   On UNIX, returns ``fd``. On Windows, this calls ``_get_osfhandle``.
+   Note that the return value is still owned by the C runtime,
+   any attempts to close it or to use it after closing the fd may lead to malfunction.

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -165,6 +165,8 @@ API
 
     Equivalent to :man:`close(2)`.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags, int mode, uv_fs_cb cb)
 
     Equivalent to :man:`open(2)`.
@@ -178,6 +180,8 @@ API
 
     Equivalent to :man:`preadv(2)`.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
     Equivalent to :man:`unlink(2)`.
@@ -185,6 +189,8 @@ API
 .. c:function:: int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`pwritev(2)`.
+
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
 
 .. c:function:: int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode, uv_fs_cb cb)
 
@@ -225,6 +231,8 @@ API
 
     Equivalent to :man:`stat(2)`, :man:`fstat(2)` and :man:`lstat(2)` respectively.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, const char* path, const char* new_path, uv_fs_cb cb)
 
     Equivalent to :man:`rename(2)`.
@@ -233,17 +241,25 @@ API
 
     Equivalent to :man:`fsync(2)`.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb)
 
     Equivalent to :man:`fdatasync(2)`.
+
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
 
 .. c:function:: int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`ftruncate(2)`.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t out_fd, uv_os_fd_t in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
 
     Limited equivalent to :man:`sendfile(2)`.
+
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
 
 .. c:function:: int uv_fs_access(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode, uv_fs_cb cb)
 
@@ -253,6 +269,8 @@ API
 .. c:function:: int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, int mode, uv_fs_cb cb)
 
     Equivalent to :man:`chmod(2)` and :man:`fchmod(2)` respectively.
+
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
 
 .. c:function:: int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime, double mtime, uv_fs_cb cb)
 .. c:function:: int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, double atime, double mtime, uv_fs_cb cb)
@@ -264,6 +282,7 @@ API
       versions but will return ``UV_ENOSYS``.
 
     .. versionchanged:: 1.10.0 sub-second precission is supported on Windows
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
 
 .. c:function:: int uv_fs_link(uv_loop_t* loop, uv_fs_t* req, const char* path, const char* new_path, uv_fs_cb cb)
 
@@ -319,6 +338,8 @@ API
     .. note::
         These functions are not implemented on Windows.
 
+    .. versionchanged:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. seealso:: The :c:type:`uv_req_t` API functions also apply.
 
 Helper functions
@@ -330,9 +351,18 @@ Helper functions
    to the OS-dependent handle.
    Upon return, the input ``fd`` parameter is invalid and closed.
 
+   This is only useful on Windows, where it calls DuplicateHandle
+   to make a new HANDLE independent from the MSVCRT library,
+   and then closes the handle out of the C runtime to avoid leaks
+   and to avoid having multiple handles open for the same underlying resource.
+
+    .. versionadded:: 2.0.0 replace uv_file with uv_os_fd_t
+
 .. c:function:: uv_os_fd_t uv_get_osfhandle(int fd)
 
    For a file descriptor in the C runtime, get the OS-dependent handle.
    On UNIX, returns ``fd``. On Windows, this calls ``_get_osfhandle``.
    Note that the return value is still owned by the C runtime,
    any attempts to close it or to use it after closing the fd may lead to malfunction.
+
+    .. versionadded:: 2.0.0 replace uv_file with uv_os_fd_t

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -211,6 +211,12 @@ just for some handle types.
         Be very careful when using this function. libuv assumes it's in control of the file
         descriptor so any change to it may lead to malfunction.
 
+.. c:function:: int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd)
+
+    Copies the platform dependent file descriptor handle.
+
+    Equivalent to :man:`dup(2)` and `DuplicateHandle <https://msdn.microsoft.com/en-us/library/windows/desktop/ms724251(v=vs.85).aspx>`_.
+    On Windows, do not call this on a SOCKET (uv_os_sock_t).
 
 .. _refcount:
 

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -211,13 +211,6 @@ just for some handle types.
         Be very careful when using this function. libuv assumes it's in control of the file
         descriptor so any change to it may lead to malfunction.
 
-.. c:function:: int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd)
-
-    Copies the platform dependent file descriptor handle.
-
-    Equivalent to :man:`dup(2)` and `DuplicateHandle <https://msdn.microsoft.com/en-us/library/windows/desktop/ms724251(v=vs.85).aspx>`_.
-    On Windows, do not call this on a SOCKET (uv_os_sock_t).
-
 .. _refcount:
 
 Reference counting

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -58,6 +58,7 @@ Migration guides for different libuv versions, starting with 1.0.
    :maxdepth: 1
 
    migration_010_100
+   migration_100_200
 
 
 Documentation

--- a/docs/src/migration_100_200.rst
+++ b/docs/src/migration_100_200.rst
@@ -25,6 +25,14 @@ Now those uses should be handled by passing the constant ``UV_STDIN_FD`` instead
 If instead a library had an open file descriptor inherited from some other library,
 instead of using the ``int fd`` directly, the value should first be converted to a native handle
 by either calling ``uv_convert_fd_to_handle`` or ``uv_get_osfhandle``, depending on the required lifetime.
-For example, a client might need to call ``int fd; uv_os_fd_t newfd; uv_dup(uv_get_osfhandle(fd), &newfd);``
+For example, a client might need to call::
+
+    int fd;
+    uv_os_fd_t newfd;
+    DuplicateHandle(GetCurrentProcess(), uv_get_osfhandle(fd),
+                    GetCurrentProcess(), &newfd,
+                    0, FALSE, DUPLICATE_SAME_ACCESS);
+
 to get a new handle to the file where either handle could be closed without affecting the other,
 and the closing of both would be required to release the underlying file resource.
+Or if it is a ``SOCKET``, the user may need to call ``WSADuplicateSocket``.

--- a/docs/src/migration_100_200.rst
+++ b/docs/src/migration_100_200.rst
@@ -1,0 +1,19 @@
+
+.. _migration_100_200:
+
+libuv v1 -> v2 migration guide
+===================================
+
+Some APIs changed quite a bit throughout the v2 development process. Here
+is a migration guide for the most significant changes that happened after v1
+was released.
+
+
+Windows HANDLEs are used instead of MSVCRT file descriptors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``uv_file`` typedef was deleted and replaced by ``uv_os_fd_t`` uniformly across all APIs.
+Constants ``UV_STDIN_FD``, ``UV_STDOUT_FD``, and ``UV_STDERR_FD`` provide cross-platform
+references to the standard constants for stdio access, and can be used in place of any ``uv_os_fd_t``.
+Existing clients can transition to the new API by using the conversion function ``uv_convert_fd_to_handle``
+defined in the libuv header file.

--- a/docs/src/migration_100_200.rst
+++ b/docs/src/migration_100_200.rst
@@ -17,3 +17,14 @@ Constants ``UV_STDIN_FD``, ``UV_STDOUT_FD``, and ``UV_STDERR_FD`` provide cross-
 references to the standard constants for stdio access, and can be used in place of any ``uv_os_fd_t``.
 Existing clients can transition to the new API by using the conversion function ``uv_convert_fd_to_handle``
 defined in the libuv header file.
+
+For example, previously a library might pass ``0`` or ``STDIN_FILENO`` to ``uv_guess_handle`` to determine its type
+before calling the appropriate uv_open function.
+Now those uses should be handled by passing the constant ``UV_STDIN_FD`` instead.
+
+If instead a library had an open file descriptor inherited from some other library,
+instead of using the ``int fd`` directly, the value should first be converted to a native handle
+by either calling ``uv_convert_fd_to_handle`` or ``uv_get_osfhandle``, depending on the required lifetime.
+For example, a client might need to call ``int fd; uv_os_fd_t newfd; uv_dup(uv_get_osfhandle(fd), &newfd);``
+to get a new handle to the file where either handle could be closed without affecting the other,
+and the closing of both would be required to release the underlying file resource.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -46,18 +46,15 @@ Data types
         Replacement function for :man:`free(3)`.
         See :c:func:`uv_replace_allocator`.
 
-.. c:type:: uv_file
+.. c:type:: uv_os_fd_t
 
     Cross platform representation of a file handle.
+    On Unix systems this is a `typedef` of `int` and on Windows a `HANDLE`.
 
 .. c:type:: uv_os_sock_t
 
     Cross platform representation of a socket handle.
-
-.. c:type:: uv_os_fd_t
-
-    Abstract representation of a file descriptor. On Unix systems this is a
-    `typedef` of `int` and on Windows a `HANDLE`.
+    On Unix systems this is a `typedef` of `int` and on Windows a `SOCKET`.
 
 .. c:type:: uv_rusage_t
 
@@ -143,7 +140,7 @@ Data types
 API
 ---
 
-.. c:function:: uv_handle_type uv_guess_handle(uv_file file)
+.. c:function:: uv_handle_type uv_guess_handle(uv_os_fd_t file)
 
     Used to detect what type of stream should be used with a given file
     descriptor. Usually this will be used during initialization to guess the
@@ -151,6 +148,9 @@ API
 
     For :man:`isatty(3)` equivalent functionality use this function and test
     for ``UV_TTY``.
+
+    STDIO file descriptor pseudo-handles ``UV_STDIN_FD``, ``UV_STDOUT_FD``, and ``UV_STDERR_FD``
+    can be passed to any uv_os_fd_t field for cross-platform support of stdio.
 
 .. c:function:: int uv_replace_allocator(uv_malloc_func malloc_func, uv_realloc_func realloc_func, uv_calloc_func calloc_func, uv_free_func free_func)
 

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -34,7 +34,7 @@ API
     Initialize a pipe handle. The `ipc` argument is a boolean to indicate if
     this pipe will be used for handle passing between processes.
 
-.. c:function:: int uv_pipe_open(uv_pipe_t* handle, uv_file file)
+.. c:function:: int uv_pipe_open(uv_pipe_t* handle, uv_os_fd_t file)
 
     Open an existing file descriptor or HANDLE as a pipe.
 

--- a/docs/src/poll.rst
+++ b/docs/src/poll.rst
@@ -69,18 +69,11 @@ N/A
 API
 ---
 
-.. c:function:: int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd)
+.. c:function:: int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, uv_os_sock_t socket)
 
     Initialize the handle using a file descriptor.
 
     .. versionchanged:: 1.2.2 the file descriptor is set to non-blocking mode.
-
-.. c:function:: int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle, uv_os_sock_t socket)
-
-    Initialize the handle using a socket descriptor. On Unix this is identical
-    to :c:func:`uv_poll_init`. On windows it takes a SOCKET handle.
-
-    .. versionchanged:: 1.2.2 the socket is set to non-blocking mode.
 
 .. c:function:: int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb)
 

--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -160,7 +160,7 @@ Public members
 
     .. note::
         On Windows file descriptors greater than 2 are available to the child process only if
-        the child processes uses the MSVCRT runtime.
+        the child executable uses the MSVCRT runtime.
 
 .. c:member:: uv_process_options_t.uid
 .. c:member:: uv_process_options_t.gid
@@ -179,7 +179,7 @@ Public members
 
 .. c:member:: uv_stdio_container_t.data
 
-    Union containing either the stream or fd to be passed on to the child
+    Union containing either the stream or fd handle to be passed on to the child
     process.
 
 

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -46,7 +46,7 @@ N/A
 API
 ---
 
-.. c:function:: int uv_tty_init(uv_loop_t* loop, uv_tty_t* handle, uv_file fd, int readable)
+.. c:function:: int uv_tty_init(uv_loop_t* loop, uv_tty_t* handle, uv_os_fd_t fd, int readable)
 
     Initialize a new TTY stream with the given file descriptor. Usually the
     file descriptor will be:

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -22,7 +22,9 @@
 #ifndef UV_ERRNO_H_
 #define UV_ERRNO_H_
 
+#ifndef _WIN32
 #include <errno.h>
+#endif
 
 #define UV__EOF     (-4095)
 #define UV__UNKNOWN (-4094)

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -125,7 +125,6 @@ typedef struct uv_buf_t {
   size_t len;
 } uv_buf_t;
 
-typedef int uv_file;
 typedef int uv_os_sock_t;
 typedef int uv_os_fd_t;
 
@@ -332,7 +331,7 @@ typedef struct {
 
 #define UV_FS_PRIVATE_FIELDS                                                  \
   const char *new_path;                                                       \
-  uv_file file;                                                               \
+  uv_os_fd_t file;                                                            \
   int flags;                                                                  \
   mode_t mode;                                                                \
   unsigned int nbufs;                                                         \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -133,7 +133,6 @@ typedef struct uv_buf_t {
   char* base;
 } uv_buf_t;
 
-typedef int uv_file;
 typedef SOCKET uv_os_sock_t;
 typedef HANDLE uv_os_fd_t;
 
@@ -473,14 +472,14 @@ typedef struct {
   union {                                                                     \
     /* TODO: remove me in 0.9. */                                             \
     WCHAR* pathw;                                                             \
-    int fd;                                                                   \
+    HANDLE hFile;                                                             \
   } file;                                                                     \
   union {                                                                     \
     struct {                                                                  \
       int mode;                                                               \
       WCHAR* new_pathw;                                                       \
       int file_flags;                                                         \
-      int fd_out;                                                             \
+      HANDLE hFile_out;                                                       \
       unsigned int nbufs;                                                     \
       uv_buf_t* bufs;                                                         \
       int64_t offset;                                                         \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -39,10 +39,6 @@ typedef intptr_t ssize_t;
 #include <ws2tcpip.h>
 #include <windows.h>
 
-#include <process.h>
-#include <signal.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <stdint.h>
 
 #include "tree.h"
@@ -54,30 +50,19 @@ typedef intptr_t ssize_t;
 # define S_IFLNK 0xA000
 #endif
 
-/* Additional signals supported by uv_signal and or uv_kill. The CRT defines
- * the following signals already:
- *
- *   #define SIGINT           2
- *   #define SIGILL           4
- *   #define SIGABRT_COMPAT   6
- *   #define SIGFPE           8
- *   #define SIGSEGV         11
- *   #define SIGTERM         15
- *   #define SIGBREAK        21
- *   #define SIGABRT         22
- *
- * The additional signals have values that are common on other Unix
- * variants (Linux and Darwin)
- */
+/* Signals supported by uv_signal and or uv_kill */
 #define SIGHUP                1
+#define SIGINT                2
+#define SIGILL                4
+#define SIGABRT_COMPAT        6
+#define SIGFPE                8
 #define SIGKILL               9
+#define SIGSEGV              11
+#define SIGTERM              15
+#define SIGBREAK             21
+#define SIGABRT              22
 #define SIGWINCH             28
 
-/* The CRT defines SIGABRT_COMPAT as 6, which equals SIGABRT on many */
-/* unix-like platforms. However MinGW doesn't define it, so we do. */
-#ifndef SIGABRT_COMPAT
-# define SIGABRT_COMPAT       6
-#endif
 
 typedef int (WSAAPI* LPFN_WSARECV)
             (SOCKET socket,

--- a/include/uv.h
+++ b/include/uv.h
@@ -450,7 +450,7 @@ UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
 # define INLINE inline
 #endif
 
-INLINE static uv_os_fd_t uv_get_osfhandle(int fd) {
+static INLINE uv_os_fd_t uv_get_osfhandle(int fd) {
 #ifdef _WIN32
   /*
    * _get_osfhandle() raises an assert in debug builds if the FD is invalid.
@@ -463,7 +463,7 @@ INLINE static uv_os_fd_t uv_get_osfhandle(int fd) {
 }
 
 
-INLINE static uv_os_fd_t uv_convert_fd_to_handle(int fd) {
+static INLINE uv_os_fd_t uv_convert_fd_to_handle(int fd) {
 #ifdef _WIN32
   HANDLE new_handle;
   if (!DuplicateHandle(GetCurrentProcess(), (HANDLE) _get_osfhandle(fd),

--- a/include/uv.h
+++ b/include/uv.h
@@ -429,7 +429,6 @@ UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value);
 UV_EXTERN int uv_recv_buffer_size(uv_handle_t* handle, int* value);
 
 UV_EXTERN int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd);
-UV_EXTERN int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd);
 
 UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
 
@@ -462,8 +461,11 @@ INLINE static uv_os_fd_t uv_get_osfhandle(int fd) {
 INLINE static uv_os_fd_t uv_convert_fd_to_handle(int fd) {
 #ifdef _WIN32
   HANDLE new_handle;
-  if (uv_dup((HANDLE) _get_osfhandle(fd), &new_handle))
+  if (!DuplicateHandle(GetCurrentProcess(), (HANDLE) _get_osfhandle(fd),
+                       GetCurrentProcess(), &new_handle,
+                       0, FALSE, DUPLICATE_SAME_ACCESS)) {
     return INVALID_HANDLE_VALUE;
+  }
   _close(fd);
   return new_handle;
 #else

--- a/include/uv.h
+++ b/include/uv.h
@@ -434,6 +434,12 @@ UV_EXTERN int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd);
 UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
 
 
+/*
+ * the following functions are declared 'static inline' to ensure that they
+ * end up in the static linkage namespace of the caller and thus point to
+ * the correct (caller's) copy of MSVCRT for resolving the `fd` pseudo-handle
+ * to the intended kernel `HANDLE`
+ */
 #ifdef _MSC_VER
 # define INLINE __inline
 #else

--- a/include/uv.h
+++ b/include/uv.h
@@ -444,8 +444,10 @@ UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
  * as their definition would not be correct when linked into that environment.
  */
 #if !defined(BUILDING_UV_SHARED)
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 # define INLINE __inline
+#elif defined(__GNUC__)
+# define INLINE __inline__
 #else
 # define INLINE inline
 #endif

--- a/src/loop-watcher.c
+++ b/src/loop-watcher.c
@@ -31,7 +31,7 @@
                                                                               \
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
-    if (cb == NULL) return -EINVAL;                                           \
+    if (cb == NULL) return -UV_EINVAL;                                        \
     QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -629,17 +629,6 @@ int uv__dup(int fd) {
 }
 
 
-int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
-  int fd2 = uv__dup(fd);
-  if (fd2 < 0) {
-    *dupfd = -1;
-    return fd2;
-  }
-  *dupfd = fd2;
-  return 0;
-}
-
-
 ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
   struct cmsghdr* cmsg;
   ssize_t rc;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -629,6 +629,17 @@ int uv__dup(int fd) {
 }
 
 
+int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
+  int fd2 = uv__dup(fd);
+  if (fd2 < 0) {
+    *dupfd = -1;
+    return fd2;
+  }
+  *dupfd = fd2;
+  return 0;
+}
+
+
 ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
   struct cmsghdr* cmsg;
   ssize_t rc;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -125,6 +125,21 @@
   }                                                                           \
   while (0)
 
+#define POST0                                                                 \
+  do {                                                                        \
+    if (cb != NULL) {                                                         \
+      uv__work_submit(loop, &req->work_req, uv__fs_work, uv__fs_done);        \
+      return 0;                                                               \
+    }                                                                         \
+    else {                                                                    \
+      uv__fs_work(&req->work_req);                                            \
+      if (req->result < 0)                                                    \
+        return req->result;                                                   \
+      return 0;                                                               \
+    }                                                                         \
+  }                                                                           \
+  while (0)
+
 
 static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
 #if defined(__linux__) || defined(__sun) || defined(__NetBSD__)
@@ -1034,7 +1049,7 @@ int uv_fs_chown(uv_loop_t* loop,
 }
 
 
-int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
+int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb) {
   INIT(CLOSE);
   req->file = file;
   POST;
@@ -1043,7 +1058,7 @@ int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
 
 int uv_fs_fchmod(uv_loop_t* loop,
                  uv_fs_t* req,
-                 uv_file file,
+                 uv_os_fd_t file,
                  int mode,
                  uv_fs_cb cb) {
   INIT(FCHMOD);
@@ -1055,7 +1070,7 @@ int uv_fs_fchmod(uv_loop_t* loop,
 
 int uv_fs_fchown(uv_loop_t* loop,
                  uv_fs_t* req,
-                 uv_file file,
+                 uv_os_fd_t file,
                  uv_uid_t uid,
                  uv_gid_t gid,
                  uv_fs_cb cb) {
@@ -1067,21 +1082,21 @@ int uv_fs_fchown(uv_loop_t* loop,
 }
 
 
-int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
+int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb) {
   INIT(FDATASYNC);
   req->file = file;
   POST;
 }
 
 
-int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
+int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb) {
   INIT(FSTAT);
   req->file = file;
   POST;
 }
 
 
-int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
+int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t file, uv_fs_cb cb) {
   INIT(FSYNC);
   req->file = file;
   POST;
@@ -1090,7 +1105,7 @@ int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
 
 int uv_fs_ftruncate(uv_loop_t* loop,
                     uv_fs_t* req,
-                    uv_file file,
+                    uv_os_fd_t file,
                     int64_t off,
                     uv_fs_cb cb) {
   INIT(FTRUNCATE);
@@ -1102,7 +1117,7 @@ int uv_fs_ftruncate(uv_loop_t* loop,
 
 int uv_fs_futime(uv_loop_t* loop,
                  uv_fs_t* req,
-                 uv_file file,
+                 uv_os_fd_t file,
                  double atime,
                  double mtime,
                  uv_fs_cb cb) {
@@ -1169,12 +1184,12 @@ int uv_fs_open(uv_loop_t* loop,
   PATH;
   req->flags = flags;
   req->mode = mode;
-  POST;
+  POST0;
 }
 
 
 int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
-               uv_file file,
+               uv_os_fd_t file,
                const uv_buf_t bufs[],
                unsigned int nbufs,
                int64_t off,
@@ -1255,8 +1270,8 @@ int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
 
 int uv_fs_sendfile(uv_loop_t* loop,
                    uv_fs_t* req,
-                   uv_file out_fd,
-                   uv_file in_fd,
+                   uv_os_fd_t out_fd,
+                   uv_os_fd_t in_fd,
                    int64_t off,
                    size_t len,
                    uv_fs_cb cb) {
@@ -1312,7 +1327,7 @@ int uv_fs_utime(uv_loop_t* loop,
 
 int uv_fs_write(uv_loop_t* loop,
                 uv_fs_t* req,
-                uv_file file,
+                uv_os_fd_t file,
                 const uv_buf_t bufs[],
                 unsigned int nbufs,
                 int64_t off,

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -137,7 +137,7 @@ void uv__pipe_close(uv_pipe_t* handle) {
 }
 
 
-int uv_pipe_open(uv_pipe_t* handle, uv_file fd) {
+int uv_pipe_open(uv_pipe_t* handle, uv_os_fd_t fd) {
   int err;
 
   err = uv__nonblock(fd, 1);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -77,12 +77,6 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
 }
 
 
-int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
-    uv_os_sock_t socket) {
-  return uv_poll_init(loop, handle, socket);
-}
-
-
 static void uv__poll_stop(uv_poll_t* handle) {
   uv__io_stop(handle->loop,
               &handle->io_watcher,

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -205,7 +205,7 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
   case UV_INHERIT_FD:
   case UV_INHERIT_STREAM:
     if (container->flags & UV_INHERIT_FD)
-      fd = container->data.fd;
+      fd = container->data.file;
     else
       fd = uv__stream_fd(container->data.stream);
 

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -253,7 +253,7 @@ int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
 }
 
 
-uv_handle_type uv_guess_handle(uv_file file) {
+uv_handle_type uv_guess_handle(uv_os_fd_t file) {
   struct sockaddr sa;
   struct stat s;
   socklen_t len;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -26,7 +26,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <stddef.h> /* NULL */
-#include <stdio.h>
+#include <stdio.h> /* FILE, printf */
 #include <stdlib.h> /* malloc */
 #include <string.h> /* memset */
 
@@ -366,7 +366,7 @@ void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
 }
 
 
-static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
+static void uv__print_handles(uv_loop_t* loop, int only_active, void* stream) {
   const char* type;
   QUEUE* q;
   uv_handle_t* h;
@@ -398,12 +398,12 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
 }
 
 
-void uv_print_all_handles(uv_loop_t* loop, FILE* stream) {
+void uv_print_all_handles(uv_loop_t* loop, void* stream) {
   uv__print_handles(loop, 0, stream);
 }
 
 
-void uv_print_active_handles(uv_loop_t* loop, FILE* stream) {
+void uv_print_active_handles(uv_loop_t* loop, void* stream) {
   uv__print_handles(loop, 1, stream);
 }
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -192,7 +192,7 @@ void uv__fs_scandir_cleanup(uv_fs_t* req);
   (((h)->flags & UV__HANDLE_REF) != 0)
 
 #if defined(_WIN32)
-# define uv__handle_platform_init(h) ((h)->u.fd = -1)
+# define uv__handle_platform_init(h)
 #else
 # define uv__handle_platform_init(h) ((h)->next_closing = NULL)
 #endif

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -83,9 +83,6 @@ static void uv_init(void) {
   /* Initialize winsock */
   uv_winsock_init();
 
-  /* Initialize FS */
-  uv_fs_init();
-
   /* Initialize signal stuff */
   uv_signals_init();
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -21,9 +21,7 @@
 
 #include <assert.h>
 #include <limits.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -20,12 +20,10 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <crtdbg.h>
 
 #include "uv.h"
 #include "internal.h"
@@ -36,45 +34,6 @@
 
 /* uv_once initialization guards */
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
-
-
-#if defined(_DEBUG)
-/* Our crt debug report handler allows us to temporarily disable asserts
- * just for the current thread.
- */
-
-UV_THREAD_LOCAL int uv__crt_assert_enabled = TRUE;
-
-static int uv__crt_dbg_report_handler(int report_type, char *message, int *ret_val) {
-  if (uv__crt_assert_enabled || report_type != _CRT_ASSERT)
-    return FALSE;
-
-  if (ret_val) {
-    /* Set ret_val to 0 to continue with normal execution.
-     * Set ret_val to 1 to trigger a breakpoint.
-    */
-
-    if(IsDebuggerPresent())
-      *ret_val = 1;
-    else
-      *ret_val = 0;
-  }
-
-  /* Don't call _CrtDbgReport. */
-  return TRUE;
-}
-#else
-UV_THREAD_LOCAL int uv__crt_assert_enabled = FALSE;
-#endif
-
-
-#if __MSVCRT_VERSION__ >= 0x800
-static void uv__crt_invalid_parameter_handler(const wchar_t* expression,
-    const wchar_t* function, const wchar_t * file, unsigned int line,
-    uintptr_t reserved) {
-  /* No-op. */
-}
-#endif
 
 static void* uv__loops[2];
 static uv_mutex_t uv__loops_lock;
@@ -112,21 +71,6 @@ static void uv_init(void) {
   /* Tell Windows that we will handle critical errors. */
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
                SEM_NOOPENFILEERRORBOX);
-
-  /* Tell the CRT to not exit the application when an invalid parameter is
-   * passed. The main issue is that invalid FDs will trigger this behavior.
-   */
-#if __MSVCRT_VERSION__ >= 0x800
-  _set_invalid_parameter_handler(uv__crt_invalid_parameter_handler);
-#endif
-
-  /* We also need to setup our debug report handler because some CRT
-   * functions (eg _get_osfhandle) raise an assert when called with invalid
-   * FDs even though they return the proper error code in the release build.
-   */
-#if defined(_DEBUG)
-  _CrtSetReportHook(uv__crt_dbg_report_handler);
-#endif
 
   /* Initialize tracking of all uv loops */
   uv__loops_init();

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -20,9 +20,8 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <stdio.h> /* printf */
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -20,8 +20,7 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <string.h>
+#include <stdio.h> /* printf */
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -118,11 +118,6 @@ const WCHAR UNC_PATH_PREFIX[] = L"\\\\?\\UNC\\";
 const WCHAR UNC_PATH_PREFIX_LEN = 8;
 
 
-void uv_fs_init() {
-  _fmode = _O_BINARY;
-}
-
-
 INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
     const char* new_path, const int copy_path) {
   char* buf;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -23,12 +23,9 @@
 #include <stdlib.h>
 #include <direct.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <io.h>
 #include <limits.h>
-#include <sys/stat.h>
-#include <sys/utime.h>
-#include <stdio.h>
+#include <fcntl.h> /* file constants */
+#include <sys/stat.h> /* stat constants */
 
 #include "uv.h"
 #include "internal.h"
@@ -42,6 +39,8 @@
 #define UV_FS_FREE_PTR           0x0008
 #define UV_FS_CLEANEDUP          0x0010
 
+/* number of attempts to generate a unique directory name before declaring failure */
+#define TMP_MAX 32767
 
 #define QUEUE_FS_TP_JOB(loop, req)                                          \
   do {                                                                      \

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -20,7 +20,6 @@
 */
 
 #include <assert.h>
-#include <stdio.h>
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/handle-inl.h
+++ b/src/win/handle-inl.h
@@ -23,7 +23,6 @@
 #define UV_WIN_HANDLE_INL_H_
 
 #include <assert.h>
-#include <io.h>
 
 #include "uv.h"
 #include "internal.h"
@@ -159,20 +158,6 @@ INLINE static void uv_process_endgames(uv_loop_t* loop) {
         break;
     }
   }
-}
-
-INLINE static HANDLE uv__get_osfhandle(int fd)
-{
-  /* _get_osfhandle() raises an assert in debug builds if the FD is invalid. */
-  /* But  it also correctly checks the FD and returns INVALID_HANDLE_VALUE */
-  /* for invalid FDs in release builds (or if you let the assert continue).  */
-  /* So this wrapper function disables asserts when calling _get_osfhandle. */
-
-  HANDLE handle;
-  UV_BEGIN_DISABLE_CRT_ASSERT();
-  handle = (HANDLE) _get_osfhandle(fd);
-  UV_END_DISABLE_CRT_ASSERT();
-  return handle;
 }
 
 #endif /* UV_WIN_HANDLE_INL_H_ */

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <io.h>
 #include <stdlib.h>
 
 #include "uv.h"

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -28,15 +28,12 @@
 #include "handle-inl.h"
 
 
-uv_handle_type uv_guess_handle(uv_file file) {
-  HANDLE handle;
+uv_handle_type uv_guess_handle(uv_os_fd_t handle) {
   DWORD mode;
 
-  if (file < 0) {
+  if (handle == INVALID_HANDLE_VALUE) {
     return UV_UNKNOWN_HANDLE;
   }
-
-  handle = uv__get_osfhandle(file);
 
   switch (GetFileType(handle)) {
     case FILE_TYPE_CHAR:

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -100,6 +100,7 @@
 /*
  * Streams: see stream-inl.h
  */
+int uv__dup(uv_os_fd_t fd, uv_os_fd_t* dupfd);
 
 
 /*

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -270,12 +270,6 @@ int uv_translate_sys_error(int sys_errno);
 
 
 /*
- * FS
- */
-void uv_fs_init();
-
-
-/*
  * FS Event
  */
 void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -38,25 +38,6 @@
 #endif
 
 
-#ifdef _DEBUG
-
-extern UV_THREAD_LOCAL int uv__crt_assert_enabled;
-
-#define UV_BEGIN_DISABLE_CRT_ASSERT()                           \
-  {                                                             \
-    int uv__saved_crt_assert_enabled = uv__crt_assert_enabled;  \
-    uv__crt_assert_enabled = FALSE;
-
-
-#define UV_END_DISABLE_CRT_ASSERT()                             \
-    uv__crt_assert_enabled = uv__saved_crt_assert_enabled;      \
-  }
-
-#else
-#define UV_BEGIN_DISABLE_CRT_ASSERT()
-#define UV_END_DISABLE_CRT_ASSERT()
-#endif
-
 /*
  * Handles
  * (also see handle-inl.h)

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -180,13 +180,7 @@ static HANDLE open_named_pipe(const WCHAR* name, DWORD* duplex_flags) {
 
 
 static void close_pipe(uv_pipe_t* pipe) {
-  assert(pipe->u.fd == -1 || pipe->u.fd > 2);
-  if (pipe->u.fd == -1)
-    CloseHandle(pipe->handle);
-  else
-    close(pipe->u.fd);
-
-  pipe->u.fd = -1;
+  CloseHandle(pipe->handle);
   pipe->handle = INVALID_HANDLE_VALUE;
 }
 
@@ -244,7 +238,6 @@ int uv_stdio_pipe_server(uv_loop_t* loop, uv_pipe_t* handle, DWORD access,
 static int uv_set_pipe_handle(uv_loop_t* loop,
                               uv_pipe_t* handle,
                               HANDLE pipeHandle,
-                              int fd,
                               DWORD duplex_flags) {
   NTSTATUS nt_status;
   IO_STATUS_BLOCK io_status;
@@ -308,7 +301,6 @@ static int uv_set_pipe_handle(uv_loop_t* loop,
   }
 
   handle->handle = pipeHandle;
-  handle->u.fd = fd;
   handle->flags |= duplex_flags;
 
   return 0;
@@ -551,7 +543,6 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   if (uv_set_pipe_handle(loop,
                          handle,
                          handle->pipe.serv.accept_reqs[0].pipeHandle,
-                         -1,
                          0)) {
     err = GetLastError();
     goto error;
@@ -605,7 +596,7 @@ static DWORD WINAPI pipe_connect_thread_proc(void* parameter) {
   }
 
   if (pipeHandle != INVALID_HANDLE_VALUE &&
-      !uv_set_pipe_handle(loop, handle, pipeHandle, -1, duplex_flags)) {
+      !uv_set_pipe_handle(loop, handle, pipeHandle, duplex_flags)) {
     SET_REQ_SUCCESS(req);
   } else {
     SET_REQ_ERROR(req, GetLastError());
@@ -673,7 +664,6 @@ void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle,
   if (uv_set_pipe_handle(loop,
                          (uv_pipe_t*) req->handle,
                          pipeHandle,
-                         -1,
                          duplex_flags)) {
     err = GetLastError();
     goto error;
@@ -815,7 +805,7 @@ static void uv_pipe_queue_accept(uv_loop_t* loop, uv_pipe_t* handle,
       return;
     }
 
-    if (uv_set_pipe_handle(loop, handle, req->pipeHandle, -1, 0)) {
+    if (uv_set_pipe_handle(loop, handle, req->pipeHandle, 0)) {
       CloseHandle(req->pipeHandle);
       req->pipeHandle = INVALID_HANDLE_VALUE;
       SET_REQ_ERROR(req, GetLastError());
@@ -1899,8 +1889,7 @@ static void eof_timer_close_cb(uv_handle_t* handle) {
 }
 
 
-int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
-  HANDLE os_handle = uv__get_osfhandle(file);
+int uv_pipe_open(uv_pipe_t* pipe, uv_os_fd_t os_handle) {
   NTSTATUS nt_status;
   IO_STATUS_BLOCK io_status;
   FILE_ACCESS_INFORMATION access;
@@ -1909,22 +1898,13 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
   if (os_handle == INVALID_HANDLE_VALUE)
     return UV_EBADF;
 
-  /* In order to avoid closing a stdio file descriptor 0-2, duplicate the
-   * underlying OS handle and forget about the original fd.
-   * We could also opt to use the original OS handle and just never close it,
-   * but then there would be no reliable way to cancel pending read operations
-   * upon close.
+  /* In order to avoid closing a stdio pseudo-handle, or having it get replaced under us,
+   * duplicate the underlying OS handle and forget about the original one.
    */
-  if (file <= 2) {
-    if (!DuplicateHandle(INVALID_HANDLE_VALUE,
-                         os_handle,
-                         INVALID_HANDLE_VALUE,
-                         &os_handle,
-                         0,
-                         FALSE,
-                         DUPLICATE_SAME_ACCESS))
-      return uv_translate_sys_error(GetLastError());
-    file = -1;
+  if (os_handle == UV_STDIN_FD || os_handle == UV_STDOUT_FD || os_handle == UV_STDERR_FD) {
+    int dup_err = uv_dup(os_handle, &os_handle);
+    if (dup_err)
+      return dup_err;
   }
 
   /* Determine what kind of permissions we have on this handle.
@@ -1955,7 +1935,6 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
       uv_set_pipe_handle(pipe->loop,
                          pipe,
                          os_handle,
-                         file,
                          duplex_flags) == -1) {
     return UV_EINVAL;
   }

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -20,10 +20,8 @@
  */
 
 #include <assert.h>
-#include <io.h>
-#include <string.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h> /* printf */
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1902,7 +1902,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_os_fd_t os_handle) {
    * duplicate the underlying OS handle and forget about the original one.
    */
   if (os_handle == UV_STDIN_FD || os_handle == UV_STDOUT_FD || os_handle == UV_STDERR_FD) {
-    int dup_err = uv_dup(os_handle, &os_handle);
+    int dup_err = uv__dup(os_handle, &os_handle);
     if (dup_err)
       return dup_err;
   }

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -505,12 +505,7 @@ static int uv__slow_poll_close(uv_loop_t* loop, uv_poll_t* handle) {
 }
 
 
-int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
-  return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
-}
-
-
-int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle,
     uv_os_sock_t socket) {
   WSAPROTOCOL_INFOW protocol_info;
   int len;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -20,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <io.h>
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -190,49 +190,38 @@ static int uv__create_stdio_pipe_pair(uv_loop_t* loop,
 }
 
 
-static int uv__duplicate_handle(uv_loop_t* loop, HANDLE handle, HANDLE* dup) {
+int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
   HANDLE current_process;
 
+  if (fd == UV_STDIN_FD || fd == UV_STDOUT_FD || fd == UV_STDERR_FD)
+    fd = GetStdHandle((DWORD)(uintptr_t) fd);
 
   /* _get_osfhandle will sometimes return -2 in case of an error. This seems */
   /* to happen when fd <= 2 and the process' corresponding stdio handle is */
   /* set to NULL. Unfortunately DuplicateHandle will happily duplicate */
   /* (HANDLE) -2, so this situation goes unnoticed until someone tries to */
   /* use the duplicate. Therefore we filter out known-invalid handles here. */
-  if (handle == INVALID_HANDLE_VALUE ||
-      handle == NULL ||
-      handle == (HANDLE) -2) {
-    *dup = INVALID_HANDLE_VALUE;
+  if (fd == INVALID_HANDLE_VALUE ||
+      fd == NULL ||
+      fd == (HANDLE) -2) {
+    *dupfd = INVALID_HANDLE_VALUE;
     return ERROR_INVALID_HANDLE;
   }
 
   current_process = GetCurrentProcess();
 
   if (!DuplicateHandle(current_process,
-                       handle,
+                       fd,
                        current_process,
-                       dup,
+                       dupfd,
                        0,
                        TRUE,
                        DUPLICATE_SAME_ACCESS)) {
-    *dup = INVALID_HANDLE_VALUE;
+    *dupfd = INVALID_HANDLE_VALUE;
     return GetLastError();
   }
 
   return 0;
-}
-
-
-static int uv__duplicate_fd(uv_loop_t* loop, int fd, HANDLE* dup) {
-  HANDLE handle;
-
-  if (fd == -1) {
-    *dup = INVALID_HANDLE_VALUE;
-    return ERROR_INVALID_HANDLE;
-  }
-
-  handle = uv__get_osfhandle(fd);
-  return uv__duplicate_handle(loop, handle, dup);
 }
 
 
@@ -352,11 +341,14 @@ int uv__stdio_create(uv_loop_t* loop,
         HANDLE child_handle;
 
         /* Make an inheritable duplicate of the handle. */
-        err = uv__duplicate_fd(loop, fdopt.data.fd, &child_handle);
+        err = uv_dup(fdopt.data.file, &child_handle);
         if (err) {
-          /* If fdopt.data.fd is not valid and fd fd <= 2, then ignore the */
-          /* error. */
-          if (fdopt.data.fd <= 2 && err == ERROR_INVALID_HANDLE) {
+          /* If fdopt.data.file is pointing at one of the pseudo stdio handles,
+           * but it is not valid ignore the error. */
+          if ((fdopt.data.file == UV_STDIN_FD ||
+               fdopt.data.file == UV_STDOUT_FD ||
+               fdopt.data.file == UV_STDERR_FD) &&
+              err == ERROR_INVALID_HANDLE) {
             CHILD_STDIO_CRT_FLAGS(buffer, i) = 0;
             CHILD_STDIO_HANDLE(buffer, i) = INVALID_HANDLE_VALUE;
             break;
@@ -425,7 +417,7 @@ int uv__stdio_create(uv_loop_t* loop,
         }
 
         /* Make an inheritable copy of the handle. */
-        err = uv__duplicate_handle(loop, stream_handle, &child_handle);
+        err = uv_dup(stream_handle, &child_handle);
         if (err)
           goto error;
 

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -190,7 +190,7 @@ static int uv__create_stdio_pipe_pair(uv_loop_t* loop,
 }
 
 
-int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
+int uv__dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
   HANDLE current_process;
 
   if (fd == UV_STDIN_FD || fd == UV_STDOUT_FD || fd == UV_STDERR_FD)
@@ -341,7 +341,7 @@ int uv__stdio_create(uv_loop_t* loop,
         HANDLE child_handle;
 
         /* Make an inheritable duplicate of the handle. */
-        err = uv_dup(fdopt.data.file, &child_handle);
+        err = uv__dup(fdopt.data.file, &child_handle);
         if (err) {
           /* If fdopt.data.file is pointing at one of the pseudo stdio handles,
            * but it is not valid ignore the error. */
@@ -417,7 +417,7 @@ int uv__stdio_create(uv_loop_t* loop,
         }
 
         /* Make an inheritable copy of the handle. */
-        err = uv_dup(stream_handle, &child_handle);
+        err = uv__dup(stream_handle, &child_handle);
         if (err)
           goto error;
 

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -20,8 +20,6 @@
  */
 
 #include <assert.h>
-#include <io.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "uv.h"

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -20,10 +20,7 @@
  */
 
 #include <assert.h>
-#include <io.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <signal.h>
 #include <limits.h>
 #include <wchar.h>
 #include <malloc.h>    /* alloca */
@@ -32,9 +29,6 @@
 #include "internal.h"
 #include "handle-inl.h"
 #include "req-inl.h"
-
-
-#define SIGKILL         9
 
 
 typedef struct env_var {

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -22,6 +22,8 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <process.h> /* _beginthreadex */
+#include <errno.h> /* _beginthreadex errors */
 
 #include "uv.h"
 #include "internal.h"

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -20,8 +20,6 @@
  */
 
 #include <assert.h>
-#include <io.h>
-#include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -629,7 +629,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 
   DWORD records_left, records_read;
   uv_buf_t buf;
-  off_t buf_used;
+  ssize_t buf_used;
 
   assert(handle->type == UV_TTY);
   assert(handle->flags & UV_HANDLE_TTY_READABLE);

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -139,30 +139,19 @@ void uv_console_init() {
 }
 
 
-int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
-  HANDLE handle;
+int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_os_fd_t handle, int readable) {
   CONSOLE_SCREEN_BUFFER_INFO screen_buffer_info;
 
-  handle = (HANDLE) uv__get_osfhandle(fd);
   if (handle == INVALID_HANDLE_VALUE)
     return UV_EBADF;
 
-  if (fd <= 2) {
-    /* In order to avoid closing a stdio file descriptor 0-2, duplicate the
-     * underlying OS handle and forget about the original fd.
-     * We could also opt to use the original OS handle and just never close it,
-     * but then there would be no reliable way to cancel pending read operations
-     * upon close.
+  if (handle == UV_STDIN_FD || handle == UV_STDOUT_FD || handle == UV_STDERR_FD) {
+    /* In order to avoid closing a stdio pseudo-handle, or having it get replaced under us,
+     * duplicate the underlying OS handle and forget about the original one.
      */
-    if (!DuplicateHandle(INVALID_HANDLE_VALUE,
-                         handle,
-                         INVALID_HANDLE_VALUE,
-                         &handle,
-                         0,
-                         FALSE,
-                         DUPLICATE_SAME_ACCESS))
-      return uv_translate_sys_error(GetLastError());
-    fd = -1;
+    int dup_err = uv_dup(handle, &handle);
+    if (dup_err)
+      return dup_err;
   }
 
   if (!readable) {
@@ -196,7 +185,6 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int readable) {
   uv_connection_init((uv_stream_t*) tty);
 
   tty->handle = handle;
-  tty->u.fd = fd;
   tty->reqs_pending = 0;
   tty->flags |= UV_HANDLE_BOUND;
 
@@ -351,9 +339,9 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
 }
 
 
-int uv_is_tty(uv_file file) {
+int uv_is_tty(uv_os_fd_t file) {
   DWORD result;
-  return GetConsoleMode((HANDLE) _get_osfhandle(file), &result) != 0;
+  return GetConsoleMode(file, &result) != 0;
 }
 
 
@@ -2180,16 +2168,11 @@ void uv_process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
 
 
 void uv_tty_close(uv_tty_t* handle) {
-  assert(handle->u.fd == -1 || handle->u.fd > 2);
-  if (handle->u.fd == -1)
-    CloseHandle(handle->handle);
-  else
-    close(handle->u.fd);
+  CloseHandle(handle->handle);
 
   if (handle->flags & UV_HANDLE_READING)
     uv_tty_read_stop(handle);
 
-  handle->u.fd = -1;
   handle->handle = INVALID_HANDLE_VALUE;
   handle->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
   uv__handle_closing(handle);

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -149,7 +149,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_os_fd_t handle, int readable)
     /* In order to avoid closing a stdio pseudo-handle, or having it get replaced under us,
      * duplicate the underlying OS handle and forget about the original one.
      */
-    int dup_err = uv_dup(handle, &handle);
+    int dup_err = uv__dup(handle, &handle);
     if (dup_err)
       return dup_err;
   }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -22,9 +22,6 @@
 #include <assert.h>
 #include <direct.h>
 #include <limits.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
 #include <wchar.h>
 
 #include "uv.h"

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -39,6 +39,8 @@ int platform_init(int argc, char **argv) {
   _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
   _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG);
 
+  /* make output mode sane */
+  _fmode = _O_BINARY;
   _setmode(0, _O_BINARY);
   _setmode(1, _O_BINARY);
   _setmode(2, _O_BINARY);

--- a/test/task.h
+++ b/test/task.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifdef _WIN32
-# include <io.h>
+# include <sys/stat.h>
 # ifndef S_IRUSR
 #  define S_IRUSR _S_IREAD
 # endif

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -84,7 +84,7 @@ static void create_file(const char* name) {
 
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);
@@ -99,7 +99,7 @@ static void touch_file(const char* name) {
 
   r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
   ASSERT(r == 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   buf = uv_buf_init("foo", 4);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -79,12 +79,12 @@ static void create_dir(const char* name) {
 
 static void create_file(const char* name) {
   int r;
-  uv_file file;
+  uv_os_fd_t file;
   uv_fs_t req;
 
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  file = r;
+  ASSERT(r == 0);
+  file = req.result;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);
@@ -93,13 +93,13 @@ static void create_file(const char* name) {
 
 static void touch_file(const char* name) {
   int r;
-  uv_file file;
+  uv_os_fd_t file;
   uv_fs_t req;
   uv_buf_t buf;
 
   r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  file = r;
+  ASSERT(r == 0);
+  file = req.result;
   uv_fs_req_cleanup(&req);
 
   buf = uv_buf_init("foo", 4);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1028,7 +1028,7 @@ TEST_IMPL(fs_async_sendfile) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req2.result >= 0);
-  file2 = (uv_os_fd_t*)open_req2.result;
+  file2 = (uv_os_fd_t)open_req2.result;
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_sendfile(loop, &sendfile_req, file2, file1,
@@ -1571,7 +1571,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = (uv_os_fd_t*)req.result;
+  link = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1596,7 +1596,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = (uv_os_fd_t*)req.result;
+  link = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1740,7 +1740,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = (uv_os_fd_t*)req.result;
+  link = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1793,7 +1793,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = (uv_os_fd_t*)req.result;
+  link = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -280,7 +280,7 @@ static void close_cb(uv_fs_t* req) {
 
 static void ftruncate_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &ftruncate_req);
   ASSERT(req->fs_type == UV_FS_FTRUNCATE);
   ASSERT(req->result == 0);
@@ -293,7 +293,7 @@ static void ftruncate_cb(uv_fs_t* req) {
 
 static void read_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &read_req);
   ASSERT(req->fs_type == UV_FS_READ);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
@@ -313,7 +313,7 @@ static void read_cb(uv_fs_t* req) {
 
 static void open_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &open_req1);
   ASSERT(req->fs_type == UV_FS_OPEN);
   if (req->result < 0) {
@@ -346,7 +346,7 @@ static void open_cb_simple(uv_fs_t* req) {
 
 static void fsync_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &fsync_req);
   ASSERT(req->fs_type == UV_FS_FSYNC);
   ASSERT(req->result == 0);
@@ -359,7 +359,7 @@ static void fsync_cb(uv_fs_t* req) {
 
 static void fdatasync_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &fdatasync_req);
   ASSERT(req->fs_type == UV_FS_FDATASYNC);
   ASSERT(req->result == 0);
@@ -372,7 +372,7 @@ static void fdatasync_cb(uv_fs_t* req) {
 
 static void write_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &write_req);
   ASSERT(req->fs_type == UV_FS_WRITE);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
@@ -385,7 +385,7 @@ static void write_cb(uv_fs_t* req) {
 
 static void create_cb(uv_fs_t* req) {
   int r;
-  uv_os_fd_t file = open_req1.result;
+  uv_os_fd_t file = (uv_os_fd_t)open_req1.result;
   ASSERT(req == &open_req1);
   ASSERT(req->fs_type == UV_FS_OPEN);
   ASSERT(req->result >= 0);
@@ -784,7 +784,7 @@ TEST_IMPL(fs_file_sync) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -801,7 +801,7 @@ TEST_IMPL(fs_file_sync) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -829,7 +829,7 @@ TEST_IMPL(fs_file_sync) {
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -872,7 +872,7 @@ TEST_IMPL(fs_file_write_null_buffer) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(NULL, 0);
@@ -915,7 +915,7 @@ TEST_IMPL(fs_async_dir) {
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
@@ -924,7 +924,7 @@ TEST_IMPL(fs_async_dir) {
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
@@ -1021,14 +1021,14 @@ TEST_IMPL(fs_async_sendfile) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file1 = open_req1.result;
+  file1 = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req2.result >= 0);
-  file2 = open_req2.result;
+  file2 = (uv_os_fd_t*)open_req2.result;
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_sendfile(loop, &sendfile_req, file2, file1,
@@ -1107,7 +1107,7 @@ TEST_IMPL(fs_fstat) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1251,7 +1251,7 @@ TEST_IMPL(fs_access) {
                  S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
@@ -1312,7 +1312,7 @@ TEST_IMPL(fs_chmod) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1418,7 +1418,7 @@ TEST_IMPL(fs_unlink_readonly) {
                  NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1477,7 +1477,7 @@ TEST_IMPL(fs_chown) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   /* sync chown */
@@ -1547,7 +1547,7 @@ TEST_IMPL(fs_link) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1571,7 +1571,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = req.result;
+  link = (uv_os_fd_t*)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1596,7 +1596,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = req.result;
+  link = (uv_os_fd_t*)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1699,7 +1699,7 @@ TEST_IMPL(fs_symlink) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1740,7 +1740,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = req.result;
+  link = (uv_os_fd_t*)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1793,7 +1793,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  link = req.result;
+  link = (uv_os_fd_t*)req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
@@ -1925,7 +1925,7 @@ TEST_IMPL(fs_symlink_dir) {
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
@@ -1934,7 +1934,7 @@ TEST_IMPL(fs_symlink_dir) {
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
@@ -1997,7 +1997,7 @@ TEST_IMPL(fs_utime) {
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
@@ -2100,7 +2100,7 @@ TEST_IMPL(fs_futime) {
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
@@ -2123,7 +2123,7 @@ TEST_IMPL(fs_futime) {
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
-  file = req.result; /* FIXME probably not how it's supposed to be used */
+  file = (uv_os_fd_t)req.result; /* FIXME probably not how it's supposed to be used */
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_futime(NULL, &req, file, atime, mtime, NULL);
@@ -2281,7 +2281,7 @@ TEST_IMPL(fs_open_dir) {
   ASSERT(r == 0);
   ASSERT(req.result >= 0);
   ASSERT(req.ptr == NULL);
-  file = req.result;
+  file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -2312,7 +2312,7 @@ TEST_IMPL(fs_file_open_append) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -2329,7 +2329,7 @@ TEST_IMPL(fs_file_open_append) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | O_APPEND, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -2346,7 +2346,7 @@ TEST_IMPL(fs_file_open_append) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -2386,7 +2386,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -2404,7 +2404,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
@@ -2420,7 +2420,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -2458,7 +2458,7 @@ TEST_IMPL(fs_read_file_eof) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -2475,7 +2475,7 @@ TEST_IMPL(fs_read_file_eof) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -2520,7 +2520,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iovs[0] = uv_buf_init(test_buf, sizeof(test_buf));
@@ -2538,7 +2538,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -2597,7 +2597,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
                  NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   for (index = 0; index < iovcount; ++index)
@@ -2687,7 +2687,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
                  NULL);
   ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
-  file = open_req1.result;
+  file = (uv_os_fd_t)open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(filler, filler_len);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -280,18 +280,20 @@ static void close_cb(uv_fs_t* req) {
 
 static void ftruncate_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &ftruncate_req);
   ASSERT(req->fs_type == UV_FS_FTRUNCATE);
   ASSERT(req->result == 0);
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
-  r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
+  r = uv_fs_close(loop, &close_req, file, close_cb);
   ASSERT(r == 0);
 }
 
 
 static void read_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &read_req);
   ASSERT(req->fs_type == UV_FS_READ);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
@@ -299,11 +301,11 @@ static void read_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   if (read_cb_count == 1) {
     ASSERT(strcmp(buf, test_buf) == 0);
-    r = uv_fs_ftruncate(loop, &ftruncate_req, open_req1.result, 7,
+    r = uv_fs_ftruncate(loop, &ftruncate_req, file, 7,
         ftruncate_cb);
   } else {
     ASSERT(strcmp(buf, "test-bu") == 0);
-    r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
+    r = uv_fs_close(loop, &close_req, file, close_cb);
   }
   ASSERT(r == 0);
 }
@@ -311,6 +313,7 @@ static void read_cb(uv_fs_t* req) {
 
 static void open_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &open_req1);
   ASSERT(req->fs_type == UV_FS_OPEN);
   if (req->result < 0) {
@@ -323,7 +326,7 @@ static void open_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
+  r = uv_fs_read(loop, &read_req, file, &iov, 1, -1,
       read_cb);
   ASSERT(r == 0);
 }
@@ -343,49 +346,53 @@ static void open_cb_simple(uv_fs_t* req) {
 
 static void fsync_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &fsync_req);
   ASSERT(req->fs_type == UV_FS_FSYNC);
   ASSERT(req->result == 0);
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
-  r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
+  r = uv_fs_close(loop, &close_req, file, close_cb);
   ASSERT(r == 0);
 }
 
 
 static void fdatasync_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &fdatasync_req);
   ASSERT(req->fs_type == UV_FS_FDATASYNC);
   ASSERT(req->result == 0);
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
-  r = uv_fs_fsync(loop, &fsync_req, open_req1.result, fsync_cb);
+  r = uv_fs_fsync(loop, &fsync_req, file, fsync_cb);
   ASSERT(r == 0);
 }
 
 
 static void write_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &write_req);
   ASSERT(req->fs_type == UV_FS_WRITE);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
   write_cb_count++;
   uv_fs_req_cleanup(req);
-  r = uv_fs_fdatasync(loop, &fdatasync_req, open_req1.result, fdatasync_cb);
+  r = uv_fs_fdatasync(loop, &fdatasync_req, file, fdatasync_cb);
   ASSERT(r == 0);
 }
 
 
 static void create_cb(uv_fs_t* req) {
   int r;
+  uv_os_fd_t file = open_req1.result;
   ASSERT(req == &open_req1);
   ASSERT(req->fs_type == UV_FS_OPEN);
   ASSERT(req->result >= 0);
   create_cb_count++;
   uv_fs_req_cleanup(req);
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(loop, &write_req, req->result, &iov, 1, -1, write_cb);
+  r = uv_fs_write(loop, &write_req, file, &iov, 1, -1, write_cb);
   ASSERT(r == 0);
 }
 
@@ -765,6 +772,7 @@ TEST_IMPL(fs_file_async) {
 
 TEST_IMPL(fs_file_sync) {
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -774,39 +782,41 @@ TEST_IMPL(fs_file_sync) {
 
   r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_ftruncate(NULL, &ftruncate_req, open_req1.result, 7, NULL);
+  r = uv_fs_ftruncate(NULL, &ftruncate_req, file, 7, NULL);
   ASSERT(r == 0);
   ASSERT(ftruncate_req.result == 0);
   uv_fs_req_cleanup(&ftruncate_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -817,19 +827,20 @@ TEST_IMPL(fs_file_sync) {
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, "test-bu") == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -850,6 +861,7 @@ TEST_IMPL(fs_file_sync) {
 
 TEST_IMPL(fs_file_write_null_buffer) {
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -858,17 +870,18 @@ TEST_IMPL(fs_file_write_null_buffer) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(NULL, 0);
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r == 0);
   ASSERT(write_req.result == 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -883,6 +896,7 @@ TEST_IMPL(fs_file_write_null_buffer) {
 TEST_IMPL(fs_async_dir) {
   int r;
   uv_dirent_t dent;
+  uv_os_fd_t file;
 
   /* Setup */
   unlink("test_dir/file1");
@@ -900,17 +914,19 @@ TEST_IMPL(fs_async_dir) {
   /* Create 2 files synchronously. */
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -978,6 +994,7 @@ TEST_IMPL(fs_async_dir) {
 TEST_IMPL(fs_async_sendfile) {
   int f, r;
   struct stat s1, s2;
+  uv_os_fd_t file1, file2;
 
   loop = uv_default_loop();
 
@@ -1002,27 +1019,29 @@ TEST_IMPL(fs_async_sendfile) {
 
   /* Test starts here. */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file1 = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req2.result >= 0);
+  file2 = open_req2.result;
   uv_fs_req_cleanup(&open_req2);
 
-  r = uv_fs_sendfile(loop, &sendfile_req, open_req2.result, open_req1.result,
+  r = uv_fs_sendfile(loop, &sendfile_req, file2, file1,
       0, 131072, sendfile_cb);
   ASSERT(r == 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(sendfile_cb_count == 1);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file1, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
-  r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file2, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -1073,7 +1092,7 @@ TEST_IMPL(fs_mkdtemp) {
 TEST_IMPL(fs_fstat) {
   int r;
   uv_fs_t req;
-  uv_file file;
+  uv_os_fd_t file;
   uv_stat_t* s;
 #ifndef _WIN32
   struct stat t;
@@ -1086,7 +1105,7 @@ TEST_IMPL(fs_fstat) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1206,7 +1225,7 @@ TEST_IMPL(fs_fstat) {
 TEST_IMPL(fs_access) {
   int r;
   uv_fs_t req;
-  uv_file file;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -1230,7 +1249,7 @@ TEST_IMPL(fs_access) {
   /* Create file */
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1282,7 +1301,7 @@ TEST_IMPL(fs_access) {
 TEST_IMPL(fs_chmod) {
   int r;
   uv_fs_t req;
-  uv_file file;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -1291,7 +1310,7 @@ TEST_IMPL(fs_chmod) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1361,7 +1380,11 @@ TEST_IMPL(fs_chmod) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fchmod_cb_count == 1);
 
-  close(file);
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -1380,7 +1403,7 @@ TEST_IMPL(fs_chmod) {
 TEST_IMPL(fs_unlink_readonly) {
   int r;
   uv_fs_t req;
-  uv_file file;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -1393,7 +1416,7 @@ TEST_IMPL(fs_unlink_readonly) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1404,7 +1427,11 @@ TEST_IMPL(fs_unlink_readonly) {
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
-  close(file);
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
@@ -1439,7 +1466,7 @@ TEST_IMPL(fs_unlink_readonly) {
 TEST_IMPL(fs_chown) {
   int r;
   uv_fs_t req;
-  uv_file file;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -1448,7 +1475,7 @@ TEST_IMPL(fs_chown) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1483,7 +1510,11 @@ TEST_IMPL(fs_chown) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fchown_cb_count == 1);
 
-  close(file);
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -1502,8 +1533,8 @@ TEST_IMPL(fs_chown) {
 TEST_IMPL(fs_link) {
   int r;
   uv_fs_t req;
-  uv_file file;
-  uv_file link;
+  uv_os_fd_t file;
+  uv_os_fd_t link;
 
   /* Setup. */
   unlink("test_file");
@@ -1514,7 +1545,7 @@ TEST_IMPL(fs_link) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1525,7 +1556,11 @@ TEST_IMPL(fs_link) {
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
-  close(file);
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
@@ -1534,7 +1569,7 @@ TEST_IMPL(fs_link) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
@@ -1546,7 +1581,11 @@ TEST_IMPL(fs_link) {
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
-  close(link);
+  /* Close link */
+  r = uv_fs_close(NULL, &req, link, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /* async link */
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
@@ -1555,7 +1594,7 @@ TEST_IMPL(fs_link) {
   ASSERT(link_cb_count == 1);
 
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
@@ -1567,7 +1606,11 @@ TEST_IMPL(fs_link) {
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
-  close(link);
+  /* Close link */
+  r = uv_fs_close(NULL, &req, link, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -1630,8 +1673,8 @@ TEST_IMPL(fs_realpath) {
 TEST_IMPL(fs_symlink) {
   int r;
   uv_fs_t req;
-  uv_file file;
-  uv_file link;
+  uv_os_fd_t file;
+  uv_os_fd_t link;
   char test_file_abs_buf[PATHMAX];
   size_t test_file_abs_size;
 
@@ -1654,7 +1697,7 @@ TEST_IMPL(fs_symlink) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
@@ -1665,7 +1708,11 @@ TEST_IMPL(fs_symlink) {
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
-  close(file);
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   /* sync symlink */
   r = uv_fs_symlink(NULL, &req, "test_file", "test_file_symlink", 0, NULL);
@@ -1691,7 +1738,7 @@ TEST_IMPL(fs_symlink) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
@@ -1703,7 +1750,11 @@ TEST_IMPL(fs_symlink) {
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
-  close(link);
+  /* Close link */
+  r = uv_fs_close(NULL, &req, link, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   r = uv_fs_symlink(NULL,
                     &req,
@@ -1740,7 +1791,7 @@ TEST_IMPL(fs_symlink) {
   ASSERT(symlink_cb_count == 1);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
@@ -1752,7 +1803,11 @@ TEST_IMPL(fs_symlink) {
   ASSERT(req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
 
-  close(link);
+  /* Close link */
+  r = uv_fs_close(NULL, &req, link, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   r = uv_fs_symlink(NULL,
                     &req,
@@ -1793,6 +1848,7 @@ TEST_IMPL(fs_symlink) {
 
 TEST_IMPL(fs_symlink_dir) {
   uv_fs_t req;
+  uv_os_fd_t file;
   int r;
   char* test_dir;
   uv_dirent_t dent;
@@ -1868,17 +1924,19 @@ TEST_IMPL(fs_symlink_dir) {
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -1930,16 +1988,23 @@ TEST_IMPL(fs_utime) {
   double atime;
   double mtime;
   uv_fs_t req;
+  uv_os_fd_t file;
   int r;
 
   /* Setup. */
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
+  file = req.result;
   uv_fs_req_cleanup(&req);
-  close(r);
+
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
@@ -1987,6 +2052,7 @@ TEST_IMPL(fs_utime) {
 TEST_IMPL(fs_stat_root) {
   int r;
   uv_loop_t* loop = uv_default_loop();
+  (void)loop;
 
   r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
   ASSERT(r == 0);
@@ -2024,7 +2090,7 @@ TEST_IMPL(fs_futime) {
   const char* path = "test_file";
   double atime;
   double mtime;
-  uv_file file;
+  uv_os_fd_t file;
   uv_fs_t req;
   int r;
 
@@ -2032,10 +2098,16 @@ TEST_IMPL(fs_futime) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
+  file = req.result;
   uv_fs_req_cleanup(&req);
-  close(r);
+
+  /* Close file */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  uv_fs_req_cleanup(&req);
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
 
@@ -2049,7 +2121,7 @@ TEST_IMPL(fs_futime) {
 #endif
 
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   file = req.result; /* FIXME probably not how it's supposed to be used */
   uv_fs_req_cleanup(&req);
@@ -2199,16 +2271,17 @@ TEST_IMPL(fs_scandir_file) {
 TEST_IMPL(fs_open_dir) {
   const char* path;
   uv_fs_t req;
-  int r, file;
+  int r;
+  uv_os_fd_t file;
 
   path = ".";
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(req.result >= 0);
   ASSERT(req.ptr == NULL);
-  file = r;
+  file = req.result;
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -2228,6 +2301,7 @@ TEST_IMPL(fs_open_dir) {
 
 TEST_IMPL(fs_file_open_append) {
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2236,17 +2310,18 @@ TEST_IMPL(fs_file_open_append) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2254,26 +2329,28 @@ TEST_IMPL(fs_file_open_append) {
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | O_APPEND, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   printf("read = %d\n", r);
   ASSERT(r == 26);
   ASSERT(read_req.result == 26);
@@ -2282,7 +2359,7 @@ TEST_IMPL(fs_file_open_append) {
                 sizeof("test-buffer\n\0test-buffer\n\0") - 1) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2297,6 +2374,7 @@ TEST_IMPL(fs_file_open_append) {
 
 TEST_IMPL(fs_rename_to_existing_file) {
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2306,28 +2384,30 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2338,19 +2418,20 @@ TEST_IMPL(fs_rename_to_existing_file) {
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2366,6 +2447,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
 TEST_IMPL(fs_read_file_eof) {
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2374,42 +2456,44 @@ TEST_IMPL(fs_read_file_eof) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  read_req.result, NULL);
   ASSERT(r == 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2425,6 +2509,7 @@ TEST_IMPL(fs_read_file_eof) {
 TEST_IMPL(fs_write_multiple_bufs) {
   uv_buf_t iovs[2];
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2433,25 +2518,27 @@ TEST_IMPL(fs_write_multiple_bufs) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iovs[0] = uv_buf_init(test_buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(test_buf2, sizeof(test_buf2));
-  r = uv_fs_write(NULL, &write_req, open_req1.result, iovs, 2, 0, NULL);
+  r = uv_fs_write(NULL, &write_req, file, iovs, 2, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(write_req.result >= 0);
   uv_fs_req_cleanup(&write_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -2459,7 +2546,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
   /* Read the strings back to separate buffers. */
   iovs[0] = uv_buf_init(buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, 2, 0, NULL);
+  r = uv_fs_read(NULL, &read_req, file, iovs, 2, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(read_req.result >= 0);
   ASSERT(strcmp(buf, test_buf) == 0);
@@ -2467,13 +2554,13 @@ TEST_IMPL(fs_write_multiple_bufs) {
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
-  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
+  r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  read_req.result, NULL);
   ASSERT(r == 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2492,6 +2579,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   char* buffer;
   size_t index;
   int r;
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2507,8 +2595,9 @@ TEST_IMPL(fs_write_alotof_bufs) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   for (index = 0; index < iovcount; ++index)
@@ -2516,7 +2605,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
 
   r = uv_fs_write(NULL,
                   &write_req,
-                  open_req1.result,
+                  file,
                   iovs,
                   iovcount,
                   -1,
@@ -2533,7 +2622,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
                               sizeof(test_buf));
 
-  r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, iovcount, 0, NULL);
+  r = uv_fs_read(NULL, &read_req, file, iovs, iovcount, 0, NULL);
   ASSERT(r >= 0);
   ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
 
@@ -2548,7 +2637,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL,
                  &read_req,
-                 open_req1.result,
+                 file,
                  &iov,
                  1,
                  read_req.result,
@@ -2557,7 +2646,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
@@ -2580,6 +2669,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   int64_t offset;
   char* filler = "0123456789";
   int filler_len = strlen(filler);
+  uv_os_fd_t file;
 
   /* Setup. */
   unlink("test_file");
@@ -2595,12 +2685,13 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT(r == 0);
   ASSERT(open_req1.result >= 0);
+  file = open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(filler, filler_len);
-  r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
+  r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT(r == filler_len);
   ASSERT(write_req.result == filler_len);
   uv_fs_req_cleanup(&write_req);
@@ -2611,7 +2702,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
 
   r = uv_fs_write(NULL,
                   &write_req,
-                  open_req1.result,
+                  file,
                   iovs,
                   iovcount,
                   offset,
@@ -2628,7 +2719,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
                               sizeof(test_buf));
 
-  r = uv_fs_read(NULL, &read_req, open_req1.result,
+  r = uv_fs_read(NULL, &read_req, file,
                  iovs, iovcount, offset, NULL);
   ASSERT(r >= 0);
   ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
@@ -2650,7 +2741,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL,
                  &read_req,
-                 open_req1.result,
+                 file,
                  &iov,
                  1,
                  read_req.result + offset,
@@ -2659,7 +2750,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
-  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT(r == 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -97,7 +97,7 @@ TEST_IMPL(handle_fileno) {
   ASSERT(r == UV_EBADF);
 
   tty_fd = get_tty_fd();
-  if (tty_fd == -1) {
+  if (tty_fd == (uv_os_fd_t)-1) {
     fprintf(stderr, "Cannot open a TTY fd");
     fflush(stderr);
   } else {

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -23,20 +23,16 @@
 #include "task.h"
 
 
-static int get_tty_fd(void) {
+static uv_os_fd_t get_tty_fd(void) {
   /* Make sure we have an FD that refers to a tty */
 #ifdef _WIN32
-  HANDLE handle;
-  handle = CreateFileA("conout$",
-                       GENERIC_READ | GENERIC_WRITE,
-                       FILE_SHARE_READ | FILE_SHARE_WRITE,
-                       NULL,
-                       OPEN_EXISTING,
-                       FILE_ATTRIBUTE_NORMAL,
-                       NULL);
-  if (handle == INVALID_HANDLE_VALUE)
-    return -1;
-  return _open_osfhandle((intptr_t) handle, 0);
+  return CreateFileA("conout$",
+                     GENERIC_READ | GENERIC_WRITE,
+                     FILE_SHARE_READ | FILE_SHARE_WRITE,
+                     NULL,
+                     OPEN_EXISTING,
+                     FILE_ATTRIBUTE_NORMAL,
+                     NULL);
 #else /* unix */
   return open("/dev/tty", O_RDONLY, 0);
 #endif
@@ -45,7 +41,7 @@ static int get_tty_fd(void) {
 
 TEST_IMPL(handle_fileno) {
   int r;
-  int tty_fd;
+  uv_os_fd_t tty_fd;
   struct sockaddr_in addr;
   uv_os_fd_t fd;
   uv_tcp_t tcp;
@@ -101,7 +97,7 @@ TEST_IMPL(handle_fileno) {
   ASSERT(r == UV_EBADF);
 
   tty_fd = get_tty_fd();
-  if (tty_fd < 0) {
+  if (tty_fd == -1) {
     fprintf(stderr, "Cannot open a TTY fd");
     fflush(stderr);
   } else {

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -376,7 +376,8 @@ int run_ipc_send_recv_helper(uv_loop_t* loop, int inprocess) {
     r = uv_listen((uv_stream_t*)&ctx2.listen, SOMAXCONN, listen_cb);
     ASSERT(r == 0);
   } else {
-    r = uv_pipe_open(&ctx2.channel, 0);
+    uv_os_fd_t stdin_handle = uv_convert_fd_to_handle(0);
+    r = uv_pipe_open(&ctx2.channel, stdin_handle);
     ASSERT(r == 0);
 
     send_recv_start();

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -634,13 +634,14 @@ int ipc_helper(int listen_after_write) {
   uv_write_t write_req;
   int r;
   uv_buf_t buf;
+  uv_os_fd_t stdin_handle = uv_convert_fd_to_handle(0);
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
   ASSERT(r == 0);
 
-  uv_pipe_open(&channel, 0);
+  uv_pipe_open(&channel, stdin_handle);
 
   ASSERT(1 == uv_is_readable((uv_stream_t*) &channel));
   ASSERT(1 == uv_is_writable((uv_stream_t*) &channel));
@@ -686,11 +687,12 @@ int ipc_helper_tcp_connection(void) {
 
   int r;
   struct sockaddr_in addr;
+  uv_os_fd_t stdin_handle = uv_convert_fd_to_handle(0);
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
   ASSERT(r == 0);
 
-  uv_pipe_open(&channel, 0);
+  uv_pipe_open(&channel, stdin_handle);
 
   ASSERT(1 == uv_is_readable((uv_stream_t*) &channel));
   ASSERT(1 == uv_is_writable((uv_stream_t*) &channel));
@@ -740,13 +742,14 @@ int ipc_helper_bind_twice(void) {
   uv_write_t write_req2;
   int r;
   uv_buf_t buf;
+  uv_os_fd_t stdin_handle = uv_convert_fd_to_handle(0);
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
   ASSERT(r == 0);
 
-  uv_pipe_open(&channel, 0);
+  uv_pipe_open(&channel, stdin_handle);
 
   ASSERT(1 == uv_is_readable((uv_stream_t*) &channel));
   ASSERT(1 == uv_is_writable((uv_stream_t*) &channel));

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -208,7 +208,6 @@ TEST_IMPL(pipe_getsockname_abstract) {
 TEST_IMPL(pipe_getsockname_blocking) {
 #ifdef _WIN32
   HANDLE readh, writeh;
-  int readfd;
   char buf1[1024], buf2[1024];
   size_t len1, len2;
   int r;
@@ -218,9 +217,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
 
   r = uv_pipe_init(uv_default_loop(), &pipe_client, 0);
   ASSERT(r == 0);
-  readfd = _open_osfhandle((intptr_t)readh, _O_RDONLY);
-  ASSERT(r != -1);
-  r = uv_pipe_open(&pipe_client, readfd);
+  r = uv_pipe_open(&pipe_client, readh);
   ASSERT(r == 0);
   r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
   ASSERT(r == 0);

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -96,7 +96,7 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   ASSERT(r != 0);
   ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
 
-  r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
+  r = uv_poll_init(uv_default_loop(), &handle, sock);
   ASSERT(r == 0);
   r = uv_poll_start(&handle, UV_READABLE | UV_WRITABLE, poll_cb);
   ASSERT(r == 0);

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -56,7 +56,7 @@ TEST_IMPL(poll_close) {
 
   for (i = 0; i < NUM_SOCKETS; i++) {
     sockets[i] = socket(AF_INET, SOCK_STREAM, 0);
-    uv_poll_init_socket(uv_default_loop(), &poll_handles[i], sockets[i]);
+    uv_poll_init(uv_default_loop(), &poll_handles[i], sockets[i]);
     uv_poll_start(&poll_handles[i], UV_READABLE | UV_WRITABLE, NULL);
   }
 

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -78,7 +78,7 @@ TEST_IMPL(poll_closesocket) {
   ASSERT(r != 0);
   ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
 
-  r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
+  r = uv_poll_init(uv_default_loop(), &handle, sock);
   ASSERT(r == 0);
   r = uv_poll_start(&handle, UV_WRITABLE, poll_cb);
   ASSERT(r == 0);

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -157,7 +157,7 @@ static connection_context_t* create_connection_context(
   context->sent_fin = 0;
   context->got_disconnect = 0;
 
-  r = uv_poll_init_socket(uv_default_loop(), &context->poll_handle, sock);
+  r = uv_poll_init(uv_default_loop(), &context->poll_handle, sock);
   context->open_handles++;
   context->poll_handle.data = context;
   ASSERT(r == 0);
@@ -449,7 +449,7 @@ static server_context_t* create_server_context(
   context->sock = sock;
   context->connections = 0;
 
-  r = uv_poll_init_socket(uv_default_loop(), &context->poll_handle, sock);
+  r = uv_poll_init(uv_default_loop(), &context->poll_handle, sock);
   context->poll_handle.data = context;
   ASSERT(r == 0);
 
@@ -604,7 +604,7 @@ TEST_IMPL(poll_bad_fdtype) {
   fd = open(".", O_RDONLY);
 #endif
   ASSERT(fd != -1);
-  ASSERT(0 != uv_poll_init(uv_default_loop(), &poll_handle, fd));
+  ASSERT(0 != uv_poll_init(uv_default_loop(), &poll_handle, uv_get_osfhandle(fd)));
   ASSERT(0 == close(fd));
 #endif
 

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -596,6 +596,7 @@ TEST_IMPL(poll_bad_fdtype) {
 #if !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__sun) && \
     !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__)
   uv_poll_t poll_handle;
+  uv_os_fd_t handle;
   int fd;
 
 #if defined(_WIN32)
@@ -604,7 +605,8 @@ TEST_IMPL(poll_bad_fdtype) {
   fd = open(".", O_RDONLY);
 #endif
   ASSERT(fd != -1);
-  ASSERT(0 != uv_poll_init(uv_default_loop(), &poll_handle, uv_get_osfhandle(fd)));
+  handle = uv_get_osfhandle(fd);
+  ASSERT(0 != uv_poll_init(uv_default_loop(), &poll_handle, (uv_os_sock_t)handle)); /* bad cast on windows to allow passing an invalid SOCKET */
   ASSERT(0 == close(fd));
 #endif
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -24,6 +24,8 @@
 
 /* For Windows we test only signum handling */
 #ifdef _WIN32
+#define NSIG 32
+
 static void signum_test_cb(uv_signal_t* handle, int signum) {
   FATAL("signum_test_cb should not be called");
 }

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -207,16 +207,18 @@ int stdio_over_pipes_helper(void) {
   int r;
   uv_loop_t* loop = uv_default_loop();
 
-  ASSERT(UV_NAMED_PIPE == uv_guess_handle(0));
-  ASSERT(UV_NAMED_PIPE == uv_guess_handle(1));
+  ASSERT(UV_NAMED_PIPE == uv_guess_handle(UV_STDIN_FD));
+  ASSERT(UV_NAMED_PIPE == uv_guess_handle(UV_STDOUT_FD));
 
   r = uv_pipe_init(loop, &stdin_pipe, 0);
   ASSERT(r == 0);
   r = uv_pipe_init(loop, &stdout_pipe, 0);
   ASSERT(r == 0);
 
-  uv_pipe_open(&stdin_pipe, 0);
-  uv_pipe_open(&stdout_pipe, 1);
+  r = uv_pipe_open(&stdin_pipe, UV_STDIN_FD);
+  ASSERT(r == 0);
+  r = uv_pipe_open(&stdout_pipe, UV_STDOUT_FD);
+  ASSERT(r == 0);
 
   /* Unref both stdio handles to make sure that all writes complete. */
   uv_unref((uv_handle_t*)&stdin_pipe);

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -209,28 +209,23 @@ TEST_IMPL(tty_raw) {
 
 TEST_IMPL(tty_empty_write) {
   int r;
-  int ttyout_fd;
+  uv_os_fd_t ttyout_fd;
   uv_tty_t tty_out;
   char dummy[1];
   uv_buf_t bufs[1];
   uv_loop_t* loop;
 
-  /* Make sure we have an FD that refers to a tty */
-  HANDLE handle;
-
   loop = uv_default_loop();
 
-  handle = CreateFileA("conout$",
+  /* Make sure we have an FD that refers to a tty */
+  ttyout_fd = CreateFileA("conout$",
                        GENERIC_READ | GENERIC_WRITE,
                        FILE_SHARE_READ | FILE_SHARE_WRITE,
                        NULL,
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
-  ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
-
-  ASSERT(ttyout_fd >= 0);
+  ASSERT(ttyout_fd != INVALID_HANDLE_VALUE);
 
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
@@ -238,7 +233,7 @@ TEST_IMPL(tty_empty_write) {
   ASSERT(r == 0);
 
   bufs[0].len = 0;
-  bufs[0].base = &dummy;
+  bufs[0].base = &dummy[0];
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
   ASSERT(r == 0);
@@ -253,28 +248,23 @@ TEST_IMPL(tty_empty_write) {
 
 TEST_IMPL(tty_large_write) {
   int r;
-  int ttyout_fd;
+  uv_os_fd_t ttyout_fd;
   uv_tty_t tty_out;
   char dummy[10000];
   uv_buf_t bufs[1];
   uv_loop_t* loop;
 
-  /* Make sure we have an FD that refers to a tty */
-  HANDLE handle;
-
   loop = uv_default_loop();
 
-  handle = CreateFileA("conout$",
+  /* Make sure we have an FD that refers to a tty */
+  ttyout_fd = CreateFileA("conout$",
                        GENERIC_READ | GENERIC_WRITE,
                        FILE_SHARE_READ | FILE_SHARE_WRITE,
                        NULL,
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
-  ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
-
-  ASSERT(ttyout_fd >= 0);
+  ASSERT(ttyout_fd != INVALID_HANDLE_VALUE);
 
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 


### PR DESCRIPTION
Since on Windows, HANDLEs are not the same as file descriptors,
confusing the two meant that almost all APIs in libuv had to go through
a thin compatibility layer, adding needless complication.

This removes that layer of external indirection and instead
works with the native Win32 API directly.

This is the implementation for https://github.com/libuv/leps/pull/8 which closes https://github.com/libuv/libuv/issues/856.

APIs added:
- `uv_get_osfhandle`
- `uv_convert_fd_to_handle`
- `uv_dup`
- `UV_STDIN_FD` / `UV_STDOUT_FD` / `UV_STDERR_FD`

APIs removed:
- `uv_poll_init_socket` (now identical to `uv_poll_init`)

TODO list:
- [x] documentation updates
- [x] merge LEP 5