### PR TITLE
unix: use async-signal-safe functions between fork and exec

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -323,7 +323,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
     }
 
     if (fd == use_fd)
-      uv__cloexec(use_fd, 0);
+      uv__cloexec_fcntl(use_fd, 0);
     else
       fd = dup2(use_fd, fd);
 
@@ -333,7 +333,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
     }
 
     if (fd <= 2)
-      uv__nonblock(fd, 0);
+      uv__nonblock_fcntl(fd, 0);
 
     if (close_fd >= stdio_count)
       uv__close(close_fd);
@@ -372,11 +372,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
     _exit(127);
   }
 
-  if (options->env != NULL) {
-    environ = options->env;
-  }
-
-  execvp(options->file, options->args);
+  execve(options->file, options->args, 
+         options->env != NULL ? options->env : environ);
   uv__write_int(error_fd, -errno);
   _exit(127);
 }

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -372,8 +372,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
     _exit(127);
   }
 
-  execve(options->file, options->args, 
-         options->env != NULL ? options->env : environ);
+  if (options->env != NULL) {
+    environ = options->env;
+  }
+
+  execvp(options->file, options->args);
   uv__write_int(error_fd, -errno);
   _exit(127);
 }


### PR DESCRIPTION
From the manual for fork

> After a fork() in a multithreaded program, the child can safely call only async-signal-safe functions (see signal(7)) until such time as it calls execve(2).

So we should force uv__process_child_init to use 

- fcntl instead of ioctl
- execve instead of execvp

I tested this on linux x86 and z/OS. Other posix compliant operating systems should also work.