### PR TITLE
win, signal: flag to disable signal control handler

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -345,6 +345,7 @@ TEST_DECLARE   (listen_no_simultaneous_accepts)
 TEST_DECLARE   (fs_stat_root)
 TEST_DECLARE   (spawn_with_an_odd_path)
 TEST_DECLARE   (ipc_listen_after_bind_twice)
+TEST_DECLARE   (win32_signum_number)
 #else
 TEST_DECLARE   (emfile)
 TEST_DECLARE   (close_fd)
@@ -694,6 +695,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_stat_root)
   TEST_ENTRY  (spawn_with_an_odd_path)
   TEST_ENTRY  (ipc_listen_after_bind_twice)
+  TEST_ENTRY  (win32_signum_number)
 #else
   TEST_ENTRY  (emfile)
   TEST_ENTRY  (close_fd)

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -19,13 +19,40 @@
  * IN THE SOFTWARE.
  */
 
-
-/* This test does not pretend to be cross-platform. */
-#ifndef _WIN32
-
 #include "uv.h"
 #include "task.h"
 
+/* For Windows we test only signum handling */
+#ifdef _WIN32
+static void signum_test_cb(uv_signal_t* handle, int signum) {
+	FATAL("signum_test_cb should not be called");
+}
+
+TEST_IMPL(win32_signum_number) {
+  uv_signal_t signal;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  uv_signal_init(loop, &signal);
+
+  ASSERT(uv_signal_start(&signal, signum_test_cb, 0) == UV_EINVAL);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGINT) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGBREAK) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGHUP) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGWINCH) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGILL) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGABRT_COMPAT) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGFPE) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGSEGV) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGTERM) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGABRT) == 0);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, -1) == UV_EINVAL);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, NSIG) == UV_EINVAL);
+  ASSERT(uv_signal_start(&signal, signum_test_cb, 1024) == UV_EINVAL);
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+#else
 #include <errno.h>
 #include <signal.h>
 #include <stdarg.h>


### PR DESCRIPTION
Trying to unregister signal handler from the handler itself can lead to deadlock. If it is the last handle, and `uv__signal_control_handler_refs` fail to zero a call to `SetConsoleCtrlHandler` is made, which blocks until all control handlers exits.

This PR adds flags that marks `uv__signal_control_handler` as disabled instead of removing it when `uv__signal_control_handler_refs` falls to zero.

Fixes part of: https://github.com/nodejs/node/issues/10165