### PR TITLE
unix: dynamically adjust poll timeout

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -219,6 +219,11 @@ typedef struct {
   } timer_heap;                                                               \
   uint64_t timer_counter;                                                     \
   uint64_t time;                                                              \
+  double timeout_adjust;                                                      \
+  struct {                                                                    \
+    int64_t deltas[16];                                                       \
+    unsigned int index;                                                       \
+  } adjust_table;                                                             \
   int signal_pipefd[2];                                                       \
   uv__io_t signal_io_watcher;                                                 \
   uv_signal_t child_watcher;                                                  \

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -109,7 +109,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
 }
 
 
-void uv__io_poll(uv_loop_t* loop, int timeout) {
+int uv__io_poll(uv_loop_t* loop, int timeout) {
   struct pollfd events[1024];
   struct pollfd pqry;
   struct pollfd* pe;
@@ -128,7 +128,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
-    return;
+    return 0;
   }
 
   while (!QUEUE_EMPTY(&loop->watcher_queue)) {
@@ -208,7 +208,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     if (nfds == 0) {
       assert(timeout != -1);
-      return;
+      return 1;
     }
 
     if (nfds == -1) {
@@ -220,7 +220,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;
 
       if (timeout == 0)
-        return;
+        return 0;
 
       /* Interrupted by a signal. Update timeout and poll again. */
       goto update_timeout;
@@ -275,7 +275,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     loop->watchers[loop->nwatchers + 1] = NULL;
 
     if (have_signals != 0)
-      return;  /* Event loop should cycle now so don't poll again. */
+      return 0;  /* Event loop should cycle now so don't poll again. */
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {
@@ -283,11 +283,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         timeout = 0;
         continue;
       }
-      return;
+      return 0;
     }
 
     if (timeout == 0)
-      return;
+      return 0;
 
     if (timeout == -1)
       continue;
@@ -297,10 +297,12 @@ update_timeout:
 
     diff = loop->time - base;
     if (diff >= (uint64_t) timeout)
-      return;
+      return 0;
 
     timeout -= diff;
   }
+
+  return 0;
 }
 
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -186,7 +186,9 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w);
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w);
 int uv__io_active(const uv__io_t* w, unsigned int events);
 int uv__io_check_fd(uv_loop_t* loop, int fd);
-void uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
+
+/* Returns 1 on timeout, and 0 if any events interrupted polling */
+int uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
 
 /* async */
 void uv__async_send(struct uv__async* wa);

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -129,7 +129,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
 }
 
 
-void uv__io_poll(uv_loop_t* loop, int timeout) {
+int uv__io_poll(uv_loop_t* loop, int timeout) {
   struct port_event events[1024];
   struct port_event* pe;
   struct timespec spec;
@@ -150,7 +150,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
-    return;
+    return 0;
   }
 
   while (!QUEUE_EMPTY(&loop->watcher_queue)) {
@@ -220,7 +220,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     if (events[0].portev_source == 0) {
       if (timeout == 0)
-        return;
+        return 0;
 
       if (timeout == -1)
         continue;
@@ -230,7 +230,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     if (nfds == 0) {
       assert(timeout != -1);
-      return;
+      return 1;
     }
 
     have_signals = 0;
@@ -281,7 +281,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     loop->watchers[loop->nwatchers + 1] = NULL;
 
     if (have_signals != 0)
-      return;  /* Event loop should cycle now so don't poll again. */
+      return 0;  /* Event loop should cycle now so don't poll again. */
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {
@@ -289,16 +289,16 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         timeout = 0;
         continue;
       }
-      return;
+      return 0;
     }
 
     if (saved_errno == ETIME) {
       assert(timeout != -1);
-      return;
+      return 0;
     }
 
     if (timeout == 0)
-      return;
+      return 0;
 
     if (timeout == -1)
       continue;
@@ -308,10 +308,12 @@ update_timeout:
 
     diff = loop->time - base;
     if (diff >= (uint64_t) timeout)
-      return;
+      return 0;
 
     timeout -= diff;
   }
+
+  return 0;
 }
 
 


### PR DESCRIPTION
Most Unixes do not respect the value of `timeout` passed to polling
syscall (either `kevent`, `epoll_wait`, `poll`, etc). The leeway varies
from system to system and may change slightly during operation of the
program, but it is more or less stable in a short period of time.
Collect leeway statistics and apply timeout adjustment to provide better
timing guarantees for `uv_timer_t`.

(Will supply "benchmark" results later today)