### PR TITLE
Added event loop before/after hooks

### DIFF
--- a/docs/src/after.rst
+++ b/docs/src/after.rst
@@ -1,0 +1,46 @@
+
+.. _after:
+
+:c:type:`uv_after_t` --- After handle
+=========================================
+
+After handles will run the given callback once per loop iteration, after all
+other handles have been run.
+
+
+Data types
+----------
+
+.. c:type:: uv_after_t
+
+    After handle type.
+
+.. c:type:: void (*uv_after_cb)(uv_after_t* handle)
+
+    Type definition for callback passed to :c:func:`uv_after_start`.
+
+
+Public members
+^^^^^^^^^^^^^^
+
+N/A
+
+.. seealso:: The :c:type:`uv_handle_t` members also apply.
+
+
+API
+---
+
+.. c:function:: int uv_after_init(uv_loop_t* loop, uv_after_t* after)
+
+    Initialize the handle.
+
+.. c:function:: int uv_after_start(uv_after_t* after, uv_after_cb cb)
+
+    Start the handle with the given callback.
+
+.. c:function:: int uv_after_stop(uv_after_t* after)
+
+    Stop the handle, the callback will no longer be called.
+
+.. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/before.rst
+++ b/docs/src/before.rst
@@ -1,0 +1,46 @@
+
+.. _before:
+
+:c:type:`uv_before_t` --- Before handle
+=========================================
+
+Before handles will run the given callback once per loop iteration, right after
+updating the loop clock, before invoking any other callbacks.
+
+
+Data types
+----------
+
+.. c:type:: uv_before_t
+
+    Before handle type.
+
+.. c:type:: void (*uv_before_cb)(uv_before_t* handle)
+
+    Type definition for callback passed to :c:func:`uv_before_start`.
+
+
+Public members
+^^^^^^^^^^^^^^
+
+N/A
+
+.. seealso:: The :c:type:`uv_handle_t` members also apply.
+
+
+API
+---
+
+.. c:function:: int uv_before_init(uv_loop_t* loop, uv_before_t* before)
+
+    Initialize the handle.
+
+.. c:function:: int uv_before_start(uv_before_t* before, uv_before_cb cb)
+
+    Start the handle with the given callback.
+
+.. c:function:: int uv_before_stop(uv_before_t* before)
+
+    Stop the handle, the callback will no longer be called.
+
+.. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -73,6 +73,8 @@ Documentation
    handle
    request
    timer
+   before
+   after
    prepare
    check
    idle

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -208,6 +208,8 @@ typedef struct {
   uv_rwlock_t cloexec_lock;                                                   \
   uv_handle_t* closing_handles;                                               \
   void* process_handles[2];                                                   \
+  void* after_handles[2];                                                     \
+  void* before_handles[2];                                                    \
   void* prepare_handles[2];                                                   \
   void* check_handles[2];                                                     \
   void* idle_handles[2];                                                      \
@@ -283,6 +285,14 @@ typedef struct {
 
 #define UV_POLL_PRIVATE_FIELDS                                                \
   uv__io_t io_watcher;
+
+#define UV_AFTER_PRIVATE_FIELDS                                               \
+  uv_after_cb after_cb;                                                       \
+  void* queue[2];                                                             \
+
+#define UV_BEFORE_PRIVATE_FIELDS                                              \
+  uv_before_cb before_cb;                                                     \
+  void* queue[2];                                                             \
 
 #define UV_PREPARE_PRIVATE_FIELDS                                             \
   uv_prepare_cb prepare_cb;                                                   \

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -321,7 +321,9 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   uv_handle_t* endgame_handles;                                               \
   /* The head of the timers tree */                                           \
   struct uv_timer_tree_s timers;                                              \
-    /* Lists of active loop (prepare / check / idle) watchers */              \
+  /* Lists of active loop (prepare / check / idle) watchers */                \
+  uv_prepare_t* after_handles;                                                \
+  uv_prepare_t* before_handles;                                               \
   uv_prepare_t* prepare_handles;                                              \
   uv_check_t* check_handles;                                                  \
   uv_idle_t* idle_handles;                                                    \
@@ -537,6 +539,16 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   uv_async_cb async_cb;                                                       \
   /* char to avoid alignment issues */                                        \
   char volatile async_sent;
+
+#define UV_AFTER_PRIVATE_FIELDS                                               \
+  uv_after_t* after_prev;                                                     \
+  uv_after_t* after_next;                                                     \
+  uv_after_cb after_cb;
+
+#define UV_BEFORE_PRIVATE_FIELDS                                              \
+  uv_before_t* before_prev;                                                   \
+  uv_before_t* before_next;                                                   \
+  uv_before_cb before_cb;
 
 #define UV_PREPARE_PRIVATE_FIELDS                                             \
   uv_prepare_t* prepare_prev;                                                 \

--- a/include/uv.h
+++ b/include/uv.h
@@ -142,7 +142,9 @@ extern "C" {
   XX(EHOSTDOWN, "host is down")                                               \
 
 #define UV_HANDLE_TYPE_MAP(XX)                                                \
+  XX(AFTER, after)                                                            \
   XX(ASYNC, async)                                                            \
+  XX(BEFORE, before)                                                          \
   XX(CHECK, check)                                                            \
   XX(FS_EVENT, fs_event)                                                      \
   XX(FS_POLL, fs_poll)                                                        \
@@ -197,6 +199,8 @@ typedef enum {
 
 
 /* Handle types. */
+typedef struct uv_after_s uv_after_t;
+typedef struct uv_before_s uv_before_t;
 typedef struct uv_loop_s uv_loop_t;
 typedef struct uv_handle_s uv_handle_t;
 typedef struct uv_stream_s uv_stream_t;
@@ -288,6 +292,8 @@ UV_EXTERN uint64_t uv_now(const uv_loop_t*);
 UV_EXTERN int uv_backend_fd(const uv_loop_t*);
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
+typedef void (*uv_after_cb)(uv_after_t* handle);
+typedef void (*uv_before_cb)(uv_before_t* handle);
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,
                             size_t suggested_size,
                             uv_buf_t* buf);
@@ -727,6 +733,26 @@ UV_EXTERN int uv_poll_init_socket(uv_loop_t* loop,
                                   uv_os_sock_t socket);
 UV_EXTERN int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb);
 UV_EXTERN int uv_poll_stop(uv_poll_t* handle);
+
+
+struct uv_after_s {
+  UV_HANDLE_FIELDS
+  UV_AFTER_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_after_init(uv_loop_t*, uv_after_t* after);
+UV_EXTERN int uv_after_start(uv_after_t* after, uv_after_cb cb);
+UV_EXTERN int uv_after_stop(uv_after_t* after);
+
+
+struct uv_before_s {
+  UV_HANDLE_FIELDS
+  UV_BEFORE_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_before_init(uv_loop_t*, uv_before_t* before);
+UV_EXTERN int uv_before_start(uv_before_t* before, uv_before_cb cb);
+UV_EXTERN int uv_before_stop(uv_before_t* before);
 
 
 struct uv_prepare_s {
@@ -1472,6 +1498,8 @@ struct uv_loop_s {
 
 
 /* Don't export the private CPP symbols. */
+#undef UV_AFTER_PRIVATE_FIELDS
+#undef UV_BEFORE_PRIVATE_FIELDS
 #undef UV_HANDLE_TYPE_PRIVATE
 #undef UV_REQ_TYPE_PRIVATE
 #undef UV_REQ_PRIVATE_FIELDS

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -63,6 +63,8 @@
     uv_##name##_stop(handle);                                                 \
   }
 
+UV_LOOP_WATCHER_DEFINE(after, AFTER)
+UV_LOOP_WATCHER_DEFINE(before, BEFORE)
 UV_LOOP_WATCHER_DEFINE(prepare, PREPARE)
 UV_LOOP_WATCHER_DEFINE(check, CHECK)
 UV_LOOP_WATCHER_DEFINE(idle, IDLE)

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -42,6 +42,8 @@ int uv_loop_init(uv_loop_t* loop) {
   QUEUE_INIT(&loop->active_reqs);
   QUEUE_INIT(&loop->idle_handles);
   QUEUE_INIT(&loop->async_handles);
+  QUEUE_INIT(&loop->after_handles);
+  QUEUE_INIT(&loop->before_handles);
   QUEUE_INIT(&loop->check_handles);
   QUEUE_INIT(&loop->prepare_handles);
   QUEUE_INIT(&loop->handle_queue);

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -246,6 +246,8 @@ int uv_loop_init(uv_loop_t* loop) {
 
   RB_INIT(&loop->timers);
 
+  loop->after_handles = NULL;
+  loop->before_handles = NULL;
   loop->check_handles = NULL;
   loop->prepare_handles = NULL;
   loop->idle_handles = NULL;
@@ -491,6 +493,7 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
 
   while (r != 0 && loop->stop_flag == 0) {
     uv_update_time(loop);
+    uv_before_invoke(loop);
     uv_process_timers(loop);
 
     ran_pending = uv_process_reqs(loop);
@@ -518,6 +521,7 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
       uv_process_timers(loop);
     }
 
+    uv_after_invoke(loop);
     r = uv__loop_alive(loop);
     if (mode == UV_RUN_ONCE || mode == UV_RUN_NOWAIT)
       break;


### PR DESCRIPTION
Adds callback queues for right at the beginning and end of the event
loop. The pre-existing non-side-effectful queues (prepare and check)
are only around the IO poll, thus does not cover timers or pending
handles. With these callbacks it is now easy to measure the total loop
execution time.