### PR TITLE
aix: enable uv_get/set_process_title

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -195,7 +195,7 @@ API
     Sets the current process title. On platforms with a fixed size buffer for the
     process title the contents of `title` will be copied to the buffer and
     truncated if larger than the available space. Other platforms will return
-    UV_ENOMEM if they cannot allocate enough space to duplicate the contents of
+    `UV_ENOMEM` if they cannot allocate enough space to duplicate the contents of
     `title`.
 
 .. c:function:: int uv_resident_set_memory(size_t* rss)

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -192,7 +192,11 @@ API
 
 .. c:function:: int uv_set_process_title(const char* title)
 
-    Sets the current process title.
+    Sets the current process title. On platforms with a fixed size buffer for the
+    process title the contents of `title` will be copied to the buffer and
+    truncated if larger than the available space. Other platforms will return
+    UV_ENOMEM if they cannot allocate enough space to duplicate the contents
+    `title`.
 
 .. c:function:: int uv_resident_set_memory(size_t* rss)
 

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -195,7 +195,7 @@ API
     Sets the current process title. On platforms with a fixed size buffer for the
     process title the contents of `title` will be copied to the buffer and
     truncated if larger than the available space. Other platforms will return
-    UV_ENOMEM if they cannot allocate enough space to duplicate the contents
+    UV_ENOMEM if they cannot allocate enough space to duplicate the contents of
     `title`.
 
 .. c:function:: int uv_resident_set_memory(size_t* rss)

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -951,13 +951,14 @@ int uv_set_process_title(const char* title) {
 
 
 int uv_get_process_title(char* buffer, size_t size) {
-  size_t len = strlen(process_argv[0]);
+  size_t len;
+  len = strlen(process_argv[0]);
   if (buffer == NULL || size == 0)
     return -EINVAL;
   else if (size <= len)
     return -ENOBUFS;
 
-  strncpy(buffer, process_argv[0], len + 1);
+  strcpy(buffer, process_argv[0]);
 
   return 0;
 }

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -64,6 +64,11 @@
 #define RDWR_BUF_SIZE   4096
 #define EQ(a,b)         (strcmp(a,b) == 0)
 
+static void* args_mem = NULL;
+static char **process_argv = NULL;
+static char process_argc = 0;
+static char *process_title_ptr = NULL;
+
 int uv__platform_loop_init(uv_loop_t* loop) {
   loop->fs_fd = -1;
 
@@ -881,21 +886,91 @@ void uv__fs_event_close(uv_fs_event_t* handle) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  return argv;
+  char** new_argv;
+  size_t size;
+  char* s;
+  int i;
+
+  if (argc <= 0)
+    return argv;
+
+  /* Save the original pointer to argv.
+   * AIX uses argv to read the process name.
+   * (Not the memory pointed to by argv[0..n] as on Linux.)
+   */
+  process_argv = argv;
+  process_argc = argc;
+
+  /* Calculate how much memory we need for the argv strings. */
+  size = 0;
+  for (i = 0; i < argc; i++)
+    size += strlen(argv[i]) + 1;
+
+  /* Add space for the argv pointers. */
+  size += (argc + 1) * sizeof(char*);
+
+  new_argv = uv__malloc(size);
+  if (new_argv == NULL)
+    return argv;
+  args_mem = new_argv;
+
+  /* Copy over the strings and set up the pointer table. */
+  s = (char*) &new_argv[argc + 1];
+  for (i = 0; i < argc; i++) {
+    size = strlen(argv[i]) + 1;
+    memcpy(s, argv[i], size);
+    new_argv[i] = s;
+    s += size;
+  }
+  new_argv[i] = NULL;
+
+  return new_argv;
 }
 
 
 int uv_set_process_title(const char* title) {
+  /* If this is the first time this is set,
+   * don't free and set argv[1] to NULL.
+   */
+  size_t len = strlen(title);
+  if( process_title_ptr != NULL )
+    uv__free(process_title_ptr);
+
+  /* We cannot free this pointer when libuv shuts down,
+   * the process may still be using it.
+   */
+  process_title_ptr = (char*) uv__malloc(len + 1);
+  if( process_title_ptr == NULL )
+    return 0;
+
+  memcpy(process_title_ptr, title, len);
+  process_title_ptr[len] = '\0';
+  process_argv[0] = process_title_ptr;
+  if( process_argc > 1 )
+     process_argv[1] = NULL;
+
   return 0;
 }
 
 
 int uv_get_process_title(char* buffer, size_t size) {
+  size_t len = 0;
   if (buffer == NULL || size == 0)
     return -EINVAL;
+  else if (size <= strlen(process_title_ptr))
+    return -ENOBUFS;
 
-  buffer[0] = '\0';
+  len = strlen(process_argv[0]);
+  memcpy(buffer, process_argv[0], len);
+  buffer[len] = '\0';
+
   return 0;
+}
+
+
+UV_DESTRUCTOR(static void free_args_mem(void)) {
+  uv__free(args_mem);  /* Keep valgrind happy. */
+  args_mem = NULL;
 }
 
 

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -932,19 +932,16 @@ int uv_set_process_title(const char* title) {
   /* If this is the first time this is set,
    * don't free and set argv[1] to NULL.
    */
-  size_t len;
   if (process_title_ptr != NULL)
     uv__free(process_title_ptr);
 
   /* We cannot free this pointer when libuv shuts down,
    * the process may still be using it.
    */
-  len = strlen(title);
-  process_title_ptr = uv__malloc(len + 1);
+  process_title_ptr = uv__strdup(title);
   if (process_title_ptr == NULL)
-    return 0;
+    return -ENOMEM;
 
-  strncpy(process_title_ptr, title, len + 1);
   process_argv[0] = process_title_ptr;
   if (process_argc > 1)
      process_argv[1] = NULL;
@@ -954,15 +951,13 @@ int uv_set_process_title(const char* title) {
 
 
 int uv_get_process_title(char* buffer, size_t size) {
-  size_t len;
+  size_t len = strlen(process_argv[0]);
   if (buffer == NULL || size == 0)
     return -EINVAL;
-  else if (size <= strlen(process_argv[0]))
+  else if (size <= len)
     return -ENOBUFS;
 
-  len = strlen(process_argv[0]);
-  memcpy(buffer, process_argv[0], len);
-  buffer[len] = '\0';
+  strncpy(buffer, process_argv[0], len + 1);
 
   return 0;
 }

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -66,7 +66,7 @@
 
 static void* args_mem = NULL;
 static char** process_argv = NULL;
-static char process_argc = 0;
+static int process_argc = 0;
 static char* process_title_ptr = NULL;
 
 int uv__platform_loop_init(uv_loop_t* loop) {
@@ -958,7 +958,7 @@ int uv_get_process_title(char* buffer, size_t size) {
   else if (size <= len)
     return -ENOBUFS;
 
-  strcpy(buffer, process_argv[0]);
+  memcpy(buffer, process_argv[0], len + 1);
 
   return 0;
 }

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -929,18 +929,22 @@ char** uv_setup_args(int argc, char** argv) {
 
 
 int uv_set_process_title(const char* title) {
+  char* new_title;
+
+  /* We cannot free this pointer when libuv shuts down,
+   * the process may still be using it.
+   */
+  new_title = uv__strdup(title);
+  if (new_title == NULL)
+    return -ENOMEM;
+
   /* If this is the first time this is set,
    * don't free and set argv[1] to NULL.
    */
   if (process_title_ptr != NULL)
     uv__free(process_title_ptr);
 
-  /* We cannot free this pointer when libuv shuts down,
-   * the process may still be using it.
-   */
-  process_title_ptr = uv__strdup(title);
-  if (process_title_ptr == NULL)
-    return -ENOMEM;
+  process_title_ptr = new_title;
 
   process_argv[0] = process_title_ptr;
   if (process_argc > 1)

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -65,9 +65,9 @@
 #define EQ(a,b)         (strcmp(a,b) == 0)
 
 static void* args_mem = NULL;
-static char **process_argv = NULL;
+static char** process_argv = NULL;
 static char process_argc = 0;
-static char *process_title_ptr = NULL;
+static char* process_title_ptr = NULL;
 
 int uv__platform_loop_init(uv_loop_t* loop) {
   loop->fs_fd = -1;
@@ -932,21 +932,21 @@ int uv_set_process_title(const char* title) {
   /* If this is the first time this is set,
    * don't free and set argv[1] to NULL.
    */
-  size_t len = strlen(title);
-  if( process_title_ptr != NULL )
+  size_t len;
+  if (process_title_ptr != NULL)
     uv__free(process_title_ptr);
 
   /* We cannot free this pointer when libuv shuts down,
    * the process may still be using it.
    */
-  process_title_ptr = (char*) uv__malloc(len + 1);
-  if( process_title_ptr == NULL )
+  len = strlen(title);
+  process_title_ptr = uv__malloc(len + 1);
+  if (process_title_ptr == NULL)
     return 0;
 
-  memcpy(process_title_ptr, title, len);
-  process_title_ptr[len] = '\0';
+  strncpy(process_title_ptr, title, len + 1);
   process_argv[0] = process_title_ptr;
-  if( process_argc > 1 )
+  if (process_argc > 1)
      process_argv[1] = NULL;
 
   return 0;
@@ -954,10 +954,10 @@ int uv_set_process_title(const char* title) {
 
 
 int uv_get_process_title(char* buffer, size_t size) {
-  size_t len = 0;
+  size_t len;
   if (buffer == NULL || size == 0)
     return -EINVAL;
-  else if (size <= strlen(process_title_ptr))
+  else if (size <= strlen(process_argv[0]))
     return -ENOBUFS;
 
   len = strlen(process_argv[0]);

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -60,7 +60,7 @@ static void uv_get_process_title_edge_cases() {
 
 
 TEST_IMPL(process_title) {
-#if defined(__sun) || defined(_AIX) || defined(__MVS__)
+#if defined(__sun) || defined(__MVS__)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #else
   /* Check for format string vulnerabilities. */


### PR DESCRIPTION
This patch enables querying and setting the process title on AIX.
libuv takes ownership of the memory for argv and returns a deep copy of the array and its contents.
This patch also enables the process_title test case on AIX.

The process title can be changed on AIX but is handled differently to Linux/Mac. Commands like ps read the original argv array passed to the process instead of the memory at argv[0]. To change the process title we need to update argv[0] to point at a new string and set argv[1] to NULL (if it exists). This means the process title can be set to a string of any length on AIX rather than limited to the total size of the strings in argv as on Linux.

This patch relates to a node issue:
https://github.com/nodejs/node/issues/10607
the root cause of that is that node was updating the original argv array and corrupting the command line options. We looked at patching it in node by having it perform a deep copy just on AIX but in the discussion here:
https://github.com/nodejs/node/pull/10633
the preference seemed to be to fix it in libuv.

Returning a deep copy via uv_setup_args like other platforms that was safe for node to change enabling the same behaviour for AIX seemed like the best way to resolve the problem and has the useful side effect of enabling the process title to be changed by assigning a new string to process.title in node.