### PR TITLE
timer: track loop time in nanoseconds

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -117,7 +117,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   QUEUE* q;
   uv__io_t* w;
   uint64_t base;
-  uint64_t diff;
+  uint64_t diffms;
+  uint64_t diffns;
   int have_signals;
   int nevents;
   int count;
@@ -295,11 +296,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 update_timeout:
     assert(timeout > 0);
 
-    diff = loop->time - base;
-    if (diff >= (uint64_t) timeout)
+    diffms = 0;
+    diffns = loop->time - base;
+    if (diffns > NSPERMS)
+      diffms = diffns / NSPERMS;
+
+    if (diffms >= (uint64_t) timeout)
       return;
 
-    timeout -= diff;
+    timeout -= diffms;
   }
 }
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -309,7 +309,7 @@ UV_UNUSED(static void uv__req_init(uv_loop_t* loop,
 UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {
   /* Use a fast time source if available.  We only need millisecond precision.
    */
-  loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000;
+  loop->time = uv__hrtime(UV_CLOCK_FAST);
 }
 
 UV_UNUSED(static char* uv__basename_r(const char* path)) {
@@ -321,5 +321,7 @@ UV_UNUSED(static char* uv__basename_r(const char* path)) {
 
   return s + 1;
 }
+
+static const uint64_t NSPERMS = 1e6;
 
 #endif /* UV_UNIX_INTERNAL_H_ */

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -77,7 +77,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t* pset;
   sigset_t set;
   uint64_t base;
-  uint64_t diff;
+  uint64_t diffms;
+  uint64_t diffns;
   int have_signals;
   int filter;
   int fflags;
@@ -305,11 +306,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 update_timeout:
     assert(timeout > 0);
 
-    diff = loop->time - base;
-    if (diff >= (uint64_t) timeout)
+    diffms = 0;
+    diffns = loop->time - base;
+    if (diffns > NSPERMS)
+      diffms = diffns / NSPERMS;
+
+    if (diffms >= (uint64_t) timeout)
       return;
 
-    timeout -= diff;
+    timeout -= diffms;
   }
 }
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -188,6 +188,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t sigset;
   uint64_t sigmask;
   uint64_t base;
+  uint64_t diffns;
   int have_signals;
   int nevents;
   int count;
@@ -412,7 +413,10 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 update_timeout:
     assert(timeout > 0);
 
-    real_timeout -= (loop->time - base);
+    diffns = loop->time - base;
+    if (diffns > NSPERMS)
+      real_timeout -= diffns / NSPERMS;
+
     if (real_timeout <= 0)
       return;
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -138,7 +138,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t* pset;
   sigset_t set;
   uint64_t base;
-  uint64_t diff;
+  uint64_t diffns;
+  uint64_t diffms;
   unsigned int nfds;
   unsigned int i;
   int saved_errno;
@@ -306,11 +307,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 update_timeout:
     assert(timeout > 0);
 
-    diff = loop->time - base;
-    if (diff >= (uint64_t) timeout)
+    diffms = 0;
+    diffns = loop->time - base;
+    if (diffns > NSPERMS)
+      diffms = diffns / NSPERMS;
+
+    if (diffms >= (uint64_t) timeout)
       return;
 
-    timeout -= diff;
+    timeout -= diffms;
   }
 }
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -426,7 +426,7 @@ void uv_stop(uv_loop_t* loop) {
 
 
 uint64_t uv_now(const uv_loop_t* loop) {
-  return loop->time;
+  return loop->time / (uint64_t) 1e6;
 }
 
 

--- a/src/win/timer.c
+++ b/src/win/timer.c
@@ -28,12 +28,12 @@
 #include "handle-inl.h"
 
 
-/* The number of milliseconds in one second. */
-#define UV__MILLISEC 1000
+/* The number of nanoseconds in one second. */
+#define UV__NANOSEC 1000000000
 
 
 void uv_update_time(uv_loop_t* loop) {
-  uint64_t new_time = uv__hrtime(UV__MILLISEC);
+  uint64_t new_time = uv__hrtime(UV__NANOSEC);
   assert(new_time >= loop->time);
   loop->time = new_time;
 }


### PR DESCRIPTION
This line indicates that the loop clock is tracked in milliseconds.
`loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000;`
This means that the difference between 2 successive updates to the loop clock could show a millisecond difference when only a nanosecond has passed. Timers are triggered in this way.
In NodeJS, this means that setTimeout used with 1 millisecond could be triggered immediately.

This change only changes the internal loop clock to nanosecond resolution but all external api's will still use millisecond resolution.