### PR TITLE
win: define ERROR_ELEVATION_REQUIRED for MinGW

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4606,6 +4606,10 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
 #endif
 
 /* from winerror.h */
+#ifndef ERROR_ELEVATION_REQUIRED
+# define ERROR_ELEVATION_REQUIRED 740
+#endif
+
 #ifndef ERROR_SYMLINK_NOT_SUPPORTED
 # define ERROR_SYMLINK_NOT_SUPPORTED 1464
 #endif

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -21,6 +21,9 @@
 
 #include "uv.h"
 #include "task.h"
+#if defined(_WIN32)
+# include "../src/win/winapi.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
MinGW64 doesn't define [`ERROR_ELEVATION_REQUIRED`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681388%28v=vs.85%29.aspx) introduced by 11ce5df. 

See #1194.