### PR TITLE
unix: move function call out of assert

### DIFF
--- a/src/unix/pthread-barrier.c
+++ b/src/unix/pthread-barrier.c
@@ -73,7 +73,8 @@ int pthread_barrier_wait(pthread_barrier_t* barrier) {
   if (++b->in == b->threshold) {
     b->in = 0;
     b->out = b->threshold - 1;
-    assert(pthread_cond_signal(&b->cond) == 0);
+    rc = pthread_cond_signal(&b->cond);
+    assert(rc == 0);
 
     pthread_mutex_unlock(&b->mutex);
     return PTHREAD_BARRIER_SERIAL_THREAD;


### PR DESCRIPTION
Assert expressions should only be scalar.
pthread_cond_signal never gets called in release mode on z/OS and macos from what I have observed.
This leaves barrier_waits hanging.