### PR TITLE
darwin: don't use clock_gettime on OS X 10.11 or earlier

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -34,11 +34,7 @@
 #include <mach-o/dyld.h> /* _NSGetExecutablePath */
 #include <sys/resource.h>
 #include <sys/sysctl.h>
-#include <time.h>
 #include <unistd.h>  /* sysconf */
-
-#undef NANOSEC
-#define NANOSEC ((uint64_t) 1e9)
 
 
 int uv__platform_loop_init(uv_loop_t* loop) {
@@ -57,11 +53,6 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
 
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
-#ifdef MAC_OS_X_VERSION_10_12
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
-#else
   static mach_timebase_info_data_t info;
 
   if ((ACCESS_ONCE(uint32_t, info.numer) == 0 ||
@@ -70,7 +61,6 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
     abort();
 
   return mach_absolute_time() * info.numer / info.denom;
-#endif
 }
 
 


### PR DESCRIPTION
As noted in the author's caveat, https://github.com/libuv/libuv/pull/1073 introduced a runtime link error when running on older operating systems.

The Xcode/Clang toolchain allows developers to define both a minimum and maximum OS on which the code will run. The `clock_gettime` symbol is only available when running on macOS 10.12, iOS 10.0, or later. Additionally, it's only defined in the corresponding SDKs.

To reproduce the issue:
- Define environment variable `MACOSX_DEPLOYMENT_TARGET=10.9` (or `IPHONEOS_DEPLOYMENT_TARGET=8.0`).
- Compile libuv 1.10.2 with Xcode 8.2 or later and macOS 10.12 SDK (or iOS 10.0 SDK or later).
- Run the code on Mac OS X 10.11.6 or earlier (or iOS 9.3.5 or earlier).

This change handles compiling against older or newer SDKs, before and after `clock_gettime` was declared, by including the `clock_gettime` call only if compiling with an SDK that declares it.

- When compiling for an older maximum OS, we exclude the `clock_gettime` call and including only the `mach_timebase_info` call.
- When compiling for an older minimum OS, but a newer maximum OS, we check for availability of the weak `clock_gettime` symbol at runtime, and fall back to `mach_timebase_info` if it is unavailable.
- When compiling for a newer minimum OS, we exclude both the availability check and the fallback, and call only `clock_gettime`.

The presence of `clock_gettime` in the latest Apple SDKs is causing problems for other POSIX-friendly projects as well:
https://github.com/c-ares/c-ares/pull/75