### PR TITLE
doc: add repitition qualifier to version

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -23,7 +23,7 @@ def get_libuv_version():
     try:
         m = re.search(r"""^#define UV_VERSION_MAJOR (\d)$""", data, re.MULTILINE)
         major = int(m.group(1))
-        m = re.search(r"""^#define UV_VERSION_MINOR (\d)$""", data, re.MULTILINE)
+        m = re.search(r"""^#define UV_VERSION_MINOR (\d+)$""", data, re.MULTILINE)
         minor = int(m.group(1))
         m = re.search(r"""^#define UV_VERSION_PATCH (\d)$""", data, re.MULTILINE)
         patch = int(m.group(1))

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -21,11 +21,11 @@ def get_libuv_version():
     with open('../../include/uv-version.h') as f:
         data = f.read()
     try:
-        m = re.search(r"""^#define UV_VERSION_MAJOR (\d)$""", data, re.MULTILINE)
+        m = re.search(r"""^#define UV_VERSION_MAJOR (\d+)$""", data, re.MULTILINE)
         major = int(m.group(1))
         m = re.search(r"""^#define UV_VERSION_MINOR (\d+)$""", data, re.MULTILINE)
         minor = int(m.group(1))
-        m = re.search(r"""^#define UV_VERSION_PATCH (\d)$""", data, re.MULTILINE)
+        m = re.search(r"""^#define UV_VERSION_PATCH (\d+)$""", data, re.MULTILINE)
         patch = int(m.group(1))
         m = re.search(r"""^#define UV_VERSION_IS_RELEASE (\d)$""", data, re.MULTILINE)
         is_release = int(m.group(1))


### PR DESCRIPTION
Currently the version is reported as unknown:
http://docs.libuv.org/en/v1.x/

It looks like this is because the UV_VERSION_MINOR is not a single digit
and the regex is not getting a match for the minor numder.