### PR TITLE
zos: use built-in proctitle implementation

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -860,20 +860,6 @@ update_timeout:
   }
 }
 
-char** uv_setup_args(int argc, char** argv) {
-  return argv;
-}
-
-
-int uv_set_process_title(const char* title) {
-  return ENOSYS;
-}
-
-
-int uv_get_process_title(char* buffer, size_t size) {
-  if (buffer == NULL || size == 0)
-    return -EINVAL;
-
-  buffer[0] = '\0';
-  return ENOSYS;
+void uv__set_process_title(const char* title) {
+  /* do nothing */
 }

--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -48,9 +48,15 @@ char** uv_setup_args(int argc, char** argv) {
   for (i = 0; i < argc; i++)
     size += strlen(argv[i]) + 1;
 
+#if defined(__MVS__)
+  /* argv is not adjacent. So just use argv[0] */
+  process_title.str = argv[0];
+  process_title.len = strlen(argv[0]);
+#else
   process_title.str = argv[0];
   process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
   assert(process_title.len + 1 == size);  /* argv memory should be adjacent. */
+#endif
 
   /* Add space for the argv pointers. */
   size += (argc + 1) * sizeof(char*);

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -60,7 +60,7 @@ static void uv_get_process_title_edge_cases() {
 
 
 TEST_IMPL(process_title) {
-#if defined(__sun) || defined(__MVS__)
+#if defined(__sun)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #else
   /* Check for format string vulnerabilities. */

--- a/uv.gyp
+++ b/uv.gyp
@@ -198,7 +198,7 @@
             }],
           ],
         }],
-        [ 'OS in "linux mac ios android"', {
+        [ 'OS in "linux mac ios android os390"', {
           'sources': [ 'src/unix/proctitle.c' ],
         }],
         [ 'OS != "os390"', {


### PR DESCRIPTION
Use built-in proctitle implementation because there
is no such thing as a process title on zOS