### PR TITLE
win: implements uv__udp_try_send

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -933,32 +933,29 @@ int uv__udp_try_send(uv_udp_t* handle,
 
   /* already sending a message */
   if (handle->send_queue_count != 0)
-  return UV_EAGAIN;
+    return UV_EAGAIN;
 
   if (!(handle->flags & UV_HANDLE_BOUND)) {
-    if (addrlen == sizeof(uv_addr_ip4_any_)) {
+    if (addrlen == sizeof(uv_addr_ip4_any_))
       bind_addr = (const struct sockaddr*) &uv_addr_ip4_any_;
-    }
-    else if (addrlen == sizeof(uv_addr_ip6_any_)) {
+    else if (addrlen == sizeof(uv_addr_ip6_any_))
       bind_addr = (const struct sockaddr*) &uv_addr_ip6_any_;
-    }
-    else {
+    else
       abort();
-    }
     err = uv_udp_maybe_bind(handle, bind_addr, addrlen, 0);
     if (err)
       return uv_translate_sys_error(err);
   }
 
   err = WSASendTo(handle->socket,
-    (WSABUF*)bufs,
-    nbufs,
-    &bytes,
-    0,
-    addr,
-    addrlen,
-    NULL,
-    NULL);
+                  (WSABUF*)bufs,
+                  nbufs,
+                  &bytes,
+                  0,
+                  addr,
+                  addrlen,
+                  NULL,
+                  NULL);
 
   if (err)
     return uv_translate_sys_error(WSAGetLastError());

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -924,14 +924,13 @@ int uv__udp_try_send(uv_udp_t* handle,
                      unsigned int nbufs,
                      const struct sockaddr* addr,
                      unsigned int addrlen) {
-
   DWORD bytes;
   const struct sockaddr* bind_addr;
   int err;
 
   assert(nbufs > 0);
 
-  /* already sending a message */
+  /* Already sending a message.*/
   if (handle->send_queue_count != 0)
     return UV_EAGAIN;
 

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -26,16 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
-
-TEST_IMPL(udp_try_send) {
-
-  MAKE_VALGRIND_HAPPY();
-  return 0;
-}
-
-#else  /* !_WIN32 */
-
 #define CHECK_HANDLE(handle) \
   ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
 
@@ -129,5 +119,3 @@ TEST_IMPL(udp_try_send) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
-
-#endif  /* !_WIN32 */


### PR DESCRIPTION
This PR implements the missing `uv__udp_try_send` method for Windows.