### PR TITLE
test: fix tests on OpenBSD

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -162,7 +162,8 @@ struct uv__stream_queued_fds_s {
     defined(__DragonFly__) || \
     defined(__FreeBSD__) || \
     defined(__FreeBSD_kernel__) || \
-    defined(__linux__)
+    defined(__linux__) || \
+    defined(__OpenBSD__)
 #define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
 #else

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -163,7 +163,7 @@ char** uv_setup_args(int argc, char** argv) {
 int uv_set_process_title(const char* title) {
   uv__free(process_title);
   process_title = uv__strdup(title);
-  setproctitle(title);
+  setproctitle("%s", title);
   return 0;
 }
 

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -594,7 +594,8 @@ TEST_IMPL(poll_unidirectional) {
  */
 TEST_IMPL(poll_bad_fdtype) {
 #if !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__sun) && \
-    !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__)
+    !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__) && \
+    !defined(__OpenBSD__)
   uv_poll_t poll_handle;
   int fd;
 


### PR DESCRIPTION
It fixes `process_title`, `poll_bad_fdtype` and `poll_nested_kqueue`
tests.