### PR TITLE
src: cleanup header files

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -23,8 +23,6 @@
 #define UV_UNIX_H
 
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <dirent.h>
 
 #include <sys/socket.h>
@@ -40,9 +38,6 @@
 #include <semaphore.h>
 #endif
 #include <pthread.h>
-#include <signal.h>
-
-#include "uv-threadpool.h"
 
 #if defined(__linux__)
 # include "uv-linux.h"
@@ -357,13 +352,7 @@ typedef struct {
   int mode;
 
 #define UV_SIGNAL_PRIVATE_FIELDS                                              \
-  /* RB_ENTRY(uv_signal_s) tree_entry; */                                     \
-  struct {                                                                    \
-    struct uv_signal_s* rbe_left;                                             \
-    struct uv_signal_s* rbe_right;                                            \
-    struct uv_signal_s* rbe_parent;                                           \
-    int rbe_color;                                                            \
-  } tree_entry;                                                               \
+  RB_ENTRY(uv_signal_s) tree_entry;                                            \
   /* Use two counters here so we don have to fiddle with atomics. */          \
   unsigned int caught_signals;                                                \
   unsigned int dispatched_signals;

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -48,18 +48,12 @@ typedef struct pollfd {
 #include <windows.h>
 
 #include <process.h>
-#include <signal.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1600
 # include "stdint-msvc2008.h"
 #else
 # include <stdint.h>
 #endif
-
-#include "tree.h"
-#include "uv-threadpool.h"
 
 #define MAX_PIPENAME_LEN 256
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -49,12 +49,12 @@ extern "C" {
 #include "uv-version.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
-#if defined(_MSC_VER) && _MSC_VER < 1600
-# include "stdint-msvc2008.h"
-#else
-# include <stdint.h>
-#endif
+#include "tree.h"
+#include "uv-threadpool.h"
 
 #if defined(_WIN32)
 # include "uv-win.h"


### PR DESCRIPTION
Move common includes from `uv-win.h` and `uv-unix.h` to `uv.h`.
Use the `RB_ENTRY` macro to define `uv_signal_t.tree_entry` on unix.