### PR TITLE
unix: remove unused code in `uv__io_start`

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -839,13 +839,8 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
    * every tick of the event loop but the other backends allow us to
    * short-circuit here if the event mask is unchanged.
    */
-  if (w->events == w->pevents) {
-    if (w->events == 0 && !QUEUE_EMPTY(&w->watcher_queue)) {
-      QUEUE_REMOVE(&w->watcher_queue);
-      QUEUE_INIT(&w->watcher_queue);
-    }
+  if (w->events == w->pevents)
     return;
-  }
 #endif
 
   if (QUEUE_EMPTY(&w->watcher_queue))


### PR DESCRIPTION
The code path in `uv__io_start` cannot be reached because `pevents` is
always non-zero at that point.

See: https://github.com/nodejs/node/issues/11307#issuecomment-279522413

cc @libuv/collaborators 