### PR TITLE
zos: treat EADDRINUSE from connect as ECONNREFUSED

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -176,12 +176,16 @@ int uv__tcp_connect(uv_connect_t* req,
   if (r == -1 && errno != 0) {
     if (errno == EINPROGRESS)
       ; /* not an error */
+#if defined(__MVS__)
+    else if (errno == ECONNREFUSED || errno == EADDRINUSE)
+#else
     else if (errno == ECONNREFUSED)
+#endif
     /* If we get a ECONNREFUSED wait until the next tick to report the
      * error. Solaris wants to report immediately--other unixes want to
      * wait.
      */
-      handle->delayed_error = -errno;
+      handle->delayed_error = -ECONNREFUSED;
     else
       return -errno;
   }


### PR DESCRIPTION
The connect call rarely returns EADDRINUSE. Treat this as a
connection refusal (ECONNREFUSED).