### PR TITLE
docs: improve UV_ENOBUFS scenario documentation

### DIFF
--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -113,10 +113,14 @@ API
     Get the path being monitored by the handle. The buffer must be preallocated
     by the user. Returns 0 on success or an error code < 0 in case of failure.
     On success, `buffer` will contain the path and `size` its length. If the buffer
-    is not big enough UV_ENOBUFS will be returned and len will be set to the
-    required size.
+    is not big enough `UV_ENOBUFS` will be returned and `size` will be set to
+    the required size, including the null terminator.
 
     .. versionchanged:: 1.3.0 the returned length no longer includes the terminating null byte,
                         and the buffer is not null terminated.
+
+    .. versionchanged:: 1.9.0 the returned length includes the terminating null
+                        byte on `UV_ENOBUFS`, and the buffer is null terminated
+                        on success.
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/fs_poll.rst
+++ b/docs/src/fs_poll.rst
@@ -63,10 +63,15 @@ API
     Get the path being monitored by the handle. The buffer must be preallocated
     by the user. Returns 0 on success or an error code < 0 in case of failure.
     On success, `buffer` will contain the path and `size` its length. If the buffer
-    is not big enough UV_ENOBUFS will be returned and len will be set to the
-    required size.
+    is not big enough `UV_ENOBUFS` will be returned and `size` will be set to
+    the required size.
 
     .. versionchanged:: 1.3.0 the returned length no longer includes the terminating null byte,
                         and the buffer is not null terminated.
+
+    .. versionchanged:: 1.9.0 the returned length includes the terminating null
+                        byte on `UV_ENOBUFS`, and the buffer is null terminated
+                        on success.
+
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -270,11 +270,19 @@ API
 
 .. c:function:: int uv_cwd(char* buffer, size_t* size)
 
-    Gets the current working directory.
+    Gets the current working directory, and stores it in `buffer`. If the
+    current working directory is too large to fit in `buffer`, this function
+    returns `UV_ENOBUFS`, and sets `size` to the required length, including the
+    null terminator.
 
     .. versionchanged:: 1.1.0
 
         On Unix the path no longer ends in a slash.
+
+    .. versionchanged:: 1.9.0 the returned length includes the terminating null
+                        byte on `UV_ENOBUFS`, and the buffer is null terminated
+                        on success.
+
 
 .. c:function:: int uv_chdir(const char* dir)
 


### PR DESCRIPTION
This commit adds additional documentation to the `UV_ENOBUFS` scenario for several methods.

Closes #1179