### PR TITLE
unix: factor out reusable hrtime implementation for POSIX platforms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -349,13 +349,17 @@ endif
 
 if DRAGONFLY
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/freebsd.c src/unix/kqueue.c
+libuv_la_SOURCES += src/unix/freebsd.c \
+                    src/unix/kqueue.c \
+                    src/unix/posix-hrtime.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
 if FREEBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/freebsd.c src/unix/kqueue.c
+libuv_la_SOURCES += src/unix/freebsd.c \
+                    src/unix/kqueue.c \
+                    src/unix/posix-hrtime.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
@@ -372,13 +376,17 @@ endif
 
 if NETBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/kqueue.c src/unix/netbsd.c
+libuv_la_SOURCES += src/unix/kqueue.c \
+                    src/unix/netbsd.c \
+                    src/unix/posix-hrtime.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
 if OPENBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/kqueue.c src/unix/openbsd.c
+libuv_la_SOURCES += src/unix/kqueue.c \
+                    src/unix/openbsd.c \
+                    src/unix/posix-hrtime.c
 test_run_tests_LDFLAGS += -lutil
 endif
 

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -41,9 +41,6 @@
 #include <unistd.h> /* sysconf */
 #include <fcntl.h>
 
-#undef NANOSEC
-#define NANOSEC ((uint64_t) 1e9)
-
 #ifndef CPUSTATES
 # define CPUSTATES 5U
 #endif
@@ -64,13 +61,6 @@ int uv__platform_loop_init(uv_loop_t* loop) {
 
 
 void uv__platform_loop_delete(uv_loop_t* loop) {
-}
-
-
-uint64_t uv__hrtime(uv_clocktype_t type) {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
 }
 
 

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -43,9 +43,6 @@
 #include <unistd.h>
 #include <time.h>
 
-#undef NANOSEC
-#define NANOSEC ((uint64_t) 1e9)
-
 static char *process_title;
 
 
@@ -55,13 +52,6 @@ int uv__platform_loop_init(uv_loop_t* loop) {
 
 
 void uv__platform_loop_delete(uv_loop_t* loop) {
-}
-
-
-uint64_t uv__hrtime(uv_clocktype_t type) {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
 }
 
 

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -40,9 +40,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#undef NANOSEC
-#define NANOSEC ((uint64_t) 1e9)
-
 
 static char *process_title;
 
@@ -53,13 +50,6 @@ int uv__platform_loop_init(uv_loop_t* loop) {
 
 
 void uv__platform_loop_delete(uv_loop_t* loop) {
-}
-
-
-uint64_t uv__hrtime(uv_clocktype_t type) {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
 }
 
 

--- a/src/unix/posix-hrtime.c
+++ b/src/unix/posix-hrtime.c
@@ -1,0 +1,35 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "internal.h"
+
+#include <stdint.h>
+#include <time.h>
+
+#undef NANOSEC
+#define NANOSEC ((uint64_t) 1e9)
+
+uint64_t uv__hrtime(uv_clocktype_t type) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
+}

--- a/uv.gyp
+++ b/uv.gyp
@@ -298,6 +298,7 @@
           'link_settings': {
             'libraries': [ '-lkvm' ],
           },
+          'sources': [ 'src/unix/posix-hrtime.c' ],
         }],
         [ 'OS in "ios mac freebsd dragonflybsd openbsd netbsd".split()', {
           'sources': [ 'src/unix/kqueue.c' ],


### PR DESCRIPTION
Create a dedicated source file to share among platforms on which we
implement hrtime using POSIX `clock_gettime`.  De-duplicate our
existing copies of this implementation on such platforms.