### PR TITLE
zos: return einval for NULL name

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1269,7 +1269,7 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
 
 
 int uv_os_setenv(const char* name, const char* value) {
-  if (value == NULL)
+  if (value == NULL || name == NULL)
     return -EINVAL;
 
   if (setenv(name, value, 1) != 0)

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -36,6 +36,8 @@ TEST_IMPL(env_vars) {
   ASSERT(r == UV_EINVAL);
   r = uv_os_setenv(name, NULL);
   ASSERT(r == UV_EINVAL);
+  r = uv_os_setenv(NULL, NULL);
+  ASSERT(r == UV_EINVAL);
 
   /* Reject invalid inputs when retrieving an environment variable */
   size = BUF_SIZE;


### PR DESCRIPTION
zos: return einval for NULL name

"setenv" on z/OS returns successfully on a NULL ptr argument
for name. To make the behavior standard, return einval on z/OS.