### PR TITLE
unix,win: add uv_timer_get_timeout()

### DIFF
--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -73,4 +73,10 @@ API
 
     Get the timer repeat value.
 
+.. c:function:: uint64_t uv_timer_get_timeout(const uv_timer_t* handle)
+
+    Get the timer timeout value.
+
+    .. versionadded:: 1.12.0
+
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/include/uv.h
+++ b/include/uv.h
@@ -787,6 +787,7 @@ UV_EXTERN int uv_timer_stop(uv_timer_t* handle);
 UV_EXTERN int uv_timer_again(uv_timer_t* handle);
 UV_EXTERN void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat);
 UV_EXTERN uint64_t uv_timer_get_repeat(const uv_timer_t* handle);
+UV_EXTERN uint64_t uv_timer_get_timeout(const uv_timer_t* handle);
 
 
 /*

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -126,6 +126,11 @@ uint64_t uv_timer_get_repeat(const uv_timer_t* handle) {
 }
 
 
+uint64_t uv_timer_get_timeout(const uv_timer_t* handle) {
+  return handle->timeout;
+}
+
+
 int uv__next_timeout(const uv_loop_t* loop) {
   const struct heap_node* heap_node;
   const uv_timer_t* handle;

--- a/src/win/timer.c
+++ b/src/win/timer.c
@@ -153,6 +153,12 @@ uint64_t uv_timer_get_repeat(const uv_timer_t* handle) {
 }
 
 
+uint64_t uv_timer_get_timeout(const uv_timer_t* handle) {
+  assert(handle->type == UV_TIMER);
+  return handle->due;
+}
+
+
 DWORD uv__next_timeout(const uv_loop_t* loop) {
   uv_timer_t* timer;
   int64_t delta;

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -161,6 +161,7 @@ TEST_IMPL(timer_init) {
 
   ASSERT(0 == uv_timer_init(uv_default_loop(), &handle));
   ASSERT(0 == uv_timer_get_repeat(&handle));
+  ASSERT(0 == uv_timer_get_timeout(&handle));
   ASSERT(0 == uv_is_active((uv_handle_t*) &handle));
 
   MAKE_VALGRIND_HAPPY();
@@ -232,6 +233,9 @@ TEST_IMPL(timer_huge_timeout) {
   ASSERT(0 == uv_timer_start(&tiny_timer, tiny_timer_cb, 1, 0));
   ASSERT(0 == uv_timer_start(&huge_timer1, tiny_timer_cb, 0xffffffffffffLL, 0));
   ASSERT(0 == uv_timer_start(&huge_timer2, tiny_timer_cb, (uint64_t) -1, 0));
+  ASSERT(1 == uv_timer_get_timeout(&tiny_timer));
+  ASSERT(0xffffffffffffLL == uv_timer_get_timeout(&huge_timer1));
+  ASSERT((uint64_t) -1 == uv_timer_get_timeout(&huge_timer2));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
See https://github.com/nodejs/node-report/pull/73#issuecomment-286207567 -- it would be nice to be able to get an individual timer handle's timeout. :)

Perhaps there is another way of doing it that I may have missed, not really sure.


Please let me know if I need to add more test assertions / where I should add them.