### PR TITLE
win: stop handle in uv_fs_event_start() on error

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -481,8 +481,10 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   memset(&handle->fo, 0, sizeof handle->fo);
   handle->fo.fo_name = handle->path;
   err = uv__fs_event_rearm(handle);
-  if (err != 0)
+  if (err != 0) {
+    uv_fs_event_stop(handle);
     return err;
+  }
 
   if (first_run) {
     uv__io_init(&handle->loop->fs_event_watcher, uv__fs_event_read, portfd);

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -306,6 +306,9 @@ error:
     handle->buffer = NULL;
   }
 
+  if (uv__is_active(handle))
+    uv__handle_stop(handle);
+
   return uv_translate_sys_error(last_error);
 }
 

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -1027,3 +1027,21 @@ TEST_IMPL(fs_event_error_reporting) {
 }
 
 #endif  /* defined(__APPLE__) */
+
+TEST_IMPL(fs_event_watch_invalid_path) {
+#if defined(MVS)
+  RETURN_SKIP("Filesystem watching not supported on this platform.");
+#endif
+
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+  r = uv_fs_event_init(loop, &fs_event);
+  ASSERT(r == 0);
+  r = uv_fs_event_start(&fs_event, fs_event_cb_file, "<:;", 0);
+  ASSERT(r != 0);
+  ASSERT(uv_is_active((uv_handle_t*) &fs_event) == 0);
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -287,6 +287,7 @@ TEST_DECLARE   (fs_event_watch_file_current_dir)
 #ifdef _WIN32
 TEST_DECLARE   (fs_event_watch_file_root_dir)
 #endif
+TEST_DECLARE   (fs_event_watch_invalid_path)
 TEST_DECLARE   (fs_event_no_callback_after_close)
 TEST_DECLARE   (fs_event_no_callback_on_close)
 TEST_DECLARE   (fs_event_immediate_close)
@@ -764,6 +765,7 @@ TASK_LIST_START
 #ifdef _WIN32
   TEST_ENTRY  (fs_event_watch_file_root_dir)
 #endif
+  TEST_ENTRY  (fs_event_watch_invalid_path)
   TEST_ENTRY  (fs_event_no_callback_after_close)
   TEST_ENTRY  (fs_event_no_callback_on_close)
   TEST_ENTRY  (fs_event_immediate_close)


### PR DESCRIPTION
This commit stops the handle in the `uv_fs_event_start()` error handler if it was started prior to the error.

Fixes: https://github.com/libuv/libuv/issues/1253