### PR TITLE
unix: factor out reusable no-proctitle impl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -399,7 +399,8 @@ endif
 if SUNOS
 include_HEADERS += include/uv-sunos.h
 libuv_la_CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=500
-libuv_la_SOURCES += src/unix/sunos.c
+libuv_la_SOURCES += src/unix/no-proctitle.c \
+                    src/unix/sunos.c
 endif
 
 if OS390

--- a/src/unix/no-proctitle.c
+++ b/src/unix/no-proctitle.c
@@ -1,0 +1,42 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "internal.h"
+
+#include <errno.h>
+#include <stddef.h>
+
+char** uv_setup_args(int argc, char** argv) {
+  return argv;
+}
+
+int uv_set_process_title(const char* title) {
+  return 0;
+}
+
+int uv_get_process_title(char* buffer, size_t size) {
+  if (buffer == NULL || size == 0)
+    return -EINVAL;
+
+  buffer[0] = '\0';
+  return 0;
+}

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -531,25 +531,6 @@ void uv__fs_event_close(uv_fs_event_t* handle) {
 #endif /* defined(PORT_SOURCE_FILE) */
 
 
-char** uv_setup_args(int argc, char** argv) {
-  return argv;
-}
-
-
-int uv_set_process_title(const char* title) {
-  return 0;
-}
-
-
-int uv_get_process_title(char* buffer, size_t size) {
-  if (buffer == NULL || size == 0)
-    return -EINVAL;
-
-  buffer[0] = '\0';
-  return 0;
-}
-
-
 int uv_resident_set_memory(size_t* rss) {
   psinfo_t psinfo;
   int err;

--- a/uv.gyp
+++ b/uv.gyp
@@ -256,7 +256,10 @@
           },
         }],
         [ 'OS=="solaris"', {
-          'sources': [ 'src/unix/sunos.c' ],
+          'sources': [
+            'src/unix/no-proctitle.c',
+            'src/unix/sunos.c',
+          ],
           'defines': [
             '__EXTENSIONS__',
             '_XOPEN_SOURCE=500',


### PR DESCRIPTION
On SunOS we implement no support for proctitle.  Other platforms may not support proctitle either, so provide a dedicated source file to use in this case.