### PR TITLE
win: fix memory leak inside uv_fs_access

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1373,7 +1373,7 @@ static void fs__access(uv_fs_t* req) {
    * - or it's a directory.
    * (Directories cannot be read-only on Windows.)
    */
-  if (!(req->flags & W_OK) ||
+  if (!(req->fs.info.mode & W_OK) ||
       !(attr & FILE_ATTRIBUTE_READONLY) ||
       (attr & FILE_ATTRIBUTE_DIRECTORY)) {
     SET_REQ_RESULT(req, 0);
@@ -2400,7 +2400,7 @@ int uv_fs_access(uv_loop_t* loop,
   if (err)
     return uv_translate_sys_error(err);
 
-  req->flags = flags;
+  req->fs.info.mode = flags;
 
   if (cb) {
     QUEUE_FS_TP_JOB(loop, req);


### PR DESCRIPTION
the mode of `uv_fs_access` parameter is stored inside `req->flags` which is supposed to contain other information.

`fs__capture_path` puts `UV_FS_FREE_PATHS` there, so that the copy of the path can be freed later:
https://github.com/libuv/libuv/blob/7b9f379923fc97817c873e25b34d46bb68897f8e/src/win/fs.c#L214
but it's overwritten four lines later:
https://github.com/libuv/libuv/blob/7b9f379923fc97817c873e25b34d46bb68897f8e/src/win/fs.c#L2403

This could lead to at least a memory leak and if not other nonsense in the future.