### PR TITLE
win: fix memory leak inside uv__pipe_getname

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2076,7 +2076,6 @@ static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size)
   buffer[addrlen] = '\0';
 
   err = 0;
-  goto cleanup;
 
 error:
   uv__free(name_info);


### PR DESCRIPTION
My debugger was still not happy: `name_info` is possibly allocated here:
https://github.com/libuv/libuv/blob/v1.x/src/win/pipe.c#L2002
copied as utf-8 to the user supplied buffer here:
https://github.com/libuv/libuv/blob/v1.x/src/win/pipe.c#L2060
but the free step is skipped in the success case. Why?
https://github.com/libuv/libuv/blob/v1.x/src/win/pipe.c#L2079
