### PR TITLE
win, fsevent: support for files without short name

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -354,8 +354,8 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
 }
 
 
-static int file_info_cmp(WCHAR* str, WCHAR* file_name, int file_name_len) {
-  int str_len;
+static int file_info_cmp(WCHAR* str, WCHAR* file_name, size_t file_name_len) {
+  size_t str_len;
 
   if (str == NULL)
     return -1;

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -156,7 +156,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   DWORD attr, last_error;
   WCHAR* dir = NULL, *dir_to_watch, *pathw = NULL;
   WCHAR short_path_buffer[MAX_PATH];
-  WCHAR* short_path = short_path_buffer;
+  WCHAR* short_path;
 
   if (uv__is_active(handle))
     return UV_EINVAL;
@@ -206,6 +206,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
      */
 
     /* Convert to short path. */
+    short_path = short_path_buffer;
     if (!GetShortPathNameW(pathw, short_path, ARRAY_SIZE(short_path))) {
       short_path = NULL;
     }

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -81,10 +81,10 @@ static void uv_relative_path(const WCHAR* filename,
 
 static int uv_split_path(const WCHAR* filename, WCHAR** dir,
     WCHAR** file) {
-  int len, i;
+  size_t len, i;
  
-  if (!filename) {
-    if (dir)
+  if (filename == NULL) {
+    if (dir != NULL)
       *dir = NULL;
     *file = NULL;
     return 0;
@@ -357,7 +357,7 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
 static int file_info_cmp(WCHAR* str, WCHAR* file_name, int file_name_len) {
   int str_len;
 
-  if (!str)
+  if (str == NULL)
     return -1;
 
   str_len = wcslen(str);


### PR DESCRIPTION
A call to `GetShortPathName` can fail as files are not guaranteed to have short name. This adds support for such case.

Fixes: https://github.com/libuv/libuv/issues/1258