### PR TITLE
unix: mark threadpool as uninitialized after fork()

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -214,3 +214,10 @@ API
        Any previous value returned from :c:func`uv_backend_fd` is now
        invalid. That function must be called again to determine the
        correct backend file descriptor.
+
+    .. caution::
+
+       The old threadpool and its state are not longer available in
+       the child process. If there were any pending tasks left, their
+       callbacks will be called with ``UV_ECANCELED``, so you can free
+       acquired resources or schedule tasks again.

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -169,6 +169,7 @@ static void init_threads(void) {
 static void reset_once(void) {
   uv_once_t child_once = UV_ONCE_INIT;
   memcpy(&once, &child_once, sizeof(child_once));
+  initialized = 0;
 }
 #endif
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -323,4 +323,6 @@ UV_UNUSED(static char* uv__basename_r(const char* path)) {
 int uv__inotify_fork(uv_loop_t* loop, void* old_watchers);
 #endif
 
+int uv__work_queue_fork(uv_loop_t* loop);
+
 #endif /* UV_UNIX_INTERNAL_H_ */

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -138,6 +138,10 @@ int uv_loop_fork(uv_loop_t* loop) {
     }
   }
 
+  err = uv__work_queue_fork(loop);
+  if (err)
+    return err;
+
   return 0;
 }
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -382,6 +382,7 @@ TEST_DECLARE  (fork_fs_events_child)
 TEST_DECLARE  (fork_fs_events_child_dir)
 TEST_DECLARE  (fork_fs_events_file_parent_child)
 TEST_DECLARE  (fork_threadpool_queue_work_simple)
+TEST_DECLARE  (fork_threadpool_queue_work_canceled)
 #endif
 
 TASK_LIST_START
@@ -821,6 +822,7 @@ TASK_LIST_START
   TEST_ENTRY  (fork_fs_events_child_dir)
   TEST_ENTRY  (fork_fs_events_file_parent_child)
   TEST_ENTRY  (fork_threadpool_queue_work_simple)
+  TEST_ENTRY  (fork_threadpool_queue_work_canceled)
 #endif
 
 #if 0


### PR DESCRIPTION
The threadpool is marked for re-initialization here:
https://github.com/libuv/libuv/blob/87df1448a48fb64c2b9ebe37e3344f7e5b81dd88/src/threadpool.c#L182

The actual re-initialization is scheduled for `uv__work_submit` (called through `uv_queue_work`):
https://github.com/libuv/libuv/blob/87df1448a48fb64c2b9ebe37e3344f7e5b81dd88/src/threadpool.c#L193

But if `uv_queue_work` is never called after the fork, it will never be re-initialized. And the destructor will access the old information and probably trigger a segmentation fault:
https://github.com/libuv/libuv/blob/87df1448a48fb64c2b9ebe37e3344f7e5b81dd88/src/threadpool.c#L105

Marking the threadpool as uninitialized during `reset_once` will prevent this scenario.

cc @jamadden  (many thanks from my side too)