### PR TITLE
tcp: enable large socket (rfc1323) data transport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -239,6 +239,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-tcp-write-fail.c \
                          test/test-tcp-try-write.c \
                          test/test-tcp-write-queue-order.c \
+                         test/test-tcp-chunk-size.c \
                          test/test-thread-equal.c \
                          test/test-thread.c \
                          test/test-threadpool-cancel.c \
@@ -328,7 +329,8 @@ libuv_la_SOURCES += src/unix/darwin.c \
                     src/unix/fsevents.c \
                     src/unix/kqueue.c \
                     src/unix/proctitle.c \
-                    src/unix/pthread-barrier.c
+                    src/unix/pthread-barrier.c \
+                    src/unix/bsd-largesock.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
@@ -340,7 +342,7 @@ endif
 
 if FREEBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/freebsd.c src/unix/kqueue.c
+libuv_la_SOURCES += src/unix/freebsd.c src/unix/kqueue.c src/unix/bsd-largesock.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
@@ -357,13 +359,13 @@ endif
 
 if NETBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/kqueue.c src/unix/netbsd.c
+libuv_la_SOURCES += src/unix/kqueue.c src/unix/netbsd.c src/unix/bsd-largesock.c
 test_run_tests_LDFLAGS += -lutil
 endif
 
 if OPENBSD
 include_HEADERS += include/uv-bsd.h
-libuv_la_SOURCES += src/unix/kqueue.c src/unix/openbsd.c
+libuv_la_SOURCES += src/unix/kqueue.c src/unix/openbsd.c src/unix/bsd-largesock.c
 test_run_tests_LDFLAGS += -lutil
 endif
 

--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -105,4 +105,20 @@ API
     The callback is made when the connection has been established or when a
     connection error happened.
 
+.. c:function:: int uv_tcp_enable_largesocket(uv_tcp_t* handle)
+
+    For TCP based full duplex streams, leverages the TCP window scaling,
+    if it is supported by the underlying system. The socket buffer size is aligned
+    to the system configuration values, and the internal I/O buffers are enlarged
+    to transport large amount of data.
+
+    Currently supported only for Linux, AIX and MAC OS X.
+
+    Will return either:
+
+    * 0: Indicates system supports TCP window scaling, and socket buffers are
+         increased (in platform specific manner)
+    * EV_ENOSYS: Indicates either no platform support,
+         or not configured to tap the capability.
+
 .. seealso:: The :c:type:`uv_stream_t` API functions also apply.

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -269,7 +269,17 @@ typedef struct {
   void* queued_fds;                                                           \
   UV_STREAM_PRIVATE_PLATFORM_FIELDS                                           \
 
+#if defined(_AIX)                 ||                                          \
+    defined(__linux__)            ||                                          \
+    defined(__APPLE__)            ||                                          \
+    defined(__OpenBSD__)          ||                                          \
+    defined(__FreeBSD__)          ||                                          \
+    defined(__NetBSD__)
+#define UV_TCP_PRIVATE_FIELDS                                                 \
+  int chunk_read_size;
+#else
 #define UV_TCP_PRIVATE_FIELDS /* empty */
+#endif
 
 #define UV_UDP_PRIVATE_FIELDS                                                 \
   uv_alloc_cb alloc_cb;                                                       \

--- a/include/uv.h
+++ b/include/uv.h
@@ -534,6 +534,9 @@ UV_EXTERN int uv_tcp_connect(uv_connect_t* req,
                              uv_tcp_t* handle,
                              const struct sockaddr* addr,
                              uv_connect_cb cb);
+UV_EXTERN int uv_tcp_enable_largesocket(uv_tcp_t* tcp);
+
+#define STDTCPWINDOW (64 * 1024)
 
 /* uv_connect_t is a subclass of uv_req_t. */
 struct uv_connect_s {

--- a/src/unix/bsd-largesock.c
+++ b/src/unix/bsd-largesock.c
@@ -1,0 +1,29 @@
+#include "uv.h"
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+int uv__tcp_enable_largesocket(uv_tcp_t *tcp) {
+  int rmem;
+  int wmem;
+  int r;
+
+  size_t size = sizeof(int);
+  if (sysctlbyname("net.inet.tcp.recvspace", &rmem, &size, NULL, 0) ||
+      rmem <= STDTCPWINDOW)
+    return UV_ENOSYS;
+  
+  if (sysctlbyname("net.inet.tcp.sendspace", &wmem, &size, NULL, 0) ||
+      wmem <= STDTCPWINDOW)
+    return UV_ENOSYS;
+
+  r = uv_recv_buffer_size((uv_handle_t*) tcp, &rmem);
+  if (r != 0)
+    return UV_ENOSYS;
+
+  r = uv_send_buffer_size((uv_handle_t*) tcp, &wmem);
+  if (r != 0)
+    return UV_ENOSYS;
+
+  tcp->chunk_read_size = rmem;
+  return 0;
+}

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1127,7 +1127,12 @@ static void uv__read(uv_stream_t* stream) {
     assert(stream->alloc_cb != NULL);
 
     buf = uv_buf_init(NULL, 0);
+#if defined(_AIX) || defined(__linux__) || defined(__APPLE__)
+    stream->alloc_cb((uv_handle_t*)stream, stream->type == UV_TCP ?
+                    ((uv_tcp_t *) stream)->chunk_read_size : STDTCPWINDOW, &buf);
+#else
     stream->alloc_cb((uv_handle_t*)stream, 64 * 1024, &buf);
+#endif
     if (buf.base == NULL || buf.len == 0) {
       /* User indicates it can't or won't handle the read. */
       stream->read_cb(stream, UV_ENOBUFS, &buf);

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -77,6 +77,14 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* tcp, unsigned int flags) {
     }
   }
 
+#if defined(_AIX)                 ||                                      \
+    defined(__linux__)            ||                                      \
+    defined(__APPLE__)            ||                                      \
+    defined(__OpenBSD__)          ||                                      \
+    defined(__FreeBSD__)          ||                                      \
+    defined(__NetBSD__)
+  tcp->chunk_read_size = STDTCPWINDOW;
+#endif
   return 0;
 }
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -107,6 +107,15 @@ TEST_DECLARE   (tcp_bind6_error_addrnotavail)
 TEST_DECLARE   (tcp_bind6_error_fault)
 TEST_DECLARE   (tcp_bind6_error_inval)
 TEST_DECLARE   (tcp_bind6_localhost_ok)
+#if defined(_AIX)                 ||                                      \
+    defined(__linux__)            ||                                      \
+    defined(__APPLE__)            ||                                      \
+    defined(__OpenBSD__)          ||                                      \
+    defined(__FreeBSD__)          ||                                      \
+    defined(__NetBSD__)
+TEST_DECLARE   (tcp_chunk_size)
+TEST_DECLARE   (tcp_chunk_size_large)
+#endif
 TEST_DECLARE   (udp_alloc_cb_fail)
 TEST_DECLARE   (udp_bind)
 TEST_DECLARE   (udp_bind_reuseaddr)
@@ -486,6 +495,15 @@ TASK_LIST_START
   TEST_ENTRY  (tcp_bind6_error_fault)
   TEST_ENTRY  (tcp_bind6_error_inval)
   TEST_ENTRY  (tcp_bind6_localhost_ok)
+#if defined(_AIX)                 ||                                      \
+    defined(__linux__)            ||                                      \
+    defined(__APPLE__)            ||                                      \
+    defined(__OpenBSD__)          ||                                      \
+    defined(__FreeBSD__)          ||                                      \
+    defined(__NetBSD__)
+  TEST_ENTRY  (tcp_chunk_size)
+  TEST_ENTRY  (tcp_chunk_size_large)
+#endif
 
   TEST_ENTRY  (udp_alloc_cb_fail)
   TEST_ENTRY  (udp_bind)

--- a/test/test-tcp-chunk-size.c
+++ b/test/test-tcp-chunk-size.c
@@ -1,0 +1,149 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "uv.h"
+#include "task.h"
+
+static uv_tcp_t server;
+static uv_tcp_t client;
+static uv_tcp_t incoming;
+static int connect_cb_called;
+static int close_cb_called;
+static int connection_cb_called;
+static uv_write_t write_req;
+
+#define DATABUFFERSIZE 10 * 1024 * 1024
+
+static char out[DATABUFFERSIZE];
+static char in[DATABUFFERSIZE];
+static int bytes_read;
+static int largesocket;
+static int large_socket_enabled;
+static int maxread;
+
+int tcp_chunk_size_test();
+int uv_tcp_enable_largesocket(uv_tcp_t *tcp);
+
+static void close_cb(uv_handle_t* handle) {
+  close_cb_called++;
+}
+
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT(status == 0);
+}
+
+static void conn_alloc_cb(uv_handle_t* handle,
+                          size_t size,
+                          uv_buf_t* buf) {
+  buf->base = in;
+  buf->len = size;
+}
+
+static void conn_read_cb(uv_stream_t* stream,
+                         ssize_t nread,
+                         const uv_buf_t* buf) {
+  if(large_socket_enabled == 0)
+    ASSERT(nread <= STDTCPWINDOW);
+  else
+    maxread = maxread < nread ? nread : maxread;
+
+  bytes_read += nread;
+
+  if(bytes_read == DATABUFFERSIZE) {
+    if(large_socket_enabled == 1) {
+      /* Not every chunk will be enlarged. So a reasonable
+       * thing to do is to track the chunk sizes and make
+       * sure that at least the largest read is big enough. */
+      ASSERT(maxread > STDTCPWINDOW);
+      fprintf(stderr, "largest chunk got: %d\n", maxread);
+    }
+
+    uv_close((uv_handle_t*) &incoming, close_cb);
+    uv_close((uv_handle_t*) &client, close_cb);
+    uv_close((uv_handle_t*) &server, close_cb);
+  }
+}
+
+static void connect_cb(uv_connect_t* req, int status) {
+  int r;
+  uv_buf_t buf;
+
+  ASSERT(status == 0);
+  connect_cb_called++;
+
+  buf = uv_buf_init(out, sizeof(out));
+  memset(out, 32, sizeof(out));
+  r = uv_write(&write_req, req->handle, &buf, 1, write_cb);
+  ASSERT(r == 0);
+}
+
+
+static void connection_cb(uv_stream_t* tcp, int status) {
+  int r;
+  ASSERT(status == 0);
+  ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
+  ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
+
+  if(largesocket == 1) {
+    r = uv_tcp_enable_largesocket((uv_tcp_t *) &incoming);
+    ASSERT(r == 0 || r == UV_ENOSYS);
+    if(r == 0)
+      large_socket_enabled = 1;
+  }
+  ASSERT(0 == uv_read_start((uv_stream_t*) &incoming,
+                            conn_alloc_cb,
+                            conn_read_cb));
+
+  connection_cb_called++;
+}
+
+
+static void start_server(void) {
+  struct sockaddr_in addr;
+  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
+  ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, connection_cb));
+}
+
+/* Negative validation: without uv_enable_largesocket,
+ * TCP read chunk sizes cannot exeed 64 KB.
+ */
+TEST_IMPL(tcp_chunk_size) {
+  tcp_chunk_size_test();
+  return 0;
+}
+
+/* With uv_enable_largesocket, validate that
+ * at least one TCP read chunk exeeds 64 KB.
+ */
+TEST_IMPL(tcp_chunk_size_large) {
+  largesocket = 1;
+  tcp_chunk_size_test();
+  return 0;
+}
+
+int tcp_chunk_size_test() {
+  uv_connect_t connect_req;
+  struct sockaddr_in addr;
+
+  start_server();
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
+  ASSERT(0 == uv_tcp_connect(&connect_req,
+                             &client,
+                             (struct sockaddr*) &addr,
+                             connect_cb));
+
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT(connect_cb_called == 1);
+  ASSERT(connection_cb_called == 1);
+  ASSERT(close_cb_called == 3);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/uv.gyp
+++ b/uv.gyp
@@ -211,7 +211,8 @@
             'src/unix/darwin.c',
             'src/unix/fsevents.c',
             'src/unix/darwin-proctitle.c',
-            'src/unix/pthread-barrier.c'
+            'src/unix/pthread-barrier.c',
+            'src/unix/bsd-largesock.c'
           ],
           'defines': [
             '_DARWIN_USE_64_BIT_INODE=1',
@@ -279,13 +280,19 @@
           },
         }],
         [ 'OS=="freebsd" or OS=="dragonflybsd"', {
-          'sources': [ 'src/unix/freebsd.c' ],
+          'sources': [ 'src/unix/freebsd.c',
+                       'src/unix/bsd-largesock.c'
+                     ],
         }],
         [ 'OS=="openbsd"', {
-          'sources': [ 'src/unix/openbsd.c' ],
+          'sources': [ 'src/unix/openbsd.c',
+                       'src/unix/bsd-largesock.c'
+                     ],
         }],
         [ 'OS=="netbsd"', {
-          'sources': [ 'src/unix/netbsd.c' ],
+          'sources': [ 'src/unix/netbsd.c',
+                       'src/unix/bsd-largesock.c'
+                     ],
         }],
         [ 'OS in "freebsd dragonflybsd openbsd netbsd".split()', {
           'link_settings': {
@@ -417,6 +424,7 @@
         'test/test-tcp-oob.c',
         'test/test-tcp-read-stop.c',
         'test/test-tcp-write-queue-order.c',
+        'test/test-tcp-chunk-size.c',
         'test/test-threadpool.c',
         'test/test-threadpool-cancel.c',
         'test/test-thread-equal.c',


### PR DESCRIPTION
For TCP based full duplex streams, leverage the TCP window scaling, if it is supported by the underlying system. The socket buffer size is aligned to the system configuration values, and the internal I/O buffers are enlarged to enable transport of large amount of data.

**Summary of changes:**

- Introduces an API uv_enable_largesocket(uv_stream_t *handle) to customize socket buffers
- Customized the stream chunk size from adjusted socket buffers
- Added a test case to validate the API as well as for negative validation.
- Changed the documentation to reflect the new API.
- Currently supported only for Linux, AIX and MAC OS X.

Custom streaming test cases (with node.js) with large data transfer (5 - 200 MB) and with reasonable processing on the data (map-reduce) in an LRTT network showed performance improvements on the lines of:

**12% (Linux)
    10% (AIX)
    16% (MAC)
    15%(WIndows - tested with a PoC, not fully developed code)**

Please refer to #1217 for background and further details.