### PR TITLE
build: make libuv buildable with vs2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,18 +152,56 @@ To build with autotools:
 
 ### Windows
 
-First, [Python][] 2.6 or 2.7 must be installed as it is required by [GYP][].
-If python is not in your path, set the environment variable `PYTHON` to its
-location. For example: `set PYTHON=C:\Python27\python.exe`
+Prerequisites:
 
-To build with Visual Studio, launch a git shell (e.g. Cmd or PowerShell)
-and run vcbuild.bat which will checkout the GYP code into build/gyp and
-generate uv.sln as well as related project files.
+* [Python 2.6 or 2.7][] as it is required
+  by [GYP][].  
+  If python is not in your path, set the environment variable `PYTHON` to its
+  location. For example: `set PYTHON=C:\Python27\python.exe`
+* One of:
+  * [Visual C++ Build Tools][]
+  * [Visual Studio 2015 Update 3][], all editions
+    including the Community edition (remember to select
+    "Common Tools for Visual C++ 2015" feature during installation).
+  * [Visual Studio 2017][], any edition (including the Build Tools SKU).
+    **Required Components:** "MSbuild", "VC++ 2017 v141 toolset" and one of the
+    Windows SDKs (10 or 8.1).
+* Basic Unix tools required for some tests,
+  [Git for Windows][] includes Git Bash
+  and tools which can be included in the global `PATH`.
 
-To have GYP generate build script for another system, checkout GYP into the
-project tree manually:
+To build, launch a git shell (e.g. Cmd or PowerShell), run `vcbuild.bat`
+(to build with VS2017 you need to explicitly add a `vs2017` argument),
+which will checkout the GYP code into `build/gyp`, generate `uv.sln`
+as well as the necesery related project files, and start building.
 
-    $ git clone https://chromium.googlesource.com/external/gyp.git build/gyp
+```console
+> vcbuild
+```
+
+Or:
+
+```console
+> vcbuild vs2017
+```
+
+To run the tests:
+
+```console
+> vcbuild test
+```
+
+To see all the options that could passed to `vcbuild`:
+
+```console
+> vcbuild help
+vcbuild.bat [debug/release] [test/bench] [clean] [noprojgen] [nobuild] [vs2017] [x86/x64] [static/shared]
+Examples:
+  vcbuild.bat              : builds debug build
+  vcbuild.bat test         : builds debug build and runs tests
+  vcbuild.bat release bench: builds release build and runs benchmarks
+```
+
 
 ### Unix
 
@@ -244,7 +282,11 @@ See the [guidelines for contributing][].
 
 [node.js]: http://nodejs.org/
 [GYP]: http://code.google.com/p/gyp/
-[Python]: https://www.python.org/downloads/
 [guidelines for contributing]: https://github.com/libuv/libuv/blob/master/CONTRIBUTING.md
 [libuv_banner]: https://raw.githubusercontent.com/libuv/libuv/master/img/banner.png
 [x32]: https://en.wikipedia.org/wiki/X32_ABI
+[Python 2.6 or 2.7]: https://www.python.org/downloads/
+[Visual C++ Build Tools]: http://landinghub.visualstudio.com/visual-cpp-build-tools
+[Visual Studio 2015 Update 3]: https://www.visualstudio.com/vs/older-downloads/
+[Visual Studio 2017]: https://www.visualstudio.com/downloads/
+[Git for Windows]: http://git-scm.com/download/win

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 libuv is a multi-platform support library with a focus on asynchronous I/O. It
-was primarily developed for use by [Node.js](http://nodejs.org), but it's also
+was primarily developed for use by [Node.js][], but it's also
 used by [Luvit](http://luvit.io/), [Julia](http://julialang.org/),
 [pyuv](https://github.com/saghul/pyuv), and [others](https://github.com/libuv/libuv/wiki/Projects-that-use-libuv).
 
@@ -62,24 +62,34 @@ formats.
 
 Show different supported building options:
 
-    $ make help
+```bash
+$ make help
+```
 
 Build documentation as HTML:
 
-    $ make html
+```bash
+$ make html
+```
 
 Build documentation as HTML and live reload it when it changes (this requires
 sphinx-autobuild to be installed and is only supported on Unix):
 
-    $ make livehtml
+```bash
+$ make livehtml
+```
 
 Build documentation as man pages:
 
-    $ make man
+```bash
+$ make man
+```
 
 Build documentation as ePub:
 
-    $ make epub
+```bash
+$ make epub
+```
 
 NOTE: Windows users need to use make.bat instead of plain 'make'.
 
@@ -116,25 +126,32 @@ file, but are also available as git blob objects for easier use.
 
 Importing a key the usual way:
 
-    $ gpg --keyserver pool.sks-keyservers.net \
-      --recv-keys AE9BC059
+```bash
+$ gpg --keyserver pool.sks-keyservers.net --recv-keys AE9BC059
+```
 
 Importing a key from a git blob object:
 
-    $ git show pubkey-saghul | gpg --import
+```bash
+$ git show pubkey-saghul | gpg --import
+```
 
 ### Verifying releases
 
 Git tags are signed with the developer's key, they can be verified as follows:
 
-    $ git verify-tag v1.6.1
+```bash
+$ git verify-tag v1.6.1
+```
 
 Starting with libuv 1.7.0, the tarballs stored in the
 [downloads site](http://dist.libuv.org/dist/) are signed and an accompanying
 signature file sit alongside each. Once both the release tarball and the
 signature file are downloaded, the file can be verified as follows:
 
-    $ gpg --verify libuv-1.7.0.tar.gz.sign
+```bash
+$ gpg --verify libuv-1.7.0.tar.gz.sign
+```
 
 ## Build Instructions
 
@@ -144,11 +161,13 @@ backends. It is best used for integration into other projects.
 
 To build with autotools:
 
-    $ sh autogen.sh
-    $ ./configure
-    $ make
-    $ make check
-    $ make install
+```bash
+$ sh autogen.sh
+$ ./configure
+$ make
+$ make check
+$ make install
+```
 
 ### Windows
 
@@ -207,13 +226,17 @@ Examples:
 
 For Debug builds (recommended) run:
 
-    $ ./gyp_uv.py -f make
-    $ make -C out
+```bash
+$ ./gyp_uv.py -f make
+$ make -C out
+```
 
 For Release builds run:
 
-    $ ./gyp_uv.py -f make
-    $ BUILDTYPE=Release make -C out
+```bash
+$ ./gyp_uv.py -f make
+$ BUILDTYPE=Release make -C out
+```
 
 Run `./gyp_uv.py -f make -Dtarget_arch=x32` to build [x32][] binaries.
 
@@ -221,13 +244,17 @@ Run `./gyp_uv.py -f make -Dtarget_arch=x32` to build [x32][] binaries.
 
 Run:
 
-    $ ./gyp_uv.py -f xcode
-    $ xcodebuild -ARCHS="x86_64" -project uv.xcodeproj \
-         -configuration Release -target All
+```bash
+$ ./gyp_uv.py -f xcode
+$ xcodebuild -ARCHS="x86_64" -project uv.xcodeproj \
+     -configuration Release -target All
+```
 
 Using Homebrew:
 
-    $ brew install --HEAD libuv
+```bash
+$ brew install --HEAD libuv
+```
 
 Note to OS X users:
 
@@ -239,8 +266,10 @@ Make sure that you specify the architecture you wish to build for in the
 
 Run:
 
-    $ source ./android-configure NDK_PATH gyp
-    $ make -C out
+```bash
+$ source ./android-configure NDK_PATH gyp
+$ make -C out
+```
 
 Note for UNIX users: compile your project with `-D_LARGEFILE_SOURCE` and
 `-D_FILE_OFFSET_BITS=64`. GYP builds take care of that automatically.
@@ -249,18 +278,22 @@ Note for UNIX users: compile your project with `-D_LARGEFILE_SOURCE` and
 
 To use ninja for build on ninja supported platforms, run:
 
-    $ ./gyp_uv.py -f ninja
-    $ ninja -C out/Debug     #for debug build OR
-    $ ninja -C out/Release
+```bash
+$ ./gyp_uv.py -f ninja
+$ ninja -C out/Debug     #for debug build OR
+$ ninja -C out/Release
+```
 
 
 ### Running tests
 
 Run:
 
-    $ ./gyp_uv.py -f make
-    $ make -C out
-    $ ./out/Debug/run-tests
+```bash
+$ ./gyp_uv.py -f make
+$ make -C out
+$ ./out/Debug/run-tests
+```
 
 ## Supported Platforms
 

--- a/tools/vswhere_usability_wrapper.cmd
+++ b/tools/vswhere_usability_wrapper.cmd
@@ -2,20 +2,32 @@
 :: Distributed under MIT style license or the libuv license
 :: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
 :: or libuv LICENSE file at https://github.com/libuv/libuv
-:: version: 1.14.0
+:: version: 1.15.0
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
+set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" exit goto :no-vswhere
+:: Manipulate %Path% for easier " handeling
+set Path=%Path%;%InstallerPath%
+where vswhere 2> nul > nul
+if errorlevel 1 goto :no-vswhere
 set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version "[15.0,16.0)"
+vswhere -prerelease > nul
+if "%~1"=="prerelase" set VSWHERE_WITH_PRERELASE=1
+if not errorlevel 1 if "%VSWHERE_WITH_PRERELASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
-set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" exit /B 1
-set Path=%Path%;%VSWHERE%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     endlocal
     set "VCINSTALLDIR=%%i\VC\"
     set "VS150COMNTOOLS=%%i\Common7\Tools\"
-    exit /B 0)
+    exit /B 0
+)
+
+:no-vswhere
+endlocal
+echo could not find "vswhere"
+exit /B 1

--- a/tools/vswhere_usability_wrapper.cmd
+++ b/tools/vswhere_usability_wrapper.cmd
@@ -2,12 +2,12 @@
 :: Distributed under MIT style license or the libuv license
 :: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
 :: or libuv LICENSE file at https://github.com/libuv/libuv
-:: version: 1.15.0
+:: version: 1.15.3
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
 set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
-if not exist "%InstallerPath%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" set "InstallerPath=%ProgramFiles%\Microsoft Visual Studio\Installer"
 if not exist "%InstallerPath%" exit goto :no-vswhere
 :: Manipulate %Path% for easier " handeling
 set Path=%Path%;%InstallerPath%

--- a/tools/vswhere_usability_wrapper.cmd
+++ b/tools/vswhere_usability_wrapper.cmd
@@ -1,0 +1,21 @@
+:: Copyright 2017 - Refael Ackermann
+:: Distributed under MIT style license or the libuv license
+:: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
+:: or libuv LICENSE file at https://github.com/libuv/libuv
+:: version: 1.14.0
+
+@if not defined DEBUG_HELPER @ECHO OFF
+setlocal
+set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+set VSWHERE_PRP=-property installationPath
+set VSWHERE_LMT=-version "[15.0,16.0)"
+SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
+if not exist "%VSWHERE%" exit /B 1
+set Path=%Path%;%VSWHERE%
+for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
+    endlocal
+    set "VCINSTALLDIR=%%i\VC\"
+    set "VS150COMNTOOLS=%%i\Common7\Tools\"
+    exit /B 0)

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -168,7 +168,7 @@ echo Failed to create vc project files.
 exit /b 1
 
 :help
-echo vcbuild.bat [debug/release] [test/bench] [clean] [noprojgen] [nobuild] [x86/x64] [static/shared]
+echo vcbuild.bat [debug/release] [test/bench] [clean] [noprojgen] [nobuild] [vs2017] [x86/x64] [static/shared]
 echo Examples:
 echo   vcbuild.bat              : builds debug build
 echo   vcbuild.bat test         : builds debug build and runs tests

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -14,10 +14,11 @@ if /i "%1"=="/?" goto help
 @rem Process arguments.
 set config=
 set target=Build
+set target_arch=ia32
+set target_env=vs2015
 set noprojgen=
 set nobuild=
 set run=
-set target_arch=ia32
 set vs_toolset=x86
 set msbuild_platform=WIN32
 set library=static_library
@@ -29,6 +30,7 @@ if /i "%1"=="release"      set config=Release&goto arg-ok
 if /i "%1"=="test"         set run=run-tests.exe&goto arg-ok
 if /i "%1"=="bench"        set run=run-benchmarks.exe&goto arg-ok
 if /i "%1"=="clean"        set target=Clean&goto arg-ok
+if /i "%1"=="vs2017"        set target_env=vs2017&goto arg-ok
 if /i "%1"=="noprojgen"    set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"      set nobuild=1&goto arg-ok
 if /i "%1"=="x86"          set target_arch=ia32&set msbuild_platform=WIN32&set vs_toolset=x86&goto arg-ok
@@ -41,26 +43,29 @@ shift
 goto next-arg
 :args-done
 
-@rem Look for a set-up Visual Studio 2017 environment
-if defined VCINSTALLDIR goto :skip-vswhere
+@rem Look for Visual Studio 2017
+:vs-set-2017
+if "%target_env%" NEQ "vs2017" goto vs-set-2015
+echo Looking for Visual Studio 2017
+@rem check if VS2017 is already setup, and for the requested arch
+if "_%VisualStudioVersion%_" == "_15.0_" if "_%VSCMD_ARG_TGT_ARCH%_"=="_%vs_toolset%_" goto found_vs2017
+set "VSINSTALLDIR="
 call tools\vswhere_usability_wrapper.cmd
-:skip-vswhere
-if not defined VCINSTALLDIR goto :no-vs2017-env
-if defined VisualStudioVersion if "%VisualStudioVersion%"=="15.0" goto :no-vcvarsall-2017
-call "%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vs_toolset%
-if not defined VisualStudioVersion if not "%VisualStudioVersion%"=="15.0" goto :no-vs2017-env
-:no-vcvarsall-2017
-echo Using Visual Studio 2017
+if "_%VCINSTALLDIR%_" == "__" goto vs-set-2015
+@rem need to clear VSINSTALLDIR for vcvarsall to work as expected
+set vcvars_call="%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vs_toolset%
+echo calling: %vcvars_call%
+call %vcvars_call%
+
+:found_vs2017
+echo Found MSVS version %VisualStudioVersion%
 if %VSCMD_ARG_TGT_ARCH%==x64 set target_arch=x64&set msbuild_platform=x64&set vs_toolset=x64
 set GYP_MSVS_VERSION=2017
 goto select-target
 
-:no-vs2017-env
-echo Environment not set for VS2017
-if defined WindowsSDKDir goto select-target
-if defined VCINSTALLDIR goto select-target
 
 @rem Look for Visual Studio 2015
+:vs-set-2015
 if not defined VS140COMNTOOLS goto vc-set-2013
 if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2013
 call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" %vs_toolset%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -30,7 +30,7 @@ if /i "%1"=="release"      set config=Release&goto arg-ok
 if /i "%1"=="test"         set run=run-tests.exe&goto arg-ok
 if /i "%1"=="bench"        set run=run-benchmarks.exe&goto arg-ok
 if /i "%1"=="clean"        set target=Clean&goto arg-ok
-if /i "%1"=="vs2017"        set target_env=vs2017&goto arg-ok
+if /i "%1"=="vs2017"       set target_env=vs2017&goto arg-ok
 if /i "%1"=="noprojgen"    set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"      set nobuild=1&goto arg-ok
 if /i "%1"=="x86"          set target_arch=ia32&set msbuild_platform=WIN32&set vs_toolset=x86&goto arg-ok

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,7 +44,6 @@ goto next-arg
 :args-done
 
 @rem Look for Visual Studio 2017
-:vs-set-2017
 if "%target_env%" NEQ "vs2017" goto vs-set-2015
 echo Looking for Visual Studio 2017
 @rem check if VS2017 is already setup, and for the requested arch

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -15,7 +15,7 @@ if /i "%1"=="/?" goto help
 set config=
 set target=Build
 set target_arch=ia32
-set target_env=vs2015
+set target_env=
 set noprojgen=
 set nobuild=
 set run=
@@ -43,15 +43,15 @@ shift
 goto next-arg
 :args-done
 
-@rem Look for Visual Studio 2017
+@rem Look for Visual Studio 2017 only if explicitly requested.
 if "%target_env%" NEQ "vs2017" goto vs-set-2015
 echo Looking for Visual Studio 2017
-@rem check if VS2017 is already setup, and for the requested arch
+@rem Check if VS2017 is already setup, and for the requested arch.
 if "_%VisualStudioVersion%_" == "_15.0_" if "_%VSCMD_ARG_TGT_ARCH%_"=="_%vs_toolset%_" goto found_vs2017
 set "VSINSTALLDIR="
 call tools\vswhere_usability_wrapper.cmd
 if "_%VCINSTALLDIR%_" == "__" goto vs-set-2015
-@rem need to clear VSINSTALLDIR for vcvarsall to work as expected
+@rem Need to clear VSINSTALLDIR for vcvarsall to work as expected.
 set vcvars_call="%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vs_toolset%
 echo calling: %vcvars_call%
 call %vcvars_call%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -41,6 +41,22 @@ shift
 goto next-arg
 :args-done
 
+@rem Look for a set-up Visual Studio 2017 environment
+if defined VCINSTALLDIR goto :skip-vswhere
+call tools\vswhere_usability_wrapper.cmd
+:skip-vswhere
+if not defined VCINSTALLDIR goto :no-vs2017-env
+if defined VisualStudioVersion if "%VisualStudioVersion%"=="15.0" goto :no-vcvarsall-2017
+call "%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vs_toolset%
+if not defined VisualStudioVersion if not "%VisualStudioVersion%"=="15.0" goto :no-vs2017-env
+:no-vcvarsall-2017
+echo Using Visual Studio 2017
+if %VSCMD_ARG_TGT_ARCH%==x64 set target_arch=x64&set msbuild_platform=x64&set vs_toolset=x64
+set GYP_MSVS_VERSION=2017
+goto select-target
+
+:no-vs2017-env
+echo Environment not set for VS2017
 if defined WindowsSDKDir goto select-target
 if defined VCINSTALLDIR goto select-target
 


### PR DESCRIPTION
Re: #1283 

This is the minimal change needed to get this to build on VS2017, it assumes the dev has run `vsvarsall.bat` (i.e. set-up the dev environment, and chose target and host arch) So to get it to build on appveyor you need to add to the YAML:
```
before_build:
  - cmd: "C:\Program Files (x86)\Microsoft Visual Studio 15.0\VC\Auxiliary\Build\vcvarsall.bat amd64"
```

I could add another PR with VS2017 detection code...