### PR TITLE
add Visual Studio 2017 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+os: Visual Studio 2017
 version: v1.11.0.build{build}
 
 install:
@@ -21,12 +22,15 @@ configuration:
 build_script:
   # Fixed tag version number if using a tag.
   - cmd: if "%APPVEYOR_REPO_TAG%" == "true" set APPVEYOR_BUILD_VERSION=%APPVEYOR_REPO_TAG_NAME%
-  # vcbuild overwrites the platform variable.
-  - cmd: set ARCH=%platform%
-  - cmd: vcbuild.bat release %ARCH% shared
+  - cmd: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+        set GYP_MSVS_VERSION=2015
+        vcbuild.bat %configuration% %platform% shared nobuild
+  - ps: .\scripts\Update-ProjectFilesToVS2017.ps1
+  - cmd: vcbuild.bat %configuration% %platform% shared noprojgen
 
 after_build:
-  - '"%PROGRAMFILES(x86)%\NSIS\makensis" /DVERSION=%APPVEYOR_BUILD_VERSION% /DARCH=%ARCH% libuv.nsi'
+  - '"%PROGRAMFILES(x86)%\NSIS\makensis" /DVERSION=%APPVEYOR_BUILD_VERSION% /DARCH=%platform% libuv.nsi'
 
 artifacts:
   - name: Installer

--- a/scripts/Add-VisualStudioPackages.ps1
+++ b/scripts/Add-VisualStudioPackages.ps1
@@ -1,0 +1,23 @@
+# run this in PowerShell as Administrator
+# it will launch Visual Studio Installer and prompt you to add
+# all packages required to build libuv
+
+if (-not (Get-Module -ListAvailable -Name VSSetup)) {
+    Install-Module VSSetup -Scope CurrentUser
+}
+$vs = Get-VSSetupInstance
+
+# to see what packages are installed on your system, you can do:
+#$vs.Packages | sort Type, Id | select Id, Type, Version
+
+# MSBuild
+# Visual C++ 2017 v141 toolset (x86,x64)
+# Standard Library Modules
+# Windows 10 SDK (10.0.14393.0)
+
+& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installershell.exe" modify `
+    --installPath $vs.InstallationPath `
+    --add Microsoft.Build `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.VC.Modules.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.14393

--- a/scripts/Update-ProjectFilesToVS2017.ps1
+++ b/scripts/Update-ProjectFilesToVS2017.ps1
@@ -1,0 +1,27 @@
+
+# gyp doesn't yet support Visual Studio 2017
+# This file modifies a 2015 project file to work with 2017.
+# vsbuild.bat creates the project file and builds it.
+# You can have it only create the project files & then run this script.
+# See appveyor.yml as an example.
+
+$files = "libuv.vcxproj", "run-benchmarks.vcxproj", "run-tests.vcxproj"
+ForEach ($file in $files) {
+    $file = (Resolve-Path $file).Path # full path
+    [xml] $proj = Get-Content $file
+    $nm = New-Object System.Xml.XmlNamespaceManager $proj.NameTable
+    $ns = $proj.Project.NamespaceURI
+    $nm.AddNamespace("msbuild", $ns)
+    
+    # change PlatformToolset from v140 to v141
+    $pt = $proj.SelectSingleNode("//msbuild:PlatformToolset", $nm)
+    $pt.InnerText = "v141"
+
+    # use Windows 10 SDK 10.0.14393.0
+    $wtpv = $proj.CreateElement("WindowsTargetPlatformVersion", $ns)
+    $wtpv.InnerText = "10.0.14393.0"
+    $pg = $proj.SelectSingleNode("//msbuild:PropertyGroup[@Label='Globals']", $nm)
+    $pg.AppendChild($wtpv)
+
+    $proj.Save($file)
+}


### PR DESCRIPTION
This is #1283, but retargeted to the v1.x branch.  I think the `Update-ProjectFilesToVS2017.ps1` may be removed if #1284 is merged. This build [passes](https://ci.appveyor.com/project/ctaggart/libuv/build/v1.11.0.build17) as is.