### PR TITLE
unix,test: deadstore fixes

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -47,7 +47,6 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   int err;
 
   pipe_fname = NULL;
-  sockfd = -1;
 
   /* Already bound? */
   if (uv__stream_fd(handle) >= 0)

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -46,7 +46,6 @@ static char socket_cb_read_buf[1024];
 
 static void socket_cb(uv_poll_t* poll, int status, int events) {
   ssize_t cnt;
-  cnt = 0;
   socket_cb_called++;
   ASSERT(0 == status);
   printf("Socket cb got events %d\n", events);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1485,6 +1485,7 @@ TEST_IMPL(fs_chown) {
   /* chown to root (fail) */
   chown_cb_count = 0;
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
+  ASSERT(r == 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(chown_cb_count == 1);
 

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -67,6 +67,7 @@ TEST_IMPL(shutdown_twice) {
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &h);
+  ASSERT(r == 0);
 
   r = uv_tcp_connect(&connect_req,
                      &h,

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -136,6 +136,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
+  ASSERT(r == 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 


### PR DESCRIPTION
Fixes deadstore in uv_pipe_bind as 'sockfd' is no longer used.
Fixes deadstore in test related to unused variables or missing assert.