### PR TITLE
unix: inline uv_pipe_bind() err_bind goto target

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -76,7 +76,9 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
     /* Convert ENOENT to EACCES for compatibility with Windows. */
     if (err == -ENOENT)
       err = -EACCES;
-    goto err_bind;
+
+    uv__close(sockfd);
+    goto err_socket;
   }
 
   /* Success. */
@@ -84,9 +86,6 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   handle->pipe_fname = pipe_fname; /* Is a strdup'ed copy. */
   handle->io_watcher.fd = sockfd;
   return 0;
-
-err_bind:
-  uv__close(sockfd);
 
 err_socket:
   uv__free((void*)pipe_fname);


### PR DESCRIPTION
This goto target is only one line, and is only reached from one place.