### PR TITLE
test: fix VC++ warning C4047

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -244,7 +244,7 @@ TEST_IMPL(tty_empty_write) {
   ASSERT(r == 0);
 
   bufs[0].len = 0;
-  bufs[0].base = &dummy;
+  bufs[0].base = &dummy[0];
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
   ASSERT(r == 0);


### PR DESCRIPTION
warning C4047: char *' differs in levels of indirection from 'char (*)[1]'