### PR TITLE
doc: libuv does not touch uv_loop_t.data

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -38,9 +38,8 @@ Public members
 
 .. c:member:: void* uv_loop_t.data
 
-    Space for user-defined arbitrary data. libuv does not use this field. libuv does, however,
-    initialize it to NULL in :c:func:`uv_loop_init`, and it poisons the value (on debug builds)
-    on :c:func:`uv_loop_close`.
+    Space for user-defined arbitrary data. libuv does not use and does not
+    touch this field.
 
 
 API


### PR DESCRIPTION
Mea culpa, I forgot to update the documentation in commit ff0ae10
("unix: preserve loop->data across loop init/done") from July 2016.