### PR TITLE
doc: fix docs/src/fs.rst build warning

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -2,7 +2,7 @@
 .. _fs:
 
 File system operations
-=====================
+======================
 
 libuv provides a wide variety of cross-platform sync and async file system
 operations. All functions defined in this document take a callback, which is


### PR DESCRIPTION
When executing `make html` the following warning is displayed:
```console
reading sources... [100%] fs
/work/libuv/docs/src/fs.rst:5: WARNING:
Title underline too short.
```
The commit removed the above warning.