### PR TITLE
zos: implement uv__io_fork, skip fs event tests

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -863,3 +863,9 @@ update_timeout:
 void uv__set_process_title(const char* title) {
   /* do nothing */
 }
+
+int uv__io_fork(uv_loop_t* loop) {
+  uv__platform_loop_delete(loop);
+
+  return uv__platform_loop_init(loop);
+}

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -506,12 +506,17 @@ static int _do_fork_fs_events_child(int file_or_dir) {
 
 
 TEST_IMPL(fork_fs_events_child) {
+#if defined(__MVS__)
+  RETURN_SKIP("Filesystem watching not supported on this platform.");
+#endif
   return _do_fork_fs_events_child(FS_TEST_FILE);
 }
 
 
 TEST_IMPL(fork_fs_events_child_dir) {
-#if defined(__APPLE__) || defined (__linux__)
+#if defined(__MVS__)
+  RETURN_SKIP("Filesystem watching not supported on this platform.");
+#elif defined(__APPLE__) || defined (__linux__)
   return _do_fork_fs_events_child(FS_TEST_DIR);
 #else
   /* You can't spin up a cfrunloop thread on an apple platform
@@ -524,7 +529,9 @@ TEST_IMPL(fork_fs_events_child_dir) {
 
 
 TEST_IMPL(fork_fs_events_file_parent_child) {
-#if defined(__sun) || defined(_AIX)
+#if defined(__MVS__)
+  RETURN_SKIP("Filesystem watching not supported on this platform.");
+#elif defined(__sun) || defined(_AIX)
   /* It's not possible to implement this without additional
    * bookkeeping on SunOS. For AIX it is possible, but has to be
    * written. See https://github.com/libuv/libuv/pull/846#issuecomment-287170420

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -1029,7 +1029,7 @@ TEST_IMPL(fs_event_error_reporting) {
 #endif  /* defined(__APPLE__) */
 
 TEST_IMPL(fs_event_watch_invalid_path) {
-#if defined(MVS)
+#if defined(__MVS__)
   RETURN_SKIP("Filesystem watching not supported on this platform.");
 #endif
 


### PR DESCRIPTION
Basic implementation of uv__io_fork on z/OS. As of now, since filesystem events are not supported, skip all of those tests on z/OS.
