### PR TITLE
Remove __declspec(inline) from atomic op on windows

### DIFF
--- a/src/win/atomicops-inl.h
+++ b/src/win/atomicops-inl.h
@@ -23,6 +23,7 @@
 #define UV_WIN_ATOMICOPS_INL_H_
 
 #include "uv.h"
+#include "internal.h"
 
 
 /* Atomic set operation on char */
@@ -34,7 +35,7 @@
 /* target to be aligned. */
 #pragma intrinsic(_InterlockedOr8)
 
-static char __declspec(inline) uv__atomic_exchange_set(char volatile* target) {
+static char INLINE uv__atomic_exchange_set(char volatile* target) {
   return _InterlockedOr8(target, 1);
 }
 


### PR DESCRIPTION
__declspec(inline) is completely undocumented, as well
as unnecessary.  The INLINE preprocessor macro is used
throughout libuv, so this simply replaces this only instance
of declspec(inline) with the macro version.