### PR TITLE
zos: implement uv_fs_event* functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -454,7 +454,6 @@ libuv_la_CFLAGS += -D_UNIX03_THREADS \
                    -qFLOAT=IEEE
 libuv_la_LDFLAGS += -qXPLINK
 libuv_la_SOURCES += src/unix/pthread-fixes.c \
-                    src/unix/no-fsevents.c \
                     src/unix/os390.c \
                     src/unix/os390-syscalls.c \
                     src/unix/proctitle.c

--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -19,7 +19,13 @@ the best backend for the job on each platform.
 
     See documentation_ for more details.
 
+    The z/OS file system events monitoring infrastructure does not notify of file
+    creation/deletion within a directory that is being monitored.
+    See the `IBM Knowledge centre`_ for more details.
+
     .. _documentation: http://www.ibm.com/developerworks/aix/library/au-aix_event_infrastructure/
+    .. _`IBM Knowledge centre`: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.2.0/com.ibm.zos.v2r1.bpxb100/ioc.htm
+
 
 
 

--- a/include/uv-os390.h
+++ b/include/uv-os390.h
@@ -27,4 +27,7 @@
 #define UV_PLATFORM_LOOP_FIELDS                                               \
   void* ep;                                                                   \
 
+#define UV_PLATFORM_FS_EVENT_FIELDS                                           \
+  char rfis_rftok[8];                                                         \
+
 #endif /* UV_MVS_H */

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <search.h>
+#include <termios.h>
+#include <sys/msg.h>
 
 #define CW_CONDVAR 32
 
@@ -103,9 +105,18 @@ static void maybe_resize(uv__os390_epoll* lst, unsigned int len) {
   unsigned int newsize;
   unsigned int i;
   struct pollfd* newlst;
+  struct pollfd event;
 
   if (len <= lst->size)
     return;
+
+  if (lst->size == 0)
+    event.fd = -1;
+  else {
+    /* Extract the message queue at the end. */
+    event = lst->items[lst->size - 1];
+    lst->items[lst->size - 1].fd = -1;
+  }
 
   newsize = next_power_of_two(len);
   newlst = uv__realloc(lst->items, newsize * sizeof(lst->items[0]));
@@ -115,8 +126,37 @@ static void maybe_resize(uv__os390_epoll* lst, unsigned int len) {
   for (i = lst->size; i < newsize; ++i)
     newlst[i].fd = -1;
 
+  /* Restore the message queue at the end */
+  newlst[newsize - 1] = event;
+
   lst->items = newlst;
   lst->size = newsize;
+}
+
+
+static void init_message_queue(uv__os390_epoll* lst) {
+  struct {
+    long int header;
+    char body;
+  } msg;
+
+  /* initialize message queue */
+  lst->msg_queue = msgget(IPC_PRIVATE, 0622 | IPC_CREAT);
+  if (lst->msg_queue == -1)
+    abort();
+
+  /*
+     On z/OS, the message queue will be affiliated with the process only
+     when a send is performed on it. Once this is done, the system
+     can be queried for all message queues belonging to our process id.
+  */
+  msg.header = 1;
+  if (msgsnd(lst->msg_queue, &msg, sizeof(msg.body), 0) != 0)
+    abort();
+
+  /* Clean up the dummy message sent above */
+  if (msgrcv(lst->msg_queue, &msg, sizeof(msg.body), 0, 0) != sizeof(msg.body))
+    abort();
 }
 
 
@@ -139,8 +179,13 @@ static void child_fork(void) {
 
   /* reset epoll list */
   while (!QUEUE_EMPTY(&global_epoll_queue)) {
+    uv__os390_epoll* lst;
     q = QUEUE_HEAD(&global_epoll_queue);
     QUEUE_REMOVE(q);
+    lst = QUEUE_DATA(q, uv__os390_epoll, member);
+    uv__free(lst->items);
+    lst->items = NULL;
+    lst->size = 0;
   }
 
   uv_mutex_unlock(&global_epoll_lock);
@@ -166,6 +211,10 @@ uv__os390_epoll* epoll_create1(int flags) {
     /* initialize list */
     lst->size = 0;
     lst->items = NULL;
+    init_message_queue(lst);
+    maybe_resize(lst, 1);
+    lst->items[lst->size - 1].fd = lst->msg_queue;
+    lst->items[lst->size - 1].events = POLLIN;
     uv_once(&once, epoll_init);
     uv_mutex_lock(&global_epoll_lock);
     QUEUE_INSERT_TAIL(&global_epoll_queue, &lst->member);
@@ -182,15 +231,20 @@ int epoll_ctl(uv__os390_epoll* lst,
               struct epoll_event *event) {
   uv_mutex_lock(&global_epoll_lock);
 
-  if(op == EPOLL_CTL_DEL) {
+  if (op == EPOLL_CTL_DEL) {
     if (fd >= lst->size || lst->items[fd].fd == -1) {
       uv_mutex_unlock(&global_epoll_lock);
       errno = ENOENT;
       return -1;
     }
     lst->items[fd].fd = -1;
-  } else if(op == EPOLL_CTL_ADD) {
-    maybe_resize(lst, fd + 1);
+  } else if (op == EPOLL_CTL_ADD) {
+
+    /* Resizing to 'fd + 1' would expand the list to contain at least
+     * 'fd'. But we need to guarantee that the last index on the list 
+     * is reserved for the message queue. So specify 'fd + 2' instead.
+     */
+    maybe_resize(lst, fd + 2);
     if (lst->items[fd].fd != -1) {
       uv_mutex_unlock(&global_epoll_lock);
       errno = EEXIST;
@@ -198,7 +252,7 @@ int epoll_ctl(uv__os390_epoll* lst,
     }
     lst->items[fd].fd = fd;
     lst->items[fd].events = event->events;
-  } else if(op == EPOLL_CTL_MOD) {
+  } else if (op == EPOLL_CTL_MOD) {
     if (fd >= lst->size || lst->items[fd].fd == -1) {
       uv_mutex_unlock(&global_epoll_lock);
       errno = ENOENT;
@@ -215,16 +269,18 @@ int epoll_ctl(uv__os390_epoll* lst,
 
 int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
                int maxevents, int timeout) {
-  size_t size;
+  nmsgsfds_t size;
   struct pollfd* pfds;
   int pollret;
   int reventcount;
 
-  size = lst->size;
+  size = _SET_FDS_MSGS(size, 1, lst->size - 1);
   pfds = lst->items;
   pollret = poll(pfds, size, timeout);
   if (pollret <= 0)
     return pollret;
+
+  pollret = _NFDS(pollret) + _NMSGS(pollret);
 
   reventcount = 0;
   for (int i = 0; 
@@ -261,9 +317,14 @@ int epoll_file_close(int fd) {
 }
 
 void epoll_queue_close(uv__os390_epoll* lst) {
+  /* Remove epoll instance from global queue */
   uv_mutex_lock(&global_epoll_lock);
   QUEUE_REMOVE(&lst->member);
   uv_mutex_unlock(&global_epoll_lock);
+
+  /* Free resources */
+  msgctl(lst->msg_queue, IPC_RMID, NULL);
+  lst->msg_queue = -1;
   uv__free(lst->items);
   lst->items = NULL;
 }

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -50,6 +50,7 @@ typedef struct {
   QUEUE member;
   struct pollfd* items;
   unsigned long size;
+  int msg_queue;
 } uv__os390_epoll;
 
 /* epoll api */

--- a/test/task.h
+++ b/test/task.h
@@ -209,7 +209,7 @@ UNUSED static int can_ipv6(void) {
   return supported;
 }
 
-#if defined(__MVS__) || defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__CYGWIN__) || defined(__MSYS__)
 # define NO_FS_EVENTS "Filesystem watching not supported on this platform."
 #endif
 

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -533,10 +533,12 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
 #if defined(NO_FS_EVENTS)
   RETURN_SKIP(NO_FS_EVENTS);
 #endif
-#if defined(__sun) || defined(_AIX)
+#if defined(__sun) || defined(_AIX) || defined(__MVS__)
   /* It's not possible to implement this without additional
    * bookkeeping on SunOS. For AIX it is possible, but has to be
    * written. See https://github.com/libuv/libuv/pull/846#issuecomment-287170420
+   * TODO: On z/OS, we need to open another message queue and subscribe to the
+   * same events as the parent.
    */
   return 0;
 #else

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -396,6 +396,8 @@ static void timer_cb_watch_twice(uv_timer_t* handle) {
 TEST_IMPL(fs_event_watch_dir) {
 #if defined(NO_FS_EVENTS)
   RETURN_SKIP(NO_FS_EVENTS);
+#elif defined(__MVS__)
+  RETURN_SKIP("Directory watching not supported on this platform.");
 #endif
 
   uv_loop_t* loop = uv_default_loop();
@@ -820,6 +822,8 @@ static void fs_event_cb_close(uv_fs_event_t* handle, const char* filename,
 TEST_IMPL(fs_event_close_in_callback) {
 #if defined(NO_FS_EVENTS)
   RETURN_SKIP(NO_FS_EVENTS);
+#elif defined(__MVS__)
+  RETURN_SKIP("Directory watching not supported on this platform.");
 #endif
   uv_loop_t* loop;
   int r;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1481,9 +1481,6 @@ TEST_IMPL(spawn_fs_open) {
 
 #ifndef _WIN32
 TEST_IMPL(closed_fd_events) {
-#if defined(__MVS__)
-  RETURN_SKIP("Filesystem watching not supported on this platform.");
-#endif
   uv_stdio_container_t stdio[3];
   uv_pipe_t pipe_handle;
   int fd[2];

--- a/uv.gyp
+++ b/uv.gyp
@@ -315,7 +315,6 @@
         ['OS=="zos"', {
           'sources': [
             'src/unix/pthread-fixes.c',
-            'src/unix/no-fsevents.c',
             'src/unix/os390.c',
             'src/unix/os390-syscalls.c'
           ]


### PR DESCRIPTION
This commit uses the Register File Interest feature on z/OS
to enable users to monitor file system events.
The poll call is used to check for file descriptors as well
as a message queue that z/OS will report file system events
on. The last item on the list used by poll will contain the
message queue id instead of a file descriptor.

Limitation:
Writes to a directory (that is, file creation and deletion)
do not generate a change message for a registered directory.