### PR TITLE
win pipe: avoid potentially leaking a handle to a thread to child processes

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -960,7 +960,7 @@ static DWORD WINAPI uv_pipe_zero_readfile_thread_proc(void* parameter) {
     uv_mutex_lock(m); /* mutex controls *setting* of readfile_thread */
     if (DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
                         GetCurrentProcess(), &hThread,
-                        0, TRUE, DUPLICATE_SAME_ACCESS)) {
+                        0, FALSE, DUPLICATE_SAME_ACCESS)) {
       handle->pipe.conn.readfile_thread = hThread;
     } else {
       hThread = NULL;


### PR DESCRIPTION
Sorry, silly mistake in my original PR - we don't want an inheritable handle here.