### PR TITLE
doc: update supported linux/glibc baseline

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -2,7 +2,7 @@
 
 |  System | Support type | Supported versions | Notes |
 |---|---|---|---|
-| GNU/Linux | Tier 1 | Linux >= 2.6.18 with glibc >= 2.5 | |
+| GNU/Linux | Tier 1 | Linux >= 2.6.32 with glibc >= 2.12 | |
 | macOS | Tier 1 | macOS >= 10.7 | |
 | Windows | Tier 1 | Windows >= XP SP1 | MSVC 2008 and later are supported |
 | FreeBSD | Tier 1 | >= 9 (see note) | |


### PR DESCRIPTION
Now that RHEL/CentOS 5 is end-of-life, update the baseline from
linux >= 2.6.18 + glibc >= 2.5 to linux >= 2.6.32 + glibc >= 2.12.

Refs: https://github.com/nodejs/node/pull/12672