### PR TITLE
win, test: support stdout output larger than 1kb

### DIFF
--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -209,22 +209,30 @@ long int process_output_size(process_info_t *p) {
 
 
 int process_copy_output(process_info_t* p, FILE* stream) {
-  DWORD read;
   char buf[1024];
+  int fd, r;
+  FILE* f;
 
-  if (SetFilePointer(p->stdio_out,
-                     0,
-                     0,
-                     FILE_BEGIN) == INVALID_SET_FILE_POINTER) {
+  fd = _open_osfhandle((intptr_t)p->stdio_out, _O_RDONLY | _O_TEXT);
+  if (fd == -1)
+    return -1;
+  f = _fdopen(fd, "rt");
+  if (f == NULL) {
+    _close(fd);
     return -1;
   }
 
-  while (ReadFile(p->stdio_out, &buf, sizeof(buf), &read, NULL) && read > 0)
-    print_lines(buf, read, stream);
-
-  if (GetLastError() != ERROR_HANDLE_EOF)
+  r = fseek(f, 0, SEEK_SET);
+  if (r < 0)
     return -1;
 
+  while (fgets(buf, sizeof(buf), f) != NULL)
+    print_lines(buf, strlen(buf), stream);
+  
+  if (ferror(f))
+    return -1;
+
+  fclose(f);
   return 0;
 }
 


### PR DESCRIPTION
Fix a bug in process_copy_output that would cause output larger than 1kb to be incorrectly split into lines. Some corrupted charters would be added, e.g. in `platform_output` test output:
![image](https://cloud.githubusercontent.com/assets/17704638/25479562/8cba2ae4-2b45-11e7-9358-f00ed8bdc7fe.png)

This changes the `process_copy_output` Windows implementation to be a mirror of the [unix one](https://github.com/libuv/libuv/blob/710989b08737c6cccfdd8e33d6ceeba0e295ddec/test/runner-unix.c#L296).