### PR TITLE
test: fix long output buffering

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -296,6 +296,7 @@ long int process_output_size(process_info_t *p) {
 int process_copy_output(process_info_t* p, FILE* stream) {
   char buf[1024];
   int r;
+  int continue_line = 0;
 
   r = fseek(p->stdout_file, 0, SEEK_SET);
   if (r < 0) {
@@ -303,9 +304,8 @@ int process_copy_output(process_info_t* p, FILE* stream) {
     return -1;
   }
 
-  /* TODO: what if the line is longer than buf */
   while (fgets(buf, sizeof(buf), p->stdout_file) != NULL)
-    print_lines(buf, strlen(buf), stream);
+    print_lines(buf, strlen(buf), stream, &continue_line);
 
   if (ferror(p->stdout_file)) {
     perror("read");

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -211,6 +211,7 @@ long int process_output_size(process_info_t *p) {
 int process_copy_output(process_info_t* p, FILE* stream) {
   DWORD read;
   char buf[1024];
+  int continue_line = 0;
 
   if (SetFilePointer(p->stdio_out,
                      0,
@@ -220,7 +221,7 @@ int process_copy_output(process_info_t* p, FILE* stream) {
   }
 
   while (ReadFile(p->stdio_out, &buf, sizeof(buf), &read, NULL) && read > 0)
-    print_lines(buf, read, stream);
+    print_lines(buf, read, stream, &continue_line);
 
   if (GetLastError() != ERROR_HANDLE_EOF)
     return -1;

--- a/test/runner.c
+++ b/test/runner.c
@@ -403,20 +403,39 @@ void print_tests(FILE* stream) {
   }
 }
 
-
-void print_lines(const char* buffer, size_t size, FILE* stream) {
+/* The continue_line parameter must be set to 1 when continuing a line or 0 to
+ * write "# " before the new line.
+ * The function updates the value of continue_line with 1 if it wrote a
+ * unfinished line.
+ */
+void print_lines(const char* buffer,
+                 size_t size,
+                 FILE* stream,
+                 int* continue_line) {
   const char* start;
   const char* end;
 
   start = buffer;
   while ((end = memchr(start, '\n', &buffer[size] - start))) {
-    fprintf(stream, "# %.*s\n", (int) (end - start), start);
+    fprintf(stream,
+            "%s%.*s\n",
+            *continue_line ? "" : "# ",
+            (int) (end - start),
+            start);
+
     fflush(stream);
     start = end + 1;
+    *continue_line = 0;
   }
 
   if (start < &buffer[size]) {
-    fprintf(stream, "# %s\n", start);
+    fprintf(stream,
+            "%s%.*s",
+            *continue_line ? "" : "# ",
+            (int) (&buffer[size] - start),
+            start);
+
     fflush(stream);
+    *continue_line = 1;
   }
 }

--- a/test/runner.h
+++ b/test/runner.h
@@ -127,7 +127,7 @@ int run_test_part(const char* test, const char* part);
 void print_tests(FILE* stream);
 
 /* Print lines in |buffer| as TAP diagnostics to |stream|. */
-void print_lines(const char* buffer, size_t size, FILE* stream);
+void print_lines(const char* buffer, size_t size, FILE* stream, int* continue_line);
 
 /*
  * Stuff that should be implemented by test-runner-<platform>.h


### PR DESCRIPTION
The tests runners sometimes forward the test output. But when the test
output is too long (over 1024 bytes), the runner output gets corrupted.

This is because unfinished lines are written without "%.*s" causing
bad behavior as the buffer is not always nul terminated (it's not the
case on windows).

The issue can be seen with the `platform_output` test on windows.

This commit changes the print_lines function so it keeps track of new
lines and never write more data than it should.