### PR TITLE
Introduce uv_dlopen_with_flags()

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1401,6 +1401,7 @@ UV_EXTERN uint64_t uv_hrtime(void);
 UV_EXTERN void uv_disable_stdio_inheritance(void);
 
 UV_EXTERN int uv_dlopen(const char* filename, uv_lib_t* lib);
+UV_EXTERN int uv_dlopen_with_flags(const char* filename, uv_lib_t* lib, int flags);
 UV_EXTERN void uv_dlclose(uv_lib_t* lib);
 UV_EXTERN int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr);
 UV_EXTERN const char* uv_dlerror(const uv_lib_t* lib);

--- a/src/unix/dl.c
+++ b/src/unix/dl.c
@@ -30,11 +30,16 @@
 static int uv__dlerror(uv_lib_t* lib);
 
 
-int uv_dlopen(const char* filename, uv_lib_t* lib) {
+int uv_dlopen_with_flags(const char* filename, uv_lib_t* lib, int flags) {
   dlerror(); /* Reset error status. */
   lib->errmsg = NULL;
-  lib->handle = dlopen(filename, RTLD_LAZY);
+  lib->handle = dlopen(filename, flags);
   return lib->handle ? 0 : uv__dlerror(lib);
+}
+
+
+int uv_dlopen(const char* filename, uv_lib_t* lib) {
+  return uv_dlopen_with_flags(filename, lib, RTLD_LAZY);
 }
 
 

--- a/src/win/dl.c
+++ b/src/win/dl.c
@@ -48,6 +48,11 @@ int uv_dlopen(const char* filename, uv_lib_t* lib) {
   return 0;
 }
 
+/* uv_dlopen_with_flags is a no-op in windows */
+int uv_dlopen_with_flags(const char* filename, uv_lib_t* lib, int flags) {
+  return uv_dlopen(filename, lib);
+}
+
 
 void uv_dlclose(uv_lib_t* lib) {
   if (lib->errmsg) {


### PR DESCRIPTION
This is a new try at extending uv_dlopen to support UNIX dlopen flags. Previous try was rejected and closed: https://github.com/libuv/libuv/pull/635.

@saghul reasons for closing were:

> Closing. Current behavior is in use in the wild and we cannot break it. Also, since this has no applicability on Windows, you could use the dl* functions directly, libuv doesn't do anything special about them anyway.

First objection is addressed by introducing a new function, `uv_dlopen_with_flags`. This is a no-op in Windows.

Now, about the Windows behavior objection. Introducing a `uv_dlopen_with_flags` function makes portable programs (such as node.js) result in much cleaner code. In other words, we would like to simply call `uv_dlopen_with_flags` without any ugly platform specific ifdef'ery.

See https://github.com/ezequielgarcia/node/commit/3820c96802ea7133d933d4185eecfebfed7c3253 for an example on how this function would be used.

It's important to mention that `uv_dlopen` implementation is maintained, keeping backwards compatibility.