### PR TITLE
Added kevent hook following Dean McNamee

### DIFF
--- a/include/uv-darwin.h
+++ b/include/uv-darwin.h
@@ -41,6 +41,7 @@
   uv_mutex_t cf_mutex;                                                        \
   uv_sem_t cf_sem;                                                            \
   void* cf_signals[2];                                                        \
+  void* keventfunc;                                                           \
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
   uv__io_t event_watcher;                                                     \

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -86,6 +86,9 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int fd;
   int op;
   int i;
+  int (*keventfunc)(int kq, const struct kevent *changelist, int nchanges,
+      struct kevent *eventlist, int nevents, const struct timespec *timeout) =
+      loop->keventfunc ? loop->keventfunc : &kevent;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -119,7 +122,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       EV_SET(events + nevents, w->fd, filter, op, fflags, 0, 0);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
+        if (keventfunc(loop->backend_fd, events, nevents, NULL, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -129,7 +132,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       EV_SET(events + nevents, w->fd, EVFILT_WRITE, EV_ADD, 0, 0, 0);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
+        if (keventfunc(loop->backend_fd, events, nevents, NULL, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -158,7 +161,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (pset != NULL)
       pthread_sigmask(SIG_BLOCK, pset, NULL);
 
-    nfds = kevent(loop->backend_fd,
+    nfds = keventfunc(loop->backend_fd,
                   events,
                   nevents,
                   events,
@@ -213,7 +216,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         struct kevent events[1];
 
         EV_SET(events + 0, fd, ev->filter, EV_DELETE, 0, 0, 0);
-        if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL))
+        if (keventfunc(loop->backend_fd, events, 1, NULL, 0, NULL))
           if (errno != EBADF && errno != ENOENT)
             abort();
 
@@ -238,7 +241,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
           /* TODO batch up */
           struct kevent events[1];
           EV_SET(events + 0, fd, ev->filter, EV_DELETE, 0, 0, 0);
-          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL))
+          if (keventfunc(loop->backend_fd, events, 1, NULL, 0, NULL))
             if (errno != ENOENT)
               abort();
         }
@@ -252,7 +255,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
           /* TODO batch up */
           struct kevent events[1];
           EV_SET(events + 0, fd, ev->filter, EV_DELETE, 0, 0, 0);
-          if (kevent(loop->backend_fd, events, 1, NULL, 0, NULL))
+          if (keventfunc(loop->backend_fd, events, 1, NULL, 0, NULL))
             if (errno != ENOENT)
               abort();
         }
@@ -337,6 +340,9 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
   uv_fs_event_t* handle;
   struct kevent ev;
   int events;
+  int (*keventfunc)(int kq, const struct kevent *changelist, int nchanges,
+      struct kevent *eventlist, int nevents, const struct timespec *timeout) =
+      loop->keventfunc ? loop->keventfunc : &kevent;
   const char* path;
 #if defined(F_GETPATH)
   /* MAXPATHLEN == PATH_MAX but the former is what XNU calls it internally. */
@@ -370,7 +376,7 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
 
   EV_SET(&ev, w->fd, EVFILT_VNODE, EV_ADD | EV_ONESHOT, fflags, 0, 0);
 
-  if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
+  if (keventfunc(loop->backend_fd, &ev, 1, NULL, 0, NULL))
     abort();
 }
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -59,6 +59,7 @@ int uv_loop_init(uv_loop_t* loop) {
   loop->signal_pipefd[1] = -1;
   loop->backend_fd = -1;
   loop->emfile_fd = -1;
+  loop->keventfunc = NULL;
 
   loop->timer_counter = 0;
   loop->stop_flag = 0;


### PR DESCRIPTION
It looks like plask has been carrying a diff against libuv for a few years, and when it came in handy for me as well, I thought I'd propose that it be upstreamed.

There is extensive commentary in
https://github.com/deanm/plask/blob/master/main.mm

My own attempts to run a uv loop as a guest inside a CFRunLoop in a Python interpreter have proven unsuccessful, perhaps for the same reasons that @deanm encountered.

Hooking kevent permits the opposite approach -- running a CFRunLoop as a guest in a uv loop.  I need a CFRunLoop to pump the Grand Central Dispatch main queue, and I want a uv loop to take advantage of the uvloop asyncio backend on the same thread.

What do you think?