### PR TITLE
win,tty: remove unused functions

### DIFF
--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -221,10 +221,16 @@ void uv_process_tty_read_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_req_t* req);
 void uv_process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_write_t* req);
-/* TODO: remove me */
+/*
+ * the function is a stub to keep DELEGATE_STREAM_REQ working
+ * TODO: find a way to remove it
+ */
 void uv_process_tty_accept_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_req_t* raw_req);
-/* TODO: remove me */
+/*
+ * the function is a stub to keep DELEGATE_STREAM_REQ working
+ * TODO: find a way to remove it
+ */
 void uv_process_tty_connect_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_connect_t* req);
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2234,14 +2234,20 @@ void uv_tty_endgame(uv_loop_t* loop, uv_tty_t* handle) {
 }
 
 
-/* TODO: remove me */
+/*
+ * the function is a stub to keep DELEGATE_STREAM_REQ working
+ * TODO: find a way to remove it
+ */
 void uv_process_tty_accept_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_req_t* raw_req) {
   abort();
 }
 
 
-/* TODO: remove me */
+/*
+ * the function is a stub to keep DELEGATE_STREAM_REQ working
+ * TODO: find a way to remove it
+ */
 void uv_process_tty_connect_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_connect_t* req) {
   abort();


### PR DESCRIPTION
Hi :)
I was trying to read and understand how libuv works and noticed two functions
`uv_process_tty_accept_req`
` uv_process_tty_connect_req`
that marked as `TODO: remove me`. 

This PR removes them actually... I hope it's ok and they are really unnecessary. As far as I can see there is no usage of both of them.  

