### PR TITLE
test: fix flaky tcp-write-queue-order

### DIFF
--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -89,6 +89,9 @@ static void connection_cb(uv_stream_t* tcp, int status) {
   ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
   ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
 
+  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer));
+  ASSERT(0 == uv_timer_start(&timer, timer_cb, 1, 0));
+
   connection_cb_called++;
 }
 
@@ -119,9 +122,6 @@ TEST_IMPL(tcp_write_queue_order) {
                              (struct sockaddr*) &addr,
                              connect_cb));
   ASSERT(0 == uv_send_buffer_size((uv_handle_t*) &client, &buffer_size));
-
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer));
-  ASSERT(0 == uv_timer_start(&timer, timer_cb, 100, 0));
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 


### PR DESCRIPTION
Delay the timer start to be sure all handles are created when `timer_cb`
is executed. In some cases this was not the case causing the following
error:

```
not ok 51 - tcp_write_queue_order
  exit code 134
  Output from process `tcp_write_queue_order`:
  lt-run-tests: src/unix/core.c:166: uv_close: Assertion `0' failed.
```