### PR TITLE
build,openbsd: Remove kvm-related code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,6 @@ LT_INIT
 # TODO(bnoordhuis) Check for -pthread vs. -pthreads
 AC_CHECK_LIB([dl], [dlopen])
 AC_CHECK_LIB([kstat], [kstat_lookup])
-AC_CHECK_LIB([kvm], [kvm_open])
 AC_CHECK_LIB([nsl], [gethostbyname])
 AC_CHECK_LIB([perfstat], [perfstat_cpu])
 AC_CHECK_LIB([pthread], [pthread_mutex_init])
@@ -64,6 +63,9 @@ AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [
     LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
+])
+AS_CASE([$host_os], [openbsd*], [], [
+    AC_CHECK_LIB([kvm], [kvm_open])
 ])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -30,7 +30,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <kvm.h>
 #include <paths.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Remove the kvm.h include since 38323c9fb replaced the use of kvm_open()
with sysctl(),

Conditionally check for kvm_open() on non-OpenBSD platforms so LIBS (and
libuv.pc) does not unnecessarily contain "-lkvm".

Fixes #1340