### PR TITLE
fs, win: add support for user symlinks

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -121,37 +121,36 @@ static int uv__usermode_symlink_available(void) {
   OSVERSIONINFOW version_information;
   int r;
 
-  if (!pRtlGetVersion) {
+  if (!pRtlGetVersion)
     return 0;
-  }
+
   pRtlGetVersion(&version_information);
   /* Usermode symlinks are only available on Win10 with Creators Update... */
   if (version_information.dwMajorVersion != 10 ||
-      version_information.dwBuildNumber < 15063) {
+      version_information.dwBuildNumber < 15063)
     return 0;
-  }
+
   r = RegOpenKeyExW(HKEY_LOCAL_MACHINE, 
                     L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
                     0, KEY_QUERY_VALUE | KEY_WOW64_64KEY, &key);
-  if (r != ERROR_SUCCESS) {
+  if (r != ERROR_SUCCESS)
     return 0;
-  }
+
   /* ...and with enabled Developer Mode */
   value_size = sizeof(value);
   r = RegQueryValueExW(key, L"AllowDevelopmentWithoutDevLicense", 0, NULL,
                        (LPBYTE)(&value), &value_size);
   RegCloseKey(key);
-  if (r != ERROR_SUCCESS) {
+  if (r != ERROR_SUCCESS)
     return 0;
-  }
+
   return value ? 1 : 0;
 }
 
 void uv_fs_init(void) {
   _fmode = _O_BINARY;
-  if (uv__usermode_symlink_available()) {
+  if (uv__usermode_symlink_available())
     uv__file_symlink_flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
-  }
 }
 
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -126,7 +126,7 @@ static int uv__usermode_symlink_available(void) {
   }
   pRtlGetVersion(&version_information);
   /* Usermode symlinks are only available on Win10 with Creators Update... */
-  if (version_information.dwMajorVersion < 10 ||
+  if (version_information.dwMajorVersion != 10 ||
       version_information.dwBuildNumber < 15063) {
     return 0;
   }

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -26,6 +26,7 @@
 
 
 /* Ntdll function pointers */
+sRtlGetVersion pRtlGetVersion;
 sRtlNtStatusToDosError pRtlNtStatusToDosError;
 sNtDeviceIoControlFile pNtDeviceIoControlFile;
 sNtQueryInformationFile pNtQueryInformationFile;
@@ -62,6 +63,10 @@ void uv_winapi_init(void) {
   if (ntdll_module == NULL) {
     uv_fatal_error(GetLastError(), "GetModuleHandleA");
   }
+
+  pRtlGetVersion = (sRtlGetVersion) GetProcAddress(
+      ntdll_module,
+      "RtlGetVersion");
 
   pRtlNtStatusToDosError = (sRtlNtStatusToDosError) GetProcAddress(
       ntdll_module,

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4104,6 +4104,10 @@
 # define JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE          0x00002000
 #endif
 
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+# define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x00000002
+#endif
+
 /* from winternl.h */
 typedef struct _UNICODE_STRING {
   USHORT Length;
@@ -4512,6 +4516,9 @@ typedef VOID (NTAPI *PIO_APC_ROUTINE)
               PIO_STATUS_BLOCK IoStatusBlock,
               ULONG Reserved);
 
+typedef NTSTATUS (NTAPI *sRtlGetVersion)
+                 (PRTL_OSVERSIONINFOW lpVersionInformation);
+
 typedef ULONG (NTAPI *sRtlNtStatusToDosError)
               (NTSTATUS Status);
 
@@ -4723,6 +4730,7 @@ typedef DWORD (WINAPI *sPowerRegisterSuspendResumeNotification)
 
 
 /* Ntdll function pointers */
+extern sRtlGetVersion pRtlGetVersion;
 extern sRtlNtStatusToDosError pRtlNtStatusToDosError;
 extern sNtDeviceIoControlFile pNtDeviceIoControlFile;
 extern sNtQueryInformationFile pNtQueryInformationFile;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -141,7 +141,7 @@ static int usermode_symlink_available(void) {
   }
   pRtlGetVersion(&version_information);
   /* Usermode symlinks are only available on Win10 with Creators Update... */
-  if (version_information.dwMajorVersion < 10 ||
+  if (version_information.dwMajorVersion != 10 ||
     version_information.dwBuildNumber < 15063) {
     return 0;
   }


### PR DESCRIPTION
Add `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE` flag to `CreateSymbolicLink` call which allows unelevated users to create symbolic link on supported platforms. This requires Windows Creators Update installed (build 15603 is first public Creators Update build) and Developer Mode enabled (we check this trough the registry).

Fixes: https://github.com/libuv/libuv/issues/1157