### PR TITLE
unix: remove FSEventStreamFlushSync() call

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -378,9 +378,6 @@ static void uv__fsevents_destroy_stream(uv_loop_t* loop) {
   if (state->fsevent_stream == NULL)
     return;
 
-  /* Flush all accumulated events */
-  pFSEventStreamFlushSync(state->fsevent_stream);
-
   /* Stop emitting events */
   pFSEventStreamStop(state->fsevent_stream);
 


### PR DESCRIPTION
This call, in the context of file watching, appears to trigger assertion warnings on some macOS configurations.

Attempt at fixing https://github.com/libuv/libuv/issues/1334, https://github.com/nodejs/node/issues/854.

cc: @indutny (https://github.com/nodejs/node/issues/854#issuecomment-298688225)