### PR TITLE
src: handle if_nametoindex errors in uv_ip6_addr

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -245,6 +245,9 @@ API
 
     Convert a string containing an IPv6 addresses to a binary structure.
 
+    .. versionchanged:: 2.0.0: :man:`if_nametoindex(3)` errors are no longer
+                        ignored on Unix platforms.
+
 .. c:function:: int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size)
 
     Convert a binary structure containing an IPv4 address to a string.

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -204,11 +204,14 @@ int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
     ip = address_part;
 
     zone_index++; /* skip '%' */
-    /* NOTE: unknown interface (id=0) is silently ignored */
 #ifdef _WIN32
+    /* NOTE: unknown interfaces are silently ignored on Windows */
     addr->sin6_scope_id = atoi(zone_index);
 #else
     addr->sin6_scope_id = if_nametoindex(zone_index);
+
+    if (addr->sin6_scope_id == 0)
+      return -errno;
 #endif
   }
 

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -139,3 +139,14 @@ TEST_IMPL(ip6_pton) {
 
 #undef GOOD_ADDR_LIST
 #undef BAD_ADDR_LIST
+
+#ifndef _WIN32
+TEST_IMPL(ip6_invalid_interface) {
+  struct sockaddr_in6 s;
+  int r;
+
+  r = uv_ip6_addr("::0%bad", 0, &s);
+  ASSERT(r < 0);
+  return 0;
+}
+#endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -54,6 +54,9 @@ TEST_DECLARE   (tty_file)
 TEST_DECLARE   (tty_pty)
 TEST_DECLARE   (stdio_over_pipes)
 TEST_DECLARE   (ip6_pton)
+#ifndef _WIN32
+TEST_DECLARE   (ip6_invalid_interface)
+#endif
 TEST_DECLARE   (ipc_listen_before_write)
 TEST_DECLARE   (ipc_listen_after_write)
 #ifndef _WIN32
@@ -427,6 +430,9 @@ TASK_LIST_START
   TEST_ENTRY  (tty_pty)
   TEST_ENTRY  (stdio_over_pipes)
   TEST_ENTRY  (ip6_pton)
+#ifndef _WIN32
+  TEST_ENTRY  (ip6_invalid_interface)
+#endif
   TEST_ENTRY  (ipc_listen_before_write)
   TEST_ENTRY  (ipc_listen_after_write)
 #ifndef _WIN32


### PR DESCRIPTION
On Unix, `uv_ip6_addr()` calls `if_nametoindex()`. This commit adds error handling for `if_nametoindex()` failures.

Fixes: https://github.com/libuv/libuv/issues/1313