### PR TITLE
unix,stream: return error on closed handle passing

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -750,6 +750,7 @@ static void uv__write(uv_stream_t* stream) {
   int iovmax;
   int iovcnt;
   ssize_t n;
+  int err;
 
 start:
 
@@ -782,13 +783,20 @@ start:
    */
 
   if (req->send_handle) {
+    int fd_to_send;
     struct msghdr msg;
     struct cmsghdr *cmsg;
-    int fd_to_send = uv__handle_fd((uv_handle_t*) req->send_handle);
     union {
       char data[64];
       struct cmsghdr alias;
     } scratch;
+
+    if (uv__is_closing(req->send_handle)) {
+      err = -EBADF;
+      goto error;
+    }
+
+    fd_to_send = uv__handle_fd((uv_handle_t*) req->send_handle);
 
     memset(&scratch, 0, sizeof(scratch));
 
@@ -852,14 +860,8 @@ start:
 
   if (n < 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK) {
-      /* Error */
-      req->error = -errno;
-      uv__write_req_finish(req);
-      uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);
-      if (!uv__io_active(&stream->io_watcher, POLLIN))
-        uv__handle_stop(stream);
-      uv__stream_osx_interrupt_select(stream);
-      return;
+      err = -errno;
+      goto error;
     } else if (stream->flags & UV_STREAM_BLOCKING) {
       /* If this is a blocking stream, try again. */
       goto start;
@@ -922,6 +924,16 @@ start:
   uv__io_start(stream->loop, &stream->io_watcher, POLLOUT);
 
   /* Notify select() thread about state change */
+  uv__stream_osx_interrupt_select(stream);
+
+  return;
+
+error:
+  req->error = err;
+  uv__write_req_finish(req);
+  uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);
+  if (!uv__io_active(&stream->io_watcher, POLLIN))
+    uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
 }
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -38,6 +38,7 @@
 
 int ipc_helper(int listen_after_write);
 int ipc_helper_tcp_connection(void);
+int ipc_helper_closed_handle(void);
 int ipc_send_recv_helper(void);
 int ipc_helper_bind_twice(void);
 int stdio_over_pipes_helper(void);
@@ -87,6 +88,10 @@ static int maybe_run_test(int argc, char **argv) {
 
   if (strcmp(argv[1], "ipc_helper_tcp_connection") == 0) {
     return ipc_helper_tcp_connection();
+  }
+
+  if (strcmp(argv[1], "ipc_helper_closed_handle") == 0) {
+    return ipc_helper_closed_handle();
   }
 
   if (strcmp(argv[1], "ipc_helper_bind_twice") == 0) {

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -44,6 +44,7 @@ static int close_cb_called;
 static int connection_accepted;
 static int tcp_conn_read_cb_called;
 static int tcp_conn_write_cb_called;
+static int closed_handle_data_read;
 
 typedef struct {
   uv_connect_t conn_req;
@@ -53,6 +54,7 @@ typedef struct {
 
 #define CONN_COUNT 100
 #define BACKLOG 128
+#define LARGE_SIZE 1000000
 
 
 static void close_server_conn_cb(uv_handle_t* handle) {
@@ -395,6 +397,26 @@ static void on_read_connection(uv_stream_t* handle,
 }
 
 
+#ifndef _WIN32
+static void on_read_closed_handle(uv_stream_t* handle,
+                                  ssize_t nread,
+                                  const uv_buf_t* buf) {
+  if (nread == 0 || nread == UV_EOF) {
+    free(buf->base);
+    return;
+  }
+
+  if (nread < 0) {
+    printf("error recving on channel: %s\n", uv_strerror(nread));
+    abort();
+  }
+
+  closed_handle_data_read += nread;
+  free(buf->base);
+}
+#endif
+
+
 static int run_ipc_test(const char* helper, uv_read_cb read_cb) {
   uv_process_t process;
   int r;
@@ -447,6 +469,15 @@ TEST_IMPL(ipc_tcp_connection) {
   ASSERT(exit_cb_called == 1);
   return r;
 }
+
+#ifndef _WIN32
+TEST_IMPL(ipc_closed_handle) {
+  int r;
+  r = run_ipc_test("ipc_helper_closed_handle", on_read_closed_handle);
+  ASSERT(r == 0);
+  return 0;
+}
+#endif
 
 
 #ifdef _WIN32
@@ -533,6 +564,17 @@ static void tcp_connection_write_cb(uv_write_t* req, int status) {
   uv_close((uv_handle_t*)&channel, close_cb);
   uv_close((uv_handle_t*)&tcp_server, close_cb);
   tcp_conn_write_cb_called++;
+}
+
+
+static void closed_handle_large_write_cb(uv_write_t* req, int status) {
+  ASSERT(status == 0);
+  ASSERT(closed_handle_data_read = LARGE_SIZE);
+}
+
+
+static void closed_handle_write_cb(uv_write_t* req, int status) {
+  ASSERT(status == UV_EBADF);
 }
 
 
@@ -741,6 +783,60 @@ int ipc_helper_tcp_connection(void) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+
+int ipc_helper_closed_handle(void) {
+  int r;
+  struct sockaddr_in addr;
+  uv_write_t write_req;
+  uv_write_t write_req2;
+  uv_buf_t buf;
+  char buffer[LARGE_SIZE];
+
+  r = uv_pipe_init(uv_default_loop(), &channel, 1);
+  ASSERT(r == 0);
+
+  uv_pipe_open(&channel, 0);
+
+  ASSERT(1 == uv_is_readable((uv_stream_t*) &channel));
+  ASSERT(1 == uv_is_writable((uv_stream_t*) &channel));
+  ASSERT(0 == uv_is_closing((uv_handle_t*) &channel));
+
+  memset(buffer, '.', LARGE_SIZE);
+  buf = uv_buf_init(buffer, LARGE_SIZE);
+
+  r = uv_tcp_init(uv_default_loop(), &tcp_server);
+  ASSERT(r == 0);
+
+  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+
+  r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
+  ASSERT(r == 0);
+
+  r = uv_write(&write_req,
+               (uv_stream_t*)&channel,
+               &buf,
+               1,
+               closed_handle_large_write_cb);
+  ASSERT(r == 0);
+
+  r = uv_write2(&write_req2,
+                (uv_stream_t*)&channel,
+                &buf,
+                1,
+                (uv_stream_t*)&tcp_server,
+                closed_handle_write_cb);
+  ASSERT(r == 0);
+
+  uv_close((uv_handle_t*)&tcp_server, NULL);
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
 
 int ipc_helper_bind_twice(void) {
   /*

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -63,6 +63,9 @@ TEST_DECLARE   (ipc_send_recv_pipe_inprocess)
 TEST_DECLARE   (ipc_send_recv_tcp)
 TEST_DECLARE   (ipc_send_recv_tcp_inprocess)
 TEST_DECLARE   (ipc_tcp_connection)
+#ifndef _WIN32
+TEST_DECLARE   (ipc_closed_handle)
+#endif
 TEST_DECLARE   (tcp_alloc_cb_fail)
 TEST_DECLARE   (tcp_ping_pong)
 TEST_DECLARE   (tcp_ping_pong_v6)
@@ -444,6 +447,9 @@ TASK_LIST_START
   TEST_ENTRY  (ipc_send_recv_tcp)
   TEST_ENTRY  (ipc_send_recv_tcp_inprocess)
   TEST_ENTRY  (ipc_tcp_connection)
+#ifndef _WIN32
+  TEST_ENTRY  (ipc_closed_handle)
+#endif
 
   TEST_ENTRY  (tcp_alloc_cb_fail)
 


### PR DESCRIPTION
Return `EBADF` when trying to send a handle which, while enqueued, was
closed.

Fixes: https://github.com/libuv/libuv/issues/806