### PR TITLE
doc: mark uv_loop_fork() as experimental

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -191,6 +191,11 @@ API
 
     This function is not implemented on Windows, where it returns ``UV_ENOSYS``.
 
+    .. caution::
+
+       This function is experimental. It may contain bugs, and is subject to
+       change or removal. API and ABI stability is not guaranteed.
+
     .. note::
 
         On Mac OS X, if directory FS event handles were in use in the


### PR DESCRIPTION
`uv_loop_fork()` was recently added, but is known to contain bugs. This commit marks the function as experimental so that bugs can be addressed without blocking further libuv releases.

Refs: https://github.com/libuv/libuv/pull/846
Refs: https://github.com/libuv/libuv/pull/1269
Refs: https://github.com/libuv/libuv/issues/1264