### PR TITLE
unix, utilities: avoid segfault with uv_get_process_title

### DIFF
--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -98,7 +98,10 @@ int uv_get_process_title(char* buffer, size_t size) {
   else if (size <= process_title.len)
     return -ENOBUFS;
 
-  memcpy(buffer, process_title.str, process_title.len + 1);
+  if (process_title.len != 0) {
+    memcpy(buffer, process_title.str, process_title.len + 1);
+  }
+
   buffer[process_title.len] = '\0';
 
   return 0;

--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -98,9 +98,8 @@ int uv_get_process_title(char* buffer, size_t size) {
   else if (size <= process_title.len)
     return -ENOBUFS;
 
-  if (process_title.len != 0) {
+  if (process_title.len != 0)
     memcpy(buffer, process_title.str, process_title.len + 1);
-  }
 
   buffer[process_title.len] = '\0';
 


### PR DESCRIPTION
If an user calls `uv_get_process_title` and `uv_setup_args` hasn't been called before that, the program terminates with a segfault. See issue #1359 for further details.