### PR TITLE
fix cmpxchgi and cmpxchgl type error on Solaris

### DIFF
--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -20,7 +20,6 @@
 
 #if defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 #include <atomic.h>
-#define __sync_val_compare_and_swap(p, o, n) atomic_cas_ptr(p, o, n)
 #endif
 
 UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval));
@@ -49,6 +48,8 @@ UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval)) {
     return oldval;
   else
     return op4;
+#elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+  return atomic_cas_uint(ptr, oldval, newval);
 #else
   return __sync_val_compare_and_swap(ptr, oldval, newval);
 #endif
@@ -83,6 +84,8 @@ UV_UNUSED(static long cmpxchgl(long* ptr, long oldval, long newval)) {
     return oldval;
   else
     return op4;
+#elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+  return atomic_cas_ulong(ptr, oldval, newval);
 #else
   return __sync_val_compare_and_swap(ptr, oldval, newval);
 #endif

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -21,6 +21,7 @@
 
 #include "uv.h"
 #include "task.h"
+#include <string.h>
 
 static uv_async_t async_handle;
 static uv_check_t check_handle;
@@ -43,6 +44,14 @@ static void check_cb(uv_check_t* handle) {
 
 
 TEST_IMPL(async_null_cb) {
+  /*
+   * Fill async_handle with garbage values.
+   * uv_async_init() should properly initialize struct fields regardless of
+   * initial values.
+   * This is added to verify paddings between fields do not affect behavior.
+   */
+  memset(&async_handle, 0xff, sizeof(async_handle));
+
   ASSERT(0 == uv_async_init(uv_default_loop(), &async_handle, NULL));
   ASSERT(0 == uv_check_init(uv_default_loop(), &check_handle));
   ASSERT(0 == uv_check_start(&check_handle, check_cb));


### PR DESCRIPTION
atomic_cas_ptr is for compare-and-swap pointer addresses. so when
building 64bit:
1. `ptr` is used casted to a pointer value (4-byte into 8-byte).
2. atomic_cas_ptr reads 8-byte at `ptr` and returns

in the case of `uv_async_send`, if handle->pending is 0, cmpxchgi
actually returns the value of the 4-bytes past handle->pending,
causing uv__async_send to never be called.

the modified test-async-null-cb.c hangs at uv_run in this case.

@see https://docs.oracle.com/cd/E86824_01/html/E54766/atomic-cas-ptr-3c.html