### PR TITLE
missing a comma in uv.gyp

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -6,7 +6,8 @@ $1/build/tools/make-standalone-toolchain.sh \
     --toolchain=arm-linux-androideabi-4.9 \
     --arch=arm \
     --install-dir=$TOOLCHAIN \
-    --platform=android-21
+    --platform=android-21 \
+    --force
 export PATH=$TOOLCHAIN/bin:$PATH
 export AR=arm-linux-androideabi-ar
 export CC=arm-linux-androideabi-gcc

--- a/uv.gyp
+++ b/uv.gyp
@@ -253,7 +253,7 @@
             'src/unix/linux-syscalls.h',
             'src/unix/pthread-fixes.c',
             'src/unix/android-ifaddrs.c',
-            'src/unix/pthread-barrier.c'
+            'src/unix/pthread-barrier.c',
             'src/unix/procfs-exepath.c',
             'src/unix/sysinfo-loadavg.c',
             'src/unix/sysinfo-memory.c',


### PR DESCRIPTION
when I compile libuv with android-ndk-toolchain, I found that libuv.target.mk is incorrect.

it contains line:
```
$(obj).target/$(TARGET)/src/unix/pthread-barrier.csrc/unix/procfs-exepath.o \
```
I thought `pthread-barrier.c` is not configured correctly.
so the change in this mr.

and also add `--force` for import toolchain