### PR TITLE
zos: avoid compiler warnings

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -49,9 +49,6 @@
         'cflags': [
           '-O3',
           '-fstrict-aliasing',
-          '-fomit-frame-pointer',
-          '-fdata-sections',
-          '-ffunction-sections',
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
@@ -82,6 +79,15 @@
             'LinkIncremental': 1, # disable incremental linking
           },
         },
+        'conditions': [
+          ['OS != "os390"', {
+            'cflags': [
+              '-fomit-frame-pointer',
+              '-fdata-sections',
+              '-ffunction-sections',
+            ],
+          }],
+        ]
       }
     },
     'msvs_settings': {

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -28,7 +28,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <unistd.h>
-#include <sys/param.h> /* MAXHOSTNAMELEN on Linux and the BSDs */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -80,6 +79,10 @@
 
 #if defined(__MVS__)
 #include <sys/ioctl.h>
+#endif
+
+#if !defined(__MVS__)
+#include <sys/param.h> /* MAXHOSTNAMELEN on Linux and the BSDs */
 #endif
 
 /* Fallback for the maximum hostname length */


### PR DESCRIPTION
Some of these compiler flags are not supported. So don't
use them.