### PR TITLE
unix: fix wrong MAC of uv_interface_address

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -145,6 +145,12 @@ enum {
   UV_LOOP_BLOCK_SIGPROF = 1
 };
 
+/* flags of excluding ifaddr */
+enum {
+  UV__EXCLUDE_IFPHYS,
+  UV__EXCLUDE_IFADDR
+};
+
 typedef enum {
   UV_CLOCK_PRECISE = 0,  /* Use the highest resolution clock available. */
   UV_CLOCK_FAST = 1      /* Use the fastest clock with <= 1ms granularity. */

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -837,7 +837,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   uv__free(cpu_infos);
 }
 
-static int uv__ifaddr_exclude(struct ifaddrs *ent) {
+static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (!((ent->ifa_flags & IFF_UP) && (ent->ifa_flags & IFF_RUNNING)))
     return 1;
   if (ent->ifa_addr == NULL)
@@ -847,8 +847,8 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent) {
    * devices. We're not interested in this information yet.
    */
   if (ent->ifa_addr->sa_family == PF_PACKET)
-    return 1;
-  return 0;
+    return exclude_type;
+  return !exclude_type;
 }
 
 int uv_interface_addresses(uv_interface_address_t** addresses,
@@ -869,7 +869,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
   /* Count the number of interfaces */
   for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
-    if (uv__ifaddr_exclude(ent))
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
       continue;
 
     (*count)++;
@@ -887,7 +887,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   address = *addresses;
 
   for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
-    if (uv__ifaddr_exclude(ent))
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
       continue;
 
     address->name = uv__strdup(ent->ifa_name);
@@ -911,7 +911,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
   /* Fill in physical addresses for each interface */
   for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
-    if (uv__ifaddr_exclude(ent))
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFPHYS))
       continue;
 
     address = *addresses;


### PR DESCRIPTION
fix a wrong `if` in `uv_interface_address` about MAC.

> `if (ent->ifa_addr->sa_family != AF_LINK)`
>
> against
>
> `if (ent->ifa_addr->sa_family == AF_LINK)`

Fixes: https://github.com/nodejs/node/issues/13581
Refs: https://github.com/libuv/libuv/blob/v1.9.1/src/unix/freebsd.c#L418-L420
Refs: https://github.com/libuv/libuv/blob/v1.9.1/src/unix/darwin.c#L303-L305
Refs: ...