### PR TITLE
unix: reset signal disposition before execve()

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -279,8 +279,10 @@ static void uv__process_child_init(const uv_process_options_t* options,
                                    int stdio_count,
                                    int (*pipes)[2],
                                    int error_fd) {
+  sigset_t set;
   int close_fd;
   int use_fd;
+  int err;
   int fd;
   int n;
 
@@ -390,6 +392,15 @@ static void uv__process_child_init(const uv_process_options_t* options,
       continue;
 
     uv__write_int(error_fd, -errno);
+    _exit(127);
+  }
+
+  /* Reset signal mask. */
+  sigemptyset(&set);
+  err = pthread_sigmask(SIG_SETMASK, &set, NULL);
+
+  if (err != 0) {
+    uv__write_int(error_fd, -err);
     _exit(127);
   }
 

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -282,6 +282,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
   int close_fd;
   int use_fd;
   int fd;
+  int n;
 
   if (options->flags & UV_PROCESS_DETACHED)
     setsid();
@@ -374,6 +375,22 @@ static void uv__process_child_init(const uv_process_options_t* options,
 
   if (options->env != NULL) {
     environ = options->env;
+  }
+
+  /* Reset signal disposition.  Use a hard-coded limit because NSIG
+   * is not fixed on Linux: it's either 32, 34 or 64, depending on
+   * whether RT signals are enabled.  We are not allowed to touch
+   * RT signal handlers, glibc uses them internally.
+   */
+  for (n = 1; n < 32; n += 1) {
+    if (n == SIGKILL || n == SIGSTOP)
+      continue;  /* Can't be changed. */
+
+    if (SIG_ERR != signal(n, SIG_DFL))
+      continue;
+
+    uv__write_int(error_fd, -errno);
+    _exit(127);
   }
 
   execvp(options->file, options->args);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -931,6 +931,12 @@ TEST_IMPL(kill) {
 
   /* Verify that uv_spawn() resets the signal disposition. */
 #ifndef _WIN32
+  {
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    ASSERT(0 == pthread_sigmask(SIG_BLOCK, &set, NULL));
+  }
   ASSERT(SIG_ERR != signal(SIGTERM, SIG_IGN));
 #endif
 
@@ -938,6 +944,12 @@ TEST_IMPL(kill) {
   ASSERT(r == 0);
 
 #ifndef _WIN32
+  {
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    ASSERT(0 == pthread_sigmask(SIG_UNBLOCK, &set, NULL));
+  }
   ASSERT(SIG_ERR != signal(SIGTERM, SIG_DFL));
 #endif
 

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -929,8 +929,17 @@ TEST_IMPL(kill) {
 
   init_process_options("spawn_helper4", kill_cb);
 
+  /* Verify that uv_spawn() resets the signal disposition. */
+#ifndef _WIN32
+  ASSERT(SIG_ERR != signal(SIGTERM, SIG_IGN));
+#endif
+
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == 0);
+
+#ifndef _WIN32
+  ASSERT(SIG_ERR != signal(SIGTERM, SIG_DFL));
+#endif
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.


### PR DESCRIPTION
Signal dispositions are inherited by child processes.  Libuv itself
does not touch them (if you don't use uv_signal_start(), that is)
but the embedder might and probably does in the case of SIGPIPE.

Reset the disposition for signals 1-31 to their defaults right before
execve'ing into the new process.

But caveat emptor:

> This does open a race window where blocked signals can get delivered
> in the interval between the pthread_sigmask() call and the execve() call
> (and may end up terminating the process)

Fixes: nodejs/node#13662

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/294/