### PR TITLE
freebsd: replace kvm with sysctl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,9 +66,7 @@ AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])
 AS_CASE([$host_os],[mingw*], [
     LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
 ])
-AS_CASE([$host_os], [openbsd*], [], [
-    AC_CHECK_LIB([kvm], [kvm_open])
-])
+AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
 AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -220,7 +220,7 @@ int uv_resident_set_memory(size_t* rss) {
     return -errno;
 
 #ifdef __DragonFly__
-  *rss = kinfo.p_vm_rssize * page_size;
+  *rss = kinfo.kp_vm_rssize * page_size;
 #else
   *rss = kinfo.ki_rssize * page_size;
 #endif

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -202,22 +202,23 @@ int uv_get_process_title(char* buffer, size_t size) {
   return 0;
 }
 
-
 int uv_resident_set_memory(size_t* rss) {
   struct kinfo_proc kinfo;
-  size_t page_size = getpagesize();
-  size_t size = sizeof(struct kinfo_proc);
-  int mib[6];
+  size_t page_size;
+  size_t kinfo_size;
+  int mib[4];
 
   mib[0] = CTL_KERN;
   mib[1] = KERN_PROC;
   mib[2] = KERN_PROC_PID;
   mib[3] = getpid();
-  mib[4] = sizeof(struct kinfo_proc);
-  mib[5] = 1;
 
-  if (sysctl(mib, 6, &kinfo, &size, NULL, 0) < 0)
+  kinfo_size = sizeof(kinfo);
+
+  if (sysctl(mib, 4, &kinfo, &kinfo_size, NULL, 0))
     return -errno;
+
+  page_size = getpagesize();
 
 #ifdef __DragonFly__
   *rss = kinfo.kp_vm_rssize * page_size;

--- a/uv.gyp
+++ b/uv.gyp
@@ -302,12 +302,12 @@
           'sources': [ 'src/unix/openbsd.c' ],
         }],
         [ 'OS=="netbsd"', {
-          'sources': [ 'src/unix/netbsd.c' ],
-        }],
-        [ 'OS in "freebsd dragonflybsd openbsd netbsd".split()', {
           'link_settings': {
             'libraries': [ '-lkvm' ],
           },
+          'sources': [ 'src/unix/netbsd.c' ],
+        }],
+        [ 'OS in "freebsd dragonflybsd openbsd netbsd".split()', {
           'sources': [ 'src/unix/posix-hrtime.c' ],
         }],
         [ 'OS in "ios mac freebsd dragonflybsd openbsd netbsd".split()', {


### PR DESCRIPTION
Removed the kvm.h include, replaced the use of kvm_open() with sysctl().
No need to specify -lkvm anymore.

Similar to https://github.com/libuv/libuv/issues/1340 for OpenBSD.