### PR TITLE
pipe: allow access from other users

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -211,6 +211,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-server-close.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
+                         test/test-pipe-set-fchmod.c \
                          test/test-platform-output.c \
                          test/test-poll-close.c \
                          test/test-poll-close-doesnt-corrupt-stack.c \

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -110,4 +110,4 @@ API
     be either ``UV_WRITABLE``, ``UV_READABLE`` or
     ``UV_WRITABLE | UV_READABLE``. This function is blocking.
 
-    .. versionadded:: 1.14.0
+    .. versionadded:: 1.15.0

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -102,3 +102,10 @@ API
     and call ``uv_accept(pipe, handle)``.
 
 .. seealso:: The :c:type:`uv_stream_t` API functions also apply.
+
+.. c:function:: int uv_pipe_chmod(uv_pipe_t* handle, int flags)
+
+    Alters pipe permissions, allowing it to be accessed from process running by
+    different users. Makes the pipe writable or readable by all users. Mode can
+    be either ``UV_WRITABLE``, ``UV_READABLE`` or
+    ``UV_WRITABLE | UV_READABLE``.

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -105,9 +105,9 @@ API
 
 .. c:function:: int uv_pipe_chmod(uv_pipe_t* handle, int flags)
 
-    Alters pipe permissions, allowing it to be accessed from process running by
+    Alters pipe permissions, allowing it to be accessed from processes run by
     different users. Makes the pipe writable or readable by all users. Mode can
-    be either ``UV_WRITABLE``, ``UV_READABLE`` or
-    ``UV_WRITABLE | UV_READABLE``. This function is blocking.
+    be ``UV_WRITABLE``, ``UV_READABLE`` or ``UV_WRITABLE | UV_READABLE``. This
+    function is blocking.
 
-    .. versionadded:: 1.15.0
+    .. versionadded:: 1.16.0

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -109,3 +109,5 @@ API
     different users. Makes the pipe writable or readable by all users. Mode can
     be either ``UV_WRITABLE``, ``UV_READABLE`` or
     ``UV_WRITABLE | UV_READABLE``.
+
+    .. versionadded:: 1.13.2

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -108,6 +108,6 @@ API
     Alters pipe permissions, allowing it to be accessed from process running by
     different users. Makes the pipe writable or readable by all users. Mode can
     be either ``UV_WRITABLE``, ``UV_READABLE`` or
-    ``UV_WRITABLE | UV_READABLE``.
+    ``UV_WRITABLE | UV_READABLE``. This function is blocking.
 
-    .. versionadded:: 1.13.2
+    .. versionadded:: 1.14.0

--- a/include/uv.h
+++ b/include/uv.h
@@ -708,6 +708,7 @@ UV_EXTERN int uv_pipe_getpeername(const uv_pipe_t* handle,
 UV_EXTERN void uv_pipe_pending_instances(uv_pipe_t* handle, int count);
 UV_EXTERN int uv_pipe_pending_count(uv_pipe_t* handle);
 UV_EXTERN uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle);
+UV_EXTERN int uv_pipe_chmod(uv_pipe_t* handle, int flags);
 
 
 struct uv_poll_s {

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -303,32 +303,85 @@ uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
     return uv__handle_type(handle->accepted_fd);
 }
 
-int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
-#if defined(__APPLE__) || defined(__FreeBSD__)
-  return UV_ENOSYS;
-#else
-  struct stat pipe_stat;
-  int fd;
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(_AIX)
+# define UV__USE_CHMOD
+#endif
 
+static int uv__pipe_chmod_validate(uv_pipe_t* handle, int mode) {
   if (!handle || uv__stream_fd(handle) == -1)
     return UV_EBADF;
-  fd = uv__stream_fd(handle);
-
   if (mode != UV_READABLE &&
       mode != UV_WRITABLE &&
       mode != (UV_WRITABLE | UV_READABLE))
-    return UV_EINVAL;  
+    return UV_EINVAL;
+  return 0;
+}
 
-  if (fstat(fd, &pipe_stat) == -1)
+#ifdef UV__USE_CHMOD
+int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
+  struct stat pipe_stat;
+  char* name_buffer;
+  size_t name_len;
+  int r;
+
+  r = uv__pipe_chmod_validate(handle, mode);
+  if (r != 0)
+    return r;
+
+  name_len = 0;
+  r = uv_pipe_getsockname(handle, NULL, &name_len);
+  if (r != UV_ENOBUFS)
+    return r;
+
+  name_buffer = uv__malloc(name_len + 1);
+  if (name_buffer == NULL)
+    return UV_ENOMEM;
+
+  r = uv_pipe_getsockname(handle, name_buffer, &name_len);
+  if (r != 0) {
+    uv__free(name_buffer);
+    return r;
+  }
+  name_buffer[name_len] = 0;
+  if (stat(name_buffer, &pipe_stat) == -1) {
+    uv__free(name_buffer);
     return -errno;
+  }
 
   if (mode & UV_READABLE)
     pipe_stat.st_mode |= S_IRUSR | S_IRGRP | S_IROTH;
   if (mode & UV_WRITABLE)
     pipe_stat.st_mode |= S_IWUSR | S_IWGRP | S_IWOTH;
+  
+  if (chmod(name_buffer, pipe_stat.st_mode) == -1) {
+    uv__free(name_buffer);
+    return - errno;
+  }
+  uv__free(name_buffer);
+
+  return 0;
+}
+#else
+int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
+  struct stat pipe_stat;
+  int fd;
+  int r;
+
+  r = uv__pipe_chmod_validate(handle, mode);
+  if (r != 0)
+    return r;
+
+  fd = uv__stream_fd(handle);
+  if (fstat(fd, &pipe_stat) == -1)
+    return -errno;
 
   if (fchmod(fd, pipe_stat.st_mode) == -1)
     return -errno;
+
   return 0;
-#endif
 }
+#endif
+
+#ifdef UV__USE_CHMOD
+# undef UV__USE_CHMOD
+#endif

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -302,3 +302,16 @@ uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
   else
     return uv__handle_type(handle->accepted_fd);
 }
+
+int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
+  struct stat pipe_stat;
+  if (fstat(handle->u.fd, &pipe_stat) == -1)
+    return -errno;
+  if (mode & UV_READABLE)
+    pipe_stat.st_mode |= S_IRUSR | S_IRGRP | S_IROTH;
+  if (mode & UV_WRITABLE)
+    pipe_stat.st_mode |= S_IWUSR | S_IWGRP | S_IWOTH;
+  if (fchmod(handle->u.fd, pipe_stat.st_mode) == -1)
+    return -errno;
+  return 0;
+}

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -303,10 +303,6 @@ uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
     return uv__handle_type(handle->accepted_fd);
 }
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(_AIX)
-# define UV__USE_CHMOD
-#endif
-
 static int uv__pipe_chmod_validate(uv_pipe_t* handle, int mode) {
   if (!handle || uv__stream_fd(handle) == -1)
     return UV_EBADF;
@@ -317,7 +313,6 @@ static int uv__pipe_chmod_validate(uv_pipe_t* handle, int mode) {
   return 0;
 }
 
-#ifdef UV__USE_CHMOD
 int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
   struct stat pipe_stat;
   char* name_buffer;
@@ -361,27 +356,3 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
 
   return 0;
 }
-#else
-int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
-  struct stat pipe_stat;
-  int fd;
-  int r;
-
-  r = uv__pipe_chmod_validate(handle, mode);
-  if (r != 0)
-    return r;
-
-  fd = uv__stream_fd(handle);
-  if (fstat(fd, &pipe_stat) == -1)
-    return -errno;
-
-  if (fchmod(fd, pipe_stat.st_mode) == -1)
-    return -errno;
-
-  return 0;
-}
-#endif
-
-#ifdef UV__USE_CHMOD
-# undef UV__USE_CHMOD
-#endif

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2142,7 +2142,7 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
   PSID everyone;
   int error;
 
-  if (!handle || handle->handle == INVALID_HANDLE_VALUE)
+  if (handle == NULL || handle->handle == INVALID_HANDLE_VALUE)
     return UV_EBADF;
 
   if (mode != UV_READABLE &&

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -31,6 +31,9 @@
 #include "stream-inl.h"
 #include "req-inl.h"
 
+#include <AclAPI.h>
+#include <AccCtrl.h>
+
 typedef struct uv__ipc_queue_item_s uv__ipc_queue_item_t;
 
 struct uv__ipc_queue_item_s {
@@ -202,7 +205,7 @@ int uv_stdio_pipe_server(uv_loop_t* loop, uv_pipe_t* handle, DWORD access,
     uv_unique_pipe_name(ptr, name, nameSize);
 
     pipeHandle = CreateNamedPipeA(name,
-      access | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+      access | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE | WRITE_DAC,
       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, 1, 65536, 65536, 0,
       NULL);
 
@@ -534,7 +537,7 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
    */
   handle->pipe.serv.accept_reqs[0].pipeHandle = CreateNamedPipeW(handle->name,
       PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED |
-      FILE_FLAG_FIRST_PIPE_INSTANCE,
+      FILE_FLAG_FIRST_PIPE_INSTANCE | WRITE_DAC,
       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
       PIPE_UNLIMITED_INSTANCES, 65536, 65536, 0, NULL);
 
@@ -803,7 +806,7 @@ static void uv_pipe_queue_accept(uv_loop_t* loop, uv_pipe_t* handle,
     assert(req->pipeHandle == INVALID_HANDLE_VALUE);
 
     req->pipeHandle = CreateNamedPipeW(handle->name,
-        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | WRITE_DAC,
         PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
         PIPE_UNLIMITED_INSTANCES, 65536, 65536, 0, NULL);
 
@@ -2129,4 +2132,71 @@ uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
     return UV_UNKNOWN_HANDLE;
   else
     return UV_TCP;
+}
+
+int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
+  SID_IDENTIFIER_AUTHORITY sid_world = SECURITY_WORLD_SID_AUTHORITY;
+  PACL old_dacl, new_dacl;
+  PSECURITY_DESCRIPTOR sd;
+  EXPLICIT_ACCESS ea;
+  PSID everyone;
+  int error;
+
+  if (!AllocateAndInitializeSid(&sid_world,
+                                1,
+                                SECURITY_WORLD_RID,
+                                0, 0, 0, 0, 0, 0, 0,
+                                &everyone)) {
+    error = GetLastError();
+    goto done;
+  }
+  if (GetSecurityInfo(handle->handle,
+                      SE_KERNEL_OBJECT,
+                      DACL_SECURITY_INFORMATION,
+                      NULL,
+                      NULL,
+                      &old_dacl,
+                      NULL,
+                      &sd)) {
+    error = GetLastError();
+    goto clean_sid;
+  }
+ 
+  ZeroMemory(&ea, sizeof(EXPLICIT_ACCESS));
+  if (mode & UV_READABLE)
+    ea.grfAccessPermissions |= GENERIC_READ | FILE_WRITE_ATTRIBUTES;
+  if (mode & UV_WRITABLE)
+    ea.grfAccessPermissions |= GENERIC_WRITE | FILE_READ_ATTRIBUTES;
+  ea.grfAccessPermissions |= SYNCHRONIZE;
+  ea.grfAccessMode = SET_ACCESS;
+  ea.grfInheritance = NO_INHERITANCE;
+  ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  ea.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+  ea.Trustee.ptstrName = (LPTSTR)everyone;
+
+  if (SetEntriesInAcl(1, &ea, old_dacl, &new_dacl)) {
+    error = GetLastError();
+    goto clean_sd;
+  }
+
+  if (SetSecurityInfo(handle->handle,
+                      SE_KERNEL_OBJECT,
+                      DACL_SECURITY_INFORMATION,
+                      NULL,
+                      NULL,
+                      new_dacl,
+                      NULL)) {
+    error = GetLastError();
+    goto clean_dacl;
+  }
+  error = 0;
+
+clean_dacl:
+  LocalFree((HLOCAL) new_dacl);
+clean_sd:
+  LocalFree((HLOCAL) sd);
+clean_sid:
+  FreeSid(everyone);
+done:
+  return uv_translate_sys_error(error);
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -202,6 +202,7 @@ TEST_DECLARE   (pipe_ref4)
 TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
+TEST_DECLARE   (pipe_set_fchmod)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (has_ref)
 TEST_DECLARE   (active)
@@ -428,6 +429,7 @@ TASK_LIST_START
   TEST_ENTRY  (pipe_close_stdout_read_stdin)
 #endif
   TEST_ENTRY  (pipe_set_non_blocking)
+  TEST_ENTRY  (pipe_set_fchmod)
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -202,7 +202,7 @@ TEST_DECLARE   (pipe_ref4)
 TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
-TEST_DECLARE   (pipe_set_fchmod)
+TEST_DECLARE   (pipe_set_chmod)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (has_ref)
 TEST_DECLARE   (active)
@@ -429,7 +429,7 @@ TASK_LIST_START
   TEST_ENTRY  (pipe_close_stdout_read_stdin)
 #endif
   TEST_ENTRY  (pipe_set_non_blocking)
-  TEST_ENTRY  (pipe_set_fchmod)
+  TEST_ENTRY  (pipe_set_chmod)
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -24,9 +24,6 @@
 #include "task.h"
 
 TEST_IMPL(pipe_set_fchmod) {
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(_AIX)
-  RETURN_SKIP("test not supported on this platform");
-#else
   uv_pipe_t pipe_handle;
   uv_loop_t* loop;
   int r;
@@ -67,5 +64,4 @@ TEST_IMPL(pipe_set_fchmod) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
-#endif
 }

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -1,9 +1,31 @@
+/* Copyright libuv project contributors. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
+
 #include "uv.h"
 #include "task.h"
 
 TEST_IMPL(pipe_set_fchmod) {
-#if defined(__APPLE__)
-  RETURN_SKIP("test not supported on OSX");
+#if defined(__APPLE__) || defined(__FreeBSD__)
+  RETURN_SKIP("test not supported on OSX nor on FreeBSD");
 #else
   uv_pipe_t pipe_handle;
   uv_loop_t* loop;
@@ -20,6 +42,10 @@ TEST_IMPL(pipe_set_fchmod) {
   /* No easy way to test if this works, we will only make sure that */
   /* the call is successful. */
   r = uv_pipe_chmod(&pipe_handle, UV_READABLE);
+  if (r == UV_EPERM) {
+    MAKE_VALGRIND_HAPPY();
+    RETURN_SKIP("Insufficient privileges to alter pipe fmode");
+  }
   ASSERT(r == 0);
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE);
@@ -27,6 +53,16 @@ TEST_IMPL(pipe_set_fchmod) {
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
   ASSERT(r == 0);
+
+  r = uv_pipe_chmod(NULL, UV_WRITABLE | UV_READABLE);
+  ASSERT(r == UV_EBADF);
+
+  r = uv_pipe_chmod(&pipe_handle, 12345678);
+  ASSERT(r == UV_EINVAL);
+
+  uv_close((uv_handle_t*)&pipe_handle, NULL);
+  r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
+  ASSERT(r == UV_EBADF);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -24,8 +24,8 @@
 #include "task.h"
 
 TEST_IMPL(pipe_set_fchmod) {
-#if defined(__APPLE__) || defined(__FreeBSD__)
-  RETURN_SKIP("test not supported on OSX nor on FreeBSD");
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(_AIX)
+  RETURN_SKIP("test not supported on this platform");
 #else
   uv_pipe_t pipe_handle;
   uv_loop_t* loop;

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -42,6 +42,7 @@ TEST_IMPL(pipe_set_fchmod) {
   /* No easy way to test if this works, we will only make sure that */
   /* the call is successful. */
   r = uv_pipe_chmod(&pipe_handle, UV_READABLE);
+  printf("uv_pipe_chmod result: %s\n", uv_err_name(r));
   if (r == UV_EPERM) {
     MAKE_VALGRIND_HAPPY();
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -2,6 +2,9 @@
 #include "task.h"
 
 TEST_IMPL(pipe_set_fchmod) {
+#if defined(__APPLE__)
+  RETURN_SKIP("test not supported on OSX");
+#else
   uv_pipe_t pipe_handle;
   uv_loop_t* loop;
   int r;
@@ -27,4 +30,5 @@ TEST_IMPL(pipe_set_fchmod) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
+#endif
 }

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -39,7 +39,6 @@ TEST_IMPL(pipe_set_chmod) {
   /* No easy way to test if this works, we will only make sure that */
   /* the call is successful. */
   r = uv_pipe_chmod(&pipe_handle, UV_READABLE);
-  printf("uv_pipe_chmod result: %s\n", uv_err_name(r));
   if (r == UV_EPERM) {
     MAKE_VALGRIND_HAPPY();
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -23,7 +23,7 @@
 #include "uv.h"
 #include "task.h"
 
-TEST_IMPL(pipe_set_fchmod) {
+TEST_IMPL(pipe_set_chmod) {
   uv_pipe_t pipe_handle;
   uv_loop_t* loop;
   int r;

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -1,0 +1,30 @@
+#include "uv.h"
+#include "task.h"
+
+TEST_IMPL(pipe_set_fchmod) {
+  uv_pipe_t pipe_handle;
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+
+  r = uv_pipe_init(loop, &pipe_handle, 0);
+  ASSERT(r == 0);
+
+  r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
+  ASSERT(r == 0);
+
+  /* No easy way to test if this works, we will only make sure that */
+  /* the call is successful. */
+  r = uv_pipe_chmod(&pipe_handle, UV_READABLE);
+  ASSERT(r == 0);
+
+  r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE);
+  ASSERT(r == 0);
+
+  r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
+  ASSERT(r == 0);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/uv.gyp
+++ b/uv.gyp
@@ -400,6 +400,7 @@
         'test/test-pipe-server-close.c',
         'test/test-pipe-close-stdout-read-stdin.c',
         'test/test-pipe-set-non-blocking.c',
+        'test/test-pipe-set-fchmod.c',
         'test/test-platform-output.c',
         'test/test-poll.c',
         'test/test-poll-close.c',


### PR DESCRIPTION
Adds new `uv_pipe_chmod` function which can be used to make the pipe writable or readable by all users.

Fixes: https://github.com/libuv/libuv/issues/1365