### PR TITLE
sunos: allow getifaddrs() to return new address families

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -747,7 +747,8 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent) {
     return 1;
   if (ent->ifa_addr == NULL)
     return 1;
-  if (ent->ifa_addr->sa_family == PF_PACKET)
+  if (ent->ifa_addr->sa_family != AF_INET &&
+      ent->ifa_addr->sa_family != AF_INET6)
     return 1;
   return 0;
 }


### PR DESCRIPTION
only accept address families actually understood. This filters for example AF_LINK.