### PR TITLE
unix: fix POLLIN assertion on server read

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -514,7 +514,7 @@ void uv__server_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   int err;
 
   stream = container_of(w, uv_stream_t, io_watcher);
-  assert(events == POLLIN);
+  assert(events & POLLIN);
   assert(stream->accepted_fd == -1);
   assert(!(stream->flags & UV_CLOSING));
 


### PR DESCRIPTION
Certain systems like z/OS have more than one bit turned
on for POLLIN events. (e.g. #define POLLIN 0x03).
Asserting that all bits are turned on would be invalid.
Instead, assert that *any* of those bits are turned on.