### PR TITLE
zos: improve loop_count benchmark performance

### DIFF
--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -183,33 +183,22 @@ int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
   int pollret;
   int reventcount;
 
-  uv_mutex_lock(&global_epoll_lock);
-  uv_mutex_unlock(&global_epoll_lock);
   size = lst->size;
   pfds = lst->items;
   pollret = poll(pfds, size, timeout);
-  if(pollret == -1)
+  if (pollret <= 0)
     return pollret;
 
   reventcount = 0;
-  for (int i = 0; i < lst->size && i < maxevents; ++i) {
+  for (int i = 0; 
+       i < lst->size && i < maxevents && reventcount < pollret; ++i) {
     struct epoll_event ev;
 
-    ev.events = 0;
-    ev.fd = pfds[i].fd;
-    if(!pfds[i].revents)
+    if (pfds[i].fd == -1 || pfds[i].revents == 0)
       continue;
 
-    if(pfds[i].revents & POLLRDNORM)
-      ev.events = ev.events | POLLIN;
-
-    if(pfds[i].revents & POLLWRNORM)
-      ev.events = ev.events | POLLOUT;
-
-    if(pfds[i].revents & POLLHUP)
-      ev.events = ev.events | POLLHUP;
-
-    pfds[i].revents = 0;
+    ev.fd = pfds[i].fd;
+    ev.events = pfds[i].revents;
     events[reventcount++] = ev;
   }
 

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -747,9 +747,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     SAVE_ERRNO(uv__update_time(loop));
     if (nfds == 0) {
       assert(timeout != -1);
-      timeout = real_timeout - timeout;
-      if (timeout > 0)
+
+      if (timeout > 0) {
+        timeout = real_timeout - timeout;
         continue;
+      }
 
       return;
     }


### PR DESCRIPTION
After the poll call, the code updates all the event objects in the array. Instead, use the integer value returned by poll to limit the number of epoll_event objects that are updated.
e.g. If poll returns 5, we know that we only need to update 5 event objects.


I have noticed approximately 4% improvement in the performance of the loop_count
and ping_pongs benchmarks.