### PR TITLE
zos: use stckf builtin for high-res timer

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -25,6 +25,7 @@
 #include <utmpx.h>
 #include <unistd.h>
 #include <sys/ps.h>
+#include <builtins.h>
 #if defined(__clang__)
 #include "csrsic.h"
 #else
@@ -118,9 +119,10 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
 
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
-  struct timeval time;
-  gettimeofday(&time, NULL);
-  return (uint64_t) time.tv_sec * 1e9 + time.tv_usec * 1e3;
+  unsigned long long timestamp;
+  __stckf(&timestamp);
+  /* Convert to nanoseconds */
+  return timestamp / 10;
 }
 
 


### PR DESCRIPTION
Instead of gettimeofday which is too heavy for a fast
monotonic clock implementation.