### PR TITLE
unix,doc: always copy process title when setting

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -186,17 +186,24 @@ API
 
 .. c:function:: int uv_get_process_title(char* buffer, size_t size)
 
-    Gets the title of the current process. If `buffer` is `NULL` or `size` is
-    zero, `UV_EINVAL` is returned. If `size` cannot accommodate the process
-    title and terminating `NULL` character, the function returns `UV_ENOBUFS`.
+    Gets the title of the current process. You *must* call `uv_setup_args`
+    before calling this function. If `buffer` is `NULL` or `size` is zero,
+    `UV_EINVAL` is returned. If `size` cannot accommodate the process title and
+    terminating `NULL` character, the function returns `UV_ENOBUFS`.
+
+    .. warning::
+        `uv_get_process_title` is not thread safe on any platform except Windows.
 
 .. c:function:: int uv_set_process_title(const char* title)
 
-    Sets the current process title. On platforms with a fixed size buffer for the
-    process title the contents of `title` will be copied to the buffer and
-    truncated if larger than the available space. Other platforms will return
-    `UV_ENOMEM` if they cannot allocate enough space to duplicate the contents of
-    `title`.
+    Sets the current process title. You *must* call `uv_setup_args` before
+    calling this function. On platforms with a fixed size buffer for the process
+    title the contents of `title` will be copied to the buffer and truncated if
+    larger than the available space. Other platforms will return `UV_ENOMEM` if
+    they cannot allocate enough space to duplicate the contents of `title`.
+
+    .. warning::
+        `uv_set_process_title` is not thread safe on any platform except Windows.
 
 .. c:function:: int uv_resident_set_memory(size_t* rss)
 

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -161,9 +161,13 @@ char** uv_setup_args(int argc, char** argv) {
 
 int uv_set_process_title(const char* title) {
   int oid[4];
+  char* new_title;
 
+  new_title = uv__strdup(title);
+  if (process_title == NULL)
+    return -ENOMEM;
   uv__free(process_title);
-  process_title = uv__strdup(title);
+  process_title = new_title;
 
   oid[0] = CTL_KERN;
   oid[1] = KERN_PROC;

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -124,9 +124,13 @@ char** uv_setup_args(int argc, char** argv) {
 
 
 int uv_set_process_title(const char* title) {
-  if (process_title) uv__free(process_title);
+  char* new_title;
 
-  process_title = uv__strdup(title);
+  new_title = uv__strdup(title);
+  if (process_title == NULL)
+    return -ENOMEM;
+  uv__free(process_title);
+  process_title = new_title;
   setproctitle("%s", title);
 
   return 0;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -146,8 +146,13 @@ char** uv_setup_args(int argc, char** argv) {
 
 
 int uv_set_process_title(const char* title) {
+  char* new_title;
+
+  new_title = uv__strdup(title);
+  if (process_title == NULL)
+    return -ENOMEM;
   uv__free(process_title);
-  process_title = uv__strdup(title);
+  process_title = new_title;
   setproctitle("%s", title);
   return 0;
 }

--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -48,16 +48,14 @@ char** uv_setup_args(int argc, char** argv) {
   for (i = 0; i < argc; i++)
     size += strlen(argv[i]) + 1;
 
+  process_title.str = uv__strdup(argv[0]);
+  if (process_title.str == NULL)
+    return argv;
+  
 #if defined(__MVS__)
   /* argv is not adjacent. So just use argv[0] */
-  process_title.str = uv__strdup(argv[0]);
-  if (process_title.str == NULL)
-    return argv;
   process_title.len = strlen(process_title.str);
 #else
-  process_title.str = uv__strdup(argv[0]);
-  if (process_title.str == NULL)
-    return argv;
   process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
   assert(process_title.len + 1 == size);  /* argv memory should be adjacent. */
 #endif


### PR DESCRIPTION
Ensures that the user's `argv` is copied into a local buffer when calling `uv_setup_args`. Before, the `argv` was simply being pointed to, which meant that libuv could end up accessing invalid memory if the user decided to later edit the memory at that location. It also meant that a subsequent call to `uv_set_process_title` would never write more characters than the length of `argv[0]`.

With the new changes, `argv[0]` is copied into a temporary buffer and any subsequent calls to `uv_set_process_title` will thus be able to copy as many characters as the call to `uv__strdup` permits. Note that on *BSD and AIX this behaviour was already in effect .

Some error checking (specifically checking the result of `uv__strdup`) has been added, and calls to `uv__free` rearranged so that in case of `ENOMEM` `uv__free` can't be called erroneously.

Finally, a warning about the thread safety of `uv_get_process_title` and `uv_set_process_title` was added to the docs.

Note: I wasn't too sure how to add a test for this, since I don't believe the current test system exposes `argv`.

Addresses https://github.com/libuv/libuv/issues/1395.