### PR TITLE
aix: fix un-initialized pointer field in fs handle

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -855,6 +855,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   uv__io_init(&handle->event_watcher, uv__ahafs_event, fd);
   handle->path = uv__strdup(filename);
   handle->cb = cb;
+  handle->dir_filename = NULL;
 
   uv__io_start(handle->loop, &handle->event_watcher, POLLIN);
 


### PR DESCRIPTION
In AIX, fs watch close call was corrupting memory in the v8
compiler, when used in node. The handle->dir_filename field
can be un-initialized, if the watch is initiated but no event
got fired. The uv_fs_event_stop was freeing this pointer as if
it was malloc'ed, leading to the crash.

Properly initialize handle->dir_filename to avoid this being garbage.
Fixes: https://github.com/nodejs/node/issues/13577

tests pass:
```
...
ok 309 - fork_fs_events_child_dir
ok 310 - fork_fs_events_file_parent_child
ok 311 - fork_threadpool_queue_work_simple
PASS: test/run-tests
=============
1 test passed
=============
```