### PR TITLE
Check for NULL in uv_os_unsetenv for parameter name

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1292,6 +1292,9 @@ int uv_os_setenv(const char* name, const char* value) {
 
 
 int uv_os_unsetenv(const char* name) {
+  if (name == NULL)
+    return -EINVAL;
+
   if (unsetenv(name) != 0)
     return -errno;
 


### PR DESCRIPTION
* Fixes segfault of unit test on musl (AlpineLinux)
* Add a check for parameter like uv_os_setenv do