### PR TITLE
aix: add netmask, mac address into net interfaces

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1018,9 +1018,10 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 int uv_interface_addresses(uv_interface_address_t** addresses,
   int* count) {
   uv_interface_address_t* address;
-  int sockfd, size = 1;
+  int sockfd, inet6, size = 1;
   struct ifconf ifc;
   struct ifreq *ifr, *p, flg;
+  struct sockaddr_dl* sa_addr;
 
   *count = 0;
 
@@ -1084,6 +1085,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
           p->ifr_addr.sa_family == AF_INET))
       continue;
 
+    inet6 = (p->ifr_addr.sa_family == AF_INET6);
+
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
@@ -1097,13 +1100,23 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
     address->name = uv__strdup(p->ifr_name);
 
-    if (p->ifr_addr.sa_family == AF_INET6) {
+    if (inet6)
       address->address.address6 = *((struct sockaddr_in6*) &p->ifr_addr);
-    } else {
+    else
       address->address.address4 = *((struct sockaddr_in*) &p->ifr_addr);
+
+    sa_addr = (struct sockaddr_dl*) &p->ifr_addr;
+    memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
+
+    if (ioctl(sockfd, SIOCGIFNETMASK, p) == -1) {
+      uv__close(sockfd);
+      return -ENOSYS;
     }
 
-    /* TODO: Retrieve netmask using SIOCGIFNETMASK ioctl */
+    if (inet6)
+      address->netmask.netmask6 = *((struct sockaddr_in6*) &p->ifr_addr);
+    else
+      address->netmask.netmask4 = *((struct sockaddr_in*) &p->ifr_addr);
 
     address->is_internal = flg.ifr_flags & IFF_LOOPBACK ? 1 : 0;
 


### PR DESCRIPTION
uv_interface_addresses API extracts the network interface entries.
In AIX, this was not fully implemented. retrieve the network mask and
the mac addresses.

Fixes: https://github.com/nodejs/node/issues/14119

```
ok 284 - thread_mutex
ok 285 - thread_rwlock
ok 286 - thread_rwlock_trylock
ok 287 - thread_create
ok 288 - thread_equal
ok 289 - dlerror
ok 290 - ip4_addr
ok 291 - ip6_addr_link_local
ok 292 - queue_foreach_delete
PASS: test/run-tests
=============
1 test passed
=============
```