### PR TITLE
win, fs: support unusual reparse points

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1118,8 +1118,6 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
      */
     if (fs__readlink_handle(handle, NULL, &statbuf->st_size) == 0) {
       statbuf->st_mode |= S_IFLNK;
-    } else if (GetLastError() != ERROR_NOT_A_REPARSE_POINT) {
-      return -1;
     }
   }
 


### PR DESCRIPTION
Allow for running uv_fs_stat and uv_fs_lstat on all reparse points. One of such points is new OneDrive drive with "files on demand" feature enabled.

[Original commit message](https://github.com/libuv/libuv/commit/4a88b3b4b72de79d8a6f3107a200f6f960f475a7) says this was added "pre-emptively". This commit removes this and fixes a node issue.

Ref: https://github.com/nodejs/node/issues/12737