### PR TITLE
Documentation builder: fix relative paths for source code examples

### DIFF
--- a/docs/src/guide/basics.rst
+++ b/docs/src/guide/basics.rst
@@ -86,7 +86,7 @@ With the basics out of the way, lets write our first libuv program. It does
 nothing, except start a loop which will exit immediately.
 
 .. rubric:: helloworld/main.c
-.. literalinclude:: ../code/helloworld/main.c
+.. literalinclude:: ../../code/helloworld/main.c
     :linenos:
 
 This program quits immediately because it has no events to process. A libuv
@@ -136,7 +136,7 @@ Handles are opaque structs named as ``uv_TYPE_t`` where type signifies what the
 handle is used for. 
 
 .. rubric:: libuv watchers
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 197-230
 
 Handles represent long-lived objects. Async operations on such handles are
@@ -170,7 +170,7 @@ watcher is stopped when the count is reached and ``uv_run()`` exits since no
 event watchers are active.
 
 .. rubric:: idle-basic/main.c
-.. literalinclude:: ../code/idle-basic/main.c
+.. literalinclude:: ../../code/idle-basic/main.c
     :emphasize-lines: 6,10,14-17
 
 Storing context

--- a/docs/src/guide/eventloops.rst
+++ b/docs/src/guide/eventloops.rst
@@ -19,7 +19,7 @@ these things can be a bit difficult to understand, so let's look at
 ``uv_run()`` where all the control flow occurs.
 
 .. rubric:: src/unix/core.c - uv_run
-.. literalinclude:: ../libuv/src/unix/core.c
+.. literalinclude:: ../../../src/unix/core.c
     :linenos:
     :lines: 304-324
     :emphasize-lines: 10,19,21
@@ -42,7 +42,7 @@ Here is a simple example that stops the loop and demonstrates how the current
 iteration of the loop still takes places.
 
 .. rubric:: uvstop/main.c
-.. literalinclude:: ../code/uvstop/main.c
+.. literalinclude:: ../../code/uvstop/main.c
     :linenos:
     :emphasize-lines: 11
 

--- a/docs/src/guide/filesystem.rst
+++ b/docs/src/guide/filesystem.rst
@@ -53,7 +53,7 @@ Let's see a simple implementation of ``cat``. We start with registering
 a callback for when the file is opened:
 
 .. rubric:: uvcat/main.c - opening a file
-.. literalinclude:: ../code/uvcat/main.c
+.. literalinclude:: ../../code/uvcat/main.c
     :linenos:
     :lines: 41-53
     :emphasize-lines: 4, 6-7
@@ -62,7 +62,7 @@ The ``result`` field of a ``uv_fs_t`` is the file descriptor in case of the
 ``uv_fs_open`` callback. If the file is successfully opened, we start reading it.
 
 .. rubric:: uvcat/main.c - read callback
-.. literalinclude:: ../code/uvcat/main.c
+.. literalinclude:: ../../code/uvcat/main.c
     :linenos:
     :lines: 26-40
     :emphasize-lines: 2,8,12
@@ -86,7 +86,7 @@ simply drives the next read. Thus read and write proceed in lockstep via
 callbacks.
 
 .. rubric:: uvcat/main.c - write callback
-.. literalinclude:: ../code/uvcat/main.c
+.. literalinclude:: ../../code/uvcat/main.c
     :linenos:
     :lines: 16-24
     :emphasize-lines: 6
@@ -99,7 +99,7 @@ callbacks.
 We set the dominos rolling in ``main()``:
 
 .. rubric:: uvcat/main.c
-.. literalinclude:: ../code/uvcat/main.c
+.. literalinclude:: ../../code/uvcat/main.c
     :linenos:
     :lines: 55-
     :emphasize-lines: 2
@@ -118,7 +118,7 @@ same patterns as the read/write/open calls, returning the result in the
 ``uv_fs_t.result`` field. The full list:
 
 .. rubric:: Filesystem operations
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 1084-1195
 
 .. _buffers-and-streams:
@@ -167,7 +167,7 @@ We start off opening pipes on the files we require. libuv pipes to a file are
 opened as bidirectional by default.
 
 .. rubric:: uvtee/main.c - read on pipes
-.. literalinclude:: ../code/uvtee/main.c
+.. literalinclude:: ../../code/uvtee/main.c
     :linenos:
     :lines: 61-80
     :emphasize-lines: 4,5,15
@@ -182,7 +182,7 @@ buffers are required to hold incoming data. ``read_stdin`` will be called with
 these buffers.
 
 .. rubric:: uvtee/main.c - reading buffers
-.. literalinclude:: ../code/uvtee/main.c
+.. literalinclude:: ../../code/uvtee/main.c
     :linenos:
     :lines: 19-22,44-60
 
@@ -206,7 +206,7 @@ The read callback may be called with ``nread = 0``, indicating that at this
 point there is nothing to be read. Most applications will just ignore this.
 
 .. rubric:: uvtee/main.c - Write to pipe
-.. literalinclude:: ../code/uvtee/main.c
+.. literalinclude:: ../../code/uvtee/main.c
     :linenos:
     :lines: 9-13,23-42
 
@@ -246,7 +246,7 @@ a command whenever any of the watched files change::
 The file change notification is started using ``uv_fs_event_init()``:
 
 .. rubric:: onchange/main.c - The setup
-.. literalinclude:: ../code/onchange/main.c
+.. literalinclude:: ../../code/onchange/main.c
     :linenos:
     :lines: 26-
     :emphasize-lines: 15
@@ -254,7 +254,7 @@ The file change notification is started using ``uv_fs_event_init()``:
 The third argument is the actual file or directory to monitor. The last
 argument, ``flags``, can be:
 
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 1299, 1308, 1315
 
 ``UV_FS_EVENT_WATCH_ENTRY`` and ``UV_FS_EVENT_STAT`` don't do anything (yet).
@@ -276,7 +276,7 @@ In our example we simply print the arguments and run the command using
 ``system()``.
 
 .. rubric:: onchange/main.c - file change notification callback
-.. literalinclude:: ../code/onchange/main.c
+.. literalinclude:: ../../code/onchange/main.c
     :linenos:
     :lines: 9-24
 

--- a/docs/src/guide/networking.rst
+++ b/docs/src/guide/networking.rst
@@ -37,7 +37,7 @@ Server sockets proceed by:
 Here is a simple echo server
 
 .. rubric:: tcp-echo-server/main.c - The listen socket
-.. literalinclude:: ../code/tcp-echo-server/main.c
+.. literalinclude:: ../../code/tcp-echo-server/main.c
     :linenos:
     :lines: 68-
     :emphasize-lines: 4-5,7-10
@@ -59,7 +59,7 @@ a handle for the client socket and associate the handle using ``uv_accept``.
 In this case we also establish interest in reading from this stream.
 
 .. rubric:: tcp-echo-server/main.c - Accepting the client
-.. literalinclude:: ../code/tcp-echo-server/main.c
+.. literalinclude:: ../../code/tcp-echo-server/main.c
     :linenos:
     :lines: 51-66
     :emphasize-lines: 9-10
@@ -107,7 +107,7 @@ address from a `DHCP`_ server -- DHCP Discover.
     numbers below 1024.
 
 .. rubric:: udp-dhcp/main.c - Setup and send UDP packets
-.. literalinclude:: ../code/udp-dhcp/main.c
+.. literalinclude:: ../../code/udp-dhcp/main.c
     :linenos:
     :lines: 7-11,104-
     :emphasize-lines: 8,10-11,17-18,21
@@ -142,7 +142,7 @@ provided by your allocator was not large enough to hold the data. *In this case
 the OS will discard the data that could not fit* (That's UDP for you!).
 
 .. rubric:: udp-dhcp/main.c - Reading packets
-.. literalinclude:: ../code/udp-dhcp/main.c
+.. literalinclude:: ../../code/udp-dhcp/main.c
     :linenos:
     :lines: 17-40
     :emphasize-lines: 1,23
@@ -167,7 +167,7 @@ Multicast
 
 A socket can (un)subscribe to a multicast group using:
 
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 594-597
 
 where ``membership`` is ``UV_JOIN_GROUP`` or ``UV_LEAVE_GROUP``.
@@ -191,7 +191,7 @@ perform normal socket operations on the retrieved addresses. Let's connect to
 Freenode to see an example of DNS resolution.
 
 .. rubric:: dns/main.c
-.. literalinclude:: ../code/dns/main.c
+.. literalinclude:: ../../code/dns/main.c
     :linenos:
     :lines: 61-
     :emphasize-lines: 12
@@ -207,7 +207,7 @@ addrinfo(s)``. This also demonstrates ``uv_tcp_connect``. It is necessary to
 call ``uv_freeaddrinfo`` in the callback.
 
 .. rubric:: dns/main.c
-.. literalinclude:: ../code/dns/main.c
+.. literalinclude:: ../../code/dns/main.c
     :linenos:
     :lines: 42-60
     :emphasize-lines: 8,16
@@ -225,7 +225,7 @@ interface details so you get an idea of the fields that are available. This is
 useful to allow your service to bind to IP addresses when it starts.
 
 .. rubric:: interfaces/main.c
-.. literalinclude:: ../code/interfaces/main.c
+.. literalinclude:: ../../code/interfaces/main.c
     :linenos:
     :emphasize-lines: 9,17
 

--- a/docs/src/guide/processes.rst
+++ b/docs/src/guide/processes.rst
@@ -26,7 +26,7 @@ The simplest case is when you simply want to launch a process and know when it
 exits. This is achieved using ``uv_spawn``.
 
 .. rubric:: spawn/main.c
-.. literalinclude:: ../code/spawn/main.c
+.. literalinclude:: ../../code/spawn/main.c
     :linenos:
     :lines: 6-8,15-
     :emphasize-lines: 11,13-17
@@ -55,7 +55,7 @@ The exit callback will be invoked with the *exit status* and the type of *signal
 which caused the exit.
 
 .. rubric:: spawn/main.c
-.. literalinclude:: ../code/spawn/main.c
+.. literalinclude:: ../../code/spawn/main.c
     :linenos:
     :lines: 9-12
     :emphasize-lines: 3
@@ -105,7 +105,7 @@ child processes which are independent of the parent so that the parent exiting
 does not affect it.
 
 .. rubric:: detach/main.c
-.. literalinclude:: ../code/detach/main.c
+.. literalinclude:: ../../code/detach/main.c
     :linenos:
     :lines: 9-30
     :emphasize-lines: 12,19
@@ -141,7 +141,7 @@ can only be associated with one signal number, with subsequent calls to
 stop watching. Here is a small example demonstrating the various possibilities:
 
 .. rubric:: signal/main.c
-.. literalinclude:: ../code/signal/main.c
+.. literalinclude:: ../../code/signal/main.c
     :linenos:
     :emphasize-lines: 17-18,27-28
 
@@ -173,7 +173,7 @@ child be the same as the stderr of the parent. In this case, libuv supports
 which is:
 
 .. rubric:: proc-streams/test.c
-.. literalinclude:: ../code/proc-streams/test.c
+.. literalinclude:: ../../code/proc-streams/test.c
 
 The actual program ``proc-streams`` runs this while sharing only ``stderr``.
 The file descriptors of the child process are set using the ``stdio`` field in
@@ -181,7 +181,7 @@ The file descriptors of the child process are set using the ``stdio`` field in
 file descriptors being set. ``uv_process_options_t.stdio`` is an array of
 ``uv_stdio_container_t``, which is:
 
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 826-834
 
 where flags can have several values. Use ``UV_IGNORE`` if it isn't going to be
@@ -192,7 +192,7 @@ Since we want to pass on an existing descriptor, we'll use ``UV_INHERIT_FD``.
 Then we set the ``fd`` to ``stderr``.
 
 .. rubric:: proc-streams/main.c
-.. literalinclude:: ../code/proc-streams/main.c
+.. literalinclude:: ../../code/proc-streams/main.c
     :linenos:
     :lines: 15-17,27-
     :emphasize-lines: 6,10,11,12
@@ -210,13 +210,13 @@ can be used to implement something like CGI_.
 A sample CGI script/executable is:
 
 .. rubric:: cgi/tick.c
-.. literalinclude:: ../code/cgi/tick.c
+.. literalinclude:: ../../code/cgi/tick.c
 
 The CGI server combines the concepts from this chapter and :doc:`networking` so
 that every client is sent ten ticks after which that connection is closed.
 
 .. rubric:: cgi/main.c
-.. literalinclude:: ../code/cgi/main.c
+.. literalinclude:: ../../code/cgi/main.c
     :linenos:
     :lines: 49-63
     :emphasize-lines: 10
@@ -225,7 +225,7 @@ Here we simply accept the TCP connection and pass on the socket (*stream*) to
 ``invoke_cgi_script``.
 
 .. rubric:: cgi/main.c
-.. literalinclude:: ../code/cgi/main.c
+.. literalinclude:: ../../code/cgi/main.c
     :linenos:
     :lines: 16, 25-45
     :emphasize-lines: 8-9,18,20
@@ -275,7 +275,7 @@ creator/owner of the socket acting as the server. After the initial setup,
 messaging is no different from TCP, so we'll re-use the echo server example.
 
 .. rubric:: pipe-echo-server/main.c
-.. literalinclude:: ../code/pipe-echo-server/main.c
+.. literalinclude:: ../../code/pipe-echo-server/main.c
     :linenos:
     :lines: 70-
     :emphasize-lines: 5,10,14
@@ -312,7 +312,7 @@ The worker process is quite simple, since the file-descriptor is handed over to
 it by the master.
 
 .. rubric:: multi-echo-server/worker.c
-.. literalinclude:: ../code/multi-echo-server/worker.c
+.. literalinclude:: ../../code/multi-echo-server/worker.c
     :linenos:
     :lines: 7-9,81-
     :emphasize-lines: 6-8
@@ -325,7 +325,7 @@ standard input of the worker, we connect the pipe to ``stdin`` using
 ``uv_pipe_open``.
 
 .. rubric:: multi-echo-server/worker.c
-.. literalinclude:: ../code/multi-echo-server/worker.c
+.. literalinclude:: ../../code/multi-echo-server/worker.c
     :linenos:
     :lines: 51-79
     :emphasize-lines: 10,15,20
@@ -343,7 +343,7 @@ Turning now to the master, let's take a look at how the workers are launched to
 allow load balancing.
 
 .. rubric:: multi-echo-server/main.c
-.. literalinclude:: ../code/multi-echo-server/main.c
+.. literalinclude:: ../../code/multi-echo-server/main.c
     :linenos:
     :lines: 9-13
 
@@ -351,7 +351,7 @@ The ``child_worker`` structure wraps the process, and the pipe between the
 master and the individual process.
 
 .. rubric:: multi-echo-server/main.c
-.. literalinclude:: ../code/multi-echo-server/main.c
+.. literalinclude:: ../../code/multi-echo-server/main.c
     :linenos:
     :lines: 51,61-95
     :emphasize-lines: 17,20-21
@@ -369,7 +369,7 @@ It is in ``on_new_connection`` (the TCP infrastructure is initialized in
 worker in the round-robin.
 
 .. rubric:: multi-echo-server/main.c
-.. literalinclude:: ../code/multi-echo-server/main.c
+.. literalinclude:: ../../code/multi-echo-server/main.c
     :linenos:
     :lines: 31-49
     :emphasize-lines: 9,12-13

--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -38,9 +38,9 @@ wait for it to close using ``uv_thread_join()``.
 .. _thread-create-example:
 
 .. rubric:: thread-create/main.c
-.. literalinclude:: ../code/thread-create/main.c
+.. literalinclude:: ../../code/thread-create/main.c
     :linenos:
-    :lines: 26-37
+    :lines: 26-36
     :emphasize-lines: 3-7
 
 .. tip::
@@ -54,7 +54,7 @@ custom parameters to the thread. The function ``hare`` will now run in a separat
 thread, scheduled pre-emptively by the operating system:
 
 .. rubric:: thread-create/main.c
-.. literalinclude:: ../code/thread-create/main.c
+.. literalinclude:: ../../code/thread-create/main.c
     :linenos:
     :lines: 6-14
     :emphasize-lines: 2
@@ -76,7 +76,7 @@ Mutexes
 The mutex functions are a **direct** map to the pthread equivalents.
 
 .. rubric:: libuv mutex functions
-.. literalinclude:: ../libuv/include/uv.h
+.. literalinclude:: ../../../include/uv.h
     :lines: 1355-1360
 
 The ``uv_mutex_init()`` and ``uv_mutex_trylock()`` functions will return 0 on
@@ -115,7 +115,7 @@ holding it. Read-write locks are frequently used in databases. Here is a toy
 example.
 
 .. rubric:: locks/main.c - simple rwlocks
-.. literalinclude:: ../code/locks/main.c
+.. literalinclude:: ../../code/locks/main.c
     :linenos:
     :emphasize-lines: 13,16,27,31,42,55
 
@@ -199,7 +199,7 @@ a separate thread so that the blocking and CPU bound task does not prevent the
 event loop from performing other activities.
 
 .. rubric:: queue-work/main.c - lazy fibonacci
-.. literalinclude:: ../code/queue-work/main.c
+.. literalinclude:: ../../code/queue-work/main.c
     :linenos:
     :lines: 17-29
 
@@ -212,10 +212,10 @@ you are changing things while both threads may be running.
 The trigger is ``uv_queue_work``:
 
 .. rubric:: queue-work/main.c
-.. literalinclude:: ../code/queue-work/main.c
+.. literalinclude:: ../../code/queue-work/main.c
     :linenos:
     :lines: 31-44
-    :emphasize-lines: 40
+    :emphasize-lines: 10
 
 The thread function will be launched in a separate thread, passed the
 ``uv_work_t`` structure and once the function returns, the *after* function
@@ -239,7 +239,7 @@ Let's modify the fibonacci example to demonstrate ``uv_cancel()``. We first set
 up a signal handler for termination.
 
 .. rubric:: queue-cancel/main.c
-.. literalinclude:: ../code/queue-cancel/main.c
+.. literalinclude:: ../../code/queue-cancel/main.c
     :linenos:
     :lines: 43-
 
@@ -247,7 +247,7 @@ When the user triggers the signal by pressing ``Ctrl+C`` we send
 ``uv_cancel()`` to all the workers. ``uv_cancel()`` will return ``0`` for those that are already executing or finished.
 
 .. rubric:: queue-cancel/main.c
-.. literalinclude:: ../code/queue-cancel/main.c
+.. literalinclude:: ../../code/queue-cancel/main.c
     :linenos:
     :lines: 33-41
     :emphasize-lines: 6
@@ -256,7 +256,7 @@ For tasks that do get cancelled successfully, the *after* function is called
 with ``status`` set to ``UV_ECANCELED``.
 
 .. rubric:: queue-cancel/main.c
-.. literalinclude:: ../code/queue-cancel/main.c
+.. literalinclude:: ../../code/queue-cancel/main.c
     :linenos:
     :lines: 28-31
     :emphasize-lines: 2
@@ -283,7 +283,7 @@ to the main thread. This is a simple example of having a download manager
 informing the user of the status of running downloads.
 
 .. rubric:: progress/main.c
-.. literalinclude:: ../code/progress/main.c
+.. literalinclude:: ../../code/progress/main.c
     :linenos:
     :lines: 7-8,34-
     :emphasize-lines: 2,11
@@ -308,7 +308,7 @@ with the async watcher whenever it receives a message.
     event.
 
 .. rubric:: progress/main.c
-.. literalinclude:: ../code/progress/main.c
+.. literalinclude:: ../../code/progress/main.c
     :linenos:
     :lines: 10-23
     :emphasize-lines: 7-8
@@ -318,7 +318,7 @@ for delivery with ``uv_async_send``. Remember: ``uv_async_send`` is also
 non-blocking and will return immediately.
 
 .. rubric:: progress/main.c
-.. literalinclude:: ../code/progress/main.c
+.. literalinclude:: ../../code/progress/main.c
     :linenos:
     :lines: 30-33
 
@@ -327,7 +327,7 @@ The callback is a standard libuv pattern, extracting the data from the watcher.
 Finally it is important to remember to clean up the watcher.
 
 .. rubric:: progress/main.c
-.. literalinclude:: ../code/progress/main.c
+.. literalinclude:: ../../code/progress/main.c
     :linenos:
     :lines: 25-28
     :emphasize-lines: 3

--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -86,7 +86,7 @@ the JS API. A ``uv_handle_t`` (the superclass of all watchers) is created per
 JS object and can be ref/unrefed.
 
 .. rubric:: ref-timer/main.c
-.. literalinclude:: ../code/ref-timer/main.c
+.. literalinclude:: ../../code/ref-timer/main.c
     :linenos:
     :lines: 5-8, 17-
     :emphasize-lines: 9
@@ -110,7 +110,7 @@ and the user will face an unresponsive application. In such a case queue up and
 idle watcher to keep the UI operational.
 
 .. rubric:: idle-compute/main.c
-.. literalinclude:: ../code/idle-compute/main.c
+.. literalinclude:: ../../code/idle-compute/main.c
     :linenos:
     :lines: 5-9, 34-
     :emphasize-lines: 13
@@ -122,7 +122,7 @@ for a brief amount as the loop deals with the input data, after which it will
 keep calling the idle callback again.
 
 .. rubric:: idle-compute/main.c
-.. literalinclude:: ../code/idle-compute/main.c
+.. literalinclude:: ../../code/idle-compute/main.c
     :linenos:
     :lines: 10-19
 
@@ -214,7 +214,7 @@ progress with the download whenever libuv notifies of I/O readiness.
 .. _multi: http://curl.haxx.se/libcurl/c/libcurl-multi.html
 
 .. rubric:: uvwget/main.c - The setup
-.. literalinclude:: ../code/uvwget/main.c
+.. literalinclude:: ../../code/uvwget/main.c
     :linenos:
     :lines: 1-9,140-
     :emphasize-lines: 7,21,24-25
@@ -234,7 +234,7 @@ Our downloader is to be invoked as::
 So we add each argument as an URL
 
 .. rubric:: uvwget/main.c - Adding urls
-.. literalinclude:: ../code/uvwget/main.c
+.. literalinclude:: ../../code/uvwget/main.c
     :linenos:
     :lines: 39-56
     :emphasize-lines: 13-14
@@ -250,7 +250,7 @@ call whenever sockets change state. But before we go into that, we need to poll
 on sockets whenever ``handle_socket`` is called.
 
 .. rubric:: uvwget/main.c - Setting up polling
-.. literalinclude:: ../code/uvwget/main.c
+.. literalinclude:: ../../code/uvwget/main.c
     :linenos:
     :lines: 102-140
     :emphasize-lines: 9,11,15,21,24
@@ -270,10 +270,10 @@ multiple times on the same handle is acceptable, it will just update the events
 mask with the new value. ``curl_perform`` is the crux of this program.
 
 .. rubric:: uvwget/main.c - Driving libcurl.
-.. literalinclude:: ../code/uvwget/main.c
+.. literalinclude:: ../../code/uvwget/main.c
     :linenos:
     :lines: 81-95
-    :emphasize-lines: 2,6-7,12,18,20
+    :emphasize-lines: 2,6-7,12
 
 The first thing we do is to stop the timer, since there has been some progress
 in the interval. Then depending on what event triggered the callback, we set
@@ -287,7 +287,7 @@ are completed. So we extract these messages, and clean up handles whose
 transfers are done.
 
 .. rubric:: uvwget/main.c - Reading transfer status.
-.. literalinclude:: ../code/uvwget/main.c
+.. literalinclude:: ../../code/uvwget/main.c
     :linenos:
     :lines: 58-79
     :emphasize-lines: 6,9-10,13-14
@@ -311,14 +311,14 @@ plugin system which does nothing except print the name of the plugin.
 Let us first look at the interface provided to plugin authors.
 
 .. rubric:: plugin/plugin.h
-.. literalinclude:: ../code/plugin/plugin.h
+.. literalinclude:: ../../code/plugin/plugin.h
     :linenos:
 
 You can similarly add more functions that plugin authors can use to do useful
 things in your application [#]_. A sample plugin using this API is:
 
 .. rubric:: plugin/hello.c
-.. literalinclude:: ../code/plugin/hello.c
+.. literalinclude:: ../../code/plugin/hello.c
     :linenos:
 
 Our interface defines that all plugins should have an ``initialize`` function
@@ -339,7 +339,7 @@ This is done by using ``uv_dlopen`` to first load the shared library
 ``uv_dlsym`` and invoke it.
 
 .. rubric:: plugin/main.c
-.. literalinclude:: ../code/plugin/main.c
+.. literalinclude:: ../../code/plugin/main.c
     :linenos:
     :lines: 7-
     :emphasize-lines: 15, 18, 24
@@ -391,7 +391,7 @@ a file, control sequences should not be written as they impede readability and
 Here is a simple example which prints white text on a red background:
 
 .. rubric:: tty/main.c
-.. literalinclude:: ../code/tty/main.c
+.. literalinclude:: ../../code/tty/main.c
     :linenos:
     :emphasize-lines: 11-12,14,17,27
 
@@ -401,7 +401,7 @@ program which does some animation using the function and character position
 escape codes.
 
 .. rubric:: tty-gravity/main.c
-.. literalinclude:: ../code/tty-gravity/main.c
+.. literalinclude:: ../../code/tty-gravity/main.c
     :linenos:
     :emphasize-lines: 19,25,38
 


### PR DESCRIPTION
This pull request adjusts the relative paths for the source code examples in the User guide so that they are properly included in the resulting html. See https://github.com/libuv/libuv/issues/1427