### PR TITLE
github: fix link to help repo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!--
 If you want to report a bug, you are in the right place!
 
-If you need help or have a question, go here: https://github.com/libuv/help/new
+If you need help or have a question, go here:
+https://github.com/libuv/help/issues/new
 
 Please include code that demonstrates the bug and keep it short and simple.
 -->


### PR DESCRIPTION
Mea culpa, I somehow managed to misspell the link...