### PR TITLE
loop-watcher: return negative number on error

### DIFF
--- a/src/loop-watcher.c
+++ b/src/loop-watcher.c
@@ -31,7 +31,7 @@
                                                                               \
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
-    if (cb == NULL) return -UV_EINVAL;                                        \
+    if (cb == NULL) return UV_EINVAL;                                         \
     QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -284,6 +284,8 @@ TEST_IMPL(loop_handles) {
 
   r = uv_prepare_init(uv_default_loop(), &prepare_1_handle);
   ASSERT(r == 0);
+  r = uv_prepare_start(&prepare_1_handle, NULL);
+  ASSERT(r == UV_EINVAL);
   r = uv_prepare_start(&prepare_1_handle, prepare_1_cb);
   ASSERT(r == 0);
 


### PR DESCRIPTION
It was already wrong inside https://github.com/libuv/libuv/pull/974 (`UV_EINVAL` and `-EINVAL` are different on Windows), but https://github.com/libuv/libuv/pull/1166 made it even worse. It's now wrong on windows and *nix 😆