### PR TITLE
win, test: fix double close in test runner

### DIFF
--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -212,8 +212,18 @@ int process_copy_output(process_info_t* p, FILE* stream) {
   char buf[1024];
   int fd, r;
   FILE* f;
+  HANDLE stdio_out_copy;
 
-  fd = _open_osfhandle((intptr_t)p->stdio_out, _O_RDONLY | _O_TEXT);
+  if (!DuplicateHandle(GetCurrentProcess(),
+                       p->stdio_out,
+                       GetCurrentProcess(),
+                       &stdio_out_copy,
+                       0,
+                       FALSE,
+                       0))
+    return -1;
+
+  fd = _open_osfhandle((intptr_t)stdio_out_copy, _O_RDONLY | _O_TEXT);
   if (fd == -1)
     return -1;
   f = _fdopen(fd, "rt");


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/1426
Credit: @tom-seddon
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/359/

