### PR TITLE
android: fix blocking recvmsg due to netlink bug

### DIFF
--- a/src/unix/android-ifaddrs.c
+++ b/src/unix/android-ifaddrs.c
@@ -43,9 +43,10 @@ typedef struct NetlinkList
     unsigned int m_size;
 } NetlinkList;
 
-static int netlink_socket(void)
+static int netlink_socket(pid_t *p_pid)
 {
     struct sockaddr_nl l_addr;
+    socklen_t l_len;
 
     int l_socket = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
     if(l_socket < 0)
@@ -60,6 +61,14 @@ static int netlink_socket(void)
         close(l_socket);
         return -1;
     }
+
+    l_len = sizeof(l_addr);
+    if(getsockname(l_socket, (struct sockaddr *)&l_addr, &l_len) < 0)
+    {
+        close(l_socket);
+        return -1;
+    }
+    *p_pid = l_addr.nl_pid;
 
     return l_socket;
 }
@@ -128,7 +137,7 @@ static int netlink_recv(int p_socket, void *p_buffer, size_t p_len)
     }
 }
 
-static struct nlmsghdr *getNetlinkResponse(int p_socket, int *p_size, int *p_done)
+static struct nlmsghdr *getNetlinkResponse(int p_socket, pid_t p_pid, int *p_size, int *p_done)
 {
     size_t l_size = 4096;
     void *l_buffer = NULL;
@@ -153,11 +162,10 @@ static struct nlmsghdr *getNetlinkResponse(int p_socket, int *p_size, int *p_don
         }
         if(l_read >= 0)
         {
-            pid_t l_pid = getpid();
             struct nlmsghdr *l_hdr;
             for(l_hdr = (struct nlmsghdr *)l_buffer; NLMSG_OK(l_hdr, (unsigned int)l_read); l_hdr = (struct nlmsghdr *)NLMSG_NEXT(l_hdr, l_read))
             {
-                if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
+                if((pid_t)l_hdr->nlmsg_pid != p_pid || (int)l_hdr->nlmsg_seq != p_socket)
                 {
                     continue;
                 }
@@ -207,7 +215,7 @@ static void freeResultList(NetlinkList *p_list)
     }
 }
 
-static NetlinkList *getResultList(int p_socket, int p_request)
+static NetlinkList *getResultList(int p_socket, int p_request, pid_t p_pid)
 {
     int l_size;
     int l_done;
@@ -227,7 +235,7 @@ static NetlinkList *getResultList(int p_socket, int p_request)
     {
         NetlinkList *l_item;
 
-        struct nlmsghdr *l_hdr = getNetlinkResponse(p_socket, &l_size, &l_done);
+        struct nlmsghdr *l_hdr = getNetlinkResponse(p_socket, p_pid, &l_size, &l_done);
         /* Error */
         if(!l_hdr)
         {
@@ -578,18 +586,17 @@ static int interpretAddr(struct nlmsghdr *p_hdr, struct ifaddrs **p_resultList, 
     return 0;
 }
 
-static int interpretLinks(int p_socket, NetlinkList *p_netlinkList, struct ifaddrs **p_resultList)
+static int interpretLinks(int p_socket, pid_t p_pid, NetlinkList *p_netlinkList, struct ifaddrs **p_resultList)
 {
 
     int l_numLinks = 0;
-    pid_t l_pid = getpid();
     for(; p_netlinkList; p_netlinkList = p_netlinkList->m_next)
     {
         unsigned int l_nlsize = p_netlinkList->m_size;
         struct nlmsghdr *l_hdr;
         for(l_hdr = p_netlinkList->m_data; NLMSG_OK(l_hdr, l_nlsize); l_hdr = NLMSG_NEXT(l_hdr, l_nlsize))
         {
-            if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
+            if((pid_t)l_hdr->nlmsg_pid != p_pid || (int)l_hdr->nlmsg_seq != p_socket)
             {
                 continue;
             }
@@ -612,16 +619,15 @@ static int interpretLinks(int p_socket, NetlinkList *p_netlinkList, struct ifadd
     return l_numLinks;
 }
 
-static int interpretAddrs(int p_socket, NetlinkList *p_netlinkList, struct ifaddrs **p_resultList, int p_numLinks)
+static int interpretAddrs(int p_socket, pid_t p_pid, NetlinkList *p_netlinkList, struct ifaddrs **p_resultList, int p_numLinks)
 {
-    pid_t l_pid = getpid();
     for(; p_netlinkList; p_netlinkList = p_netlinkList->m_next)
     {
         unsigned int l_nlsize = p_netlinkList->m_size;
         struct nlmsghdr *l_hdr;
         for(l_hdr = p_netlinkList->m_data; NLMSG_OK(l_hdr, l_nlsize); l_hdr = NLMSG_NEXT(l_hdr, l_nlsize))
         {
-            if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
+            if((pid_t)l_hdr->nlmsg_pid != p_pid || (int)l_hdr->nlmsg_seq != p_socket)
             {
                 continue;
             }
@@ -648,6 +654,7 @@ int getifaddrs(struct ifaddrs **ifap)
     int l_socket;
     int l_result;
     int l_numLinks;
+    pid_t l_pid;
     NetlinkList *l_linkResults;
     NetlinkList *l_addrResults;
 
@@ -657,20 +664,20 @@ int getifaddrs(struct ifaddrs **ifap)
     }
     *ifap = NULL;
 
-    l_socket = netlink_socket();
+    l_socket = netlink_socket(&l_pid);
     if(l_socket < 0)
     {
         return -1;
     }
 
-    l_linkResults = getResultList(l_socket, RTM_GETLINK);
+    l_linkResults = getResultList(l_socket, RTM_GETLINK, l_pid);
     if(!l_linkResults)
     {
         close(l_socket);
         return -1;
     }
 
-    l_addrResults = getResultList(l_socket, RTM_GETADDR);
+    l_addrResults = getResultList(l_socket, RTM_GETADDR, l_pid);
     if(!l_addrResults)
     {
         close(l_socket);
@@ -679,8 +686,8 @@ int getifaddrs(struct ifaddrs **ifap)
     }
 
     l_result = 0;
-    l_numLinks = interpretLinks(l_socket, l_linkResults, ifap);
-    if(l_numLinks == -1 || interpretAddrs(l_socket, l_addrResults, ifap, l_numLinks) == -1)
+    l_numLinks = interpretLinks(l_socket, l_pid, l_linkResults, ifap);
+    if(l_numLinks == -1 || interpretAddrs(l_socket, l_pid, l_addrResults, ifap, l_numLinks) == -1)
     {
         l_result = -1;
     }


### PR DESCRIPTION
Code was assuming that the nl_pid was always equal to the process id. As
the netlink documentation says, "nl_pid is usually the PID of the process
owning the destination socket. However, nl_pid identifies a netlink
socket, not a process".

There are two cases in which this assumption breaks down. The first is
that some other part of the application has already bound a netlink socket
with a nl_pid equal to the PID of the process. The second is Android
version 5.0 where it appears that nl_pid is not always defaulted to the
PID of the process.

The result of this bad assumption is that netlink message responses to our
request are ignored due to having a bad nl_pid. We eventually run out of
messages on the netlink socket and block forever awaiting our response.