### PR TITLE
test,zos: use gid=-1 to test spawn_setgid_fails

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1351,10 +1351,14 @@ TEST_IMPL(spawn_setgid_fails) {
   init_process_options("spawn_helper1", fail_cb);
 
   options.flags |= UV_PROCESS_SETGID;
+#if defined(__MVS__)
+  options.gid = -1;
+#else
   options.gid = 0;
+#endif
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-#if defined(__CYGWIN__)
+#if defined(__CYGWIN__) || defined(__MVS__)
   ASSERT(r == UV_EINVAL);
 #else
   ASSERT(r == UV_EPERM);


### PR DESCRIPTION
This is because on some platforms like z/OS, setgid(0) isallowed for non-superusers. So instead, use setgid(-2) to get UV_EINVAL to test that spawn failure returns the right return code.