### PR TITLE
zos: avoid -fstrict-aliasing compile option

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -32,7 +32,6 @@
         },
         'xcode_settings': {
           'GCC_OPTIMIZATION_LEVEL': '0',
-          'OTHER_CFLAGS': [ '-Wno-strict-aliasing' ],
         },
         'conditions': [
           ['OS != "zos"', {
@@ -48,7 +47,6 @@
         'defines': [ 'NDEBUG' ],
         'cflags': [
           '-O3',
-          '-fstrict-aliasing',
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
@@ -178,9 +176,6 @@
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
           'USE_HEADERMAP': 'NO',
-          'OTHER_CFLAGS': [
-            '-fstrict-aliasing',
-          ],
           'WARNING_CFLAGS': [
             '-Wall',
             '-Wendif-labels',

--- a/uv.gyp
+++ b/uv.gyp
@@ -224,11 +224,6 @@
             '_DARWIN_UNLIMITED_SELECT=1',
           ]
         }],
-        [ 'OS!="mac" and OS!="zos"', {
-          # Enable on all platforms except OS X. The antique gcc/clang that
-          # ships with Xcode emits waaaay too many false positives.
-          'cflags': [ '-Wstrict-aliasing' ],
-        }],
         [ 'OS=="linux"', {
           'defines': [ '_GNU_SOURCE' ],
           'sources': [


### PR DESCRIPTION
This is not supported by the z/OS compler.