### PR TITLE
win, util: fix the incorrect size of the buffer

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1388,7 +1388,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
   if (OpenProcessToken(GetCurrentProcess(), TOKEN_READ, &token) == 0)
     return uv_translate_sys_error(GetLastError());
 
-  bufsize = sizeof(path) / sizeof(wchar_t);
+  bufsize = ARRAY_SIZE(path);
   if (!GetUserProfileDirectoryW(token, path, &bufsize)) {
     r = GetLastError();
     CloseHandle(token);
@@ -1403,7 +1403,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
   CloseHandle(token);
 
   /* Get the username using GetUserNameW() */
-  bufsize = sizeof(username) / sizeof(wchar_t);
+  bufsize = ARRAY_SIZE(username);
   if (!GetUserNameW(username, &bufsize)) {
     r = GetLastError();
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1388,7 +1388,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
   if (OpenProcessToken(GetCurrentProcess(), TOKEN_READ, &token) == 0)
     return uv_translate_sys_error(GetLastError());
 
-  bufsize = sizeof(path);
+  bufsize = sizeof(path) / sizeof(wchar_t);
   if (!GetUserProfileDirectoryW(token, path, &bufsize)) {
     r = GetLastError();
     CloseHandle(token);
@@ -1403,7 +1403,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
   CloseHandle(token);
 
   /* Get the username using GetUserNameW() */
-  bufsize = sizeof(username);
+  bufsize = sizeof(username) / sizeof(wchar_t);
   if (!GetUserNameW(username, &bufsize)) {
     r = GetLastError();
 


### PR DESCRIPTION
The buffer size is the count of characters, not sizeof(buffer).