### PR TITLE
doc: differentiate SmartOS and SunOS support

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -9,9 +9,10 @@
 | AIX | Tier 2 | >= 6 | Maintainers: @libuv/aix |
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |
 | Linux with musl | Tier 2 | musl >= 1.0 | |
-| SunOS | Tier 2 | Solaris 121 and later | Maintainers: @libuv/sunos |
+| SmartOS | Tier 2 | >= 14.4 | Maintainers: @libuv/smartos |
 | Android | Tier 3 | NDK >= r15b | |
 | MinGW | Tier 3 | MinGW32 and MinGW-w64 | |
+| SunOS | Tier 3 | Solaris 121 and later | |
 | Other | Tier 3 | N/A | |
 
 #### Note on FreeBSD 9


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/issues/1458
Refs: https://github.com/libuv/libuv/pull/991

This would also require an owner to rename the existing sunos team.