### PR TITLE
zos: fix readlink for mounts with system variables

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -125,6 +125,10 @@
   }                                                                           \
   while (0)
 
+#if defined(__MVS__)
+#define readlink(...) os390_readlink(__VA_ARGS__)
+#endif
+
 
 static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
 #if defined(__linux__) || defined(__sun) || defined(__NetBSD__)

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -125,10 +125,6 @@
   }                                                                           \
   while (0)
 
-#if defined(__MVS__)
-#define readlink(...) os390_readlink(__VA_ARGS__)
-#endif
-
 
 static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
 #if defined(__linux__) || defined(__sun) || defined(__NetBSD__)
@@ -436,7 +432,12 @@ static ssize_t uv__fs_readlink(uv_fs_t* req) {
     return -1;
   }
 
+#if defined(__MVS__)
+  len = os390_readlink(req->path, buf, len);
+#else
   len = readlink(req->path, buf, len);
+#endif
+
 
   if (len == -1) {
     uv__free(buf);

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -332,3 +332,48 @@ char* mkdtemp(char* path) {
 
   return path;
 }
+
+
+ssize_t os390_readlink(const char* path, char* buf, size_t len) {
+  ssize_t rlen;
+  char* delimiter;
+  char old_delim;
+  char tmpbuf[len + 1];
+  char realpathstr[PATH_MAX];
+
+  rlen = readlink(path, tmpbuf, len);
+  if (rlen < 0)
+    return rlen;
+
+  if (rlen < 3 || strncmp("/$", tmpbuf, 2) != 0) {
+    /* Straightforward readlink */
+    memcpy(buf, tmpbuf, rlen);
+    return rlen;
+  }
+
+  /*
+   * There is a parmlib variable at the beginning
+   * which needs interpretation
+   */
+  tmpbuf[rlen] = '\0';
+  delimiter = strchr(tmpbuf + 2, '/'); 
+  if (delimiter == NULL)
+    /* No slash at the end */
+    delimiter = strchr(tmpbuf + 2, '\0');
+
+  /* Read real path of the variable */
+  old_delim = *delimiter;
+  *delimiter = '\0';
+  if (realpath(tmpbuf, realpathstr) == NULL)
+    return -1;
+
+  /* Reset the delimiter and fill up the buffer */
+  *delimiter = old_delim;
+  rlen = snprintf(buf, len, "%s%s", realpathstr, delimiter);
+  if (rlen >= len) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+
+  return rlen;
+}

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -336,6 +336,8 @@ char* mkdtemp(char* path) {
 
 ssize_t os390_readlink(const char* path, char* buf, size_t len) {
   ssize_t rlen;
+  ssize_t vlen;
+  ssize_t plen;
   char* delimiter;
   char old_delim;
   char tmpbuf[len + 1];
@@ -369,11 +371,15 @@ ssize_t os390_readlink(const char* path, char* buf, size_t len) {
 
   /* Reset the delimiter and fill up the buffer */
   *delimiter = old_delim;
-  rlen = snprintf(buf, len, "%s%s", realpathstr, delimiter);
-  if (rlen >= len) {
+  plen = strlen(delimiter);
+  vlen = strlen(realpathstr);
+  rlen = plen + vlen;
+  if (rlen > len) {
     errno = ENAMETOOLONG;
     return -1;
   }
+  memcpy(buf, realpathstr, vlen);
+  memcpy(buf + vlen, delimiter, plen);
 
   return rlen;
 }

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -65,5 +65,6 @@ int scandir(const char* maindir, struct dirent*** namelist,
             int (*compar)(const struct dirent **,
             const struct dirent **));
 char *mkdtemp(char* path);
+ssize_t os390_readlink(const char* path, char* buf, size_t len);
 
 #endif /* UV_OS390_SYSCALL_H_ */


### PR DESCRIPTION
On z/OS, fs mounts can have variables starting with '$'. The problem is that following symlinks that contain these variables can lead to a loop because readlink($SYSVAR) will return $SYSVAR.
To work around this, we must resolve the $SYSVAR to an actual path using realpath.
More information about z/OS symlink resolution is available here.
https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.bpxb100/sym.htm