### PR TITLE
zos: langlvl extended c99 to enable static inline

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -28,7 +28,7 @@
               '_AE_BIMODAL',
               'PATH_MAX=255'
             ],
-            'cflags': [ '-qxplink' ],
+            'cflags': [ '-qxplink', '-qlanglvl=extc99' ],
             'ldflags': [ '-qxplink' ],
           }]
         ],


### PR DESCRIPTION
This language level is necessary to use "static inline" function.s