### PR TITLE
unix: modify argv[0] when process title is set

### DIFF
--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -48,14 +48,12 @@ char** uv_setup_args(int argc, char** argv) {
   for (i = 0; i < argc; i++)
     size += strlen(argv[i]) + 1;
 
-  process_title.str = uv__strdup(argv[0]);
-  if (process_title.str == NULL)
-    return argv;
-  
 #if defined(__MVS__)
   /* argv is not adjacent. So just use argv[0] */
-  process_title.len = strlen(process_title.str);
+  process_title.str = argv[0];
+  process_title.len = strlen(argv[0]);
 #else
+  process_title.str = argv[0];
   process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
   assert(process_title.len + 1 == size);  /* argv memory should be adjacent. */
 #endif
@@ -83,15 +81,11 @@ char** uv_setup_args(int argc, char** argv) {
 
 
 int uv_set_process_title(const char* title) {
-  char* new_title;
-  /* Copy the title into our own buffer. We don't want to free the pointer
-   * on libuv shutdown because the program might still be using it. */
-  new_title = uv__strdup(title);
-  if (new_title == NULL)
-    return -ENOMEM;
-  uv__free(process_title.str);
-  process_title.str = new_title;
-  process_title.len = strlen(new_title);
+  if (process_title.len == 0)
+    return 0;
+
+  /* No need to terminate, byte after is always '\0'. */
+  strncpy(process_title.str, title, process_title.len);
   uv__set_process_title(title);
 
   return 0;


### PR DESCRIPTION
Ensures that argv[0] is changed when uv_set_process_title is called. Before, on some unix systems uv__set_process_title was being called but argv[0] was not modified.

See #1396 for more details.
This partially reverts commit 78c17238f48d9083359206a2215fc63dd7a0283d.