### PR TITLE
zos: reset epoll data after fork

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -31,7 +31,6 @@ int uv_loop_init(uv_loop_t* loop) {
   void* saved_data;
   int err;
 
-  uv__signal_global_once_init();
 
   saved_data = loop->data;
   memset(loop, 0, sizeof(*loop));
@@ -68,6 +67,7 @@ int uv_loop_init(uv_loop_t* loop) {
   if (err)
     return err;
 
+  uv__signal_global_once_init();
   err = uv_signal_init(loop, &loop->child_watcher);
   if (err)
     goto fail_signal_init;

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -120,9 +120,40 @@ static void maybe_resize(uv__os390_epoll* lst, unsigned int len) {
 }
 
 
+static void before_fork(void) {
+  uv_mutex_lock(&global_epoll_lock);
+}
+
+
+static void after_fork(void) {
+  uv_mutex_unlock(&global_epoll_lock);
+}
+
+
+static void child_fork(void) {
+  QUEUE* q;
+  uv_once_t child_once = UV_ONCE_INIT;
+
+  /* reset once */
+  memcpy(&once, &child_once, sizeof(child_once));
+
+  /* reset epoll list */
+  while (!QUEUE_EMPTY(&global_epoll_queue)) {
+    q = QUEUE_HEAD(&global_epoll_queue);
+    QUEUE_REMOVE(q);
+  }
+
+  uv_mutex_unlock(&global_epoll_lock);
+  uv_mutex_destroy(&global_epoll_lock);
+}
+
+
 static void epoll_init(void) {
   QUEUE_INIT(&global_epoll_queue);
   if (uv_mutex_init(&global_epoll_lock))
+    abort();
+
+  if (pthread_atfork(&before_fork, &after_fork, &child_fork))
     abort();
 }
 


### PR DESCRIPTION
Remove all the epoll file descriptors after a fork since they are no longer valid. The  uv__signal_global_once_init function needs to be run after uv__platform_loop_init so that the epoll pthread_atfork handlers get run first.
I think it makes sense to run the "platform atfork handlers" before any others in any case.