### PR TITLE
win, pipe: null-initialize stream->shutdown_req

### DIFF
--- a/src/win/stream-inl.h
+++ b/src/win/stream-inl.h
@@ -36,6 +36,7 @@ INLINE static void uv_stream_init(uv_loop_t* loop,
   uv__handle_init(loop, (uv_handle_t*) handle, type);
   handle->write_queue_size = 0;
   handle->activecnt = 0;
+  handle->stream.conn.shutdown_req = NULL;
 }
 
 
@@ -47,8 +48,6 @@ INLINE static void uv_connection_init(uv_stream_t* handle) {
   handle->read_req.event_handle = NULL;
   handle->read_req.wait_handle = INVALID_HANDLE_VALUE;
   handle->read_req.data = handle;
-
-  handle->stream.conn.shutdown_req = NULL;
 }
 
 


### PR DESCRIPTION
When initializing a stream, this also inits the shutdown_req field, instead of waiting for a successfully connection. A NULL value is used as a sentinel to check for whether this handle is currently in the shutdown state, and it may not get set if a stream was not connected immediately.