### PR TITLE
stream: limit unix read/write to 2GB at a time

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -743,6 +743,7 @@ static int uv__handle_fd(uv_handle_t* handle) {
   }
 }
 
+
 static void uv__write(uv_stream_t* stream) {
   struct iovec* iov;
   QUEUE* q;
@@ -839,11 +840,36 @@ start:
 #endif
   } else {
     do {
+      /* On some platforms, notably OSX, the sum of iov_len must not
+       * overflow a 32-bit integer.
+       */
+      size_t old_iov_len = iov[iovcnt - 1].iov_len;
+
+      if (stream->write_queue_size > INT32_MAX) {
+        size_t total_bytes = 0;
+        int new_iov_cnt = 0;
+        int i;
+
+        for (i = 0; i < iovcnt; i++) {
+          new_iov_cnt++;
+          old_iov_len = iov[i].iov_len;
+          if ((total_bytes + iov[i].iov_len) >= INT32_MAX) {
+            iov[i].iov_len = INT32_MAX - (int32_t)total_bytes;
+            break;
+          }
+          total_bytes += iov[i].iov_len;
+        }
+
+        iovcnt = new_iov_cnt;
+      }
+
       if (iovcnt == 1) {
         n = write(uv__stream_fd(stream), iov[0].iov_base, iov[0].iov_len);
       } else {
         n = writev(uv__stream_fd(stream), iov, iovcnt);
       }
+
+      iov[iovcnt - 1].iov_len = old_iov_len;
     }
 #if defined(__APPLE__)
     /*
@@ -1156,7 +1182,14 @@ static void uv__read(uv_stream_t* stream) {
 
     if (!is_ipc) {
       do {
-        nread = read(uv__stream_fd(stream), buf.base, buf.len);
+       /* On some platforms, notably OSX, reads > 2GB returns an
+        * EINVAL
+        */
+       size_t buflen_limit = buf.len;
+       if (buflen_limit > INT32_MAX) {
+         buflen_limit = INT32_MAX;
+       }
+       nread = read(uv__stream_fd(stream), buf.base, buflen_limit);
       }
       while (nread < 0 && errno == EINTR);
     } else {


### PR DESCRIPTION
On some platforms, notably OSX, read/readv/write/writev all return
an EINVAL if the requested number of bytes is greater than INT32_MAX.

We therefore limit each such call to 2GB on all platforms. On
platforms where this is not an issue, the overhead of an extra syscall
for every 2GB of read/write is negligible.

(For original PR and issue report, see https://github.com/JuliaLang/libuv/pull/33)