### PR TITLE
unix: fix calculation of process title length

### DIFF
--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -51,14 +51,8 @@ char** uv_setup_args(int argc, char** argv) {
   process_title.str = uv__strdup(argv[0]);
   if (process_title.str == NULL)
     return argv;
-  
-#if defined(__MVS__)
-  /* argv is not adjacent. So just use argv[0] */
+
   process_title.len = strlen(process_title.str);
-#else
-  process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
-  assert(process_title.len + 1 == size);  /* argv memory should be adjacent. */
-#endif
 
   /* Add space for the argv pointers. */
   size += (argc + 1) * sizeof(char*);


### PR DESCRIPTION
Since commit 78c1723 (unix: always copy process title into local buffer)
we always strdup(argv[0]) so we should always use the strlen to
calulate the lenght of process title. Otherwise uv_get_process_title may
end up reading memory outside the allocated process title.

This fixes #1502

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>