### PR TITLE
android: fix uv_cond_timedwait on API level < 21

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -618,7 +618,16 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   timeout += uv__hrtime(UV_CLOCK_PRECISE);
   ts.tv_sec = timeout / NANOSEC;
   ts.tv_nsec = timeout % NANOSEC;
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 21
+
+  /*
+   * The bionic pthread implementation doesn't support CLOCK_MONOTONIC,
+   * but has this alternative function instead.
+   */
+  r = pthread_cond_timedwait_monotonic_np(cond, mutex, &ts);
+#else
   r = pthread_cond_timedwait(cond, mutex, &ts);
+#endif /* __ANDROID_API__ */
 #endif
 
 


### PR DESCRIPTION
This commit partly reverses libuv#1441.
It is true that pthread_cond_timedwait is available on older API levels,
but if we do not call pthread_condattr_setclock then we cannot use
timestamps from CLOCK_MONOTONIC with pthread_cond_timedwait.