### PR TITLE
Solaris: implement equivalent of getifaddrs() with ioctl()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -432,6 +432,10 @@ endif
 if SUNOS
 include_HEADERS += include/uv-sunos.h
 libuv_la_CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=500
+if SUNOS_NO_IFADDRS
+libuv_la_CFLAGS += -DSUNOS_NO_IFADDRS
+endif
+
 libuv_la_SOURCES += src/unix/no-proctitle.c \
                     src/unix/sunos.c
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ AS_CASE([$host_os],[mingw*], [
     LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
 ])
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
+AM_CONDITIONAL([SUNOS_NO_IFADDRS], [AS_CASE([$host_os],[solaris*], [AC_CHECK_LIB([socket], [getifaddrs])], [false])])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
 AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -105,14 +105,16 @@ TEST_IMPL(platform_output) {
   for (i = 0; i < count; i++) {
     printf("  name: %s\n", interfaces[i].name);
     printf("  internal: %d\n", interfaces[i].is_internal);
-    printf("  physical address: ");
-    printf("%02x:%02x:%02x:%02x:%02x:%02x\n",
-           (unsigned char)interfaces[i].phys_addr[0],
-           (unsigned char)interfaces[i].phys_addr[1],
-           (unsigned char)interfaces[i].phys_addr[2],
-           (unsigned char)interfaces[i].phys_addr[3],
-           (unsigned char)interfaces[i].phys_addr[4],
-           (unsigned char)interfaces[i].phys_addr[5]);
+    if (!interfaces[i].is_internal) {
+      printf("  physical address: ");
+      printf("%02x:%02x:%02x:%02x:%02x:%02x\n",
+          (unsigned char)interfaces[i].phys_addr[0],
+          (unsigned char)interfaces[i].phys_addr[1],
+          (unsigned char)interfaces[i].phys_addr[2],
+          (unsigned char)interfaces[i].phys_addr[3],
+          (unsigned char)interfaces[i].phys_addr[4],
+          (unsigned char)interfaces[i].phys_addr[5]);
+    }
 
     if (interfaces[i].address.address4.sin_family == AF_INET) {
       uv_ip4_name(&interfaces[i].address.address4, buffer, sizeof(buffer));


### PR DESCRIPTION
I propose a first draft to fix the issue #1458 
I wait for your feedbacks.

PS: why are you building with -std=gnu89 and not -std=c99 or -std=gnu99 ?
C99 has really nice features that allows to write cleaner code.