### PR TITLE
windows: fix non-symlink reparse points

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -282,6 +282,9 @@ TEST_DECLARE   (fs_readlink)
 TEST_DECLARE   (fs_realpath)
 TEST_DECLARE   (fs_symlink)
 TEST_DECLARE   (fs_symlink_dir)
+#ifdef _WIN32
+TEST_DECLARE   (fs_non_symlink_reparse_point)
+#endif
 TEST_DECLARE   (fs_utime)
 TEST_DECLARE   (fs_futime)
 TEST_DECLARE   (fs_file_open_append)
@@ -789,6 +792,9 @@ TASK_LIST_START
   TEST_ENTRY  (fs_realpath)
   TEST_ENTRY  (fs_symlink)
   TEST_ENTRY  (fs_symlink_dir)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_non_symlink_reparse_point)
+#endif
   TEST_ENTRY  (fs_stat_missing_path)
   TEST_ENTRY  (fs_read_file_eof)
   TEST_ENTRY  (fs_file_open_append)


### PR DESCRIPTION
Fixes uv_fs_stat and uv_fs_lstat returning EINVAL when invoked on a non-symlink reparse point.

1. Only tries to read symlinks when invoked via lstat (do_lstat == 1).

Rationale is that only lstat can set S_IFLNK because when a file is tested by stat, symlinks are resolved by the OS and the returned file must be real. Note that broken symlinks fail at CreateFile.

FILE_ATTRIBUTE_REPARSE_POINT is used by filesystem drivers for purposes besides symlinks, and uv_fs_stat fails when invoked on these files because fs__readlink_handle returns ERROR_SYMLINK_NOT_SUPPORTED. By ignoring the attribute in uv_fs_stat, these files are now handled correctly.

2. Modifies the logic added to fs__stat_handle to fix #995 as follows:

A failed fs__readlink_handle on a file with a reparse point indicates that the file is not a symlink. The fix for #995 added code to fall through and behave as with a normal file in this case. However, this is not correct because lstat had opened the file with FILE_FLAG_OPEN_REPARSE_POINT, preventing the filesystem from acting based on the reparse point contents.

The fix makes fs__stat_handle fail back to the higher level fs__stat_impl, which sets do_lstat to 0 and re-opens the file without FILE_FLAG_OPEN_REPARSE_POINT, allowing normal filesystem processing to take place.

This is also a slightly cleaner solution as symlink fallback is only handled in one place (fs__stat_impl) instead of two (fs__stat_impl and fs__stat_handle).

Note that the error tested in the fix for #995, ERROR_NOT_A_REPARSE_POINT, is not actually returned by Windows in the case of a non-symlink reparse point. I attempted to reproduce the error by repeating the test steps in the issue but failed. However, the the fix logic is preserved out of caution.

3. Adds tests to fs-test.c for the above two changes.

Thorough testing requires some non-trivial setup - like an OSX computer on the LAN or a custom filesystem driver - so these tests are left commented out for manual invocation.