### PR TITLE
kqueue: Restrict uv__has_forked_with_cfrunloop to Apple platforms

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -59,7 +59,9 @@ int uv__kqueue_init(uv_loop_t* loop) {
 }
 
 
+#if defined(__APPLE__)
 static int uv__has_forked_with_cfrunloop;
+#endif
 
 int uv__io_fork(uv_loop_t* loop) {
   int err;


### PR DESCRIPTION
The uv__has_forked_with_cfrunloop local variable is unused on BSDs
and causes compilation warnings.

Caught on NetBSD/amd64 8.99.2 with GCC 5.4.0.