### PR TITLE
doc: document uv_timer_start on an active timer

### DIFF
--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -45,6 +45,8 @@ API
     .. note::
         Does not update the event loop's concept of "now". See :c:func:`uv_update_time` for more information.
 
+        If the timer is active already, it is simply updated.
+
 .. c:function:: int uv_timer_stop(uv_timer_t* handle)
 
     Stop the timer, the callback will not be called anymore.


### PR DESCRIPTION
Fixes https://github.com/libuv/libuv/issues/1401

- I didn't verify the fact beyond reading the commit message in 028fef84b824450.
- I assume this PR is enough to keep contributors from (accidentally) breaking this property in future.