### PR TITLE
unix: correctly handle sysconf returning -1 in uv__getiovmax

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -41,6 +41,10 @@
 #include <sys/resource.h> /* getrusage */
 #include <pwd.h>
 
+#if defined(__linux__) && !defined(IOV_MAX)
+#include <linux/uio.h>
+#endif
+
 #ifdef __sun
 # include <netdb.h> /* MAXHOSTNAMELEN on Solaris */
 # include <sys/filio.h>
@@ -237,6 +241,11 @@ int uv__getiovmax(void) {
          */
         iovmax = 1;
       }
+#if defined(__linux__) && !defined(IOV_MAX)
+      else {
+        iovmax = UIO_MAXIOV;
+      }
+#else
       /*
        * TODO: should this be set to a (rather arbitrary) maximum value,
        * or should the caller check for -1?
@@ -245,6 +254,7 @@ int uv__getiovmax(void) {
       /*else {
         iovmax = 1024;
       }*/
+#endif
     }
   }
   return iovmax;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -218,8 +218,8 @@ int uv__getiovmax(void) {
 #if defined(IOV_MAX)
   return IOV_MAX;
 #elif defined(_SC_IOV_MAX)
-  static int iovmax = -1;
-  if (iovmax == -1) {
+  static int iovmax = -2;
+  if (iovmax == -2) {
     /*
      * From sysconf(3): "If name corresponds to a maximum or minimum
      * limit, and that limit is indeterminate, -1 is returned and errno

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -220,12 +220,32 @@ int uv__getiovmax(void) {
 #elif defined(_SC_IOV_MAX)
   static int iovmax = -1;
   if (iovmax == -1) {
-    iovmax = sysconf(_SC_IOV_MAX);
-    /* On some embedded devices (arm-linux-uclibc based ip camera),
-     * sysconf(_SC_IOV_MAX) can not get the correct value. The return
-     * value is -1 and the errno is EINPROGRESS. Degrade the value to 1.
+    /*
+     * From sysconf(3): "If name corresponds to a maximum or minimum
+     * limit, and that limit is indeterminate, -1 is returned and errno
+     * is not changed. (To distinguish an indeterminate limit from an
+     * error, set errno to zero before the call, and then check whether
+     * errno is nonzero when -1 is returned.)"
      */
-    if (iovmax == -1) iovmax = 1;
+    errno = 0;
+    iovmax = sysconf(_SC_IOV_MAX);
+    if (iovmax == -1) {
+      if (errno) {
+        /* On some embedded devices (arm-linux-uclibc based ip camera),
+         * sysconf(_SC_IOV_MAX) can not get the correct value. The return
+         * value is -1 and the errno is EINPROGRESS. Degrade the value to 1.
+         */
+        iovmax = 1;
+      }
+      /*
+       * TODO: should this be set to a (rather arbitrary) maximum value,
+       * or should the caller check for -1?
+       * Currently, the latter is being done.
+       */
+      /*else {
+        iovmax = 1024;
+      }*/
+    }
   }
   return iovmax;
 #else

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -241,7 +241,7 @@ int uv__getiovmax(void) {
          */
         iovmax = 1;
       }
-#if defined(__linux__) && !defined(IOV_MAX)
+#if defined(__linux__) && defined(UIO_MAXIOV)
       else {
         iovmax = UIO_MAXIOV;
       }

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1006,7 +1006,7 @@ static ssize_t uv__fs_buf_iter(uv_fs_t* req, uv__fs_buf_iter_processor process) 
 
   while (nbufs > 0) {
     req->nbufs = nbufs;
-    if (req->nbufs > iovmax)
+    if (req->nbufs > iovmax && iovmax != -1)
       req->nbufs = iovmax;
 
     result = process(req);

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -194,6 +194,11 @@ int uv__socket(int domain, int type, int protocol);
 int uv__dup(int fd);
 ssize_t uv__recvmsg(int fd, struct msghdr *msg, int flags);
 void uv__make_close_pending(uv_handle_t* handle);
+/*
+ * NOTE: this can return -1 if there is no limit, so don't simply
+ * use this as a maximum value without checking for -1, or bad
+ * things will happen
+ */
 int uv__getiovmax(void);
 
 void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -774,7 +774,7 @@ start:
   iovmax = uv__getiovmax();
 
   /* Limit iov count to avoid EINVALs from writev() */
-  if (iovcnt > iovmax)
+  if (iovcnt > iovmax && iovmax != -1)
     iovcnt = iovmax;
 
   /*


### PR DESCRIPTION
According to the sysconf(3) manpage, sysconf can return -1 even when no
error happens: it won't set errno if there is no limit. The current
code sets iovmax to 1 regardless or error, and this commit fixes that.