### PR TITLE
Add uv_timer_close_now()

### DIFF
--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -34,6 +34,17 @@ API
 
     Initialize the handle.
 
+.. c:function:: int uv_timer_close_now(uv_timer_t* handle)
+
+    Close the timer immediately.
+
+    The timer handle is closed, the callback will not be called anymore,
+    and the memory can be released. This may be more practical than using
+    :c:func:`uv_close` which is an asynchronous operation.
+
+    This function must not be called on a timer for which :c:func:`uv_close`
+    has already been called.
+
 .. c:function:: int uv_timer_start(uv_timer_t* handle, uv_timer_cb cb, uint64_t timeout, uint64_t repeat)
 
     Start the timer. `timeout` and `repeat` are in milliseconds.

--- a/include/uv.h
+++ b/include/uv.h
@@ -835,6 +835,7 @@ struct uv_timer_s {
 };
 
 UV_EXTERN int uv_timer_init(uv_loop_t*, uv_timer_t* handle);
+UV_EXTERN int uv_timer_close_now(uv_timer_t* handle);
 UV_EXTERN int uv_timer_start(uv_timer_t* handle,
                              uv_timer_cb cb,
                              uint64_t timeout,

--- a/src/timer.c
+++ b/src/timer.c
@@ -59,6 +59,15 @@ int uv_timer_init(uv_loop_t* loop, uv_timer_t* handle) {
 }
 
 
+int uv_timer_close_now(uv_timer_t* handle) {
+  assert(!uv_is_closing((uv_handle_t *)handle));
+
+  uv_timer_stop(handle);
+  QUEUE_REMOVE(&handle->handle_queue);
+  return 0;
+}
+
+
 int uv_timer_start(uv_timer_t* handle,
                    uv_timer_cb cb,
                    uint64_t timeout,

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -180,6 +180,7 @@ TEST_DECLARE   (timer_run_once)
 TEST_DECLARE   (timer_from_check)
 TEST_DECLARE   (timer_null_callback)
 TEST_DECLARE   (timer_early_check)
+TEST_DECLARE   (timer_close_now)
 TEST_DECLARE   (idle_starvation)
 TEST_DECLARE   (loop_handles)
 TEST_DECLARE   (get_loadavg)
@@ -615,6 +616,7 @@ TASK_LIST_START
   TEST_ENTRY  (timer_from_check)
   TEST_ENTRY  (timer_null_callback)
   TEST_ENTRY  (timer_early_check)
+  TEST_ENTRY  (timer_close_now)
 
   TEST_ENTRY  (idle_starvation)
 


### PR DESCRIPTION
Fixes #1537 by introducing a new function to close a timer immediately. Tested on Linux and Windows, new unit test passes.