### PR TITLE
Add uv_overlapped_t for custom IOCP integration (WIP)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,7 @@ libuv_la_SOURCES += src/win/async.c \
                     src/win/handle.c \
                     src/win/handle-inl.h \
                     src/win/internal.h \
+                    src/win/overlapped.c \
                     src/win/pipe.c \
                     src/win/poll.c \
                     src/win/process-stdio.c \

--- a/include/uv.h
+++ b/include/uv.h
@@ -155,6 +155,14 @@ extern "C" {
   XX(TTY, tty)                                                                \
   XX(UDP, udp)                                                                \
   XX(SIGNAL, signal)                                                          \
+  UV_HANDLE_TYPE_MAP_WIN(XX)                                                  \
+
+#if defined(_WIN32)
+#define UV_HANDLE_TYPE_MAP_WIN(XX)                                            \
+  XX(OVERLAPPED, overlapped)
+#else
+#define UV_HANDLE_TYPE_MAP_WIN(XX)
+#endif
 
 #define UV_REQ_TYPE_MAP(XX)                                                   \
   XX(REQ, req)                                                                \
@@ -211,6 +219,9 @@ typedef struct uv_process_s uv_process_t;
 typedef struct uv_fs_event_s uv_fs_event_t;
 typedef struct uv_fs_poll_s uv_fs_poll_t;
 typedef struct uv_signal_s uv_signal_t;
+#if defined(_WIN32)
+typedef struct uv_overlapped_s uv_overlapped_t;
+#endif
 
 /* Request types. */
 typedef struct uv_req_s uv_req_t;
@@ -315,6 +326,9 @@ typedef void (*uv_getnameinfo_cb)(uv_getnameinfo_t* req,
                                   int status,
                                   const char* hostname,
                                   const char* service);
+#if defined(_WIN32)
+typedef void (*uv_overlapped_cb)(uv_overlapped_t* handle);
+#endif
 
 typedef struct {
   long tv_sec;
@@ -1390,6 +1404,22 @@ UV_EXTERN int uv_signal_start_oneshot(uv_signal_t* handle,
 UV_EXTERN int uv_signal_stop(uv_signal_t* handle);
 
 UV_EXTERN void uv_loadavg(double avg[3]);
+
+
+#if defined(_WIN32)
+
+struct uv_overlapped_s {
+  UV_HANDLE_FIELDS
+  UV_OVERLAPPED_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_overlapped_init(uv_loop_t* loop, uv_overlapped_t* handle);
+UV_EXTERN HANDLE uv_overlapped_get_iocp(uv_overlapped_t* handle);
+UV_EXTERN OVERLAPPED* uv_overlapped_get_overlapped(uv_overlapped_t* handle);
+UV_EXTERN void uv_overlapped_start(uv_overlapped_t* handle,
+                                   uv_overlapped_cb overlapped_cb);
+
+#endif
 
 
 /*

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -221,7 +221,8 @@ typedef struct {
   UV_READ,                                                                    \
   UV_UDP_RECV,                                                                \
   UV_WAKEUP,                                                                  \
-  UV_SIGNAL_REQ,
+  UV_SIGNAL_REQ,                                                              \
+  UV_OVERLAPPED_REQ,
 
 #define UV_REQ_PRIVATE_FIELDS                                                 \
   union {                                                                     \
@@ -495,6 +496,10 @@ typedef struct {
   RB_ENTRY(uv_signal_s) tree_entry;                                           \
   struct uv_req_s signal_req;                                                 \
   unsigned long pending_signum;
+
+#define UV_OVERLAPPED_PRIVATE_FIELDS                                          \
+  uv_overlapped_cb overlapped_cb;                                             \
+  struct uv_req_s overlapped_req;
 
 #ifndef F_OK
 #define F_OK 0

--- a/src/win/handle-inl.h
+++ b/src/win/handle-inl.h
@@ -141,6 +141,10 @@ INLINE static void uv_process_endgames(uv_loop_t* loop) {
         uv_signal_endgame(loop, (uv_signal_t*) handle);
         break;
 
+      case UV_OVERLAPPED:
+        uv_overlapped_endgame(loop, (uv_overlapped_t*) handle);
+        break;
+
       case UV_PROCESS:
         uv_process_endgame(loop, (uv_process_t*) handle);
         break;

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -124,6 +124,10 @@ void uv_close(uv_handle_t* handle, uv_close_cb cb) {
       uv_signal_close(loop, (uv_signal_t*) handle);
       return;
 
+    case UV_OVERLAPPED:
+      uv_overlapped_close(loop, (uv_overlapped_t*) handle);
+      return;
+
     case UV_PROCESS:
       uv_process_close(loop, (uv_process_t*) handle);
       return;

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -257,6 +257,14 @@ void uv_process_signal_req(uv_loop_t* loop, uv_signal_t* handle,
 
 
 /*
+ * Overlapped integration
+ */
+void uv_overlapped_close(uv_loop_t* loop, uv_overlapped_t* handle);
+void uv_overlapped_endgame(uv_loop_t* loop, uv_overlapped_t* handle);
+void uv_process_overlapped_req(uv_loop_t* loop, uv_overlapped_t* handle);
+
+
+/*
  * Spawn
  */
 void uv_process_proc_exit(uv_loop_t* loop, uv_process_t* handle);

--- a/src/win/overlapped.c
+++ b/src/win/overlapped.c
@@ -1,0 +1,115 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include <string.h>
+
+#include "uv.h"
+#include "internal.h"
+#include "handle-inl.h"
+
+
+int uv_overlapped_init(uv_loop_t* loop, uv_overlapped_t* handle) {
+  uv__handle_init(loop, (uv_handle_t*) handle, UV_OVERLAPPED);
+  handle->overlapped_cb = NULL;
+
+  UV_REQ_INIT(&handle->overlapped_req, UV_OVERLAPPED_REQ);
+  handle->overlapped_req.data = handle;
+
+  OVERLAPPED *overlapped = &handle->overlapped_req.u.io.overlapped;
+  memset(overlapped, 0, sizeof(*overlapped));
+
+  return 0;
+}
+
+
+HANDLE uv_overlapped_get_iocp(uv_overlapped_t* handle) {
+  return handle->loop->iocp;
+}
+
+
+OVERLAPPED* uv_overlapped_get_overlapped(uv_overlapped_t* handle) {
+  return &handle->overlapped_req.u.io.overlapped;
+}
+
+
+void uv_overlapped_start(uv_overlapped_t* handle,
+                         uv_overlapped_cb overlapped_cb) {
+  assert(!(handle->flags & UV__HANDLE_CLOSING));
+  assert(!uv__is_active(handle));
+  assert(handle->overlapped_cb == NULL);
+  assert(overlapped_cb != NULL);
+
+  uv__handle_start(handle);
+  handle->overlapped_cb = overlapped_cb;
+}
+
+
+void uv_overlapped_close(uv_loop_t* loop, uv_overlapped_t* handle) {
+  /* Check uv__is_active before uv__handle_closing since that makes */
+  /* it not active. */
+  int active = uv__is_active(handle);
+  assert(active == (handle->overlapped_cb != NULL));
+
+  uv__handle_closing(handle);
+
+  if (active) {
+    /* we will wait for completion (uv_process_overlapped_req) */
+  } else {
+    if (handle->close_cb == NULL) {
+      /* close immediately */
+      uv_overlapped_endgame(loop, handle);
+    } else {
+      /* queue handle for calling the close callback */
+      uv_want_endgame(loop, (uv_handle_t*) handle);
+    }
+  }
+}
+
+
+void uv_overlapped_endgame(uv_loop_t* loop, uv_overlapped_t* handle) {
+  assert(handle->flags & UV__HANDLE_CLOSING);
+  assert(!(handle->flags & UV_HANDLE_CLOSED));
+  assert(handle->overlapped_cb == NULL);
+
+  uv__handle_close(handle);
+}
+
+
+void uv_process_overlapped_req(uv_loop_t* loop, uv_overlapped_t* handle) {
+  assert(handle->type == UV_OVERLAPPED);
+  assert((handle->flags & UV__HANDLE_CLOSING) || uv__is_active(handle));
+  assert(handle->overlapped_cb != NULL);
+
+  uv_overlapped_cb overlapped_cb = handle->overlapped_cb;
+  handle->overlapped_cb = NULL;
+
+  if ((handle->flags & UV__HANDLE_CLOSING)) {
+    uv_want_endgame(loop, (uv_handle_t*) handle);
+    return;
+  }
+
+  uv__handle_stop(handle);
+
+  overlapped_cb(handle);
+}
+
+

--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -193,6 +193,10 @@ INLINE static int uv_process_reqs(uv_loop_t* loop) {
         uv_process_signal_req(loop, (uv_signal_t*) req->data, req);
         break;
 
+      case UV_OVERLAPPED_REQ:
+        uv_process_overlapped_req(loop, (uv_overlapped_t*) req->data);
+        break;
+
       case UV_POLL_REQ:
         uv_process_poll_req(loop, (uv_poll_t*) req->data, req);
         break;

--- a/uv.gyp
+++ b/uv.gyp
@@ -104,6 +104,7 @@
             'src/win/handle.c',
             'src/win/handle-inl.h',
             'src/win/internal.h',
+            'src/win/overlapped.c',
             'src/win/pipe.c',
             'src/win/thread.c',
             'src/win/poll.c',


### PR DESCRIPTION
This is my first attempt to add support for integration of arbitrary handles with IOCP (issue #1541). It is slightly different from my initial proposal.

The `uv_overlapped_t` handle is used like this:
- `uv_overlapped_get_iocp` is used to get the IOCP handle of the event loop.
- `uv_overlapped_get_overlapped` is used to get the pointer to the `OVERLAPPED` structure.
- `uv_overlapped_start` must be called after the application has submitted an I/O request (before the event loop next does the polling; else we crash sooner or later). This makes the `uv_overlapped_t` handle active, and `uv_overlapped_start` must not be called again before the callback is invoked.
- When the completion arrives, the `uv_overlapped_t` handle becomes inactive and the callback is invoked.

`uv_close` on `uv_overlapped_t` behaves like this:
- If inactive and the close callback is null, the handle is closed immediately.
- If inactive and the close callback is not null, the handle is marked as closing and the close is completed asynchronously via the existing "endgame" mechanism that is in place.
- If active, the close is completed asynchronously only after the completion arrives.

This is currently untested (but compiles).