### PR TITLE
unix: use fchmod() in uv_fs_copyfile()

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -828,6 +828,11 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
     goto out;
   }
 
+  if (fchmod(dstfd, statsbuf.st_mode) == -1) {
+    err = -errno;
+    goto out;
+  }
+
   bytes_to_send = statsbuf.st_size;
   in_offset = 0;
   while (bytes_to_send != 0) {


### PR DESCRIPTION
This commit introduces `fchmod()` in `uv_fs_copyfile()` to set the mode of the destination file.

Refs: https://github.com/nodejs/node/issues/15394