### PR TITLE
unix: truncate dst path for uv_fs_copyfile

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -809,7 +809,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
     goto out;
   }
 
-  dst_flags = O_WRONLY | O_CREAT;
+  dst_flags = O_WRONLY | O_CREAT | O_TRUNC;
 
   if (req->flags & UV_FS_COPYFILE_EXCL)
     dst_flags |= O_EXCL;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -68,7 +68,7 @@ static void touch_file(const char* name, unsigned int size) {
   int r;
   unsigned int i;
 
-  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR, NULL);
   uv_fs_req_cleanup(&req);
   ASSERT(r >= 0);
   file = r;
@@ -129,6 +129,12 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(r == UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
+  /* Copies a smaller file. */
+  touch_file(src, 0);
+  r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
+  ASSERT(r == 0);
+  handle_result(&req);
+
   /* Copies a larger file. */
   unlink(dst);
   touch_file(src, 4096 * 2);
@@ -141,9 +147,9 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
   ASSERT(r == 0);
-  ASSERT(result_check_count == 3);
-  uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 4);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(result_check_count == 5);
   unlink(dst); /* Cleanup */
 
   return 0;


### PR DESCRIPTION
Win32 CopyFile and OSX copyfile(3) truncate when overwriting, but
on Linux this behavior was not being observed.