### PR TITLE
Support empty files and truncation in uv_fs_copyfile()

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -795,6 +795,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
   int64_t in_offset;
 
   dstfd = -1;
+  err = 0;
 
   /* Open the source file. */
   srcfd = uv_fs_open(NULL, &fs_req, req->path, O_RDONLY, 0, NULL);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -810,7 +810,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
     goto out;
   }
 
-  dst_flags = O_WRONLY | O_CREAT;
+  dst_flags = O_WRONLY | O_CREAT | O_TRUNC;
 
   if (req->flags & UV_FS_COPYFILE_EXCL)
     dst_flags |= O_EXCL;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -68,7 +68,8 @@ static void touch_file(const char* name, unsigned int size) {
   int r;
   unsigned int i;
 
-  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT | O_TRUNC,
+                 S_IWUSR | S_IRUSR, NULL);
   uv_fs_req_cleanup(&req);
   ASSERT(r >= 0);
   file = r;
@@ -136,6 +137,12 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(r == UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
+  /* Truncates when an existing destination is larger than the source file. */
+  touch_file(src, 1);
+  r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
+  ASSERT(r == 0);
+  handle_result(&req);
+
   /* Copies a larger file. */
   unlink(dst);
   touch_file(src, 4096 * 2);
@@ -148,9 +155,9 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
   ASSERT(r == 0);
-  ASSERT(result_check_count == 4);
-  uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 5);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(result_check_count == 6);
   unlink(dst); /* Cleanup */
 
   return 0;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -119,6 +119,13 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(r == 0);
   handle_result(&req);
 
+  /* Copies a file of size zero. */
+  unlink(dst);
+  touch_file(src, 0);
+  r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
+  ASSERT(r == 0);
+  handle_result(&req);
+
   /* Copies file synchronously. Overwrites existing file. */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
   ASSERT(r == 0);
@@ -141,9 +148,9 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
   ASSERT(r == 0);
-  ASSERT(result_check_count == 3);
-  uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 4);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(result_check_count == 5);
   unlink(dst); /* Cleanup */
 
   return 0;


### PR DESCRIPTION
This PR fixes two bugs in the `sendfile()` fallback for `uv_fs_copyfile()`.

- Copying empty files. The `err` variable was never initialized through the course of execution if the source file is empty. That was causing failures on FreeBSD, as exposed in the test from #1551.
- Truncating destination files. If the source file was smaller than the destination file, then the result of the copy was incorrect. This is @ugexe's fix from #1551, with style nits addressed.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/472/