### PR TITLE
zos: change platform name to match python

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
           'OTHER_CFLAGS': [ '-Wno-strict-aliasing' ],
         },
         'conditions': [
-          ['OS != "os390"', {
+          ['OS != "zos"', {
             'cflags': [ '-O0', '-fwrapv' ]
           }],
           ['OS == "android"', {
@@ -80,7 +80,7 @@
           },
         },
         'conditions': [
-          ['OS != "os390"', {
+          ['OS != "zos"', {
             'cflags': [
               '-fomit-frame-pointer',
               '-fdata-sections',
@@ -160,7 +160,7 @@
             'cflags': [ '-pthreads' ],
             'ldflags': [ '-pthreads' ],
           }],
-          [ 'OS not in "solaris android os390"', {
+          [ 'OS not in "solaris android zos"', {
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
           }],

--- a/uv.gyp
+++ b/uv.gyp
@@ -10,10 +10,10 @@
           ['OS=="solaris"', {
             'cflags': [ '-pthreads' ],
           }],
-          ['OS not in "solaris android os390"', {
+          ['OS not in "solaris android zos"', {
             'cflags': [ '-pthread' ],
           }],
-          ['OS in "os390"', {
+          ['OS in "zos"', {
             'defines': [
               '_UNIX03_THREADS',
               '_UNIX03_SOURCE',
@@ -172,10 +172,10 @@
               ['OS=="solaris"', {
                 'ldflags': [ '-pthreads' ],
               }],
-              [ 'OS=="os390" and uv_library=="shared_library"', {
+              [ 'OS=="zos" and uv_library=="shared_library"', {
                 'ldflags': [ '-Wl,DLL' ],
               }],
-              ['OS != "solaris" and OS != "android" and OS != "os390"', {
+              ['OS != "solaris" and OS != "android" and OS != "zos"', {
                 'ldflags': [ '-pthread' ],
               }],
             ],
@@ -183,14 +183,14 @@
           'conditions': [
             ['uv_library=="shared_library"', {
               'conditions': [
-                ['OS=="os390"', {
+                ['OS=="zos"', {
                   'cflags': [ '-qexportall' ],
                 }, {
                   'cflags': [ '-fPIC' ],
                 }],
               ],
             }],
-            ['uv_library=="shared_library" and OS!="mac" and OS!="os390"', {
+            ['uv_library=="shared_library" and OS!="mac" and OS!="zos"', {
               # This will cause gyp to set soname
               # Must correspond with UV_VERSION_MAJOR
               # in include/uv-version.h
@@ -198,10 +198,10 @@
             }],
           ],
         }],
-        [ 'OS in "linux mac ios android os390"', {
+        [ 'OS in "linux mac ios android zos"', {
           'sources': [ 'src/unix/proctitle.c' ],
         }],
-        [ 'OS != "os390"', {
+        [ 'OS != "zos"', {
           'cflags': [
             '-fvisibility=hidden',
             '-g',
@@ -224,7 +224,7 @@
             '_DARWIN_UNLIMITED_SELECT=1',
           ]
         }],
-        [ 'OS!="mac" and OS!="os390"', {
+        [ 'OS!="mac" and OS!="zos"', {
           # Enable on all platforms except OS X. The antique gcc/clang that
           # ships with Xcode emits waaaay too many false positives.
           'cflags': [ '-Wstrict-aliasing' ],
@@ -317,7 +317,7 @@
         ['uv_library=="shared_library"', {
           'defines': [ 'BUILDING_UV_SHARED=1' ]
         }],
-        ['OS=="os390"', {
+        ['OS=="zos"', {
           'sources': [
             'src/unix/pthread-fixes.c',
             'src/unix/no-fsevents.c',
@@ -489,7 +489,7 @@
             'test/runner-unix.h',
           ],
           'conditions': [
-            [ 'OS != "os390"', {
+            [ 'OS != "zos"', {
               'defines': [ '_GNU_SOURCE' ],
               'cflags': [ '-Wno-long-long' ],
               'xcode_settings': {
@@ -518,7 +518,7 @@
         ['uv_library=="shared_library"', {
           'defines': [ 'USING_UV_SHARED=1' ],
           'conditions': [
-            [ 'OS == "os390"', {
+            [ 'OS == "zos"', {
               'cflags': [ '-Wc,DLL' ],
             }],
           ],
@@ -579,7 +579,7 @@
         ['uv_library=="shared_library"', {
           'defines': [ 'USING_UV_SHARED=1' ],
           'conditions': [
-            [ 'OS == "os390"', {
+            [ 'OS == "zos"', {
               'cflags': [ '-Wc,DLL' ],
             }],
           ],


### PR DESCRIPTION
Sigh! The latest python on z/OS (2.7.13) was changed to update sys.platform to return "zos" instead of "os390". So a change has been submitted to the official gyp repository here.
https://chromium-review.googlesource.com/c/external/gyp/+/679077