### PR TITLE
win: let UV_PROCESS_WINDOWS_HIDE hide consoles

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1058,14 +1058,17 @@ int uv_spawn(uv_loop_t* loop,
   startup.hStdOutput = uv__stdio_handle(process->child_stdio_buffer, 1);
   startup.hStdError = uv__stdio_handle(process->child_stdio_buffer, 2);
 
+  process_flags = CREATE_UNICODE_ENVIRONMENT;
+
   if (options->flags & UV_PROCESS_WINDOWS_HIDE) {
     /* Use SW_HIDE to avoid any potential process window. */
     startup.wShowWindow = SW_HIDE;
+
+    /* Hide console windows. */
+    process_flags |= CREATE_NO_WINDOW;
   } else {
     startup.wShowWindow = SW_SHOWDEFAULT;
   }
-
-  process_flags = CREATE_UNICODE_ENVIRONMENT;
 
   if (options->flags & UV_PROCESS_DETACHED) {
     /* Note that we're not setting the CREATE_BREAKAWAY_FROM_JOB flag. That


### PR DESCRIPTION
For a while now, Node users on Windows have reported that console windows sometimes pop up when spawning child processes. libuv has the `UV_PROCESS_WINDOWS_HIDE` flag, that is supposed to solve this problem. I tried exposing the flag to Node in https://github.com/nodejs/node/pull/15380, but it didn't seem to fix the problem.

`UV_PROCESS_WINDOWS_HIDE` was added in https://github.com/joyent/libuv/pull/627. That PR states:

> UV_PROCESS_WINDOWS_HIDE enables suppression of process windows when launching subprocesses on Windows platforms from a executable linked to the WINDOWS subsystem (as opposed to the CONSOLE subsystem).

In #965 @saghul mentioned that [Electron is setting the `CREATE_NO_WINDOW` flag on child processes to suppress console windows](https://github.com/electron/node/commit/e6afee64f8f214d95381f6f36616c88bad2b945f).

In this PR, I'm proposing that `UV_PROCESS_WINDOWS_HIDE` should hide console windows too. I believe this behavior would better align with user expectations.

cc: @bzoz 

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/485/