### PR TITLE
zos: lock protect global epoll list in epoll_ctl

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -117,7 +117,7 @@ void uv_loadavg(double avg[3]) {
 int uv__platform_loop_init(uv_loop_t* loop) {
   uv__os390_epoll* ep;
 
-  ep = epoll_create1(UV__EPOLL_CLOEXEC);
+  ep = epoll_create1(0);
   loop->ep = ep;
   if (ep == NULL)
     return -errno;


### PR DESCRIPTION
This will eliminate a race condition that occurs between epoll_close_fd , epoll_ctl and epoll_create in the signal_multiple_loops test.