### PR TITLE
win: change st_blksize from `2048` to `4096`

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1178,6 +1178,10 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
    *
    * Therefore we'll just report a sensible value that's quite commonly okay
    * on modern hardware.
+   *
+   * 4096 is the minimum required to be compatible with newer Advanced Format
+   * drives (which have 4096 bytes per physical sector), and to be backwards
+   * compatible with older drives (which have 512 bytes per physical sector).
    */
   statbuf->st_blksize = 4096;
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1179,7 +1179,7 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
    * Therefore we'll just report a sensible value that's quite commonly okay
    * on modern hardware.
    */
-  statbuf->st_blksize = 2048;
+  statbuf->st_blksize = 4096;
 
   /* Todo: set st_flags to something meaningful. Also provide a wrapper for
    * chattr(2).


### PR DESCRIPTION
`fs__stat_handle()` used to set st_blksize to `2048` regardless of the
underlying physical sector size of the disk.

`4096` is a better constant to avoid read-modify-write behavior on
advanced format drives.

fixes: https://github.com/libuv/libuv/issues/1563