### PR TITLE
unix: check watcher queue in uv_backend_timeout()

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -326,6 +326,9 @@ int uv_backend_timeout(const uv_loop_t* loop) {
   if (!QUEUE_EMPTY(&loop->pending_queue))
     return 0;
 
+  if (!QUEUE_EMPTY(&loop->watcher_queue))
+    return 0;
+
   if (loop->closing_handles)
     return 0;
 


### PR DESCRIPTION
Return 0 in uv_backend_timeout() if the watcher queue is not empty.

See issue #1565.