### PR TITLE
fsevents: watch files with fsevents on macos 10.7+

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -230,6 +230,7 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
   uv_loop_t* loop;
   uv__cf_loop_state_t* state;
   uv__fsevents_event_t* event;
+  FSEventStreamEventFlags flags;
   QUEUE head;
 
   loop = info;
@@ -245,8 +246,10 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
 
     /* Process and filter out events */
     for (i = 0; i < numEvents; i++) {
+      flags = eventFlags[i];
+
       /* Ignore system events */
-      if (eventFlags[i] & kFSEventsSystem)
+      if (flags & kFSEventsSystem)
         continue;
 
       path = paths[i];
@@ -271,6 +274,9 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
       /* Ignore events with path equal to directory itself */
       if (len == 0)
         continue;
+#else
+      if (len == 0 && (flags & kFSEventStreamEventFlagItemIsDir))
+        continue;
 #endif /* MAC_OS_X_VERSION_10_7 */
 
       /* Do not emit events from subdirectories (without option set) */
@@ -291,12 +297,24 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
 
       memset(event, 0, sizeof(*event));
       memcpy(event->path, path, len + 1);
+      event->events = UV_RENAME;
 
-      if ((eventFlags[i] & kFSEventsModified) != 0 &&
-          (eventFlags[i] & kFSEventsRenamed) == 0)
+#ifdef MAC_OS_X_VERSION_10_7
+      if (0 != (flags & kFSEventsModified) &&
+          0 == (flags & kFSEventsRenamed)) {
         event->events = UV_CHANGE;
-      else
-        event->events = UV_RENAME;
+      }
+#else
+      if (0 != (flags & kFSEventsModified) &&
+          0 != (flags & kFSEventStreamEventFlagItemIsDir) &&
+          0 == (flags & kFSEventStreamEventFlagItemRenamed)) {
+        event->events = UV_CHANGE;
+      }
+      if (0 == (flags & kFSEventStreamEventFlagItemIsDir) &&
+          0 == (flags & kFSEventStreamEventFlagItemRenamed)) {
+        event->events = UV_CHANGE;
+      }
+#endif /* MAC_OS_X_VERSION_10_7 */
 
       QUEUE_INSERT_TAIL(&head, &event->member);
     }


### PR DESCRIPTION
Adopted from an earlier pull request by Evan Lucas.  Avoids opening a
file descriptor per watched file.

Fixes: https://github.com/libuv/libuv/issues/387
Refs: https://github.com/libuv/libuv/pull/641
CI: https://ci.nodejs.org/job/libuv-test-commit/505/