### PR TITLE
unix: Support ENOBUFS in sendmsg(2) like EWOULDBLOCK and EAGAIN

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -859,7 +859,7 @@ start:
   }
 
   if (n < 0) {
-    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS) {
       err = -errno;
       goto error;
     } else if (stream->flags & UV_STREAM_BLOCKING) {

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -237,8 +237,10 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
       size = sendmsg(handle->io_watcher.fd, &h, 0);
     } while (size == -1 && errno == EINTR);
 
-    if (size == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
-      break;
+    if (size == -1) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
+        break;
+    }
 
     req->status = (size == -1 ? -errno : size);
 
@@ -472,7 +474,7 @@ int uv__udp_try_send(uv_udp_t* handle,
   } while (size == -1 && errno == EINTR);
 
   if (size == -1) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
+    if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
       return -EAGAIN;
     else
       return -errno;


### PR DESCRIPTION
NetBSD can return ENOBUFS for sendmsg(2) when CPU is loaded.

     [ENOBUFS]          The system was unable to allocate an internal buffer.
                        The operation may succeed when buffers become
                        available.

                        An alternative reason: the output queue for a network
                        interface was full.  This generally indicates that the
                        interface has stopped sending, but may be caused by
                        transient congestion.

  -- sendmsg(2)

This call can be repeated similar to EAGAIN or EWOULDBLOCK.

Fixes test udp_send_hang_loop.