### PR TITLE
netbsd: Disable poll_bad_fdtype on NetBSD

### DIFF
--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -601,7 +601,8 @@ TEST_IMPL(poll_unidirectional) {
 TEST_IMPL(poll_bad_fdtype) {
 #if !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__sun) && \
     !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__) && \
-    !defined(__OpenBSD__) && !defined(__CYGWIN__) && !defined(__MSYS__)
+    !defined(__OpenBSD__) && !defined(__CYGWIN__) && !defined(__MSYS__) && \
+    !defined(__NetBSD__)
   uv_poll_t poll_handle;
   int fd;
 


### PR DESCRIPTION
Follow other BSDs and disable the failing poll_bad_fdtype test on
NetBSD.