### PR TITLE
netbsd: Switch uv__cloexec and uv__nonblock to ioctl(2)

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -175,7 +175,8 @@ struct uv__stream_queued_fds_s {
     defined(__FreeBSD__) || \
     defined(__FreeBSD_kernel__) || \
     defined(__linux__) || \
-    defined(__OpenBSD__)
+    defined(__OpenBSD__) || \
+    defined(__NetBSD__)
 #define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
 #else


### PR DESCRIPTION
NetBSD like other BSDs should reuse uv__cloexec_ioctl and uv__nonblock_ioctl.

This fixes poll_nested_kqueue.