### PR TITLE
test: Fix udp_multicast_join6 on NetBSD

### DIFF
--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -122,7 +122,8 @@ TEST_IMPL(udp_multicast_join6) {
 #if defined(__APPLE__)          || \
     defined(_AIX)               || \
     defined(__MVS__)            || \
-    defined(__FreeBSD_kernel__)
+    defined(__FreeBSD_kernel__) || \
+    defined(__NetBSD__)
   r = uv_udp_set_membership(&client, "ff02::1", "::1%lo0", UV_JOIN_GROUP);
 #else
   r = uv_udp_set_membership(&client, "ff02::1", NULL, UV_JOIN_GROUP);


### PR DESCRIPTION
NetBSD must use the uv_udp_set_membership call with "::1%lo0", similar
to FreeBSD.