### PR TITLE
unix: fall back to fsync() if F_FULLFSYNC fails

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -132,18 +132,6 @@
   while (0)
 
 
-static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
-#if defined(__linux__) || defined(__sun) || defined(__NetBSD__)
-  return fdatasync(req->file);
-#elif defined(__APPLE__)
-  /* See the comment in uv__fs_fsync. */
-  return uv__fs_fsync(req);
-#else
-  return fsync(req->file);
-#endif
-}
-
-
 static ssize_t uv__fs_fsync(uv_fs_t* req) {
 #if defined(__APPLE__)
   /* Apple's fdatasync and fsync explicitly do NOT flush the drive write cache
@@ -159,6 +147,18 @@ static ssize_t uv__fs_fsync(uv_fs_t* req) {
   if (r != 0 && errno == ENOTTY)
     r = fsync(req->file);
   return r;
+#else
+  return fsync(req->file);
+#endif
+}
+
+
+static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
+#if defined(__linux__) || defined(__sun) || defined(__NetBSD__)
+  return fdatasync(req->file);
+#elif defined(__APPLE__)
+  /* See the comment in uv__fs_fsync. */
+  return uv__fs_fsync(req);
 #else
   return fsync(req->file);
 #endif

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -153,8 +153,10 @@ static ssize_t uv__fs_fsync(uv_fs_t* req) {
    * supported by the file system we should fall back to fsync(). This is the
    * same approach taken by sqlite.
    */
-  int r = fcntl(req->file, F_FULLFSYNC);
-  if (r != 0)
+  int r;
+
+  r = fcntl(req->file, F_FULLFSYNC);
+  if (r != 0 && errno == ENOTTY)
     r = fsync(req->file);
   return r;
 #else

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -154,7 +154,8 @@ static ssize_t uv__fs_fsync(uv_fs_t* req) {
    * same approach taken by sqlite.
    */
   int r = fcntl(req->file, F_FULLFSYNC);
-  if (r) r = fsync(req->file);
+  if (r != 0)
+    r = fsync(req->file);
   return r;
 #else
   return fsync(req->file);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -136,12 +136,8 @@ static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
 #if defined(__linux__) || defined(__sun) || defined(__NetBSD__)
   return fdatasync(req->file);
 #elif defined(__APPLE__)
-  /* Apple's fdatasync and fsync explicitly do NOT flush the drive write cache
-   * to the drive platters. This is in contrast to Linux's fdatasync and fsync
-   * which do, according to recent man pages. F_FULLFSYNC is Apple's equivalent
-   * for flushing buffered data to permanent storage.
-   */
-  return fcntl(req->file, F_FULLFSYNC);
+  /* See the comment in uv__fs_fsync. */
+  return uv__fs_fsync(req);
 #else
   return fsync(req->file);
 #endif
@@ -150,8 +146,16 @@ static ssize_t uv__fs_fdatasync(uv_fs_t* req) {
 
 static ssize_t uv__fs_fsync(uv_fs_t* req) {
 #if defined(__APPLE__)
-  /* See the comment in uv__fs_fdatasync. */
-  return fcntl(req->file, F_FULLFSYNC);
+  /* Apple's fdatasync and fsync explicitly do NOT flush the drive write cache
+   * to the drive platters. This is in contrast to Linux's fdatasync and fsync
+   * which do, according to recent man pages. F_FULLFSYNC is Apple's equivalent
+   * for flushing buffered data to permanent storage. If F_FULLFSYNC is not
+   * supported by the file system we should fall back to fsync(). This is the
+   * same approach taken by sqlite.
+   */
+  int r = fcntl(req->file, F_FULLFSYNC);
+  if (r) r = fsync(req->file);
+  return r;
 #else
   return fsync(req->file);
 #endif


### PR DESCRIPTION
F_FULLFSYNC may fail on non-Apple block devices.

fixes: https://github.com/libuv/libuv/issues/1579