### PR TITLE
test: fix -Wstrict-prototypes warnings

### DIFF
--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -36,9 +36,9 @@ static int TARGET_CONNECTIONS;
 
 
 static void do_write(uv_stream_t*);
-static void maybe_connect_some();
+static void maybe_connect_some(void);
 
-static uv_req_t* req_alloc();
+static uv_req_t* req_alloc(void);
 static void req_free(uv_req_t* uv_req);
 
 static void buf_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf);


### PR DESCRIPTION
These have been around for some time apparently (commit 391f0098de from
May 2011) but went unnoticed so far.  No longer.