### PR TITLE
unix: do not close invalid kqueue fd after fork

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -65,7 +65,6 @@ static int uv__has_forked_with_cfrunloop;
 
 int uv__io_fork(uv_loop_t* loop) {
   int err;
-  uv__close(loop->backend_fd);
   loop->backend_fd = -1;
   err = uv__kqueue_init(loop);
   if (err)


### PR DESCRIPTION
The kqueue documentation states that the file descriptor is not inherited by the child process. Hence, do not close it in uv_loop_fork to avoid tampering with a possibly valid file descriptor already opened by the child process.