### PR TITLE
win: fix non-English dlopen error message

### DIFF
--- a/src/win/dl.c
+++ b/src/win/dl.c
@@ -89,7 +89,6 @@ static void uv__format_fallback_error(uv_lib_t* lib, int errorno){
 
 
 static int uv__dlerror(uv_lib_t* lib, const char* filename, DWORD errorno) {
-  static const char not_win32_app_msg[] = "%1 is not a valid Win32 application";
   DWORD_PTR arg;
   DWORD res;
   char* msg;
@@ -115,7 +114,6 @@ static int uv__dlerror(uv_lib_t* lib, const char* filename, DWORD errorno) {
                          0, (LPSTR) &lib->errmsg, 0, NULL);
   }
 
-  /* Inexpert hack to get the filename into the error message. */
   if (res && errorno == ERROR_BAD_EXE_FORMAT && strstr(lib->errmsg, "%1")) {
     msg = lib->errmsg;
     lib->errmsg = NULL;

--- a/src/win/dl.c
+++ b/src/win/dl.c
@@ -92,6 +92,7 @@ static int uv__dlerror(uv_lib_t* lib, const char* filename, DWORD errorno) {
   static const char not_win32_app_msg[] = "%1 is not a valid Win32 application";
   DWORD_PTR arg;
   DWORD res;
+  char* msg;
 
   if (lib->errmsg) {
     LocalFree(lib->errmsg);
@@ -115,15 +116,16 @@ static int uv__dlerror(uv_lib_t* lib, const char* filename, DWORD errorno) {
   }
 
   /* Inexpert hack to get the filename into the error message. */
-  if (res && strstr(lib->errmsg, not_win32_app_msg)) {
-    LocalFree(lib->errmsg);
+  if (res && errorno == ERROR_BAD_EXE_FORMAT && strstr(lib->errmsg, "%1")) {
+    msg = lib->errmsg;
     lib->errmsg = NULL;
     arg = (DWORD_PTR) filename;
     res = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
                          FORMAT_MESSAGE_ARGUMENT_ARRAY |
                          FORMAT_MESSAGE_FROM_STRING,
-                         not_win32_app_msg,
+                         msg,
                          0, 0, (LPSTR) &lib->errmsg, 0, (va_list*) &arg);
+    LocalFree(msg);
   }
 
   if (!res)


### PR DESCRIPTION
Extend https://github.com/libuv/libuv/pull/1116 to work on other Windows languages.

This also makes `dlerror` test pass on non-English Windows.