### PR TITLE
test: fix const qualification compiler warning

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1721,9 +1721,9 @@ TEST_IMPL(spawn_quoted_path) {
   RETURN_SKIP("Test for Windows");
 #else
   char* quoted_path_env[2];
-  options.file = "not_existing";
-  args[0] = options.file;
+  args[0] = "not_existing";
   args[1] = NULL;
+  options.file = args[0];
   options.args = args;
   options.exit_cb = exit_cb;
   options.flags = 0;


### PR DESCRIPTION
`options.file` is of type `const char*`, don't assign it to a variable
that is a non-const `char*`.  The other way around is perfectly legal,
though.

CI: https://ci.nodejs.org/job/libuv-test-commit/521/