### PR TITLE
uv_default_loop is not thread-safe: doc update

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -86,6 +86,10 @@ API
     should) be closed with :c:func:`uv_loop_close` so the resources associated
     with it are freed.
 
+    .. note::
+        This function is not intended to be called from multiple threads. Therefore, it is not
+        thread-safe.
+
 .. c:function:: int uv_run(uv_loop_t* loop, uv_run_mode mode)
 
     This function runs the event loop. It will act differently depending on the


### PR DESCRIPTION
#1461 

Modified the documentation for uv_default_loop to represent its current state (not thread-safe).