### PR TITLE
Let uv_timer_again() fail when called on a non-repeating timer.

### DIFF
--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -51,9 +51,9 @@ API
 
 .. c:function:: int uv_timer_again(uv_timer_t* handle)
 
-    Stop the timer, and if it is repeating restart it using the repeat value
-    as the timeout. If the timer has never been started before it returns
-    UV_EINVAL.
+    Stop the timer and restart it using the repeat value as the timeout.
+    If the timer has never been started before or is not repeating, it
+    returns UV_EINVAL.
 
 .. c:function:: void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat)
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -104,15 +104,12 @@ int uv_timer_stop(uv_timer_t* handle) {
 
 
 int uv_timer_again(uv_timer_t* handle) {
-  if (handle->timer_cb == NULL)
+  /* If timer_cb is NULL that means that the timer was never started. */
+  if (handle->timer_cb == NULL || handle->repeat == 0)
     return -EINVAL;
 
-  if (handle->repeat) {
-    uv_timer_stop(handle);
-    uv_timer_start(handle, handle->timer_cb, handle->repeat, handle->repeat);
-  }
-
-  return 0;
+  return uv_timer_start(handle, handle->timer_cb, handle->repeat,
+                        handle->repeat);
 }
 
 

--- a/src/win/timer.c
+++ b/src/win/timer.c
@@ -128,16 +128,11 @@ int uv_timer_stop(uv_timer_t* handle) {
 
 int uv_timer_again(uv_timer_t* handle) {
   /* If timer_cb is NULL that means that the timer was never started. */
-  if (!handle->timer_cb) {
+  if (handle->timer_cb == NULL || handle->repeat == 0)
     return UV_EINVAL;
-  }
 
-  if (handle->repeat) {
-    uv_timer_stop(handle);
-    uv_timer_start(handle, handle->timer_cb, handle->repeat, handle->repeat);
-  }
-
-  return 0;
+  return uv_timer_start(handle, handle->timer_cb, handle->repeat,
+                        handle->repeat);
 }
 
 

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -112,6 +112,10 @@ TEST_IMPL(timer_again) {
   ASSERT(r == 0);
   ASSERT(uv_timer_get_repeat(&repeat_1) == 0);
 
+  /* Verify that it is not possible to uv_timer_again a non-repeating timer. */
+  r = uv_timer_again(&repeat_1);
+  ASSERT(r == UV_EINVAL);
+
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);
   ASSERT(uv_timer_get_repeat(&repeat_1) == 50);


### PR DESCRIPTION
The existing documentation and implementation contradict on what this
function is supposed to do when called on non-repeating timers. The
documentation says the timer should be stopped, whereas the
implementation leaves the timer alone. Disallowing it in the first place
makes more sense.

Fixed: #1591