### PR TITLE
Clarify the description of uv_loop_alive() to match reality.

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -106,7 +106,8 @@ API
 
 .. c:function:: int uv_loop_alive(const uv_loop_t* loop)
 
-    Returns non-zero if there are active handles or request in the loop.
+    Returns non-zero if there are referenced active handles, active
+    request or closing handles in the loop.
 
 .. c:function:: void uv_stop(uv_loop_t* loop)
 


### PR DESCRIPTION
This function not only returns true if there are active handles or
requests. First of all, it also takes into account whether handles are
referenced. Second, handles that are being closed also contribute to
whether a loop is alive.

Fixes: #1592