### PR TITLE
zos: skip fork_threadpool_queue_work_simple

### DIFF
--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -636,6 +636,7 @@ static void assert_run_work(uv_loop_t* const loop) {
 }
 
 
+#ifndef __MVS__
 TEST_IMPL(fork_threadpool_queue_work_simple) {
   /* The threadpool works in a child process. */
 
@@ -672,6 +673,7 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+#endif /* !__MVS__ */
 
 
 #endif /* !_WIN32 */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -401,7 +401,9 @@ TEST_DECLARE  (fork_signal_to_child_closed)
 TEST_DECLARE  (fork_fs_events_child)
 TEST_DECLARE  (fork_fs_events_child_dir)
 TEST_DECLARE  (fork_fs_events_file_parent_child)
+#ifndef __MVS__
 TEST_DECLARE  (fork_threadpool_queue_work_simple)
+#endif
 #endif
 
 TASK_LIST_START
@@ -867,7 +869,9 @@ TASK_LIST_START
   TEST_ENTRY  (fork_fs_events_child)
   TEST_ENTRY  (fork_fs_events_child_dir)
   TEST_ENTRY  (fork_fs_events_file_parent_child)
+#ifndef __MVS__
   TEST_ENTRY  (fork_threadpool_queue_work_simple)
+#endif
 #endif
 
 #if 0


### PR DESCRIPTION
z/OS does not allow a child process to create threads if it was
forked from a multi-threaded parent.