### PR TITLE
unix,win: add uv_os_getppid()

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -59,6 +59,12 @@ Data types
     Abstract representation of a file descriptor. On Unix systems this is a
     `typedef` of `int` and on Windows a `HANDLE`.
 
+.. c:type:: uv_pid_t
+
+    Cross platform representation of a `pid_t`.
+
+    .. versionadded:: 1.16.0
+
 .. c:type:: uv_rusage_t
 
     Data type for resource usage results.
@@ -220,6 +226,12 @@ API
     .. note::
         On Windows not all fields are set, the unsupported fields are filled with zeroes.
         See :c:type:`uv_rusage_t` for more details.
+
+.. c:function:: uv_pid_t uv_os_getppid(void)
+
+    Returns the parent process ID.
+
+    .. versionadded:: 1.16.0
 
 .. c:function:: int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count)
 

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -123,6 +123,7 @@ typedef struct uv_buf_t {
 typedef int uv_file;
 typedef int uv_os_sock_t;
 typedef int uv_os_fd_t;
+typedef pid_t uv_pid_t;
 
 #define UV_ONCE_INIT PTHREAD_ONCE_INIT
 

--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -222,6 +222,7 @@ typedef struct uv_buf_t {
 typedef int uv_file;
 typedef SOCKET uv_os_sock_t;
 typedef HANDLE uv_os_fd_t;
+typedef int uv_pid_t;
 
 typedef HANDLE uv_thread_t;
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1069,6 +1069,7 @@ UV_EXTERN int uv_os_homedir(char* buffer, size_t* size);
 UV_EXTERN int uv_os_tmpdir(char* buffer, size_t* size);
 UV_EXTERN int uv_os_get_passwd(uv_passwd_t* pwd);
 UV_EXTERN void uv_os_free_passwd(uv_passwd_t* pwd);
+UV_EXTERN uv_pid_t uv_os_getppid(void);
 
 UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);
 UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1343,3 +1343,8 @@ int uv_os_gethostname(char* buffer, size_t* size) {
 uv_os_fd_t uv_get_osfhandle(int fd) {
   return fd;
 }
+
+
+uv_pid_t uv_os_getppid(void) {
+  return getppid();
+}

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -326,7 +326,6 @@ void uv__fs_poll_endgame(uv_loop_t* loop, uv_fs_poll_t* handle);
 void uv__util_init(void);
 
 uint64_t uv__hrtime(double scale);
-int uv_parent_pid(void);
 int uv_current_pid(void);
 __declspec(noreturn) void uv_fatal_error(const int errorno, const char* syscall);
 int uv__getpwuid_r(uv_passwd_t* pwd);

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1969,7 +1969,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
 
   if (pipe->ipc) {
     assert(!(pipe->flags & UV_HANDLE_NON_OVERLAPPED_PIPE));
-    pipe->pipe.conn.ipc_pid = uv_parent_pid();
+    pipe->pipe.conn.ipc_pid = uv_os_getppid();
     assert(pipe->pipe.conn.ipc_pid != -1);
   }
   return 0;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -331,7 +331,7 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-int uv_parent_pid(void) {
+uv_pid_t uv_os_getppid(void) {
   int parent_pid = -1;
   HANDLE handle;
   PROCESSENTRY32 pe;

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -29,6 +29,7 @@ TEST_IMPL(platform_output) {
   size_t rss;
   size_t size;
   double uptime;
+  uv_pid_t ppid;
   uv_rusage_t rusage;
   uv_cpu_info_t* cpus;
   uv_interface_address_t* interfaces;
@@ -143,6 +144,10 @@ TEST_IMPL(platform_output) {
   printf("  username: %s\n", pwd.username);
   printf("  shell: %s\n", pwd.shell);
   printf("  home directory: %s\n", pwd.homedir);
+
+  ppid = uv_os_getppid();
+  ASSERT(ppid > 0);
+  printf("uv_os_getppid: %d\n", (int) ppid);
 
   return 0;
 }


### PR DESCRIPTION
Requested in https://github.com/nodejs/node/issues/14957. The only real work is on Windows, and libuv already had the functionality internally, so I thought I'd take a shot at exposing it.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/542/