### PR TITLE
win: map ERROR_ACCESS_DENIED to UV_EACCES

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -67,6 +67,7 @@ int uv_translate_sys_error(int sys_errno) {
   }
 
   switch (sys_errno) {
+    case ERROR_ACCESS_DENIED:               return UV_EACCES;
     case ERROR_NOACCESS:                    return UV_EACCES;
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
@@ -151,7 +152,6 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENOTSOCK:                       return UV_ENOTSOCK;
     case ERROR_NOT_SUPPORTED:               return UV_ENOTSUP;
     case ERROR_BROKEN_PIPE:                 return UV_EOF;
-    case ERROR_ACCESS_DENIED:               return UV_EPERM;
     case ERROR_PRIVILEGE_NOT_HELD:          return UV_EPERM;
     case ERROR_BAD_PIPE:                    return UV_EPIPE;
     case ERROR_NO_DATA:                     return UV_EPIPE;


### PR DESCRIPTION
E.g. when trying to modify a read-only file.

See https://github.com/nodejs/node/issues/16596

1. Attempting to write to a read-only file results in `UV_EACCES` on Linux.
2. `ERROR_ACCESS_DENIED` is "Access is denied.". ([source](https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx)) `UV_EACCES` is "permission denied". `UV_EPERM` is "operation not permitted". ([source](http://docs.libuv.org/en/v1.x/errors.html)) `UV_EACCES` is clearly closer in meaning.
3. The following code outputs "EACCES: Permission denied" when "00000" is a read-only file.

```cpp
#include <cstdio>
#include <cerrno>
#include <cstring>
#include <cerrno>
#include <iostream>

using namespace std;

int main()
{
  auto woo = fopen("00000", "w");
  if (errno == EPERM) {
    perror("EPERM");
  } else if (errno == EACCES) {
			perror("EACCES");
	} else {
    perror("somethign else??");
  }
}
```

It was changed in https://github.com/libuv/libuv/commit/495853ee2b5d25f3848264139ab5214ddfc602bb but there is no explanation in the commit message.