### PR TITLE
unix: move net/if.h include

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -32,7 +32,6 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#include <net/if.h>
 
 #include <termios.h>
 #include <pwd.h>

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -32,6 +32,7 @@
 #include <stddef.h> /* NULL */
 #include <stdlib.h>
 #include <string.h>
+#include <net/if.h> /* if_indextoname() */
 
 /* EAI_* constants. */
 #include <netdb.h>


### PR DESCRIPTION
This commit moves the `net/if.h` include into `src/getaddrinfo.c` to prevent AIX compilation errors. With these symbols exposed publicly, Node.js compilation failed on AIX by exposing `Free()`, which conflicts with another API.

Refs: https://github.com/nodejs/node/pull/16835
Refs: https://github.com/libuv/libuv/pull/1445

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/564/