### PR TITLE
win: fix undeclared NDIS_IF_MAX_STRING_SIZE

### DIFF
--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -49,6 +49,9 @@ int uv__getaddrinfo_translate_error(int sys_err) {
 /* Do we need different versions of this for different architectures? */
 #define ALIGNED_SIZE(X)     ((((X) + 3) >> 2) << 2)
 
+#ifndef NDIS_IF_MAX_STRING_SIZE  
+#define NDIS_IF_MAX_STRING_SIZE 256
+#endif
 
 static void uv__getaddrinfo_work(struct uv__work* w) {
   uv_getaddrinfo_t* req;

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -49,8 +49,8 @@ int uv__getaddrinfo_translate_error(int sys_err) {
 /* Do we need different versions of this for different architectures? */
 #define ALIGNED_SIZE(X)     ((((X) + 3) >> 2) << 2)
 
-#ifndef NDIS_IF_MAX_STRING_SIZE  
-#define NDIS_IF_MAX_STRING_SIZE 256
+#ifndef NDIS_IF_MAX_STRING_SIZE
+#define NDIS_IF_MAX_STRING_SIZE IF_MAX_STRING_SIZE
 #endif
 
 static void uv__getaddrinfo_work(struct uv__work* w) {


### PR DESCRIPTION
NDIS_IF_MAX_STRING_SIZE does not appear to be available on many windows system.