### PR TITLE
zos: strnlen implementation

### DIFF
--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -427,3 +427,12 @@ ssize_t os390_readlink(const char* path, char* buf, size_t len) {
 
   return rlen;
 }
+
+
+size_t strnlen(const char* str, size_t maxlen) {
+  void* p = memchr(str, 0, maxlen);
+  if (p == NULL)
+    return maxlen;
+  else
+    return p - str;
+}

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -66,5 +66,6 @@ int scandir(const char* maindir, struct dirent*** namelist,
             const struct dirent **));
 char *mkdtemp(char* path);
 ssize_t os390_readlink(const char* path, char* buf, size_t len);
+size_t strnlen(const char* str, size_t maxlen);
 
 #endif /* UV_OS390_SYSCALL_H_ */


### PR DESCRIPTION
Implementation of strnlen which is not provided by default.