### PR TITLE
win: fix test runner build with mingw64

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2171,7 +2171,6 @@ TEST_IMPL(fs_utime) {
 #ifdef _WIN32
 TEST_IMPL(fs_stat_root) {
   int r;
-  uv_loop_t* loop = uv_default_loop();
 
   r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
   ASSERT(r == 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -32,8 +32,12 @@
     defined(__APPLE__) || defined(_AIX) || defined(__MVS__)
 #include <unistd.h> /* unlink, rmdir, etc. */
 #else
+# include <winioctl.h>
 # include <direct.h>
 # include <io.h>
+# ifndef ERROR_SYMLINK_NOT_SUPPORTED
+#  define ERROR_SYMLINK_NOT_SUPPORTED 1464
+# endif
 # define unlink _unlink
 # define rmdir _rmdir
 # define open _open


### PR DESCRIPTION
Include `<winioctl.h>` for the definition of `FSCTL_SET_REPARSE_POINT`
and define `ERROR_SYMLINK_NOT_SUPPORTED` if not already defined.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/575/