### PR TITLE
doc: remove note about SIGWINCH on Windows

### DIFF
--- a/docs/src/signal.rst
+++ b/docs/src/signal.rst
@@ -17,13 +17,6 @@ Reception of some signals is emulated on Windows:
   program is given approximately 10 seconds to perform cleanup. After that
   Windows will unconditionally terminate it.
 
-* SIGWINCH is raised whenever libuv detects that the console has been
-  resized. SIGWINCH is emulated by libuv when the program uses a :c:type:`uv_tty_t`
-  handle to write to the console. SIGWINCH may not always be delivered in a
-  timely manner; libuv will only detect size changes when the cursor is
-  being moved. When a readable :c:type:`uv_tty_t` handle is used in raw mode,
-  resizing the console buffer will also trigger a SIGWINCH signal.
-
 Watchers for other signals can be successfully created, but these signals
 are never received. These signals are: `SIGILL`, `SIGABRT`, `SIGFPE`, `SIGSEGV`,
 `SIGTERM` and `SIGKILL.`
@@ -36,6 +29,7 @@ not detected by libuv; these will not trigger a signal watcher.
     manage threads. Installing watchers for those signals will lead to unpredictable behavior
     and is strongly discouraged. Future versions of libuv may simply reject them.
 
+.. versionchanged:: 1.15.0 SIGWINCH support on Windows was improved
 
 Data types
 ----------


### PR DESCRIPTION
`SIGWINCH` support was improved by https://github.com/libuv/libuv/commit/6ad1e81547c83f9fe7c5a806b6b282642e8d3bca, the note is no longer valid.