### PR TITLE
test: fix test-spawn compilation

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -654,6 +654,7 @@ TEST_IMPL(spawn_tcp_server) {
   struct sockaddr_in addr;
   int fd;
   int r;
+  uv_os_fd_t handle;
 
   init_process_options("spawn_tcp_server_helper", exit_cb);
 


### PR DESCRIPTION
https://github.com/libuv/libuv/pull/1348 broke Windows compilation. This ubreaks it.

/cc @jBarz @santigimeno 