### PR TITLE
enhance ability of embed with other event loop.

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -674,3 +674,14 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
 #define UV_FS_O_NONBLOCK     0
 #define UV_FS_O_SYMLINK      0
 #define UV_FS_O_SYNC         0x08000000 /* FILE_FLAG_WRITE_THROUGH */
+
+
+/*
+ * This function is used for embed uv loop into win32 gui application or other thread which has it's own event loop.
+ *  1. get iocp handle
+ *  2. call GetQueuedCompletionStatus() in backgound thread
+ *  3. call uv_insert_overlapped_result() with result of iocp in main thread
+ *  4. call uv_run(... UV_RUN_NOWAIT) in main thread
+ */
+UV_EXTERN void uv_insert_overlapped_result(uv_loop_t* loop, LPOVERLAPPED lpoverlap);
+

--- a/include/uv.h
+++ b/include/uv.h
@@ -56,6 +56,45 @@ extern "C" {
 # include <stdint.h>
 #endif
 
+/* Types forward declaration. */
+
+/* Handle types. */
+typedef struct uv_loop_s uv_loop_t;
+typedef struct uv_handle_s uv_handle_t;
+typedef struct uv_stream_s uv_stream_t;
+typedef struct uv_tcp_s uv_tcp_t;
+typedef struct uv_udp_s uv_udp_t;
+typedef struct uv_pipe_s uv_pipe_t;
+typedef struct uv_tty_s uv_tty_t;
+typedef struct uv_poll_s uv_poll_t;
+typedef struct uv_timer_s uv_timer_t;
+typedef struct uv_prepare_s uv_prepare_t;
+typedef struct uv_check_s uv_check_t;
+typedef struct uv_idle_s uv_idle_t;
+typedef struct uv_async_s uv_async_t;
+typedef struct uv_process_s uv_process_t;
+typedef struct uv_fs_event_s uv_fs_event_t;
+typedef struct uv_fs_poll_s uv_fs_poll_t;
+typedef struct uv_signal_s uv_signal_t;
+
+/* Request types. */
+typedef struct uv_req_s uv_req_t;
+typedef struct uv_getaddrinfo_s uv_getaddrinfo_t;
+typedef struct uv_getnameinfo_s uv_getnameinfo_t;
+typedef struct uv_shutdown_s uv_shutdown_t;
+typedef struct uv_write_s uv_write_t;
+typedef struct uv_connect_s uv_connect_t;
+typedef struct uv_udp_send_s uv_udp_send_t;
+typedef struct uv_fs_s uv_fs_t;
+typedef struct uv_work_s uv_work_t;
+
+/* None of the above. */
+typedef struct uv_cpu_info_s uv_cpu_info_t;
+typedef struct uv_interface_address_s uv_interface_address_t;
+typedef struct uv_dirent_s uv_dirent_t;
+typedef struct uv_passwd_s uv_passwd_t;
+
+
 #if defined(_WIN32)
 # include "uv-win.h"
 #else
@@ -198,44 +237,13 @@ typedef enum {
 } uv_req_type;
 
 
-/* Handle types. */
-typedef struct uv_loop_s uv_loop_t;
-typedef struct uv_handle_s uv_handle_t;
-typedef struct uv_stream_s uv_stream_t;
-typedef struct uv_tcp_s uv_tcp_t;
-typedef struct uv_udp_s uv_udp_t;
-typedef struct uv_pipe_s uv_pipe_t;
-typedef struct uv_tty_s uv_tty_t;
-typedef struct uv_poll_s uv_poll_t;
-typedef struct uv_timer_s uv_timer_t;
-typedef struct uv_prepare_s uv_prepare_t;
-typedef struct uv_check_s uv_check_t;
-typedef struct uv_idle_s uv_idle_t;
-typedef struct uv_async_s uv_async_t;
-typedef struct uv_process_s uv_process_t;
-typedef struct uv_fs_event_s uv_fs_event_t;
-typedef struct uv_fs_poll_s uv_fs_poll_t;
-typedef struct uv_signal_s uv_signal_t;
 
-/* Request types. */
-typedef struct uv_req_s uv_req_t;
-typedef struct uv_getaddrinfo_s uv_getaddrinfo_t;
-typedef struct uv_getnameinfo_s uv_getnameinfo_t;
-typedef struct uv_shutdown_s uv_shutdown_t;
-typedef struct uv_write_s uv_write_t;
-typedef struct uv_connect_s uv_connect_t;
-typedef struct uv_udp_send_s uv_udp_send_t;
-typedef struct uv_fs_s uv_fs_t;
-typedef struct uv_work_s uv_work_t;
-
-/* None of the above. */
-typedef struct uv_cpu_info_s uv_cpu_info_t;
-typedef struct uv_interface_address_s uv_interface_address_t;
-typedef struct uv_dirent_s uv_dirent_t;
-typedef struct uv_passwd_s uv_passwd_t;
+typedef void(*uv_timeout_observer_func)(uv_loop_t* loop, uint64_t timeout);
 
 typedef enum {
-  UV_LOOP_BLOCK_SIGNAL
+  UV_LOOP_BLOCK_SIGNAL,
+  /* pass a uv_timeout_observer_func as callback, if backend timeout of uv_loop_t changed, the callback will run */
+  UV_LOOP_TIMEOUT_OBSERVER 
 } uv_loop_option;
 
 typedef enum {
@@ -288,7 +296,7 @@ UV_EXTERN int uv_has_ref(const uv_handle_t*);
 UV_EXTERN void uv_update_time(uv_loop_t*);
 UV_EXTERN uint64_t uv_now(const uv_loop_t*);
 
-UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+UV_EXTERN uv_os_fd_t uv_backend_fd(const uv_loop_t*);
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,
@@ -1512,6 +1520,7 @@ struct uv_loop_s {
   void* active_reqs[2];
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
+  uv_timeout_observer_func on_timeout_change;
   UV_LOOP_PRIVATE_FIELDS
 };
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -577,11 +577,15 @@ int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent) {
 
 int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
   va_list ap;
-  int err;
+  int err = 0;
 
   va_start(ap, option);
-  /* Any platform-agnostic options should be handled here. */
-  err = uv__loop_configure(loop, option, ap);
+  if (option == UV_LOOP_TIMEOUT_OBSERVER) {    
+    loop->on_timeout_change = va_arg(ap, uv_timeout_observer_func);
+  } else {
+    /* Any platform-agnostic options should be handled here. */
+    err = uv__loop_configure(loop, option, ap);
+  }
   va_end(ap);
 
   return err;

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -231,6 +231,8 @@ int uv_loop_init(uv_loop_t* loop) {
   if (loop->iocp == NULL)
     return uv_translate_sys_error(GetLastError());
 
+  loop->on_timeout_change = NULL;
+
   /* To prevent uninitialized memory access, loop->time must be initialized
    * to zero before calling uv_update_time for the first time.
    */
@@ -329,8 +331,8 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
-  return -1;
+uv_os_fd_t uv_backend_fd(const uv_loop_t* loop) {
+  return loop->iocp;
 }
 
 
@@ -603,3 +605,10 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
 
   return 0;
 }
+
+
+void uv_insert_overlapped_result(uv_loop_t* loop, LPOVERLAPPED lpoverlap) {
+	uv_req_t* req = uv_overlapped_to_req(lpoverlap);
+	uv_insert_pending_req(loop, req);	
+}
+

--- a/src/win/timer.c
+++ b/src/win/timer.c
@@ -101,6 +101,14 @@ int uv_timer_start(uv_timer_t* handle, uv_timer_cb timer_cb, uint64_t timeout,
   handle->timer_cb = timer_cb;
   handle->due = get_clamped_due_time(loop->time, timeout);
   handle->repeat = repeat;
+    
+  if (loop->on_timeout_change) {
+    old = RB_MIN(uv_timer_tree_s, &((uv_loop_t*)loop)->timers);
+    if (!old || old->due > handle->due) {
+      loop->on_timeout_change(loop, timeout);
+    }
+  }
+
   uv__handle_start(handle);
 
   /* start_id is the second index to be compared in uv__timer_cmp() */


### PR DESCRIPTION
changes:
1. add UV_LOOP_TIMEOUT_OBSERVER for uv_loop_option.
  observer function call when backend timeout of uv loop changed.
  for interrupt your self event loop.

2. uv_backend_fd return iocp handle in windows.
  for call GetQueuedCompletionStatus your self.

3. add uv_insert_overlapped_result windows specific function.
  for pass result of GetQueuedCompletionStatus to uv loop.


------
Example case for win32 gui application:
in main thread just run default win32 message loop.
```
while(GetMessage(&msg,NULL,0,0)){
  TranslateMessage(&msg);
  DispatchMessage(&msg);
}
```

create a window to handle uv events in it's WndProc.
```
if(msg == WM_UV_READY){
  if(lparam)uv_insert_overlapped_result(loop, (LPOVERLAPPED)lparam); 
  uv_run(loop, UV_RUN_NOWAIT);
}
```

create a thread to poll iocp events.
```
LPOVERLAPPED overlapped;
while(1){
  GetQueuedCompletionStatus(... overlapped, timeout_);
  SendMessage(hwnd, WM_UV_READY, 0, overlapped);  
}
```

in timeout observer function, interrupt GetQueuedCompletionStatus
```
void on_timeout_change(... timeout){
  timeout_ = timeout;
  PostQueuedCompletionStatus(iocp,0,0,NULL);
}
uv_loop_configure(loop, UV_LOOP_TIMEOUT_OBSERVER, on_timeout_change);
```

