### PR TITLE
unix,win: add uv_os_getpid()

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -227,6 +227,12 @@ API
         On Windows not all fields are set, the unsupported fields are filled with zeroes.
         See :c:type:`uv_rusage_t` for more details.
 
+.. c:function:: uv_pid_t uv_os_getpid(void)
+
+    Returns current process ID.
+
+    .. versionadded:: 1.18.0
+
 .. c:function:: uv_pid_t uv_os_getppid(void)
 
     Returns the parent process ID.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1070,6 +1070,7 @@ UV_EXTERN int uv_os_homedir(char* buffer, size_t* size);
 UV_EXTERN int uv_os_tmpdir(char* buffer, size_t* size);
 UV_EXTERN int uv_os_get_passwd(uv_passwd_t* pwd);
 UV_EXTERN void uv_os_free_passwd(uv_passwd_t* pwd);
+UV_EXTERN uv_pid_t uv_os_getpid(void);
 UV_EXTERN uv_pid_t uv_os_getppid(void);
 
 UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1345,6 +1345,11 @@ uv_os_fd_t uv_get_osfhandle(int fd) {
 }
 
 
+uv_pid_t uv_os_getpid(void) {
+  return getpid();
+}
+
+
 uv_pid_t uv_os_getppid(void) {
   return getppid();
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -331,6 +331,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uv_pid_t uv_os_getpid(void) {
+  return GetCurrentProcessId();
+}
+
+
 uv_pid_t uv_os_getppid(void) {
   int parent_pid = -1;
   HANDLE handle;

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -29,6 +29,7 @@ TEST_IMPL(platform_output) {
   size_t rss;
   size_t size;
   double uptime;
+  uv_pid_t pid;
   uv_pid_t ppid;
   uv_rusage_t rusage;
   uv_cpu_info_t* cpus;
@@ -145,6 +146,9 @@ TEST_IMPL(platform_output) {
   printf("  shell: %s\n", pwd.shell);
   printf("  home directory: %s\n", pwd.homedir);
 
+  pid = uv_os_getpid();
+  ASSERT(pid > 0);
+  printf("uv_os_getpid: %d\n", (int) pid);
   ppid = uv_os_getppid();
   ASSERT(ppid > 0);
   printf("uv_os_getppid: %d\n", (int) ppid);


### PR DESCRIPTION
Adds a multi platform way to get current process id.