### PR TITLE
win: Fix commmon.gypi comment

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -16,9 +16,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['uv_library=="static_library"', {
-                'RuntimeLibrary': 1, # static debug
+                'RuntimeLibrary': 1, # /MTd static debug
               }, {
-                'RuntimeLibrary': 3, # DLL debug
+                'RuntimeLibrary': 3, # /MDd DLL debug
               }],
             ],
             'Optimization': 0, # /Od, no optimization
@@ -52,9 +52,9 @@
           'VCCLCompilerTool': {
             'target_conditions': [
               ['uv_library=="static_library"', {
-                'RuntimeLibrary': 0, # static release
+                'RuntimeLibrary': 0, # /MT static release
               }, {
-                'RuntimeLibrary': 2, # debug release
+                'RuntimeLibrary': 2, # /MD DLL release
               }],
             ],
             'Optimization': 3, # /Ox, full optimization


### PR DESCRIPTION
I noticed `'RuntimeLibrary': 2` means `debug release` instead of `DLL release`.

And I think writing `/MTd`, `/MDd`, ... is easier to understand than `static debug`, `DLL debug`, ... so also fixed.

cf. https://chromium.googlesource.com/external/gyp/+/master/test/win/compiler-flags/runtime-library.gyp