### PR TITLE
win: set _WIN32_WINNT to 0x0600

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -20,7 +20,7 @@
  */
 
 #ifndef _WIN32_WINNT
-# define _WIN32_WINNT   0x0502
+# define _WIN32_WINNT   0x0600
 #endif
 
 #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)


### PR DESCRIPTION
This updates the value to Windows Vista.

I agree with https://github.com/libuv/libuv/issues/1671#issuecomment-350009867, that we should drop this completely. I'd like to update it here and remove it on master.

Fixes: https://github.com/libuv/libuv/issues/1671