### PR TITLE
test: remove custom timeout for thread test on ppc

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -857,14 +857,7 @@ TASK_LIST_START
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (threadpool_queue_work_simple)
   TEST_ENTRY  (threadpool_queue_work_einval)
-#if defined(__PPC__) || defined(__PPC64__)  /* For linux PPC and AIX */
-  /* pthread_join takes a while, especially on AIX.
-   * Therefore being gratuitous with timeout.
-   */
-  TEST_ENTRY_CUSTOM (threadpool_multiple_event_loops, 0, 0, 120000)
-#else
   TEST_ENTRY  (threadpool_multiple_event_loops)
-#endif
   TEST_ENTRY  (threadpool_cancel_getaddrinfo)
   TEST_ENTRY  (threadpool_cancel_getnameinfo)
   TEST_ENTRY  (threadpool_cancel_work)


### PR DESCRIPTION
The two minute timeout should not be necessary anymore after commit
aeaff5f0 ("test: lower number of tasks in threadpool test".)

https://ci.nodejs.org/view/libuv/job/libuv-test-commit/639/