### PR TITLE
doc: mark Windows 7 as Tier 1 support

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -4,7 +4,7 @@
 |---|---|---|---|
 | GNU/Linux | Tier 1 | Linux >= 2.6.32 with glibc >= 2.12 | |
 | macOS | Tier 1 | macOS >= 10.7 | |
-| Windows | Tier 1 | Windows >= 8.1 | MSVC 2008 and later are supported |
+| Windows | Tier 1 | >= Windows 7 | MSVC 2008 and later are supported |
 | FreeBSD | Tier 1 | >= 9 (see note) | |
 | AIX | Tier 2 | >= 6 | Maintainers: @libuv/aix |
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |


### PR DESCRIPTION
Marks Windows 7 as Tier 1 support.

Windows 7 is in Tier 1 in [Node.js](https://github.com/nodejs/node/blob/master/BUILDING.md#supported-platforms-1) and we run CI on Win7 anyway.
