### PR TITLE
Add a UV_PROCESS_WINDOWS_SUSPENDED flag

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -958,7 +958,12 @@ enum uv_process_flags {
    * option is only meaningful on Windows systems. On Unix it is silently
    * ignored.
    */
-  UV_PROCESS_WINDOWS_HIDE = (1 << 4)
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+  /*
+   * Invoke the process in suspended state. The caller must un-suspend the
+   * the process by calling the undocumented NtResumeProcess() call.
+   */
+  UV_PROCESS_WINDOWS_SUSPENDED = (1 << 5)
 };
 
 /*

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -959,7 +959,8 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_SETGID |
                               UV_PROCESS_SETUID |
                               UV_PROCESS_WINDOWS_HIDE |
-                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
+                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
+                              UV_PROCESS_WINDOWS_SUSPENDED)));
 
   err = uv_utf8_to_utf16_alloc(options->file, &application);
   if (err)
@@ -1082,6 +1083,10 @@ int uv_spawn(uv_loop_t* loop,
      * breakaway.
      */
     process_flags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
+  }
+
+  if (options->flags & UV_PROCESS_WINDOWS_SUSPENDED) {
+    process_flags |= CREATE_SUSPENDED;
   }
 
   if (!CreateProcessW(application_path,


### PR DESCRIPTION
This is necessary to perform initializations, like moving to a job
group (btw, this requires using _DETACHED flag currently) before the
process has a chance to spawn children.