### PR TITLE
Add two process flags to allow proper job management

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -958,7 +958,24 @@ enum uv_process_flags {
    * option is only meaningful on Windows systems. On Unix it is silently
    * ignored.
    */
-  UV_PROCESS_WINDOWS_HIDE = (1 << 4)
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+  /*
+   * Invoke the process in suspended state. This is currently only implemented for
+   * Windows, though unix could imlement sending a SIGSTOP if needed.
+   * The purpose of this flag is to allow manipulations of the process before it has
+   * the opportunity to spawn children or exit. If used, the caller *must* un-suspend the
+   * the process by calling the undocumented NtResumeProcess() call in Windows.
+   */
+  UV_PROCESS_START_SUSPENDED = (1 << 5),
+  /*
+   * Internally, libuv may choose to manage a child process automatically in case
+   * this (parent) process terminates before the child. In Windows, this is done by
+   * moving the child immediately to a global/shared job object which may not be desirable
+   * if the caller wishes to move the child into a different job object in older versions
+   * (pre windows 8) where multiple job objects are not allowed. To retain current behavior,
+   * this flag is required to opt-out of any OS-specific management that may exist.
+   */
+  UV_PROCESS_NOMANAGE = (1 << 6)
 };
 
 /*

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -959,7 +959,9 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_SETGID |
                               UV_PROCESS_SETUID |
                               UV_PROCESS_WINDOWS_HIDE |
-                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
+                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
+                              UV_PROCESS_NOMANAGE |
+                              UV_PROCESS_START_SUSPENDED)));
 
   err = uv_utf8_to_utf16_alloc(options->file, &application);
   if (err)
@@ -1084,6 +1086,10 @@ int uv_spawn(uv_loop_t* loop,
     process_flags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
   }
 
+  if (options->flags & UV_PROCESS_START_SUSPENDED) {
+    process_flags |= CREATE_SUSPENDED;
+  }
+
   if (!CreateProcessW(application_path,
                      arguments,
                      NULL,
@@ -1107,7 +1113,7 @@ int uv_spawn(uv_loop_t* loop,
 
   /* If the process isn't spawned as detached, assign to the global job */
   /* object so windows will kill it when the parent process dies. */
-  if (!(options->flags & UV_PROCESS_DETACHED)) {
+  if (!(options->flags & UV_PROCESS_DETACHED) && !(options->flags & UV_PROCESS_NOMANAGE)) {
     uv_once(&uv_global_job_handle_init_guard_, uv__init_global_job_handle);
 
     if (!AssignProcessToJobObject(uv_global_job_handle_, info.hProcess)) {


### PR DESCRIPTION
UV_PROCESS_START_SUSPENDED is necessary on windows to move
a process before it has a chance to create children. It could be
generally useful to a caller who wants to query or manipulate the
process after creation, though it is currently only implemented for
windows.

UV_PROCESS_NOMANAGE deals with the one-off already in place for the
windows process code which adds a process to a global job object
whenever the _DETACHED flag is not specified. This current behavior
is undesirable in pre-windows-8 versions because once a child goes
into this global job it cannot be assigned to another, but using
the detached flag may not be the desired effect either.