### PR TITLE
unix: add UV_ERR() macro

### DIFF
--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -22,15 +22,13 @@
 #ifndef UV_ERRNO_H_
 #define UV_ERRNO_H_
 
+#include <errno.h>
 #ifndef _WIN32
-# include <errno.h>
 # if EDOM > 0
 #  define UV_ERR(x) (-(x))
 # else
 #  define UV_ERR(x) (x)
 # endif
-#else
-# define UV_ERR(x)  (x)
 #endif
 
 #define UV__EOF     (-4095)

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -23,12 +23,10 @@
 #define UV_ERRNO_H_
 
 #include <errno.h>
-#ifndef _WIN32
-# if EDOM > 0
-#  define UV__ERR(x) (-(x))
-# else
-#  define UV__ERR(x) (x)
-# endif
+#if EDOM > 0
+# define UV__ERR(x) (-(x))
+#else
+# define UV__ERR(x) (x)
 #endif
 
 #define UV__EOF     (-4095)

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -22,7 +22,16 @@
 #ifndef UV_ERRNO_H_
 #define UV_ERRNO_H_
 
-#include <errno.h>
+#ifndef _WIN32
+# include <errno.h>
+# if EDOM > 0
+#  define UV_ERR(x) (-(x))
+# else
+#  define UV_ERR(x) (x)
+# endif
+#else
+# define UV_ERR(x)  (x)
+#endif
 
 #define UV__EOF     (-4095)
 #define UV__UNKNOWN (-4094)
@@ -46,355 +55,355 @@
  * a fairly common practice for Windows programmers to redefine errno codes.
  */
 #if defined(E2BIG) && !defined(_WIN32)
-# define UV__E2BIG (-E2BIG)
+# define UV__E2BIG UV_ERR(E2BIG)
 #else
 # define UV__E2BIG (-4093)
 #endif
 
 #if defined(EACCES) && !defined(_WIN32)
-# define UV__EACCES (-EACCES)
+# define UV__EACCES UV_ERR(EACCES)
 #else
 # define UV__EACCES (-4092)
 #endif
 
 #if defined(EADDRINUSE) && !defined(_WIN32)
-# define UV__EADDRINUSE (-EADDRINUSE)
+# define UV__EADDRINUSE UV_ERR(EADDRINUSE)
 #else
 # define UV__EADDRINUSE (-4091)
 #endif
 
 #if defined(EADDRNOTAVAIL) && !defined(_WIN32)
-# define UV__EADDRNOTAVAIL (-EADDRNOTAVAIL)
+# define UV__EADDRNOTAVAIL UV_ERR(EADDRNOTAVAIL)
 #else
 # define UV__EADDRNOTAVAIL (-4090)
 #endif
 
 #if defined(EAFNOSUPPORT) && !defined(_WIN32)
-# define UV__EAFNOSUPPORT (-EAFNOSUPPORT)
+# define UV__EAFNOSUPPORT UV_ERR(EAFNOSUPPORT)
 #else
 # define UV__EAFNOSUPPORT (-4089)
 #endif
 
 #if defined(EAGAIN) && !defined(_WIN32)
-# define UV__EAGAIN (-EAGAIN)
+# define UV__EAGAIN UV_ERR(EAGAIN)
 #else
 # define UV__EAGAIN (-4088)
 #endif
 
 #if defined(EALREADY) && !defined(_WIN32)
-# define UV__EALREADY (-EALREADY)
+# define UV__EALREADY UV_ERR(EALREADY)
 #else
 # define UV__EALREADY (-4084)
 #endif
 
 #if defined(EBADF) && !defined(_WIN32)
-# define UV__EBADF (-EBADF)
+# define UV__EBADF UV_ERR(EBADF)
 #else
 # define UV__EBADF (-4083)
 #endif
 
 #if defined(EBUSY) && !defined(_WIN32)
-# define UV__EBUSY (-EBUSY)
+# define UV__EBUSY UV_ERR(EBUSY)
 #else
 # define UV__EBUSY (-4082)
 #endif
 
 #if defined(ECANCELED) && !defined(_WIN32)
-# define UV__ECANCELED (-ECANCELED)
+# define UV__ECANCELED UV_ERR(ECANCELED)
 #else
 # define UV__ECANCELED (-4081)
 #endif
 
 #if defined(ECHARSET) && !defined(_WIN32)
-# define UV__ECHARSET (-ECHARSET)
+# define UV__ECHARSET UV_ERR(ECHARSET)
 #else
 # define UV__ECHARSET (-4080)
 #endif
 
 #if defined(ECONNABORTED) && !defined(_WIN32)
-# define UV__ECONNABORTED (-ECONNABORTED)
+# define UV__ECONNABORTED UV_ERR(ECONNABORTED)
 #else
 # define UV__ECONNABORTED (-4079)
 #endif
 
 #if defined(ECONNREFUSED) && !defined(_WIN32)
-# define UV__ECONNREFUSED (-ECONNREFUSED)
+# define UV__ECONNREFUSED UV_ERR(ECONNREFUSED)
 #else
 # define UV__ECONNREFUSED (-4078)
 #endif
 
 #if defined(ECONNRESET) && !defined(_WIN32)
-# define UV__ECONNRESET (-ECONNRESET)
+# define UV__ECONNRESET UV_ERR(ECONNRESET)
 #else
 # define UV__ECONNRESET (-4077)
 #endif
 
 #if defined(EDESTADDRREQ) && !defined(_WIN32)
-# define UV__EDESTADDRREQ (-EDESTADDRREQ)
+# define UV__EDESTADDRREQ UV_ERR(EDESTADDRREQ)
 #else
 # define UV__EDESTADDRREQ (-4076)
 #endif
 
 #if defined(EEXIST) && !defined(_WIN32)
-# define UV__EEXIST (-EEXIST)
+# define UV__EEXIST UV_ERR(EEXIST)
 #else
 # define UV__EEXIST (-4075)
 #endif
 
 #if defined(EFAULT) && !defined(_WIN32)
-# define UV__EFAULT (-EFAULT)
+# define UV__EFAULT UV_ERR(EFAULT)
 #else
 # define UV__EFAULT (-4074)
 #endif
 
 #if defined(EHOSTUNREACH) && !defined(_WIN32)
-# define UV__EHOSTUNREACH (-EHOSTUNREACH)
+# define UV__EHOSTUNREACH UV_ERR(EHOSTUNREACH)
 #else
 # define UV__EHOSTUNREACH (-4073)
 #endif
 
 #if defined(EINTR) && !defined(_WIN32)
-# define UV__EINTR (-EINTR)
+# define UV__EINTR UV_ERR(EINTR)
 #else
 # define UV__EINTR (-4072)
 #endif
 
 #if defined(EINVAL) && !defined(_WIN32)
-# define UV__EINVAL (-EINVAL)
+# define UV__EINVAL UV_ERR(EINVAL)
 #else
 # define UV__EINVAL (-4071)
 #endif
 
 #if defined(EIO) && !defined(_WIN32)
-# define UV__EIO (-EIO)
+# define UV__EIO UV_ERR(EIO)
 #else
 # define UV__EIO (-4070)
 #endif
 
 #if defined(EISCONN) && !defined(_WIN32)
-# define UV__EISCONN (-EISCONN)
+# define UV__EISCONN UV_ERR(EISCONN)
 #else
 # define UV__EISCONN (-4069)
 #endif
 
 #if defined(EISDIR) && !defined(_WIN32)
-# define UV__EISDIR (-EISDIR)
+# define UV__EISDIR UV_ERR(EISDIR)
 #else
 # define UV__EISDIR (-4068)
 #endif
 
 #if defined(ELOOP) && !defined(_WIN32)
-# define UV__ELOOP (-ELOOP)
+# define UV__ELOOP UV_ERR(ELOOP)
 #else
 # define UV__ELOOP (-4067)
 #endif
 
 #if defined(EMFILE) && !defined(_WIN32)
-# define UV__EMFILE (-EMFILE)
+# define UV__EMFILE UV_ERR(EMFILE)
 #else
 # define UV__EMFILE (-4066)
 #endif
 
 #if defined(EMSGSIZE) && !defined(_WIN32)
-# define UV__EMSGSIZE (-EMSGSIZE)
+# define UV__EMSGSIZE UV_ERR(EMSGSIZE)
 #else
 # define UV__EMSGSIZE (-4065)
 #endif
 
 #if defined(ENAMETOOLONG) && !defined(_WIN32)
-# define UV__ENAMETOOLONG (-ENAMETOOLONG)
+# define UV__ENAMETOOLONG UV_ERR(ENAMETOOLONG)
 #else
 # define UV__ENAMETOOLONG (-4064)
 #endif
 
 #if defined(ENETDOWN) && !defined(_WIN32)
-# define UV__ENETDOWN (-ENETDOWN)
+# define UV__ENETDOWN UV_ERR(ENETDOWN)
 #else
 # define UV__ENETDOWN (-4063)
 #endif
 
 #if defined(ENETUNREACH) && !defined(_WIN32)
-# define UV__ENETUNREACH (-ENETUNREACH)
+# define UV__ENETUNREACH UV_ERR(ENETUNREACH)
 #else
 # define UV__ENETUNREACH (-4062)
 #endif
 
 #if defined(ENFILE) && !defined(_WIN32)
-# define UV__ENFILE (-ENFILE)
+# define UV__ENFILE UV_ERR(ENFILE)
 #else
 # define UV__ENFILE (-4061)
 #endif
 
 #if defined(ENOBUFS) && !defined(_WIN32)
-# define UV__ENOBUFS (-ENOBUFS)
+# define UV__ENOBUFS UV_ERR(ENOBUFS)
 #else
 # define UV__ENOBUFS (-4060)
 #endif
 
 #if defined(ENODEV) && !defined(_WIN32)
-# define UV__ENODEV (-ENODEV)
+# define UV__ENODEV UV_ERR(ENODEV)
 #else
 # define UV__ENODEV (-4059)
 #endif
 
 #if defined(ENOENT) && !defined(_WIN32)
-# define UV__ENOENT (-ENOENT)
+# define UV__ENOENT UV_ERR(ENOENT)
 #else
 # define UV__ENOENT (-4058)
 #endif
 
 #if defined(ENOMEM) && !defined(_WIN32)
-# define UV__ENOMEM (-ENOMEM)
+# define UV__ENOMEM UV_ERR(ENOMEM)
 #else
 # define UV__ENOMEM (-4057)
 #endif
 
 #if defined(ENONET) && !defined(_WIN32)
-# define UV__ENONET (-ENONET)
+# define UV__ENONET UV_ERR(ENONET)
 #else
 # define UV__ENONET (-4056)
 #endif
 
 #if defined(ENOSPC) && !defined(_WIN32)
-# define UV__ENOSPC (-ENOSPC)
+# define UV__ENOSPC UV_ERR(ENOSPC)
 #else
 # define UV__ENOSPC (-4055)
 #endif
 
 #if defined(ENOSYS) && !defined(_WIN32)
-# define UV__ENOSYS (-ENOSYS)
+# define UV__ENOSYS UV_ERR(ENOSYS)
 #else
 # define UV__ENOSYS (-4054)
 #endif
 
 #if defined(ENOTCONN) && !defined(_WIN32)
-# define UV__ENOTCONN (-ENOTCONN)
+# define UV__ENOTCONN UV_ERR(ENOTCONN)
 #else
 # define UV__ENOTCONN (-4053)
 #endif
 
 #if defined(ENOTDIR) && !defined(_WIN32)
-# define UV__ENOTDIR (-ENOTDIR)
+# define UV__ENOTDIR UV_ERR(ENOTDIR)
 #else
 # define UV__ENOTDIR (-4052)
 #endif
 
 #if defined(ENOTEMPTY) && !defined(_WIN32)
-# define UV__ENOTEMPTY (-ENOTEMPTY)
+# define UV__ENOTEMPTY UV_ERR(ENOTEMPTY)
 #else
 # define UV__ENOTEMPTY (-4051)
 #endif
 
 #if defined(ENOTSOCK) && !defined(_WIN32)
-# define UV__ENOTSOCK (-ENOTSOCK)
+# define UV__ENOTSOCK UV_ERR(ENOTSOCK)
 #else
 # define UV__ENOTSOCK (-4050)
 #endif
 
 #if defined(ENOTSUP) && !defined(_WIN32)
-# define UV__ENOTSUP (-ENOTSUP)
+# define UV__ENOTSUP UV_ERR(ENOTSUP)
 #else
 # define UV__ENOTSUP (-4049)
 #endif
 
 #if defined(EPERM) && !defined(_WIN32)
-# define UV__EPERM (-EPERM)
+# define UV__EPERM UV_ERR(EPERM)
 #else
 # define UV__EPERM (-4048)
 #endif
 
 #if defined(EPIPE) && !defined(_WIN32)
-# define UV__EPIPE (-EPIPE)
+# define UV__EPIPE UV_ERR(EPIPE)
 #else
 # define UV__EPIPE (-4047)
 #endif
 
 #if defined(EPROTO) && !defined(_WIN32)
-# define UV__EPROTO (-EPROTO)
+# define UV__EPROTO UV_ERR(EPROTO)
 #else
-# define UV__EPROTO (-4046)
+# define UV__EPROTO UV_ERR(4046)
 #endif
 
 #if defined(EPROTONOSUPPORT) && !defined(_WIN32)
-# define UV__EPROTONOSUPPORT (-EPROTONOSUPPORT)
+# define UV__EPROTONOSUPPORT UV_ERR(EPROTONOSUPPORT)
 #else
 # define UV__EPROTONOSUPPORT (-4045)
 #endif
 
 #if defined(EPROTOTYPE) && !defined(_WIN32)
-# define UV__EPROTOTYPE (-EPROTOTYPE)
+# define UV__EPROTOTYPE UV_ERR(EPROTOTYPE)
 #else
 # define UV__EPROTOTYPE (-4044)
 #endif
 
 #if defined(EROFS) && !defined(_WIN32)
-# define UV__EROFS (-EROFS)
+# define UV__EROFS UV_ERR(EROFS)
 #else
 # define UV__EROFS (-4043)
 #endif
 
 #if defined(ESHUTDOWN) && !defined(_WIN32)
-# define UV__ESHUTDOWN (-ESHUTDOWN)
+# define UV__ESHUTDOWN UV_ERR(ESHUTDOWN)
 #else
 # define UV__ESHUTDOWN (-4042)
 #endif
 
 #if defined(ESPIPE) && !defined(_WIN32)
-# define UV__ESPIPE (-ESPIPE)
+# define UV__ESPIPE UV_ERR(ESPIPE)
 #else
 # define UV__ESPIPE (-4041)
 #endif
 
 #if defined(ESRCH) && !defined(_WIN32)
-# define UV__ESRCH (-ESRCH)
+# define UV__ESRCH UV_ERR(ESRCH)
 #else
 # define UV__ESRCH (-4040)
 #endif
 
 #if defined(ETIMEDOUT) && !defined(_WIN32)
-# define UV__ETIMEDOUT (-ETIMEDOUT)
+# define UV__ETIMEDOUT UV_ERR(ETIMEDOUT)
 #else
 # define UV__ETIMEDOUT (-4039)
 #endif
 
 #if defined(ETXTBSY) && !defined(_WIN32)
-# define UV__ETXTBSY (-ETXTBSY)
+# define UV__ETXTBSY UV_ERR(ETXTBSY)
 #else
 # define UV__ETXTBSY (-4038)
 #endif
 
 #if defined(EXDEV) && !defined(_WIN32)
-# define UV__EXDEV (-EXDEV)
+# define UV__EXDEV UV_ERR(EXDEV)
 #else
 # define UV__EXDEV (-4037)
 #endif
 
 #if defined(EFBIG) && !defined(_WIN32)
-# define UV__EFBIG (-EFBIG)
+# define UV__EFBIG UV_ERR(EFBIG)
 #else
 # define UV__EFBIG (-4036)
 #endif
 
 #if defined(ENOPROTOOPT) && !defined(_WIN32)
-# define UV__ENOPROTOOPT (-ENOPROTOOPT)
+# define UV__ENOPROTOOPT UV_ERR(ENOPROTOOPT)
 #else
 # define UV__ENOPROTOOPT (-4035)
 #endif
 
 #if defined(ERANGE) && !defined(_WIN32)
-# define UV__ERANGE (-ERANGE)
+# define UV__ERANGE UV_ERR(ERANGE)
 #else
 # define UV__ERANGE (-4034)
 #endif
 
 #if defined(ENXIO) && !defined(_WIN32)
-# define UV__ENXIO (-ENXIO)
+# define UV__ENXIO UV_ERR(ENXIO)
 #else
 # define UV__ENXIO (-4033)
 #endif
 
 #if defined(EMLINK) && !defined(_WIN32)
-# define UV__EMLINK (-EMLINK)
+# define UV__EMLINK UV_ERR(EMLINK)
 #else
 # define UV__EMLINK (-4032)
 #endif
@@ -404,7 +413,7 @@
  * icky to hard-code it.
  */
 #if defined(EHOSTDOWN) && !defined(_WIN32)
-# define UV__EHOSTDOWN (-EHOSTDOWN)
+# define UV__EHOSTDOWN UV_ERR(EHOSTDOWN)
 #elif defined(__APPLE__) || \
       defined(__DragonFly__) || \
       defined(__FreeBSD__) || \
@@ -417,15 +426,16 @@
 #endif
 
 #if defined(EREMOTEIO) && !defined(_WIN32)
-# define UV__EREMOTEIO (-EREMOTEIO)
+# define UV__EREMOTEIO UV_ERR(EREMOTEIO)
 #else
 # define UV__EREMOTEIO (-4030)
 #endif
 
 #if defined(ENOTTY) && !defined(_WIN32)
-# define UV__ENOTTY (-ENOTTY)
+# define UV__ENOTTY UV_ERR(ENOTTY)
 #else
 # define UV__ENOTTY (-4029)
 #endif
+
 
 #endif /* UV_ERRNO_H_ */

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -25,9 +25,9 @@
 #include <errno.h>
 #ifndef _WIN32
 # if EDOM > 0
-#  define UV_ERR(x) (-(x))
+#  define UV__ERR(x) (-(x))
 # else
-#  define UV_ERR(x) (x)
+#  define UV__ERR(x) (x)
 # endif
 #endif
 
@@ -53,355 +53,355 @@
  * a fairly common practice for Windows programmers to redefine errno codes.
  */
 #if defined(E2BIG) && !defined(_WIN32)
-# define UV__E2BIG UV_ERR(E2BIG)
+# define UV__E2BIG UV__ERR(E2BIG)
 #else
 # define UV__E2BIG (-4093)
 #endif
 
 #if defined(EACCES) && !defined(_WIN32)
-# define UV__EACCES UV_ERR(EACCES)
+# define UV__EACCES UV__ERR(EACCES)
 #else
 # define UV__EACCES (-4092)
 #endif
 
 #if defined(EADDRINUSE) && !defined(_WIN32)
-# define UV__EADDRINUSE UV_ERR(EADDRINUSE)
+# define UV__EADDRINUSE UV__ERR(EADDRINUSE)
 #else
 # define UV__EADDRINUSE (-4091)
 #endif
 
 #if defined(EADDRNOTAVAIL) && !defined(_WIN32)
-# define UV__EADDRNOTAVAIL UV_ERR(EADDRNOTAVAIL)
+# define UV__EADDRNOTAVAIL UV__ERR(EADDRNOTAVAIL)
 #else
 # define UV__EADDRNOTAVAIL (-4090)
 #endif
 
 #if defined(EAFNOSUPPORT) && !defined(_WIN32)
-# define UV__EAFNOSUPPORT UV_ERR(EAFNOSUPPORT)
+# define UV__EAFNOSUPPORT UV__ERR(EAFNOSUPPORT)
 #else
 # define UV__EAFNOSUPPORT (-4089)
 #endif
 
 #if defined(EAGAIN) && !defined(_WIN32)
-# define UV__EAGAIN UV_ERR(EAGAIN)
+# define UV__EAGAIN UV__ERR(EAGAIN)
 #else
 # define UV__EAGAIN (-4088)
 #endif
 
 #if defined(EALREADY) && !defined(_WIN32)
-# define UV__EALREADY UV_ERR(EALREADY)
+# define UV__EALREADY UV__ERR(EALREADY)
 #else
 # define UV__EALREADY (-4084)
 #endif
 
 #if defined(EBADF) && !defined(_WIN32)
-# define UV__EBADF UV_ERR(EBADF)
+# define UV__EBADF UV__ERR(EBADF)
 #else
 # define UV__EBADF (-4083)
 #endif
 
 #if defined(EBUSY) && !defined(_WIN32)
-# define UV__EBUSY UV_ERR(EBUSY)
+# define UV__EBUSY UV__ERR(EBUSY)
 #else
 # define UV__EBUSY (-4082)
 #endif
 
 #if defined(ECANCELED) && !defined(_WIN32)
-# define UV__ECANCELED UV_ERR(ECANCELED)
+# define UV__ECANCELED UV__ERR(ECANCELED)
 #else
 # define UV__ECANCELED (-4081)
 #endif
 
 #if defined(ECHARSET) && !defined(_WIN32)
-# define UV__ECHARSET UV_ERR(ECHARSET)
+# define UV__ECHARSET UV__ERR(ECHARSET)
 #else
 # define UV__ECHARSET (-4080)
 #endif
 
 #if defined(ECONNABORTED) && !defined(_WIN32)
-# define UV__ECONNABORTED UV_ERR(ECONNABORTED)
+# define UV__ECONNABORTED UV__ERR(ECONNABORTED)
 #else
 # define UV__ECONNABORTED (-4079)
 #endif
 
 #if defined(ECONNREFUSED) && !defined(_WIN32)
-# define UV__ECONNREFUSED UV_ERR(ECONNREFUSED)
+# define UV__ECONNREFUSED UV__ERR(ECONNREFUSED)
 #else
 # define UV__ECONNREFUSED (-4078)
 #endif
 
 #if defined(ECONNRESET) && !defined(_WIN32)
-# define UV__ECONNRESET UV_ERR(ECONNRESET)
+# define UV__ECONNRESET UV__ERR(ECONNRESET)
 #else
 # define UV__ECONNRESET (-4077)
 #endif
 
 #if defined(EDESTADDRREQ) && !defined(_WIN32)
-# define UV__EDESTADDRREQ UV_ERR(EDESTADDRREQ)
+# define UV__EDESTADDRREQ UV__ERR(EDESTADDRREQ)
 #else
 # define UV__EDESTADDRREQ (-4076)
 #endif
 
 #if defined(EEXIST) && !defined(_WIN32)
-# define UV__EEXIST UV_ERR(EEXIST)
+# define UV__EEXIST UV__ERR(EEXIST)
 #else
 # define UV__EEXIST (-4075)
 #endif
 
 #if defined(EFAULT) && !defined(_WIN32)
-# define UV__EFAULT UV_ERR(EFAULT)
+# define UV__EFAULT UV__ERR(EFAULT)
 #else
 # define UV__EFAULT (-4074)
 #endif
 
 #if defined(EHOSTUNREACH) && !defined(_WIN32)
-# define UV__EHOSTUNREACH UV_ERR(EHOSTUNREACH)
+# define UV__EHOSTUNREACH UV__ERR(EHOSTUNREACH)
 #else
 # define UV__EHOSTUNREACH (-4073)
 #endif
 
 #if defined(EINTR) && !defined(_WIN32)
-# define UV__EINTR UV_ERR(EINTR)
+# define UV__EINTR UV__ERR(EINTR)
 #else
 # define UV__EINTR (-4072)
 #endif
 
 #if defined(EINVAL) && !defined(_WIN32)
-# define UV__EINVAL UV_ERR(EINVAL)
+# define UV__EINVAL UV__ERR(EINVAL)
 #else
 # define UV__EINVAL (-4071)
 #endif
 
 #if defined(EIO) && !defined(_WIN32)
-# define UV__EIO UV_ERR(EIO)
+# define UV__EIO UV__ERR(EIO)
 #else
 # define UV__EIO (-4070)
 #endif
 
 #if defined(EISCONN) && !defined(_WIN32)
-# define UV__EISCONN UV_ERR(EISCONN)
+# define UV__EISCONN UV__ERR(EISCONN)
 #else
 # define UV__EISCONN (-4069)
 #endif
 
 #if defined(EISDIR) && !defined(_WIN32)
-# define UV__EISDIR UV_ERR(EISDIR)
+# define UV__EISDIR UV__ERR(EISDIR)
 #else
 # define UV__EISDIR (-4068)
 #endif
 
 #if defined(ELOOP) && !defined(_WIN32)
-# define UV__ELOOP UV_ERR(ELOOP)
+# define UV__ELOOP UV__ERR(ELOOP)
 #else
 # define UV__ELOOP (-4067)
 #endif
 
 #if defined(EMFILE) && !defined(_WIN32)
-# define UV__EMFILE UV_ERR(EMFILE)
+# define UV__EMFILE UV__ERR(EMFILE)
 #else
 # define UV__EMFILE (-4066)
 #endif
 
 #if defined(EMSGSIZE) && !defined(_WIN32)
-# define UV__EMSGSIZE UV_ERR(EMSGSIZE)
+# define UV__EMSGSIZE UV__ERR(EMSGSIZE)
 #else
 # define UV__EMSGSIZE (-4065)
 #endif
 
 #if defined(ENAMETOOLONG) && !defined(_WIN32)
-# define UV__ENAMETOOLONG UV_ERR(ENAMETOOLONG)
+# define UV__ENAMETOOLONG UV__ERR(ENAMETOOLONG)
 #else
 # define UV__ENAMETOOLONG (-4064)
 #endif
 
 #if defined(ENETDOWN) && !defined(_WIN32)
-# define UV__ENETDOWN UV_ERR(ENETDOWN)
+# define UV__ENETDOWN UV__ERR(ENETDOWN)
 #else
 # define UV__ENETDOWN (-4063)
 #endif
 
 #if defined(ENETUNREACH) && !defined(_WIN32)
-# define UV__ENETUNREACH UV_ERR(ENETUNREACH)
+# define UV__ENETUNREACH UV__ERR(ENETUNREACH)
 #else
 # define UV__ENETUNREACH (-4062)
 #endif
 
 #if defined(ENFILE) && !defined(_WIN32)
-# define UV__ENFILE UV_ERR(ENFILE)
+# define UV__ENFILE UV__ERR(ENFILE)
 #else
 # define UV__ENFILE (-4061)
 #endif
 
 #if defined(ENOBUFS) && !defined(_WIN32)
-# define UV__ENOBUFS UV_ERR(ENOBUFS)
+# define UV__ENOBUFS UV__ERR(ENOBUFS)
 #else
 # define UV__ENOBUFS (-4060)
 #endif
 
 #if defined(ENODEV) && !defined(_WIN32)
-# define UV__ENODEV UV_ERR(ENODEV)
+# define UV__ENODEV UV__ERR(ENODEV)
 #else
 # define UV__ENODEV (-4059)
 #endif
 
 #if defined(ENOENT) && !defined(_WIN32)
-# define UV__ENOENT UV_ERR(ENOENT)
+# define UV__ENOENT UV__ERR(ENOENT)
 #else
 # define UV__ENOENT (-4058)
 #endif
 
 #if defined(ENOMEM) && !defined(_WIN32)
-# define UV__ENOMEM UV_ERR(ENOMEM)
+# define UV__ENOMEM UV__ERR(ENOMEM)
 #else
 # define UV__ENOMEM (-4057)
 #endif
 
 #if defined(ENONET) && !defined(_WIN32)
-# define UV__ENONET UV_ERR(ENONET)
+# define UV__ENONET UV__ERR(ENONET)
 #else
 # define UV__ENONET (-4056)
 #endif
 
 #if defined(ENOSPC) && !defined(_WIN32)
-# define UV__ENOSPC UV_ERR(ENOSPC)
+# define UV__ENOSPC UV__ERR(ENOSPC)
 #else
 # define UV__ENOSPC (-4055)
 #endif
 
 #if defined(ENOSYS) && !defined(_WIN32)
-# define UV__ENOSYS UV_ERR(ENOSYS)
+# define UV__ENOSYS UV__ERR(ENOSYS)
 #else
 # define UV__ENOSYS (-4054)
 #endif
 
 #if defined(ENOTCONN) && !defined(_WIN32)
-# define UV__ENOTCONN UV_ERR(ENOTCONN)
+# define UV__ENOTCONN UV__ERR(ENOTCONN)
 #else
 # define UV__ENOTCONN (-4053)
 #endif
 
 #if defined(ENOTDIR) && !defined(_WIN32)
-# define UV__ENOTDIR UV_ERR(ENOTDIR)
+# define UV__ENOTDIR UV__ERR(ENOTDIR)
 #else
 # define UV__ENOTDIR (-4052)
 #endif
 
 #if defined(ENOTEMPTY) && !defined(_WIN32)
-# define UV__ENOTEMPTY UV_ERR(ENOTEMPTY)
+# define UV__ENOTEMPTY UV__ERR(ENOTEMPTY)
 #else
 # define UV__ENOTEMPTY (-4051)
 #endif
 
 #if defined(ENOTSOCK) && !defined(_WIN32)
-# define UV__ENOTSOCK UV_ERR(ENOTSOCK)
+# define UV__ENOTSOCK UV__ERR(ENOTSOCK)
 #else
 # define UV__ENOTSOCK (-4050)
 #endif
 
 #if defined(ENOTSUP) && !defined(_WIN32)
-# define UV__ENOTSUP UV_ERR(ENOTSUP)
+# define UV__ENOTSUP UV__ERR(ENOTSUP)
 #else
 # define UV__ENOTSUP (-4049)
 #endif
 
 #if defined(EPERM) && !defined(_WIN32)
-# define UV__EPERM UV_ERR(EPERM)
+# define UV__EPERM UV__ERR(EPERM)
 #else
 # define UV__EPERM (-4048)
 #endif
 
 #if defined(EPIPE) && !defined(_WIN32)
-# define UV__EPIPE UV_ERR(EPIPE)
+# define UV__EPIPE UV__ERR(EPIPE)
 #else
 # define UV__EPIPE (-4047)
 #endif
 
 #if defined(EPROTO) && !defined(_WIN32)
-# define UV__EPROTO UV_ERR(EPROTO)
+# define UV__EPROTO UV__ERR(EPROTO)
 #else
-# define UV__EPROTO UV_ERR(4046)
+# define UV__EPROTO UV__ERR(4046)
 #endif
 
 #if defined(EPROTONOSUPPORT) && !defined(_WIN32)
-# define UV__EPROTONOSUPPORT UV_ERR(EPROTONOSUPPORT)
+# define UV__EPROTONOSUPPORT UV__ERR(EPROTONOSUPPORT)
 #else
 # define UV__EPROTONOSUPPORT (-4045)
 #endif
 
 #if defined(EPROTOTYPE) && !defined(_WIN32)
-# define UV__EPROTOTYPE UV_ERR(EPROTOTYPE)
+# define UV__EPROTOTYPE UV__ERR(EPROTOTYPE)
 #else
 # define UV__EPROTOTYPE (-4044)
 #endif
 
 #if defined(EROFS) && !defined(_WIN32)
-# define UV__EROFS UV_ERR(EROFS)
+# define UV__EROFS UV__ERR(EROFS)
 #else
 # define UV__EROFS (-4043)
 #endif
 
 #if defined(ESHUTDOWN) && !defined(_WIN32)
-# define UV__ESHUTDOWN UV_ERR(ESHUTDOWN)
+# define UV__ESHUTDOWN UV__ERR(ESHUTDOWN)
 #else
 # define UV__ESHUTDOWN (-4042)
 #endif
 
 #if defined(ESPIPE) && !defined(_WIN32)
-# define UV__ESPIPE UV_ERR(ESPIPE)
+# define UV__ESPIPE UV__ERR(ESPIPE)
 #else
 # define UV__ESPIPE (-4041)
 #endif
 
 #if defined(ESRCH) && !defined(_WIN32)
-# define UV__ESRCH UV_ERR(ESRCH)
+# define UV__ESRCH UV__ERR(ESRCH)
 #else
 # define UV__ESRCH (-4040)
 #endif
 
 #if defined(ETIMEDOUT) && !defined(_WIN32)
-# define UV__ETIMEDOUT UV_ERR(ETIMEDOUT)
+# define UV__ETIMEDOUT UV__ERR(ETIMEDOUT)
 #else
 # define UV__ETIMEDOUT (-4039)
 #endif
 
 #if defined(ETXTBSY) && !defined(_WIN32)
-# define UV__ETXTBSY UV_ERR(ETXTBSY)
+# define UV__ETXTBSY UV__ERR(ETXTBSY)
 #else
 # define UV__ETXTBSY (-4038)
 #endif
 
 #if defined(EXDEV) && !defined(_WIN32)
-# define UV__EXDEV UV_ERR(EXDEV)
+# define UV__EXDEV UV__ERR(EXDEV)
 #else
 # define UV__EXDEV (-4037)
 #endif
 
 #if defined(EFBIG) && !defined(_WIN32)
-# define UV__EFBIG UV_ERR(EFBIG)
+# define UV__EFBIG UV__ERR(EFBIG)
 #else
 # define UV__EFBIG (-4036)
 #endif
 
 #if defined(ENOPROTOOPT) && !defined(_WIN32)
-# define UV__ENOPROTOOPT UV_ERR(ENOPROTOOPT)
+# define UV__ENOPROTOOPT UV__ERR(ENOPROTOOPT)
 #else
 # define UV__ENOPROTOOPT (-4035)
 #endif
 
 #if defined(ERANGE) && !defined(_WIN32)
-# define UV__ERANGE UV_ERR(ERANGE)
+# define UV__ERANGE UV__ERR(ERANGE)
 #else
 # define UV__ERANGE (-4034)
 #endif
 
 #if defined(ENXIO) && !defined(_WIN32)
-# define UV__ENXIO UV_ERR(ENXIO)
+# define UV__ENXIO UV__ERR(ENXIO)
 #else
 # define UV__ENXIO (-4033)
 #endif
 
 #if defined(EMLINK) && !defined(_WIN32)
-# define UV__EMLINK UV_ERR(EMLINK)
+# define UV__EMLINK UV__ERR(EMLINK)
 #else
 # define UV__EMLINK (-4032)
 #endif
@@ -411,7 +411,7 @@
  * icky to hard-code it.
  */
 #if defined(EHOSTDOWN) && !defined(_WIN32)
-# define UV__EHOSTDOWN UV_ERR(EHOSTDOWN)
+# define UV__EHOSTDOWN UV__ERR(EHOSTDOWN)
 #elif defined(__APPLE__) || \
       defined(__DragonFly__) || \
       defined(__FreeBSD__) || \
@@ -424,13 +424,13 @@
 #endif
 
 #if defined(EREMOTEIO) && !defined(_WIN32)
-# define UV__EREMOTEIO UV_ERR(EREMOTEIO)
+# define UV__EREMOTEIO UV__ERR(EREMOTEIO)
 #else
 # define UV__EREMOTEIO (-4030)
 #endif
 
 #if defined(ENOTTY) && !defined(_WIN32)
-# define UV__ENOTTY UV_ERR(ENOTTY)
+# define UV__ENOTTY UV__ERR(ENOTTY)
 #else
 # define UV__ENOTTY (-4029)
 #endif

--- a/include/uv.h
+++ b/include/uv.h
@@ -1559,6 +1559,7 @@ UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
 #undef UV_SIGNAL_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_PLATFORM_FIELDS
+#undef UV_ERR
 
 #ifdef __cplusplus
 }

--- a/include/uv.h
+++ b/include/uv.h
@@ -1559,7 +1559,7 @@ UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
 #undef UV_SIGNAL_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_PLATFORM_FIELDS
-#undef UV_ERR
+#undef UV__ERR
 
 #ifdef __cplusplus
 }

--- a/src/unix/aix-common.c
+++ b/src/unix/aix-common.c
@@ -83,12 +83,12 @@ int uv_exepath(char* buffer, size_t* size) {
   struct procsinfo pi;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   pi.pi_pid = getpid();
   res = getargs(&pi, sizeof(pi), args, sizeof(args));
   if (res < 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /*
    * Possibilities for args:
@@ -101,7 +101,7 @@ int uv_exepath(char* buffer, size_t* size) {
   /* Case i) and ii) absolute or relative paths */
   if (strchr(args, '/') != NULL) {
     if (realpath(args, abspath) != abspath)
-      return -errno;
+      return UV_ERR(errno);
 
     abspath_size = strlen(abspath);
 
@@ -121,11 +121,11 @@ int uv_exepath(char* buffer, size_t* size) {
     char *path = getenv("PATH");
 
     if (path == NULL)
-      return -EINVAL;
+      return UV_EINVAL;
 
     clonedpath = uv__strdup(path);
     if (clonedpath == NULL)
-      return -ENOMEM;
+      return UV_ENOMEM;
 
     token = strtok(clonedpath, ":");
     while (token != NULL) {
@@ -151,7 +151,7 @@ int uv_exepath(char* buffer, size_t* size) {
     uv__free(clonedpath);
 
     /* Out of tokens (path entries), and no match found */
-    return -EINVAL;
+    return UV_EINVAL;
   }
 }
 
@@ -177,19 +177,19 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   *count = 0;
 
   if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP))) {
-    return -errno;
+    return UV_ERR(errno);
   }
 
   if (ioctl(sockfd, SIOCGSIZIFCONF, &size) == -1) {
     uv__close(sockfd);
-    return -errno;
+    return UV_ERR(errno);
   }
 
   ifc.ifc_req = (struct ifreq*)uv__malloc(size);
   ifc.ifc_len = size;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     uv__close(sockfd);
-    return -errno;
+    return UV_ERR(errno);
   }
 
 #define ADDR_SIZE(p) MAX((p).sa_len, sizeof(p))
@@ -208,7 +208,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return -errno;
+      return UV_ERR(errno);
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
@@ -221,7 +221,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   *addresses = uv__malloc(*count * sizeof(uv_interface_address_t));
   if (!(*addresses)) {
     uv__close(sockfd);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
   address = *addresses;
 
@@ -240,7 +240,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return -ENOSYS;
+      return UV_ENOSYS;
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
@@ -260,7 +260,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
 
     if (ioctl(sockfd, SIOCGIFNETMASK, p) == -1) {
       uv__close(sockfd);
-      return -ENOSYS;
+      return UV_ENOSYS;
     }
 
     if (inet6)

--- a/src/unix/aix-common.c
+++ b/src/unix/aix-common.c
@@ -101,7 +101,7 @@ int uv_exepath(char* buffer, size_t* size) {
   /* Case i) and ii) absolute or relative paths */
   if (strchr(args, '/') != NULL) {
     if (realpath(args, abspath) != abspath)
-      return UV_ERR(errno);
+      return UV__ERR(errno);
 
     abspath_size = strlen(abspath);
 
@@ -177,19 +177,19 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   *count = 0;
 
   if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP))) {
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   if (ioctl(sockfd, SIOCGSIZIFCONF, &size) == -1) {
     uv__close(sockfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   ifc.ifc_req = (struct ifreq*)uv__malloc(size);
   ifc.ifc_len = size;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     uv__close(sockfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
 #define ADDR_SIZE(p) MAX((p).sa_len, sizeof(p))
@@ -208,7 +208,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -119,7 +119,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   pc.fd = fd;
 
   if (pollset_ctl(loop->backend_fd, &pc, 1))
-    return -errno;
+    return UV_ERR(errno);
 
   pc.cmd = PS_DELETE;
   if (pollset_ctl(loop->backend_fd, &pc, 1))
@@ -409,22 +409,22 @@ static int uv__is_ahafs_mounted(void){
 
   p = uv__malloc(siz);
   if (p == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   /* Retrieve all mounted filesystems */
   rv = mntctl(MCTL_QUERY, siz, (char*)p);
   if (rv < 0)
-    return -errno;
+    return UV_ERR(errno);
   if (rv == 0) {
     /* buffer was not large enough, reallocate to correct size */
     siz = *(int*)p;
     uv__free(p);
     p = uv__malloc(siz);
     if (p == NULL)
-      return -errno;
+      return UV_ERR(errno);
     rv = mntctl(MCTL_QUERY, siz, (char*)p);
     if (rv < 0)
-      return -errno;
+      return UV_ERR(errno);
   }
 
   /* Look for dev in filesystems mount info */
@@ -495,7 +495,7 @@ static int uv__make_subdirs_p(const char *filename) {
   rc = uv__makedir_p(cmd);
 
   if (rc == -1 && errno != EEXIST){
-    return -errno;
+    return UV_ERR(errno);
   }
 
   return rc;
@@ -522,7 +522,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
     sprintf(mon_file, "/aha/fs/modFile.monFactory");
 
   if ((strlen(mon_file) + strlen(filename) + 5) > PATH_MAX)
-    return -ENAMETOOLONG;
+    return UV_ENAMETOOLONG;
 
   /* Make the necessary subdirectories for the monitor file */
   rc = uv__make_subdirs_p(filename);
@@ -537,7 +537,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
   /* Open the monitor file, creating it if necessary */
   *fd = open(mon_file, O_CREAT|O_RDWR);
   if (*fd < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   /* Write out the monitoring specifications.
    * In this case, we are monitoring for a state change event type
@@ -558,7 +558,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
 
   rc = write(*fd, mon_file_write_string, strlen(mon_file_write_string)+1);
   if (rc < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -716,7 +716,7 @@ int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle) {
   uv__handle_init(loop, (uv_handle_t*)handle, UV_FS_EVENT);
   return 0;
 #else
-  return -ENOSYS;
+  return UV_ENOSYS;
 #endif
 }
 
@@ -771,7 +771,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   return 0;
 #else
-  return -ENOSYS;
+  return UV_ENOSYS;
 #endif
 }
 
@@ -796,7 +796,7 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
 
   return 0;
 #else
-  return -ENOSYS;
+  return UV_ENOSYS;
 #endif
 }
 
@@ -861,7 +861,7 @@ int uv_set_process_title(const char* title) {
    */
   new_title = uv__strdup(title);
   if (new_title == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
@@ -888,9 +888,9 @@ int uv_get_process_title(char* buffer, size_t size) {
   size_t len;
   len = strlen(process_argv[0]);
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
   else if (size <= len)
-    return -ENOBUFS;
+    return UV_ENOBUFS;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
@@ -919,10 +919,10 @@ int uv_resident_set_memory(size_t* rss) {
 
   fd = open(pp, O_RDONLY);
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   /* FIXME(bnoordhuis) Handle EINTR. */
-  err = -EINVAL;
+  err = UV_EINVAL;
   if (read(fd, &psinfo, sizeof(psinfo)) == sizeof(psinfo)) {
     *rss = (size_t)psinfo.pr_rssize * 1024;
     err = 0;
@@ -953,7 +953,7 @@ int uv_uptime(double* uptime) {
   endutent();
 
   if (boot_time == 0)
-    return -ENOSYS;
+    return UV_ENOSYS;
 
   *uptime = time(NULL) - boot_time;
   return 0;
@@ -969,30 +969,30 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   result = perfstat_cpu_total(NULL, &ps_total, sizeof(ps_total), 1);
   if (result == -1) {
-    return -ENOSYS;
+    return UV_ENOSYS;
   }
 
   ncpus = result = perfstat_cpu(NULL, NULL, sizeof(perfstat_cpu_t), 0);
   if (result == -1) {
-    return -ENOSYS;
+    return UV_ENOSYS;
   }
 
   ps_cpus = (perfstat_cpu_t*) uv__malloc(ncpus * sizeof(perfstat_cpu_t));
   if (!ps_cpus) {
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   strcpy(cpu_id.name, FIRST_CPU);
   result = perfstat_cpu(&cpu_id, ps_cpus, sizeof(perfstat_cpu_t), ncpus);
   if (result == -1) {
     uv__free(ps_cpus);
-    return -ENOSYS;
+    return UV_ENOSYS;
   }
 
   *cpu_infos = (uv_cpu_info_t*) uv__malloc(ncpus * sizeof(uv_cpu_info_t));
   if (!*cpu_infos) {
     uv__free(ps_cpus);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   *count = ncpus;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -119,7 +119,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   pc.fd = fd;
 
   if (pollset_ctl(loop->backend_fd, &pc, 1))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   pc.cmd = PS_DELETE;
   if (pollset_ctl(loop->backend_fd, &pc, 1))
@@ -409,22 +409,22 @@ static int uv__is_ahafs_mounted(void){
 
   p = uv__malloc(siz);
   if (p == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   /* Retrieve all mounted filesystems */
   rv = mntctl(MCTL_QUERY, siz, (char*)p);
   if (rv < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   if (rv == 0) {
     /* buffer was not large enough, reallocate to correct size */
     siz = *(int*)p;
     uv__free(p);
     p = uv__malloc(siz);
     if (p == NULL)
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     rv = mntctl(MCTL_QUERY, siz, (char*)p);
     if (rv < 0)
-      return UV_ERR(errno);
+      return UV__ERR(errno);
   }
 
   /* Look for dev in filesystems mount info */
@@ -495,7 +495,7 @@ static int uv__make_subdirs_p(const char *filename) {
   rc = uv__makedir_p(cmd);
 
   if (rc == -1 && errno != EEXIST){
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   return rc;
@@ -537,7 +537,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
   /* Open the monitor file, creating it if necessary */
   *fd = open(mon_file, O_CREAT|O_RDWR);
   if (*fd < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   /* Write out the monitoring specifications.
    * In this case, we are monitoring for a state change event type
@@ -558,7 +558,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
 
   rc = write(*fd, mon_file_write_string, strlen(mon_file_write_string)+1);
   if (rc < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }
@@ -919,7 +919,7 @@ int uv_resident_set_memory(size_t* rss) {
 
   fd = open(pp, O_RDONLY);
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   /* FIXME(bnoordhuis) Handle EINTR. */
   err = UV_EINVAL;

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -166,7 +166,7 @@ static int uv__async_start(uv_loop_t* loop) {
     pipefd[0] = err;
     pipefd[1] = -1;
   }
-  else if (err == -ENOSYS) {
+  else if (err == UV_ENOSYS) {
     err = uv__make_pipe(pipefd, UV__F_NONBLOCK);
 #if defined(__linux__)
     /* Save a file descriptor by opening one of the pipe descriptors as
@@ -240,7 +240,7 @@ static int uv__async_eventfd(void) {
     return fd;
 
   if (errno != ENOSYS)
-    return -errno;
+    return UV_ERR(errno);
 
   no_eventfd2 = 1;
 
@@ -257,7 +257,7 @@ skip_eventfd2:
   }
 
   if (errno != ENOSYS)
-    return -errno;
+    return UV_ERR(errno);
 
   no_eventfd = 1;
 
@@ -265,5 +265,5 @@ skip_eventfd:
 
 #endif
 
-  return -ENOSYS;
+  return UV_ENOSYS;
 }

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -240,7 +240,7 @@ static int uv__async_eventfd(void) {
     return fd;
 
   if (errno != ENOSYS)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   no_eventfd2 = 1;
 
@@ -257,7 +257,7 @@ skip_eventfd2:
   }
 
   if (errno != ENOSYS)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   no_eventfd = 1;
 

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -68,7 +68,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   int i;
 
   if (getifaddrs(&addrs) != 0)
-    return -errno;
+    return UV_ERR(errno);
 
   *count = 0;
 
@@ -83,7 +83,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   if (*addresses == NULL) {
     freeifaddrs(addrs);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   address = *addresses;

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -68,7 +68,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   int i;
 
   if (getifaddrs(&addrs) != 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *count = 0;
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -191,14 +191,14 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
   socklen_t len;
 
   if (handle == NULL || value == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (handle->type == UV_TCP || handle->type == UV_NAMED_PIPE)
     fd = uv__stream_fd((uv_stream_t*) handle);
   else if (handle->type == UV_UDP)
     fd = ((uv_udp_t *) handle)->io_watcher.fd;
   else
-    return -ENOTSUP;
+    return UV_ENOTSUP;
 
   len = sizeof(*value);
 
@@ -208,7 +208,7 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
     r = setsockopt(fd, SOL_SOCKET, optname, (const void*) value, len);
 
   if (r < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -418,12 +418,12 @@ int uv__socket(int domain, int type, int protocol) {
     return sockfd;
 
   if (errno != EINVAL)
-    return -errno;
+    return UV_ERR(errno);
 #endif
 
   sockfd = socket(domain, type, protocol);
   if (sockfd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__nonblock(sockfd, 1);
   if (err == 0)
@@ -487,7 +487,7 @@ int uv__accept(int sockfd) {
       continue;
 
     if (errno != ENOSYS)
-      return -errno;
+      return UV_ERR(errno);
 
     no_accept4 = 1;
 skip:
@@ -497,7 +497,7 @@ skip:
     if (peerfd == -1) {
       if (errno == EINTR)
         continue;
-      return -errno;
+      return UV_ERR(errno);
     }
 
     err = uv__cloexec(peerfd, 1);
@@ -523,8 +523,8 @@ int uv__close_nocheckstdio(int fd) {
   saved_errno = errno;
   rc = close(fd);
   if (rc == -1) {
-    rc = -errno;
-    if (rc == -EINTR || rc == -EINPROGRESS)
+    rc = UV_ERR(errno);
+    if (rc == UV_EINTR || rc == UV_ERR(EINPROGRESS))
       rc = 0;    /* The close is in progress, not an error. */
     errno = saved_errno;
   }
@@ -550,7 +550,7 @@ int uv__nonblock_ioctl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -565,7 +565,7 @@ int uv__cloexec_ioctl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -581,7 +581,7 @@ int uv__nonblock_fcntl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   /* Bail out now if already set/clear. */
   if (!!(r & O_NONBLOCK) == !!set)
@@ -597,7 +597,7 @@ int uv__nonblock_fcntl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -612,7 +612,7 @@ int uv__cloexec_fcntl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   /* Bail out now if already set/clear. */
   if (!!(r & FD_CLOEXEC) == !!set)
@@ -628,7 +628,7 @@ int uv__cloexec_fcntl(int fd, int set) {
   while (r == -1 && errno == EINTR);
 
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -643,7 +643,7 @@ int uv__dup(int fd) {
   fd = dup(fd);
 
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err) {
@@ -667,10 +667,10 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
     if (rc != -1)
       return rc;
     if (errno != EINVAL)
-      return -errno;
+      return UV_ERR(errno);
     rc = recvmsg(fd, msg, flags);
     if (rc == -1)
-      return -errno;
+      return UV_ERR(errno);
     no_msg_cmsg_cloexec = 1;
   } else {
     rc = recvmsg(fd, msg, flags);
@@ -679,7 +679,7 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
   rc = recvmsg(fd, msg, flags);
 #endif
   if (rc == -1)
-    return -errno;
+    return UV_ERR(errno);
   if (msg->msg_controllen == 0)
     return rc;
   for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg))
@@ -695,10 +695,10 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
 
 int uv_cwd(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (getcwd(buffer, *size) == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   *size = strlen(buffer);
   if (*size > 1 && buffer[*size - 1] == '/') {
@@ -712,7 +712,7 @@ int uv_cwd(char* buffer, size_t* size) {
 
 int uv_chdir(const char* dir) {
   if (chdir(dir))
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -749,11 +749,11 @@ int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
     break;
 
   default:
-    return -EINVAL;
+    return UV_EINVAL;
   }
 
   if (uv__is_closing(handle) || fd_out == -1)
-    return -EBADF;
+    return UV_EBADF;
 
   *fd = fd_out;
   return 0;
@@ -931,7 +931,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
   struct rusage usage;
 
   if (getrusage(RUSAGE_SELF, &usage))
-    return -errno;
+    return UV_ERR(errno);
 
   rusage->ru_utime.tv_sec = usage.ru_utime.tv_sec;
   rusage->ru_utime.tv_usec = usage.ru_utime.tv_usec;
@@ -973,7 +973,7 @@ int uv__open_cloexec(const char* path, int flags) {
       return fd;
 
     if (errno != EINVAL)
-      return -errno;
+      return UV_ERR(errno);
 
     /* O_CLOEXEC not supported. */
     no_cloexec = 1;
@@ -982,7 +982,7 @@ int uv__open_cloexec(const char* path, int flags) {
 
   fd = open(path, flags);
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err) {
@@ -999,14 +999,14 @@ int uv__dup2_cloexec(int oldfd, int newfd) {
 #if (defined(__FreeBSD__) && __FreeBSD__ >= 10) || defined(__NetBSD__)
   r = dup3(oldfd, newfd, O_CLOEXEC);
   if (r == -1)
-    return -errno;
+    return UV_ERR(errno);
   return r;
 #elif defined(__FreeBSD__) && defined(F_DUP2FD_CLOEXEC)
   r = fcntl(oldfd, F_DUP2FD_CLOEXEC, newfd);
   if (r != -1)
     return r;
   if (errno != EINVAL)
-    return -errno;
+    return UV_ERR(errno);
   /* Fall through. */
 #elif defined(__linux__)
   static int no_dup3;
@@ -1017,7 +1017,7 @@ int uv__dup2_cloexec(int oldfd, int newfd) {
     if (r != -1)
       return r;
     if (errno != ENOSYS)
-      return -errno;
+      return UV_ERR(errno);
     /* Fall through. */
     no_dup3 = 1;
   }
@@ -1033,7 +1033,7 @@ int uv__dup2_cloexec(int oldfd, int newfd) {
 #endif
 
     if (r == -1)
-      return -errno;
+      return UV_ERR(errno);
 
     err = uv__cloexec(newfd, 1);
     if (err) {
@@ -1053,7 +1053,7 @@ int uv_os_homedir(char* buffer, size_t* size) {
   int r;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* Check if the HOME environment variable is set first */
   buf = getenv("HOME");
@@ -1063,7 +1063,7 @@ int uv_os_homedir(char* buffer, size_t* size) {
 
     if (len >= *size) {
       *size = len + 1;
-      return -ENOBUFS;
+      return UV_ENOBUFS;
     }
 
     memcpy(buffer, buf, len + 1);
@@ -1084,7 +1084,7 @@ int uv_os_homedir(char* buffer, size_t* size) {
   if (len >= *size) {
     *size = len + 1;
     uv_os_free_passwd(&pwd);
-    return -ENOBUFS;
+    return UV_ENOBUFS;
   }
 
   memcpy(buffer, pwd.homedir, len + 1);
@@ -1100,7 +1100,7 @@ int uv_os_tmpdir(char* buffer, size_t* size) {
   size_t len;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
 #define CHECK_ENV_VAR(name)                                                   \
   do {                                                                        \
@@ -1130,7 +1130,7 @@ return_buffer:
 
   if (len >= *size) {
     *size = len + 1;
-    return -ENOBUFS;
+    return UV_ENOBUFS;
   }
 
   /* The returned directory should not have a trailing slash. */
@@ -1162,11 +1162,11 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
 
   getpwuid_r = dlsym(RTLD_DEFAULT, "getpwuid_r");
   if (getpwuid_r == NULL)
-    return -ENOSYS;
+    return UV_ENOSYS;
 #endif
 
   if (pwd == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   initsize = sysconf(_SC_GETPW_R_SIZE_MAX);
 
@@ -1183,7 +1183,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
     buf = uv__malloc(bufsize);
 
     if (buf == NULL)
-      return -ENOMEM;
+      return UV_ENOMEM;
 
     r = getpwuid_r(uid, &pw, buf, bufsize, &result);
 
@@ -1200,7 +1200,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
 
   if (result == NULL) {
     uv__free(buf);
-    return -ENOENT;
+    return UV_ENOENT;
   }
 
   /* Allocate memory for the username, shell, and home directory */
@@ -1211,7 +1211,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
 
   if (pwd->username == NULL) {
     uv__free(buf);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   /* Copy the username */
@@ -1267,18 +1267,18 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
   size_t len;
 
   if (name == NULL || buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   var = getenv(name);
 
   if (var == NULL)
-    return -ENOENT;
+    return UV_ENOENT;
 
   len = strlen(var);
 
   if (len >= *size) {
     *size = len + 1;
-    return -ENOBUFS;
+    return UV_ENOBUFS;
   }
 
   memcpy(buffer, var, len + 1);
@@ -1290,10 +1290,10 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
 
 int uv_os_setenv(const char* name, const char* value) {
   if (name == NULL || value == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (setenv(name, value, 1) != 0)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -1301,10 +1301,10 @@ int uv_os_setenv(const char* name, const char* value) {
 
 int uv_os_unsetenv(const char* name) {
   if (name == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (unsetenv(name) != 0)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -1321,17 +1321,17 @@ int uv_os_gethostname(char* buffer, size_t* size) {
   size_t len;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (gethostname(buf, sizeof(buf)) != 0)
-    return -errno;
+    return UV_ERR(errno);
 
   buf[sizeof(buf) - 1] = '\0'; /* Null terminate, just to be safe. */
   len = strlen(buf);
 
   if (len >= *size) {
     *size = len + 1;
-    return -ENOBUFS;
+    return UV_ENOBUFS;
   }
 
   memcpy(buffer, buf, len + 1);

--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -29,7 +29,7 @@ int uv_uptime(double* uptime) {
   struct sysinfo info;
 
   if (sysinfo(&info) < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   *uptime = info.uptime;
   return 0;

--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -29,7 +29,7 @@ int uv_uptime(double* uptime) {
   struct sysinfo info;
 
   if (sysinfo(&info) < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *uptime = info.uptime;
   return 0;

--- a/src/unix/darwin-proctitle.c
+++ b/src/unix/darwin-proctitle.c
@@ -19,6 +19,7 @@
  */
 
 #include "uv.h"
+#include "internal.h"
 
 #include <dlfcn.h>
 #include <errno.h>

--- a/src/unix/darwin-proctitle.c
+++ b/src/unix/darwin-proctitle.c
@@ -50,7 +50,7 @@ static int uv__pthread_setname_np(const char* name) {
 
   err = dynamic_pthread_setname_np(namebuf);
   if (err)
-    return UV_ERR(err);
+    return UV__ERR(err);
 
   return 0;
 }

--- a/src/unix/darwin-proctitle.c
+++ b/src/unix/darwin-proctitle.c
@@ -18,6 +18,8 @@
  * IN THE SOFTWARE.
  */
 
+#include "uv.h"
+
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -41,14 +43,14 @@ static int uv__pthread_setname_np(const char* name) {
       dlsym(RTLD_DEFAULT, "pthread_setname_np");
 
   if (dynamic_pthread_setname_np == NULL)
-    return -ENOSYS;
+    return UV_ENOSYS;
 
   strncpy(namebuf, name, sizeof(namebuf) - 1);
   namebuf[sizeof(namebuf) - 1] = '\0';
 
   err = dynamic_pthread_setname_np(namebuf);
   if (err)
-    return -err;
+    return UV_ERR(err);
 
   return 0;
 }
@@ -84,7 +86,7 @@ int uv__set_process_title(const char* title) {
   CFTypeRef asn;
   int err;
 
-  err = -ENOENT;
+  err = UV_ENOENT;
   application_services_handle = dlopen("/System/Library/Frameworks/"
                                        "ApplicationServices.framework/"
                                        "Versions/A/ApplicationServices",
@@ -151,7 +153,7 @@ int uv__set_process_title(const char* title) {
   /* Black 10.9 magic, to remove (Not responding) mark in Activity Monitor */
   hi_services_bundle =
       pCFBundleGetBundleWithIdentifier(S("com.apple.HIServices"));
-  err = -ENOENT;
+  err = UV_ENOENT;
   if (hi_services_bundle == NULL)
     goto out;
 
@@ -182,7 +184,7 @@ int uv__set_process_title(const char* title) {
 
   asn = pLSGetCurrentApplicationASN();
 
-  err = -EINVAL;
+  err = UV_EINVAL;
   if (pLSSetApplicationInformationItem(-2,  /* Magic value. */
                                        asn,
                                        *display_name_key,

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -37,7 +37,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   loop->cf_state = NULL;
 
   if (uv__kqueue_init(loop))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }
@@ -75,7 +75,7 @@ int uv_exepath(char* buffer, size_t* size) {
     return UV_EIO;
 
   if (realpath(exepath, abspath) != abspath)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   abspath_size = strlen(abspath);
   if (abspath_size == 0)
@@ -111,7 +111,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info;
 }
@@ -158,7 +158,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   now = time(NULL);
   *uptime = now - info.tv_sec;
@@ -181,12 +181,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(model);
   if (sysctlbyname("machdep.cpu.brand_string", &model, &size, NULL, 0) &&
       sysctlbyname("hw.model", &model, &size, NULL, 0)) {
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   size = sizeof(cpuspeed);
   if (sysctlbyname("hw.cpufrequency", &cpuspeed, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   if (host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numcpus,
                           (processor_info_array_t*)&info,

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -37,7 +37,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   loop->cf_state = NULL;
 
   if (uv__kqueue_init(loop))
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -68,18 +68,18 @@ int uv_exepath(char* buffer, size_t* size) {
   size_t abspath_size;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   exepath_size = sizeof(exepath);
   if (_NSGetExecutablePath(exepath, &exepath_size))
-    return -EIO;
+    return UV_EIO;
 
   if (realpath(exepath, abspath) != abspath)
-    return -errno;
+    return UV_ERR(errno);
 
   abspath_size = strlen(abspath);
   if (abspath_size == 0)
-    return -EIO;
+    return UV_EIO;
 
   *size -= 1;
   if (*size > abspath_size)
@@ -98,7 +98,7 @@ uint64_t uv_get_free_memory(void) {
 
   if (host_statistics(mach_host_self(), HOST_VM_INFO,
                       (host_info_t)&info, &count) != KERN_SUCCESS) {
-    return -EINVAL;  /* FIXME(bnoordhuis) Translate error. */
+    return UV_EINVAL;  /* FIXME(bnoordhuis) Translate error. */
   }
 
   return (uint64_t) info.free_count * sysconf(_SC_PAGESIZE);
@@ -111,7 +111,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info;
 }
@@ -158,7 +158,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   now = time(NULL);
   *uptime = now - info.tv_sec;
@@ -181,23 +181,23 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(model);
   if (sysctlbyname("machdep.cpu.brand_string", &model, &size, NULL, 0) &&
       sysctlbyname("hw.model", &model, &size, NULL, 0)) {
-    return -errno;
+    return UV_ERR(errno);
   }
 
   size = sizeof(cpuspeed);
   if (sysctlbyname("hw.cpufrequency", &cpuspeed, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   if (host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numcpus,
                           (processor_info_array_t*)&info,
                           &msg_type) != KERN_SUCCESS) {
-    return -EINVAL;  /* FIXME(bnoordhuis) Translate error. */
+    return UV_EINVAL;  /* FIXME(bnoordhuis) Translate error. */
   }
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos)) {
     vm_deallocate(mach_task_self(), (vm_address_t)info, msg_type);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   *count = numcpus;

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -72,11 +72,11 @@ int uv_exepath(char* buffer, size_t* size) {
   ssize_t abspath_size;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   abspath_size = readlink("/proc/curproc/file", abspath, sizeof(abspath));
   if (abspath_size < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   assert(abspath_size > 0);
   *size -= 1;
@@ -96,7 +96,7 @@ int uv_exepath(char* buffer, size_t* size) {
   size_t abspath_size;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   mib[0] = CTL_KERN;
   mib[1] = KERN_PROC;
@@ -105,7 +105,7 @@ int uv_exepath(char* buffer, size_t* size) {
 
   abspath_size = sizeof abspath;
   if (sysctl(mib, 4, abspath, &abspath_size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   assert(abspath_size > 0);
   abspath_size -= 1;
@@ -126,7 +126,7 @@ uint64_t uv_get_free_memory(void) {
   size_t size = sizeof(freecount);
 
   if (sysctlbyname("vm.stats.vm.v_free_count", &freecount, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) freecount * sysconf(_SC_PAGESIZE);
 
@@ -140,7 +140,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info;
 }
@@ -176,7 +176,7 @@ int uv_set_process_title(const char* title) {
 
   if (process_title == NULL) {
     uv_mutex_unlock(&process_title_mutex);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   uv__free(process_title);
@@ -204,7 +204,7 @@ int uv_get_process_title(char* buffer, size_t size) {
   size_t len;
 
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
@@ -214,7 +214,7 @@ int uv_get_process_title(char* buffer, size_t size) {
 
     if (size < len) {
       uv_mutex_unlock(&process_title_mutex);
-      return -ENOBUFS;
+      return UV_ENOBUFS;
     }
 
     memcpy(buffer, process_title, len);
@@ -243,7 +243,7 @@ int uv_resident_set_memory(size_t* rss) {
   kinfo_size = sizeof(kinfo);
 
   if (sysctl(mib, 4, &kinfo, &kinfo_size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   page_size = getpagesize();
 
@@ -262,7 +262,7 @@ int uv_uptime(double* uptime) {
   struct timespec sp;
   r = clock_gettime(CLOCK_MONOTONIC, &sp);
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   *uptime = sp.tv_sec;
   return 0;
@@ -309,15 +309,15 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   size = sizeof(model);
   if (sysctlbyname(model_key, &model, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   size = sizeof(numcpus);
   if (sysctlbyname("hw.ncpu", &numcpus, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos))
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   *count = numcpus;
 
@@ -327,7 +327,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(maxcpus);
   if (sysctlbyname(maxcpus_key, &maxcpus, &size, NULL, 0)) {
     uv__free(*cpu_infos);
-    return -errno;
+    return UV_ERR(errno);
   }
 
   size = maxcpus * CPUSTATES * sizeof(long);
@@ -335,13 +335,13 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   cp_times = uv__malloc(size);
   if (cp_times == NULL) {
     uv__free(*cpu_infos);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   if (sysctlbyname(cptimes_key, cp_times, &size, NULL, 0)) {
     uv__free(cp_times);
     uv__free(*cpu_infos);
-    return -errno;
+    return UV_ERR(errno);
   }
 
   for (i = 0; i < numcpus; i++) {

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -76,7 +76,7 @@ int uv_exepath(char* buffer, size_t* size) {
 
   abspath_size = readlink("/proc/curproc/file", abspath, sizeof(abspath));
   if (abspath_size < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   assert(abspath_size > 0);
   *size -= 1;
@@ -105,7 +105,7 @@ int uv_exepath(char* buffer, size_t* size) {
 
   abspath_size = sizeof abspath;
   if (sysctl(mib, 4, abspath, &abspath_size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   assert(abspath_size > 0);
   abspath_size -= 1;
@@ -126,7 +126,7 @@ uint64_t uv_get_free_memory(void) {
   size_t size = sizeof(freecount);
 
   if (sysctlbyname("vm.stats.vm.v_free_count", &freecount, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) freecount * sysconf(_SC_PAGESIZE);
 
@@ -140,7 +140,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info;
 }
@@ -243,7 +243,7 @@ int uv_resident_set_memory(size_t* rss) {
   kinfo_size = sizeof(kinfo);
 
   if (sysctl(mib, 4, &kinfo, &kinfo_size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   page_size = getpagesize();
 
@@ -262,7 +262,7 @@ int uv_uptime(double* uptime) {
   struct timespec sp;
   r = clock_gettime(CLOCK_MONOTONIC, &sp);
   if (r)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *uptime = sp.tv_sec;
   return 0;
@@ -309,11 +309,11 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   size = sizeof(model);
   if (sysctlbyname(model_key, &model, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   size = sizeof(numcpus);
   if (sysctlbyname("hw.ncpu", &numcpus, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos))
@@ -327,7 +327,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(maxcpus);
   if (sysctlbyname(maxcpus_key, &maxcpus, &size, NULL, 0)) {
     uv__free(*cpu_infos);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   size = maxcpus * CPUSTATES * sizeof(long);
@@ -341,7 +341,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   if (sysctlbyname(cptimes_key, cp_times, &size, NULL, 0)) {
     uv__free(cp_times);
     uv__free(*cpu_infos);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   for (i = 0; i < numcpus; i++) {

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -67,7 +67,7 @@
 #define INIT(subtype)                                                         \
   do {                                                                        \
     if (req == NULL)                                                          \
-      return -EINVAL;                                                         \
+      return UV_EINVAL;                                                       \
     req->type = UV_FS;                                                        \
     if (cb != NULL)                                                           \
       uv__req_init(loop, req, UV_FS);                                         \
@@ -90,7 +90,7 @@
       req->path = uv__strdup(path);                                           \
       if (req->path == NULL) {                                                \
         uv__req_unregister(loop, req);                                        \
-        return -ENOMEM;                                                       \
+        return UV_ENOMEM;                                                     \
       }                                                                       \
     }                                                                         \
   }                                                                           \
@@ -109,7 +109,7 @@
       req->path = uv__malloc(path_len + new_path_len);                        \
       if (req->path == NULL) {                                                \
         uv__req_unregister(loop, req);                                        \
-        return -ENOMEM;                                                       \
+        return UV_ENOMEM;                                                     \
       }                                                                       \
       req->new_path = req->path + path_len;                                   \
       memcpy((void*) req->path, path, path_len);                              \
@@ -782,7 +782,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
 
   /* Get the source file's mode. */
   if (fstat(srcfd, &statsbuf)) {
-    err = -errno;
+    err = UV_ERR(errno);
     goto out;
   }
 
@@ -806,7 +806,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
   }
 
   if (fchmod(dstfd, statsbuf.st_mode) == -1) {
-    err = -errno;
+    err = UV_ERR(errno);
     goto out;
   }
 
@@ -1085,7 +1085,7 @@ static void uv__fs_work(struct uv__work* w) {
   } while (r == -1 && errno == EINTR && retry_on_eintr);
 
   if (r == -1)
-    req->result = -errno;
+    req->result = UV_ERR(errno);
   else
     req->result = r;
 
@@ -1103,9 +1103,9 @@ static void uv__fs_done(struct uv__work* w, int status) {
   req = container_of(w, uv_fs_t, work_req);
   uv__req_unregister(req->loop, req);
 
-  if (status == -ECANCELED) {
+  if (status == UV_ECANCELED) {
     assert(req->result == 0);
-    req->result = -ECANCELED;
+    req->result = UV_ECANCELED;
   }
 
   req->cb(req);
@@ -1269,7 +1269,7 @@ int uv_fs_mkdtemp(uv_loop_t* loop,
   if (req->path == NULL) {
     if (cb != NULL)
       uv__req_unregister(loop, req);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
   POST;
 }
@@ -1298,7 +1298,7 @@ int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
   INIT(READ);
 
   if (bufs == NULL || nbufs == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   req->file = file;
 
@@ -1310,7 +1310,7 @@ int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
   if (req->bufs == NULL) {
     if (cb != NULL)
       uv__req_unregister(loop, req);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
@@ -1437,7 +1437,7 @@ int uv_fs_write(uv_loop_t* loop,
   INIT(WRITE);
 
   if (bufs == NULL || nbufs == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   req->file = file;
 
@@ -1449,7 +1449,7 @@ int uv_fs_write(uv_loop_t* loop,
   if (req->bufs == NULL) {
     if (cb != NULL)
       uv__req_unregister(loop, req);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
@@ -1492,7 +1492,7 @@ int uv_fs_copyfile(uv_loop_t* loop,
   INIT(COPYFILE);
 
   if (flags & ~UV_FS_COPYFILE_EXCL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   PATH2;
   req->flags = flags;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -782,7 +782,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
 
   /* Get the source file's mode. */
   if (fstat(srcfd, &statsbuf)) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
     goto out;
   }
 
@@ -806,7 +806,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
   }
 
   if (fchmod(dstfd, statsbuf.st_mode) == -1) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
     goto out;
   }
 
@@ -1085,7 +1085,7 @@ static void uv__fs_work(struct uv__work* w) {
   } while (r == -1 && errno == EINTR && retry_on_eintr);
 
   if (r == -1)
-    req->result = UV_ERR(errno);
+    req->result = UV__ERR(errno);
   else
     req->result = r;
 

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -655,7 +655,7 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   loop->cf_state = state;
 
   /* uv_thread_t is an alias for pthread_t. */
-  err = UV_ERR(pthread_create(&loop->cf_thread, attr, uv__cf_loop_runner, loop));
+  err = UV__ERR(pthread_create(&loop->cf_thread, attr, uv__cf_loop_runner, loop));
 
   if (attr != NULL)
     pthread_attr_destroy(attr);
@@ -817,7 +817,7 @@ int uv__fsevents_init(uv_fs_event_t* handle) {
   /* Get absolute path to file */
   handle->realpath = realpath(handle->path, NULL);
   if (handle->realpath == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   handle->realpath_len = strlen(handle->realpath);
 
   /* Initialize event queue */
@@ -895,7 +895,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
   assert(handle != NULL);
   err = uv__cf_loop_signal(handle->loop, handle, kUVCFLoopSignalClosing);
   if (err)
-    return UV_ERR(err);
+    return UV__ERR(err);
 
   /* Wait for deinitialization */
   uv_sem_wait(&state->fsevent_sem);

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -379,7 +379,7 @@ static int uv__fsevents_create_stream(uv_loop_t* loop, CFArrayRef paths) {
   if (!pFSEventStreamStart(ref)) {
     pFSEventStreamInvalidate(ref);
     pFSEventStreamRelease(ref);
-    return -EMFILE;
+    return UV_EMFILE;
   }
 
   state->fsevent_stream = ref;
@@ -440,7 +440,7 @@ static void uv__fsevents_reschedule(uv_fs_event_t* handle,
   uv__fsevents_destroy_stream(handle->loop);
 
   /* Any failure below will be a memory failure */
-  err = -ENOMEM;
+  err = UV_ENOMEM;
 
   /* Create list of all watched paths */
   uv_mutex_lock(&state->fsevent_mutex);
@@ -474,7 +474,7 @@ static void uv__fsevents_reschedule(uv_fs_event_t* handle,
     /* Create new FSEventStream */
     cf_paths = pCFArrayCreate(NULL, (const void**) paths, path_count, NULL);
     if (cf_paths == NULL) {
-      err = -ENOMEM;
+      err = UV_ENOMEM;
       goto final;
     }
     err = uv__fsevents_create_stream(handle->loop, cf_paths);
@@ -528,7 +528,7 @@ static int uv__fsevents_global_init(void) {
    * but if it ever becomes one, we can turn the dynamic library handles into
    * per-event loop properties and have the dynamic linker keep track for us.
    */
-  err = -ENOSYS;
+  err = UV_ENOSYS;
   core_foundation_handle = dlopen("/System/Library/Frameworks/"
                                   "CoreFoundation.framework/"
                                   "Versions/A/CoreFoundation",
@@ -543,7 +543,7 @@ static int uv__fsevents_global_init(void) {
   if (core_services_handle == NULL)
     goto out;
 
-  err = -ENOENT;
+  err = UV_ENOENT;
 #define V(handle, symbol)                                                     \
   do {                                                                        \
     *(void **)(&p ## symbol) = dlsym((handle), #symbol);                      \
@@ -607,7 +607,7 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
 
   state = uv__calloc(1, sizeof(*state));
   if (state == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   err = uv_mutex_init(&loop->cf_mutex);
   if (err)
@@ -636,7 +636,7 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   ctx.perform = uv__cf_loop_cb;
   state->signal_source = pCFRunLoopSourceCreate(NULL, 0, &ctx);
   if (state->signal_source == NULL) {
-    err = -ENOMEM;
+    err = UV_ENOMEM;
     goto fail_signal_source_create;
   }
 
@@ -655,7 +655,7 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   loop->cf_state = state;
 
   /* uv_thread_t is an alias for pthread_t. */
-  err = -pthread_create(&loop->cf_thread, attr, uv__cf_loop_runner, loop);
+  err = UV_ERR(pthread_create(&loop->cf_thread, attr, uv__cf_loop_runner, loop));
 
   if (attr != NULL)
     pthread_attr_destroy(attr);
@@ -787,7 +787,7 @@ int uv__cf_loop_signal(uv_loop_t* loop,
 
   item = uv__malloc(sizeof(*item));
   if (item == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   item->handle = handle;
   item->type = type;
@@ -817,7 +817,7 @@ int uv__fsevents_init(uv_fs_event_t* handle) {
   /* Get absolute path to file */
   handle->realpath = realpath(handle->path, NULL);
   if (handle->realpath == NULL)
-    return -errno;
+    return UV_ERR(errno);
   handle->realpath_len = strlen(handle->realpath);
 
   /* Initialize event queue */
@@ -830,7 +830,7 @@ int uv__fsevents_init(uv_fs_event_t* handle) {
    */
   handle->cf_cb = uv__malloc(sizeof(*handle->cf_cb));
   if (handle->cf_cb == NULL) {
-    err = -ENOMEM;
+    err = UV_ENOMEM;
     goto fail_cf_cb_malloc;
   }
 
@@ -881,7 +881,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
   uv__cf_loop_state_t* state;
 
   if (handle->cf_cb == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* Remove handle from  the list */
   state = handle->loop->cf_state;
@@ -895,7 +895,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
   assert(handle != NULL);
   err = uv__cf_loop_signal(handle->loop, handle, kUVCFLoopSignalClosing);
   if (err)
-    return -err;
+    return UV_ERR(err);
 
   /* Wait for deinitialization */
   uv_sem_wait(&state->fsevent_sem);

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -86,7 +86,7 @@ int uv__getaddrinfo_translate_error(int sys_err) {
   case EAI_SOCKTYPE: return UV_EAI_SOCKTYPE;
 #endif
 #if defined(EAI_SYSTEM)
-  case EAI_SYSTEM: return UV_ERR(errno);
+  case EAI_SYSTEM: return UV__ERR(errno);
 #endif
   }
   assert(!"unknown EAI_* error code");
@@ -211,7 +211,7 @@ int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
     return UV_EINVAL;
 
   if (if_indextoname(ifindex, ifname_buf) == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   len = strnlen(ifname_buf, sizeof(ifname_buf));
 

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -86,7 +86,7 @@ int uv__getaddrinfo_translate_error(int sys_err) {
   case EAI_SOCKTYPE: return UV_EAI_SOCKTYPE;
 #endif
 #if defined(EAI_SYSTEM)
-  case EAI_SYSTEM: return -errno;
+  case EAI_SYSTEM: return UV_ERR(errno);
 #endif
   }
   assert(!"unknown EAI_* error code");
@@ -125,7 +125,7 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   req->service = NULL;
   req->hostname = NULL;
 
-  if (status == -ECANCELED) {
+  if (status == UV_ECANCELED) {
     assert(req->retcode == 0);
     req->retcode = UV_EAI_CANCELED;
   }
@@ -148,7 +148,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   char* buf;
 
   if (req == NULL || (hostname == NULL && service == NULL))
-    return -EINVAL;
+    return UV_EINVAL;
 
   hostname_len = hostname ? strlen(hostname) + 1 : 0;
   service_len = service ? strlen(service) + 1 : 0;
@@ -156,7 +156,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   buf = uv__malloc(hostname_len + service_len + hints_len);
 
   if (buf == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   uv__req_init(loop, req, UV_GETADDRINFO);
   req->loop = loop;
@@ -211,7 +211,7 @@ int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
     return UV_EINVAL;
 
   if (if_indextoname(ifindex, ifname_buf) == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   len = strnlen(ifname_buf, sizeof(ifname_buf));
 

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -61,7 +61,7 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
   uv__req_unregister(req->loop, req);
   host = service = NULL;
 
-  if (status == -ECANCELED) {
+  if (status == UV_ECANCELED) {
     assert(req->retcode == 0);
     req->retcode = UV_EAI_CANCELED;
   } else if (req->retcode == 0) {

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -92,7 +92,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   *cpu_infos = uv__malloc(numcpus * sizeof(uv_cpu_info_t));
   if (!*cpu_infos) {
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   cpu_info = *cpu_infos;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -31,12 +31,6 @@
 #include <stdio.h>
 #include <errno.h>
 
-#if EDOM > 0
-# define UV__ERR(x) (-(x))
-#else
-# define UV__ERR(x) (x)
-#endif
-
 #if defined(__STRICT_ANSI__)
 # define inline __inline
 #endif

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -32,9 +32,9 @@
 #include <errno.h>
 
 #if EDOM > 0
-# define UV_ERR(x) (-(x))
+# define UV__ERR(x) (-(x))
 #else
-# define UV_ERR(x) (x)
+# define UV__ERR(x) (x)
 #endif
 
 #if defined(__STRICT_ANSI__)

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -29,6 +29,13 @@
 #include <string.h> /* strrchr */
 #include <fcntl.h>  /* O_CLOEXEC, may be */
 #include <stdio.h>
+#include <errno.h>
+
+#if EDOM > 0
+# define UV_ERR(x) (-(x))
+#else
+# define UV_ERR(x) (x)
+#endif
 
 #if defined(__STRICT_ANSI__)
 # define inline __inline

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -51,7 +51,7 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags);
 int uv__kqueue_init(uv_loop_t* loop) {
   loop->backend_fd = kqueue();
   if (loop->backend_fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   uv__cloexec(loop->backend_fd, 1);
 
@@ -98,7 +98,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   rc = 0;
   EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
   if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
-    rc = -errno;
+    rc = UV_ERR(errno);
 
   EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
   if (rc == 0)
@@ -458,12 +458,12 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   int fd;
 
   if (uv__is_active(handle))
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* TODO open asynchronously - but how do we report back errors? */
   fd = open(path, O_RDONLY);
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -51,7 +51,7 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags);
 int uv__kqueue_init(uv_loop_t* loop) {
   loop->backend_fd = kqueue();
   if (loop->backend_fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   uv__cloexec(loop->backend_fd, 1);
 
@@ -98,7 +98,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   rc = 0;
   EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
   if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
-    rc = UV_ERR(errno);
+    rc = UV__ERR(errno);
 
   EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
   if (rc == 0)
@@ -463,7 +463,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   /* TODO open asynchronously - but how do we report back errors? */
   fd = open(path, O_RDONLY);
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -101,7 +101,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   loop->inotify_watchers = NULL;
 
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -175,7 +175,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   rc = 0;
   if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_ADD, fd, &e))
     if (errno != EEXIST)
-      rc = -errno;
+      rc = UV_ERR(errno);
 
   if (rc == 0)
     if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_DEL, fd, &e))
@@ -485,7 +485,7 @@ int uv_resident_set_memory(size_t* rss) {
   while (fd == -1 && errno == EINTR);
 
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   do
     n = read(fd, buf, sizeof(buf) - 1);
@@ -493,7 +493,7 @@ int uv_resident_set_memory(size_t* rss) {
 
   uv__close(fd);
   if (n == -1)
-    return -errno;
+    return UV_ERR(errno);
   buf[n] = '\0';
 
   s = strchr(buf, ' ');
@@ -525,7 +525,7 @@ int uv_resident_set_memory(size_t* rss) {
   return 0;
 
 err:
-  return -EINVAL;
+  return UV_EINVAL;
 }
 
 
@@ -547,7 +547,7 @@ int uv_uptime(double* uptime) {
   }
 
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   *uptime = now.tv_sec;
   return 0;
@@ -559,7 +559,7 @@ static int uv__cpu_num(FILE* statfile_fp, unsigned int* numcpus) {
   char buf[1024];
 
   if (!fgets(buf, sizeof(buf), statfile_fp))
-    return -EIO;
+    return UV_EIO;
 
   num = 0;
   while (fgets(buf, sizeof(buf), statfile_fp)) {
@@ -569,7 +569,7 @@ static int uv__cpu_num(FILE* statfile_fp, unsigned int* numcpus) {
   }
 
   if (num == 0)
-    return -EIO;
+    return UV_EIO;
 
   *numcpus = num;
   return 0;
@@ -587,13 +587,13 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   statfile_fp = uv__open_file("/proc/stat");
   if (statfile_fp == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__cpu_num(statfile_fp, &numcpus);
   if (err < 0)
     goto out;
 
-  err = -ENOMEM;
+  err = UV_ENOMEM;
   ci = uv__calloc(numcpus, sizeof(*ci));
   if (ci == NULL)
     goto out;
@@ -667,7 +667,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
     defined(__x86_64__)
   fp = uv__open_file("/proc/cpuinfo");
   if (fp == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   while (fgets(buf, sizeof(buf), fp)) {
     if (model_idx < numcpus) {
@@ -676,7 +676,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
         model = uv__strndup(model, strlen(model) - 1);  /* Strip newline. */
         if (model == NULL) {
           fclose(fp);
-          return -ENOMEM;
+          return UV_ENOMEM;
         }
         ci[model_idx++].model = model;
         continue;
@@ -695,7 +695,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
         model = uv__strndup(model, strlen(model) - 1);  /* Strip newline. */
         if (model == NULL) {
           fclose(fp);
-          return -ENOMEM;
+          return UV_ENOMEM;
         }
         ci[model_idx++].model = model;
         continue;
@@ -725,7 +725,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
   while (model_idx < numcpus) {
     model = uv__strndup(inferred_model, strlen(inferred_model));
     if (model == NULL)
-      return -ENOMEM;
+      return UV_ENOMEM;
     ci[model_idx++].model = model;
   }
 
@@ -854,7 +854,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
 int uv_interface_addresses(uv_interface_address_t** addresses,
   int* count) {
 #ifndef HAVE_IFADDRS_H
-  return -ENOSYS;
+  return UV_ENOSYS;
 #else
   struct ifaddrs *addrs, *ent;
   uv_interface_address_t* address;
@@ -862,7 +862,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   struct sockaddr_ll *sll;
 
   if (getifaddrs(&addrs))
-    return -errno;
+    return UV_ERR(errno);
 
   *count = 0;
   *addresses = NULL;
@@ -881,7 +881,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   *addresses = uv__malloc(*count * sizeof(**addresses));
   if (!(*addresses)) {
     freeifaddrs(addrs);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   address = *addresses;

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -101,7 +101,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   loop->inotify_watchers = NULL;
 
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }
@@ -175,7 +175,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   rc = 0;
   if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_ADD, fd, &e))
     if (errno != EEXIST)
-      rc = UV_ERR(errno);
+      rc = UV__ERR(errno);
 
   if (rc == 0)
     if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_DEL, fd, &e))
@@ -485,7 +485,7 @@ int uv_resident_set_memory(size_t* rss) {
   while (fd == -1 && errno == EINTR);
 
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   do
     n = read(fd, buf, sizeof(buf) - 1);
@@ -493,7 +493,7 @@ int uv_resident_set_memory(size_t* rss) {
 
   uv__close(fd);
   if (n == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   buf[n] = '\0';
 
   s = strchr(buf, ' ');
@@ -547,7 +547,7 @@ int uv_uptime(double* uptime) {
   }
 
   if (r)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *uptime = now.tv_sec;
   return 0;
@@ -587,7 +587,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   statfile_fp = uv__open_file("/proc/stat");
   if (statfile_fp == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   err = uv__cpu_num(statfile_fp, &numcpus);
   if (err < 0)
@@ -667,7 +667,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
     defined(__x86_64__)
   fp = uv__open_file("/proc/cpuinfo");
   if (fp == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   while (fgets(buf, sizeof(buf), fp)) {
     if (model_idx < numcpus) {
@@ -862,7 +862,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
   struct sockaddr_ll *sll;
 
   if (getifaddrs(&addrs))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *count = 0;
   *addresses = NULL;

--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -73,11 +73,11 @@ static int new_inotify_fd(void) {
     return fd;
 
   if (errno != ENOSYS)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   fd = uv__inotify_init();
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err == 0)
@@ -300,7 +300,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   wd = uv__inotify_add_watch(handle->loop->inotify_fd, path, events);
   if (wd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   w = find_watcher(handle->loop, wd);
   if (w)

--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -73,11 +73,11 @@ static int new_inotify_fd(void) {
     return fd;
 
   if (errno != ENOSYS)
-    return -errno;
+    return UV_ERR(errno);
 
   fd = uv__inotify_init();
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err == 0)
@@ -283,7 +283,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   int wd;
 
   if (uv__is_active(handle))
-    return -EINVAL;
+    return UV_EINVAL;
 
   err = init_inotify(handle->loop);
   if (err)
@@ -300,7 +300,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   wd = uv__inotify_add_watch(handle->loop->inotify_fd, path, events);
   if (wd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   w = find_watcher(handle->loop, wd);
   if (w)
@@ -308,7 +308,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   w = uv__malloc(sizeof(*w) + strlen(path) + 1);
   if (w == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   w->wd = wd;
   w->path = strcpy((char*)(w + 1), path);

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -31,7 +31,7 @@
                                                                               \
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
-    if (cb == NULL) return -EINVAL;                                           \
+    if (cb == NULL) return UV_EINVAL;                                         \
     QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -91,7 +91,7 @@ int uv_exepath(char* buffer, size_t* size) {
   int_size = ARRAY_SIZE(int_buf);
 
   if (sysctl(mib, 4, int_buf, &int_size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   /* Copy string from the intermediate buffer to outer one with appropriate
    * length.
@@ -111,7 +111,7 @@ uint64_t uv_get_free_memory(void) {
   int which[] = {CTL_VM, VM_UVMEXP};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
 }
@@ -128,7 +128,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info;
 }
@@ -230,7 +230,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   now = time(NULL);
 
@@ -254,12 +254,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(model);
   if (sysctlbyname("machdep.cpu_brand", &model, &size, NULL, 0) &&
       sysctlbyname("hw.model", &model, &size, NULL, 0)) {
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   size = sizeof(numcpus);
   if (sysctlbyname("hw.ncpu", &numcpus, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   *count = numcpus;
 
   /* Only i386 and amd64 have machdep.tsc_freq */
@@ -273,7 +273,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     return UV_ENOMEM;
 
   if (sysctlbyname("kern.cp_time", cp_times, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos)) {

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -82,7 +82,7 @@ int uv_exepath(char* buffer, size_t* size) {
   int mib[4];
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   mib[0] = CTL_KERN;
   mib[1] = KERN_PROC_ARGS;
@@ -91,7 +91,7 @@ int uv_exepath(char* buffer, size_t* size) {
   int_size = ARRAY_SIZE(int_buf);
 
   if (sysctl(mib, 4, int_buf, &int_size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   /* Copy string from the intermediate buffer to outer one with appropriate
    * length.
@@ -111,7 +111,7 @@ uint64_t uv_get_free_memory(void) {
   int which[] = {CTL_VM, VM_UVMEXP};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
 }
@@ -128,7 +128,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info;
 }
@@ -150,7 +150,7 @@ int uv_set_process_title(const char* title) {
 
   if (process_title == NULL) {
     uv_mutex_unlock(&process_title_mutex);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   uv__free(process_title);
@@ -167,7 +167,7 @@ int uv_get_process_title(char* buffer, size_t size) {
   size_t len;
 
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
@@ -177,7 +177,7 @@ int uv_get_process_title(char* buffer, size_t size) {
 
     if (size < len) {
       uv_mutex_unlock(&process_title_mutex);
-      return -ENOBUFS;
+      return UV_ENOBUFS;
     }
 
     memcpy(buffer, process_title, len);
@@ -219,7 +219,7 @@ int uv_resident_set_memory(size_t* rss) {
 
 error:
   if (kd) kvm_close(kd);
-  return -EPERM;
+  return UV_EPERM;
 }
 
 
@@ -230,7 +230,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   now = time(NULL);
 
@@ -254,12 +254,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(model);
   if (sysctlbyname("machdep.cpu_brand", &model, &size, NULL, 0) &&
       sysctlbyname("hw.model", &model, &size, NULL, 0)) {
-    return -errno;
+    return UV_ERR(errno);
   }
 
   size = sizeof(numcpus);
   if (sysctlbyname("hw.ncpu", &numcpus, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
   *count = numcpus;
 
   /* Only i386 and amd64 have machdep.tsc_freq */
@@ -270,16 +270,16 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = numcpus * CPUSTATES * sizeof(*cp_times);
   cp_times = uv__malloc(size);
   if (cp_times == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   if (sysctlbyname("kern.cp_time", cp_times, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos)) {
     uv__free(cp_times);
     uv__free(*cpu_infos);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   for (i = 0; i < numcpus; i++) {

--- a/src/unix/no-fsevents.c
+++ b/src/unix/no-fsevents.c
@@ -25,16 +25,16 @@
 #include <errno.h>
 
 int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb,
                       const char* filename, unsigned int flags) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 int uv_fs_event_stop(uv_fs_event_t* handle) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 void uv__fs_event_close(uv_fs_event_t* handle) {

--- a/src/unix/no-proctitle.c
+++ b/src/unix/no-proctitle.c
@@ -35,7 +35,7 @@ int uv_set_process_title(const char* title) {
 
 int uv_get_process_title(char* buffer, size_t size) {
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   buffer[0] = '\0';
   return 0;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -95,7 +95,7 @@ int uv_exepath(char* buffer, size_t* size) {
       break;
     }
     if (errno != ENOMEM) {
-      err = UV_ERR(errno);
+      err = UV__ERR(errno);
       goto out;
     }
     argsbuf_size *= 2U;
@@ -128,7 +128,7 @@ uint64_t uv_get_free_memory(void) {
   int which[] = {CTL_VM, VM_UVMEXP};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
 }
@@ -140,7 +140,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return (uint64_t) info;
 }
@@ -219,7 +219,7 @@ int uv_resident_set_memory(size_t* rss) {
   mib[5] = 1;
 
   if (sysctl(mib, 6, &kinfo, &size, NULL, 0) < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *rss = kinfo.p_vm_rssize * page_size;
   return 0;
@@ -233,7 +233,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   now = time(NULL);
 
@@ -255,12 +255,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   size = sizeof(model);
   if (sysctl(which, 2, &model, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   which[1] = HW_NCPU;
   size = sizeof(numcpus);
   if (sysctl(which, 2, &numcpus, &size, NULL, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos))
@@ -272,7 +272,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(cpuspeed);
   if (sysctl(which, 2, &cpuspeed, &size, NULL, 0)) {
     uv__free(*cpu_infos);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   size = sizeof(info);
@@ -283,7 +283,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     size = sizeof(info);
     if (sysctl(which, 3, &info, &size, NULL, 0)) {
       uv__free(*cpu_infos);
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
 
     cpu_info = &(*cpu_infos)[i];

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -78,11 +78,11 @@ int uv_exepath(char* buffer, size_t* size) {
   int err;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   mypid = getpid();
   for (;;) {
-    err = -ENOMEM;
+    err = UV_ENOMEM;
     argsbuf_tmp = uv__realloc(argsbuf, argsbuf_size);
     if (argsbuf_tmp == NULL)
       goto out;
@@ -95,14 +95,14 @@ int uv_exepath(char* buffer, size_t* size) {
       break;
     }
     if (errno != ENOMEM) {
-      err = -errno;
+      err = UV_ERR(errno);
       goto out;
     }
     argsbuf_size *= 2U;
   }
 
   if (argsbuf[0] == NULL) {
-    err = -EINVAL;  /* FIXME(bnoordhuis) More appropriate error. */
+    err = UV_EINVAL;  /* FIXME(bnoordhuis) More appropriate error. */
     goto out;
   }
 
@@ -128,7 +128,7 @@ uint64_t uv_get_free_memory(void) {
   int which[] = {CTL_VM, VM_UVMEXP};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
 }
@@ -140,7 +140,7 @@ uint64_t uv_get_total_memory(void) {
   size_t size = sizeof(info);
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   return (uint64_t) info;
 }
@@ -162,7 +162,7 @@ int uv_set_process_title(const char* title) {
 
   if (process_title == NULL) {
     uv_mutex_unlock(&process_title_mutex);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   uv__free(process_title);
@@ -179,7 +179,7 @@ int uv_get_process_title(char* buffer, size_t size) {
   size_t len;
 
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
@@ -189,7 +189,7 @@ int uv_get_process_title(char* buffer, size_t size) {
 
     if (size < len) {
       uv_mutex_unlock(&process_title_mutex);
-      return -ENOBUFS;
+      return UV_ENOBUFS;
     }
 
     memcpy(buffer, process_title, len);
@@ -219,7 +219,7 @@ int uv_resident_set_memory(size_t* rss) {
   mib[5] = 1;
 
   if (sysctl(mib, 6, &kinfo, &size, NULL, 0) < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   *rss = kinfo.p_vm_rssize * page_size;
   return 0;
@@ -233,7 +233,7 @@ int uv_uptime(double* uptime) {
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, 2, &info, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   now = time(NULL);
 
@@ -255,16 +255,16 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   size = sizeof(model);
   if (sysctl(which, 2, &model, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   which[1] = HW_NCPU;
   size = sizeof(numcpus);
   if (sysctl(which, 2, &numcpus, &size, NULL, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
   if (!(*cpu_infos))
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   *count = numcpus;
 
@@ -272,7 +272,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   size = sizeof(cpuspeed);
   if (sysctl(which, 2, &cpuspeed, &size, NULL, 0)) {
     uv__free(*cpu_infos);
-    return -errno;
+    return UV_ERR(errno);
   }
 
   size = sizeof(info);
@@ -283,7 +283,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     size = sizeof(info);
     if (sysctl(which, 3, &info, &size, NULL, 0)) {
       uv__free(*cpu_infos);
-      return -errno;
+      return UV_ERR(errno);
     }
 
     cpu_info = &(*cpu_infos)[i];

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -122,7 +122,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   ep = epoll_create1(0);
   loop->ep = ep;
   if (ep == NULL)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -259,12 +259,12 @@ int uv_exepath(char* buffer, size_t* size) {
   int pid;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   pid = getpid();
   res = getexe(pid, args, sizeof(args));
   if (res < 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /*
    * Possibilities for args:
@@ -277,7 +277,7 @@ int uv_exepath(char* buffer, size_t* size) {
   /* Case i) and ii) absolute or relative paths */
   if (strchr(args, '/') != NULL) {
     if (realpath(args, abspath) != abspath)
-      return -errno;
+      return UV_ERR(errno);
 
     abspath_size = strlen(abspath);
 
@@ -297,11 +297,11 @@ int uv_exepath(char* buffer, size_t* size) {
     char* path = getenv("PATH");
 
     if (path == NULL)
-      return -EINVAL;
+      return UV_EINVAL;
 
     clonedpath = uv__strdup(path);
     if (clonedpath == NULL)
-      return -ENOMEM;
+      return UV_ENOMEM;
 
     token = strtok(clonedpath, ":");
     while (token != NULL) {
@@ -327,7 +327,7 @@ int uv_exepath(char* buffer, size_t* size) {
     uv__free(clonedpath);
 
     /* Out of tokens (path entries), and no match found */
-    return -EINVAL;
+    return UV_EINVAL;
   }
 }
 
@@ -407,7 +407,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   *cpu_infos = uv__malloc(*count * sizeof(uv_cpu_info_t));
   if (!*cpu_infos)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   cpu_info = *cpu_infos;
   idx = 0;
@@ -452,7 +452,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
   maxsize = 16384;
 
   if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)))
-    return -errno;
+    return UV_ERR(errno);
 
   ifc.__nif6h_version = 1;
   ifc.__nif6h_buflen = maxsize;
@@ -460,7 +460,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
 
   if (ioctl(sockfd, SIOCGIFCONF6, &ifc) == -1) {
     uv__close(sockfd);
-    return -errno;
+    return UV_ERR(errno);
   }
 
 
@@ -484,7 +484,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
   *addresses = uv__malloc(*count * sizeof(uv_interface_address_t));
   if (!(*addresses)) {
     uv__close(sockfd);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
   address = *addresses;
 
@@ -543,13 +543,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
   if (0 > sockfd)
-    return -errno;
+    return UV_ERR(errno);
 
   ifc.ifc_req = uv__calloc(1, maxsize);
   ifc.ifc_len = maxsize;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     uv__close(sockfd);
-    return -errno;
+    return UV_ERR(errno);
   }
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
@@ -569,7 +569,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return -errno;
+      return UV_ERR(errno);
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
@@ -584,7 +584,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   if (!(*addresses)) {
     uv__close(sockfd);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
   address = *addresses;
 
@@ -607,7 +607,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return -ENOSYS;
+      return UV_ENOSYS;
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
@@ -706,7 +706,7 @@ int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb,
   int rc;
 
   if (uv__is_active(handle))
-    return -EINVAL;
+    return UV_EINVAL;
 
   ep = handle->loop->ep;
   assert(ep->msg_queue != -1);
@@ -718,11 +718,11 @@ int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb,
 
   path = uv__strdup(filename);
   if (path == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   rc = __w_pioctl(path, _IOCC_REGFILEINT, sizeof(reg_struct), &reg_struct);
   if (rc != 0)
-    return -errno;
+    return UV_ERR(errno);
 
   uv__handle_start(handle);
   handle->path = path;

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -122,7 +122,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
   ep = epoll_create1(0);
   loop->ep = ep;
   if (ep == NULL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }
@@ -277,7 +277,7 @@ int uv_exepath(char* buffer, size_t* size) {
   /* Case i) and ii) absolute or relative paths */
   if (strchr(args, '/') != NULL) {
     if (realpath(args, abspath) != abspath)
-      return UV_ERR(errno);
+      return UV__ERR(errno);
 
     abspath_size = strlen(abspath);
 
@@ -452,7 +452,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
   maxsize = 16384;
 
   if (0 > (sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   ifc.__nif6h_version = 1;
   ifc.__nif6h_buflen = maxsize;
@@ -460,7 +460,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
 
   if (ioctl(sockfd, SIOCGIFCONF6, &ifc) == -1) {
     uv__close(sockfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
 
@@ -543,13 +543,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
   if (0 > sockfd)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   ifc.ifc_req = uv__calloc(1, maxsize);
   ifc.ifc_len = maxsize;
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     uv__close(sockfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
@@ -569,7 +569,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       uv__close(sockfd);
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
 
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
@@ -722,7 +722,7 @@ int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb,
 
   rc = __w_pioctl(path, _IOCC_REGFILEINT, sizeof(reg_struct), &reg_struct);
   if (rc != 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   uv__handle_start(handle);
   handle->path = path;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -50,12 +50,12 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
 
   /* Already bound? */
   if (uv__stream_fd(handle) >= 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* Make a copy of the file name, it outlives this function's scope. */
   pipe_fname = uv__strdup(name);
   if (pipe_fname == NULL)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   /* We've got a copy, don't touch the original any more. */
   name = NULL;
@@ -71,10 +71,10 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   saddr.sun_family = AF_UNIX;
 
   if (bind(sockfd, (struct sockaddr*)&saddr, sizeof saddr)) {
-    err = -errno;
+    err = UV_ERR(errno);
     /* Convert ENOENT to EACCES for compatibility with Windows. */
-    if (err == -ENOENT)
-      err = -EACCES;
+    if (err == UV_ENOENT)
+      err = UV_EACCES;
 
     uv__close(sockfd);
     goto err_socket;
@@ -94,7 +94,7 @@ err_socket:
 
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
   if (uv__stream_fd(handle) == -1)
-    return -EINVAL;
+    return UV_EINVAL;
 
 #if defined(__MVS__)
   /* On zOS, backlog=0 has undefined behaviour */
@@ -105,7 +105,7 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
 #endif
 
   if (listen(uv__stream_fd(handle), backlog))
-    return -errno;
+    return UV_ERR(errno);
 
   handle->connection_cb = cb;
   handle->io_watcher.cb = uv__server_io;
@@ -180,14 +180,14 @@ void uv_pipe_connect(uv_connect_t* req,
   while (r == -1 && errno == EINTR);
 
   if (r == -1 && errno != EINPROGRESS) {
-    err = -errno;
+    err = UV_ERR(errno);
 #if defined(__CYGWIN__) || defined(__MSYS__)
     /* EBADF is supposed to mean that the socket fd is bad, but
        Cygwin reports EBADF instead of ENOTSOCK when the file is
        not a socket.  We do not expect to see a bad fd here
        (e.g. due to new_sock), so translate the error.  */
-    if (err == -EBADF)
-      err = -ENOTSOCK;
+    if (err == UV_EBADF)
+      err = UV_ENOTSOCK;
 #endif
     goto out;
   }
@@ -234,7 +234,7 @@ static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
   err = func(uv__stream_fd(handle), (struct sockaddr*) &sa, &addrlen);
   if (err < 0) {
     *size = 0;
-    return -errno;
+    return UV_ERR(errno);
   }
 
 #if defined(__linux__)
@@ -312,15 +312,15 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
   int r;
 
   if (handle == NULL || uv__stream_fd(handle) == -1)
-    return -EBADF;
+    return UV_EBADF;
 
   if (mode != UV_READABLE &&
       mode != UV_WRITABLE &&
       mode != (UV_WRITABLE | UV_READABLE))
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (fstat(uv__stream_fd(handle), &pipe_stat) == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   desired_mode = 0;
   if (mode & UV_READABLE)
@@ -353,5 +353,5 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
   r = chmod(name_buffer, pipe_stat.st_mode);
   uv__free(name_buffer);
 
-  return r != -1 ? 0 : -errno;
+  return r != -1 ? 0 : UV_ERR(errno);
 }

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -71,7 +71,7 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   saddr.sun_family = AF_UNIX;
 
   if (bind(sockfd, (struct sockaddr*)&saddr, sizeof saddr)) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
     /* Convert ENOENT to EACCES for compatibility with Windows. */
     if (err == UV_ENOENT)
       err = UV_EACCES;
@@ -105,7 +105,7 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
 #endif
 
   if (listen(uv__stream_fd(handle), backlog))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   handle->connection_cb = cb;
   handle->io_watcher.cb = uv__server_io;
@@ -180,7 +180,7 @@ void uv_pipe_connect(uv_connect_t* req,
   while (r == -1 && errno == EINTR);
 
   if (r == -1 && errno != EINPROGRESS) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
 #if defined(__CYGWIN__) || defined(__MSYS__)
     /* EBADF is supposed to mean that the socket fd is bad, but
        Cygwin reports EBADF instead of ENOTSOCK when the file is
@@ -234,7 +234,7 @@ static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
   err = func(uv__stream_fd(handle), (struct sockaddr*) &sa, &addrlen);
   if (err < 0) {
     *size = 0;
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
 #if defined(__linux__)
@@ -320,7 +320,7 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
     return UV_EINVAL;
 
   if (fstat(uv__stream_fd(handle), &pipe_stat) == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   desired_mode = 0;
   if (mode & UV_READABLE)
@@ -353,5 +353,5 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
   r = chmod(name_buffer, pipe_stat.st_mode);
   uv__free(name_buffer);
 
-  return r != -1 ? 0 : UV_ERR(errno);
+  return r != -1 ? 0 : UV__ERR(errno);
 }

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -47,7 +47,7 @@ static void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   if ((events & POLLERR) && !(events & UV__POLLPRI)) {
     uv__io_stop(loop, w, POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI);
     uv__handle_stop(handle);
-    handle->poll_cb(handle, -EBADF, 0);
+    handle->poll_cb(handle, UV_EBADF, 0);
     return;
   }
 
@@ -76,7 +76,7 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    * Workaround for e.g. kqueue fds not supporting ioctls.
    */
   err = uv__nonblock(fd, 1);
-  if (err == -ENOTTY)
+  if (err == UV_ENOTTY)
     if (uv__nonblock == uv__nonblock_ioctl)
       err = uv__nonblock_fcntl(fd, 1);
 

--- a/src/unix/posix-poll.c
+++ b/src/unix/posix-poll.c
@@ -315,10 +315,10 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   while (rv == -1 && (errno == EINTR || errno == EAGAIN));
 
   if (rv == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   if (p[0].revents & POLLNVAL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   return 0;
 }

--- a/src/unix/posix-poll.c
+++ b/src/unix/posix-poll.c
@@ -315,7 +315,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   while (rv == -1 && (errno == EINTR || errno == EAGAIN));
 
   if (rv == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   if (p[0].revents & POLLNVAL)
     return UV_EINVAL;

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -126,7 +126,7 @@ int uv__make_socketpair(int fds[2], int flags) {
    * Anything else is a genuine error.
    */
   if (errno != EINVAL)
-    return -errno;
+    return UV_ERR(errno);
 
   no_cloexec = 1;
 
@@ -134,7 +134,7 @@ skip:
 #endif
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds))
-    return -errno;
+    return UV_ERR(errno);
 
   uv__cloexec(fds[0], 1);
   uv__cloexec(fds[1], 1);
@@ -159,7 +159,7 @@ int uv__make_pipe(int fds[2], int flags) {
     return 0;
 
   if (errno != ENOSYS)
-    return -errno;
+    return UV_ERR(errno);
 
   no_pipe2 = 1;
 
@@ -167,7 +167,7 @@ skip:
 #endif
 
   if (pipe(fds))
-    return -errno;
+    return UV_ERR(errno);
 
   uv__cloexec(fds[0], 1);
   uv__cloexec(fds[1], 1);
@@ -198,7 +198,7 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
   case UV_CREATE_PIPE:
     assert(container->data.stream != NULL);
     if (container->data.stream->type != UV_NAMED_PIPE)
-      return -EINVAL;
+      return UV_EINVAL;
     else
       return uv__make_socketpair(fds, 0);
 
@@ -210,14 +210,14 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
       fd = uv__stream_fd(container->data.stream);
 
     if (fd == -1)
-      return -EINVAL;
+      return UV_EINVAL;
 
     fds[1] = fd;
     return 0;
 
   default:
     assert(0 && "Unexpected flags");
-    return -EINVAL;
+    return UV_EINVAL;
   }
 }
 
@@ -299,7 +299,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
       continue;
     pipes[fd][1] = fcntl(use_fd, F_DUPFD, stdio_count);
     if (pipes[fd][1] == -1) {
-      uv__write_int(error_fd, -errno);
+      uv__write_int(error_fd, UV_ERR(errno));
       _exit(127);
     }
   }
@@ -319,7 +319,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
         close_fd = use_fd;
 
         if (use_fd == -1) {
-          uv__write_int(error_fd, -errno);
+          uv__write_int(error_fd, UV_ERR(errno));
           _exit(127);
         }
       }
@@ -331,7 +331,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
       fd = dup2(use_fd, fd);
 
     if (fd == -1) {
-      uv__write_int(error_fd, -errno);
+      uv__write_int(error_fd, UV_ERR(errno));
       _exit(127);
     }
 
@@ -350,7 +350,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
   }
 
   if (options->cwd != NULL && chdir(options->cwd)) {
-    uv__write_int(error_fd, -errno);
+    uv__write_int(error_fd, UV_ERR(errno));
     _exit(127);
   }
 
@@ -366,12 +366,12 @@ static void uv__process_child_init(const uv_process_options_t* options,
   }
 
   if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
-    uv__write_int(error_fd, -errno);
+    uv__write_int(error_fd, UV_ERR(errno));
     _exit(127);
   }
 
   if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid)) {
-    uv__write_int(error_fd, -errno);
+    uv__write_int(error_fd, UV_ERR(errno));
     _exit(127);
   }
 
@@ -391,7 +391,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (SIG_ERR != signal(n, SIG_DFL))
       continue;
 
-    uv__write_int(error_fd, -errno);
+    uv__write_int(error_fd, UV_ERR(errno));
     _exit(127);
   }
 
@@ -400,12 +400,12 @@ static void uv__process_child_init(const uv_process_options_t* options,
   err = pthread_sigmask(SIG_SETMASK, &set, NULL);
 
   if (err != 0) {
-    uv__write_int(error_fd, -err);
+    uv__write_int(error_fd, UV_ERR(err));
     _exit(127);
   }
 
   execvp(options->file, options->args);
-  uv__write_int(error_fd, -errno);
+  uv__write_int(error_fd, UV_ERR(errno));
   _exit(127);
 }
 #endif
@@ -416,7 +416,7 @@ int uv_spawn(uv_loop_t* loop,
              const uv_process_options_t* options) {
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   /* fork is marked __WATCHOS_PROHIBITED __TVOS_PROHIBITED. */
-  return -ENOSYS;
+  return UV_ENOSYS;
 #else
   int signal_pipe[2] = { -1, -1 };
   int pipes_storage[8][2];
@@ -443,7 +443,7 @@ int uv_spawn(uv_loop_t* loop,
   if (stdio_count < 3)
     stdio_count = 3;
 
-  err = -ENOMEM;
+  err = UV_ENOMEM;
   pipes = pipes_storage;
   if (stdio_count > (int) ARRAY_SIZE(pipes_storage))
     pipes = uv__malloc(stdio_count * sizeof(*pipes));
@@ -493,7 +493,7 @@ int uv_spawn(uv_loop_t* loop,
   pid = fork();
 
   if (pid == -1) {
-    err = -errno;
+    err = UV_ERR(errno);
     uv_rwlock_wrunlock(&loop->cloexec_lock);
     uv__close(signal_pipe[0]);
     uv__close(signal_pipe[1]);
@@ -585,7 +585,7 @@ int uv_process_kill(uv_process_t* process, int signum) {
 
 int uv_kill(int pid, int signum) {
   if (kill(pid, signum))
-    return -errno;
+    return UV_ERR(errno);
   else
     return 0;
 }

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -126,7 +126,7 @@ int uv__make_socketpair(int fds[2], int flags) {
    * Anything else is a genuine error.
    */
   if (errno != EINVAL)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   no_cloexec = 1;
 
@@ -134,7 +134,7 @@ skip:
 #endif
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   uv__cloexec(fds[0], 1);
   uv__cloexec(fds[1], 1);
@@ -159,7 +159,7 @@ int uv__make_pipe(int fds[2], int flags) {
     return 0;
 
   if (errno != ENOSYS)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   no_pipe2 = 1;
 
@@ -167,7 +167,7 @@ skip:
 #endif
 
   if (pipe(fds))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   uv__cloexec(fds[0], 1);
   uv__cloexec(fds[1], 1);
@@ -299,7 +299,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
       continue;
     pipes[fd][1] = fcntl(use_fd, F_DUPFD, stdio_count);
     if (pipes[fd][1] == -1) {
-      uv__write_int(error_fd, UV_ERR(errno));
+      uv__write_int(error_fd, UV__ERR(errno));
       _exit(127);
     }
   }
@@ -319,7 +319,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
         close_fd = use_fd;
 
         if (use_fd == -1) {
-          uv__write_int(error_fd, UV_ERR(errno));
+          uv__write_int(error_fd, UV__ERR(errno));
           _exit(127);
         }
       }
@@ -331,7 +331,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
       fd = dup2(use_fd, fd);
 
     if (fd == -1) {
-      uv__write_int(error_fd, UV_ERR(errno));
+      uv__write_int(error_fd, UV__ERR(errno));
       _exit(127);
     }
 
@@ -350,7 +350,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
   }
 
   if (options->cwd != NULL && chdir(options->cwd)) {
-    uv__write_int(error_fd, UV_ERR(errno));
+    uv__write_int(error_fd, UV__ERR(errno));
     _exit(127);
   }
 
@@ -366,12 +366,12 @@ static void uv__process_child_init(const uv_process_options_t* options,
   }
 
   if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
-    uv__write_int(error_fd, UV_ERR(errno));
+    uv__write_int(error_fd, UV__ERR(errno));
     _exit(127);
   }
 
   if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid)) {
-    uv__write_int(error_fd, UV_ERR(errno));
+    uv__write_int(error_fd, UV__ERR(errno));
     _exit(127);
   }
 
@@ -391,7 +391,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (SIG_ERR != signal(n, SIG_DFL))
       continue;
 
-    uv__write_int(error_fd, UV_ERR(errno));
+    uv__write_int(error_fd, UV__ERR(errno));
     _exit(127);
   }
 
@@ -400,12 +400,12 @@ static void uv__process_child_init(const uv_process_options_t* options,
   err = pthread_sigmask(SIG_SETMASK, &set, NULL);
 
   if (err != 0) {
-    uv__write_int(error_fd, UV_ERR(err));
+    uv__write_int(error_fd, UV__ERR(err));
     _exit(127);
   }
 
   execvp(options->file, options->args);
-  uv__write_int(error_fd, UV_ERR(errno));
+  uv__write_int(error_fd, UV__ERR(errno));
   _exit(127);
 }
 #endif
@@ -493,7 +493,7 @@ int uv_spawn(uv_loop_t* loop,
   pid = fork();
 
   if (pid == -1) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
     uv_rwlock_wrunlock(&loop->cloexec_lock);
     uv__close(signal_pipe[0]);
     uv__close(signal_pipe[1]);
@@ -585,7 +585,7 @@ int uv_process_kill(uv_process_t* process, int signum) {
 
 int uv_kill(int pid, int signum) {
   if (kill(pid, signum))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   else
     return 0;
 }

--- a/src/unix/procfs-exepath.c
+++ b/src/unix/procfs-exepath.c
@@ -29,14 +29,14 @@ int uv_exepath(char* buffer, size_t* size) {
   ssize_t n;
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   n = *size - 1;
   if (n > 0)
     n = readlink("/proc/self/exe", buffer, n);
 
   if (n == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   buffer[n] = '\0';
   *size = n;

--- a/src/unix/procfs-exepath.c
+++ b/src/unix/procfs-exepath.c
@@ -36,7 +36,7 @@ int uv_exepath(char* buffer, size_t* size) {
     n = readlink("/proc/self/exe", buffer, n);
 
   if (n == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   buffer[n] = '\0';
   *size = n;

--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -105,14 +105,14 @@ int uv_set_process_title(const char* title) {
 
 int uv_get_process_title(char* buffer, size_t size) {
   if (buffer == NULL || size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
 
   if (size <= process_title.len) {
     uv_mutex_unlock(&process_title_mutex);
-    return -ENOBUFS;
+    return UV_ENOBUFS;
   }
 
   if (process_title.len != 0)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -225,7 +225,7 @@ static int uv__signal_register_handler(int signum, int oneshot) {
 
   /* XXX save old action so we can restore it later on? */
   if (sigaction(signum, &sa, NULL))
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -362,7 +362,7 @@ static int uv__signal_start(uv_signal_t* handle,
    * eventually.
    */
   if (signum == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* Short circuit: if the signal watcher is already watching {signum} don't
    * go through the process of deregistering and registering the handler.

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -225,7 +225,7 @@ static int uv__signal_register_handler(int signum, int oneshot) {
 
   /* XXX save old action so we can restore it later on? */
   if (sigaction(signum, &sa, NULL))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -73,7 +73,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
 
   fd = port_create();
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err) {
@@ -132,7 +132,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 
 int uv__io_check_fd(uv_loop_t* loop, int fd) {
   if (port_associate(loop->backend_fd, PORT_SOURCE_FD, fd, POLLIN, 0))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   if (port_dissociate(loop->backend_fd, PORT_SOURCE_FD, fd))
     abort();
@@ -351,7 +351,7 @@ int uv_exepath(char* buffer, size_t* size) {
     res = readlink(buf, buffer, res);
 
   if (res == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   buffer[res] = '\0';
   *size = res;
@@ -385,7 +385,7 @@ static int uv__fs_event_rearm(uv_fs_event_t *handle) {
                      (uintptr_t) &handle->fo,
                      FILE_ATTRIB | FILE_MODIFIED,
                      handle) == -1) {
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
   handle->fd = PORT_LOADED;
 
@@ -468,7 +468,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   if (handle->loop->fs_fd == -1) {
     portfd = port_create();
     if (portfd == -1)
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     handle->loop->fs_fd = portfd;
     first_run = 1;
   }
@@ -552,7 +552,7 @@ int uv_resident_set_memory(size_t* rss) {
 
   fd = open("/proc/self/psinfo", O_RDONLY);
   if (fd == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   /* FIXME(bnoordhuis) Handle EINTR. */
   err = UV_EINVAL;
@@ -730,11 +730,11 @@ static int uv__set_phys_addr(uv_interface_address_t* address,
 
   sockfd = socket(AF_INET, SOCK_DGRAM, 0);
   if (sockfd < 0)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   if (ioctl(sockfd, SIOCGARP, (char*)&arpreq) == -1) {
     uv__close(sockfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
   memcpy(address->phys_addr, arpreq.arp_ha.sa_data, sizeof(address->phys_addr));
   uv__close(sockfd);
@@ -759,7 +759,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   struct ifaddrs* ent;
 
   if (getifaddrs(&addrs))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *count = 0;
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -73,7 +73,7 @@ int uv__platform_loop_init(uv_loop_t* loop) {
 
   fd = port_create();
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   err = uv__cloexec(fd, 1);
   if (err) {
@@ -132,7 +132,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 
 int uv__io_check_fd(uv_loop_t* loop, int fd) {
   if (port_associate(loop->backend_fd, PORT_SOURCE_FD, fd, POLLIN, 0))
-    return -errno;
+    return UV_ERR(errno);
 
   if (port_dissociate(loop->backend_fd, PORT_SOURCE_FD, fd))
     abort();
@@ -342,7 +342,7 @@ int uv_exepath(char* buffer, size_t* size) {
   char buf[128];
 
   if (buffer == NULL || size == NULL || *size == 0)
-    return -EINVAL;
+    return UV_EINVAL;
 
   snprintf(buf, sizeof(buf), "/proc/%lu/path/a.out", (unsigned long) getpid());
 
@@ -351,7 +351,7 @@ int uv_exepath(char* buffer, size_t* size) {
     res = readlink(buf, buffer, res);
 
   if (res == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   buffer[res] = '\0';
   *size = res;
@@ -378,14 +378,14 @@ void uv_loadavg(double avg[3]) {
 
 static int uv__fs_event_rearm(uv_fs_event_t *handle) {
   if (handle->fd == -1)
-    return -EBADF;
+    return UV_EBADF;
 
   if (port_associate(handle->loop->fs_fd,
                      PORT_SOURCE_FILE,
                      (uintptr_t) &handle->fo,
                      FILE_ATTRIB | FILE_MODIFIED,
                      handle) == -1) {
-    return -errno;
+    return UV_ERR(errno);
   }
   handle->fd = PORT_LOADED;
 
@@ -462,13 +462,13 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   int err;
 
   if (uv__is_active(handle))
-    return -EINVAL;
+    return UV_EINVAL;
 
   first_run = 0;
   if (handle->loop->fs_fd == -1) {
     portfd = port_create();
     if (portfd == -1)
-      return -errno;
+      return UV_ERR(errno);
     handle->loop->fs_fd = portfd;
     first_run = 1;
   }
@@ -521,7 +521,7 @@ void uv__fs_event_close(uv_fs_event_t* handle) {
 #else /* !defined(PORT_SOURCE_FILE) */
 
 int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 
@@ -529,12 +529,12 @@ int uv_fs_event_start(uv_fs_event_t* handle,
                       uv_fs_event_cb cb,
                       const char* filename,
                       unsigned int flags) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 
 int uv_fs_event_stop(uv_fs_event_t* handle) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 
 
@@ -552,10 +552,10 @@ int uv_resident_set_memory(size_t* rss) {
 
   fd = open("/proc/self/psinfo", O_RDONLY);
   if (fd == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   /* FIXME(bnoordhuis) Handle EINTR. */
-  err = -EINVAL;
+  err = UV_EINVAL;
   if (read(fd, &psinfo, sizeof(psinfo)) == sizeof(psinfo)) {
     *rss = (size_t)psinfo.pr_rssize * 1024;
     err = 0;
@@ -575,7 +575,7 @@ int uv_uptime(double* uptime) {
 
   kc = kstat_open();
   if (kc == NULL)
-    return -EPERM;
+    return UV_EPERM;
 
   ksp = kstat_lookup(kc, (char*) "unix", 0, (char*) "system_misc");
   if (kstat_read(kc, ksp, NULL) == -1) {
@@ -599,7 +599,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   kc = kstat_open();
   if (kc == NULL)
-    return -EPERM;
+    return UV_EPERM;
 
   /* Get count of cpus */
   lookup_instance = 0;
@@ -610,7 +610,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *cpu_infos = uv__malloc(lookup_instance * sizeof(**cpu_infos));
   if (!(*cpu_infos)) {
     kstat_close(kc);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   *count = lookup_instance;
@@ -692,7 +692,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 
 #ifdef SUNOS_NO_IFADDRS
 int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-  return -ENOSYS;
+  return UV_ENOSYS;
 }
 #else  /* SUNOS_NO_IFADDRS */
 /*
@@ -730,11 +730,11 @@ static int uv__set_phys_addr(uv_interface_address_t* address,
 
   sockfd = socket(AF_INET, SOCK_DGRAM, 0);
   if (sockfd < 0)
-    return -errno;
+    return UV_ERR(errno);
 
   if (ioctl(sockfd, SIOCGARP, (char*)&arpreq) == -1) {
     uv__close(sockfd);
-    return -errno;
+    return UV_ERR(errno);
   }
   memcpy(address->phys_addr, arpreq.arp_ha.sa_data, sizeof(address->phys_addr));
   uv__close(sockfd);
@@ -759,7 +759,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   struct ifaddrs* ent;
 
   if (getifaddrs(&addrs))
-    return -errno;
+    return UV_ERR(errno);
 
   *count = 0;
 
@@ -773,7 +773,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   *addresses = uv__malloc(*count * sizeof(**addresses));
   if (!(*addresses)) {
     freeifaddrs(addrs);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   address = *addresses;

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -89,7 +89,7 @@ static int maybe_new_socket(uv_tcp_t* handle, int domain, unsigned long flags) {
       slen = sizeof(saddr);
       memset(&saddr, 0, sizeof(saddr));
       if (getsockname(uv__stream_fd(handle), (struct sockaddr*) &saddr, &slen))
-        return -errno;
+        return UV_ERR(errno);
 
       if ((saddr.ss_family == AF_INET6 &&
           ((struct sockaddr_in6*) &saddr)->sin6_port != 0) ||
@@ -102,7 +102,7 @@ static int maybe_new_socket(uv_tcp_t* handle, int domain, unsigned long flags) {
 
       /* Bind to arbitrary port */
       if (bind(uv__stream_fd(handle), (struct sockaddr*) &saddr, slen))
-        return -errno;
+        return UV_ERR(errno);
     }
 
     handle->flags |= flags;
@@ -119,10 +119,10 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* tcp, unsigned int flags) {
   /* Use the lower 8 bits for the domain */
   domain = flags & 0xFF;
   if (domain != AF_INET && domain != AF_INET6 && domain != AF_UNSPEC)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (flags & ~0xFF)
-    return -EINVAL;
+    return UV_EINVAL;
 
   uv__stream_init(loop, (uv_stream_t*)tcp, UV_TCP);
 
@@ -156,7 +156,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 
   /* Cannot set IPv6-only mode on non-IPv6 socket. */
   if ((flags & UV_TCP_IPV6ONLY) && addr->sa_family != AF_INET6)
-    return -EINVAL;
+    return UV_EINVAL;
 
   err = maybe_new_socket(tcp, addr->sa_family, 0);
   if (err)
@@ -164,7 +164,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 
   on = 1;
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
-    return -errno;
+    return UV_ERR(errno);
 
 #ifdef IPV6_V6ONLY
   if (addr->sa_family == AF_INET6) {
@@ -176,9 +176,9 @@ int uv__tcp_bind(uv_tcp_t* tcp,
                    sizeof on) == -1) {
 #if defined(__MVS__)
       if (errno == EOPNOTSUPP)
-        return -EINVAL;
+        return UV_EINVAL;
 #endif
-      return -errno;
+      return UV_ERR(errno);
     }
   }
 #endif
@@ -188,10 +188,10 @@ int uv__tcp_bind(uv_tcp_t* tcp,
     if (errno == EAFNOSUPPORT)
       /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
        * socket created with AF_INET to an AF_INET6 address or vice versa. */
-      return -EINVAL;
-    return -errno;
+      return UV_EINVAL;
+    return UV_ERR(errno);
   }
-  tcp->delayed_error = -errno;
+  tcp->delayed_error = UV_ERR(errno);
 
   tcp->flags |= UV_HANDLE_BOUND;
   if (addr->sa_family == AF_INET6)
@@ -212,7 +212,7 @@ int uv__tcp_connect(uv_connect_t* req,
   assert(handle->type == UV_TCP);
 
   if (handle->connect_req != NULL)
-    return -EALREADY;  /* FIXME(bnoordhuis) -EINVAL or maybe -EBUSY. */
+    return UV_EALREADY;  /* FIXME(bnoordhuis) UV_EINVAL or maybe UV_EBUSY. */
 
   err = maybe_new_socket(handle,
                          addr->sa_family,
@@ -240,9 +240,9 @@ int uv__tcp_connect(uv_connect_t* req,
      * error. Solaris wants to report immediately--other unixes want to
      * wait.
      */
-      handle->delayed_error = -errno;
+      handle->delayed_error = UV_ERR(errno);
     else
-      return -errno;
+      return UV_ERR(errno);
   }
 
   uv__req_init(handle->loop, req, UV_CONNECT);
@@ -282,13 +282,13 @@ int uv_tcp_getsockname(const uv_tcp_t* handle,
     return handle->delayed_error;
 
   if (uv__stream_fd(handle) < 0)
-    return -EINVAL;  /* FIXME(bnoordhuis) -EBADF */
+    return UV_EINVAL;  /* FIXME(bnoordhuis) UV_EBADF */
 
   /* sizeof(socklen_t) != sizeof(int) on some systems. */
   socklen = (socklen_t) *namelen;
 
   if (getsockname(uv__stream_fd(handle), name, &socklen))
-    return -errno;
+    return UV_ERR(errno);
 
   *namelen = (int) socklen;
   return 0;
@@ -304,13 +304,13 @@ int uv_tcp_getpeername(const uv_tcp_t* handle,
     return handle->delayed_error;
 
   if (uv__stream_fd(handle) < 0)
-    return -EINVAL;  /* FIXME(bnoordhuis) -EBADF */
+    return UV_EINVAL;  /* FIXME(bnoordhuis) UV_EBADF */
 
   /* sizeof(socklen_t) != sizeof(int) on some systems. */
   socklen = (socklen_t) *namelen;
 
   if (getpeername(uv__stream_fd(handle), name, &socklen))
-    return -errno;
+    return UV_ERR(errno);
 
   *namelen = (int) socklen;
   return 0;
@@ -346,7 +346,7 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
     return err;
 
   if (listen(tcp->io_watcher.fd, backlog))
-    return -errno;
+    return UV_ERR(errno);
 
   tcp->connection_cb = cb;
   tcp->flags |= UV_HANDLE_BOUND;
@@ -361,18 +361,18 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
 
 int uv__tcp_nodelay(int fd, int on) {
   if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)))
-    return -errno;
+    return UV_ERR(errno);
   return 0;
 }
 
 
 int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
   if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
-    return -errno;
+    return UV_ERR(errno);
 
 #ifdef TCP_KEEPIDLE
   if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &delay, sizeof(delay)))
-    return -errno;
+    return UV_ERR(errno);
 #endif
 
   /* Solaris/SmartOS, if you don't support keep-alive,
@@ -381,7 +381,7 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
   /* FIXME(bnoordhuis) That's possibly because sizeof(delay) should be 1. */
 #if defined(TCP_KEEPALIVE) && !defined(__sun)
   if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &delay, sizeof(delay)))
-    return -errno;
+    return UV_ERR(errno);
 #endif
 
   return 0;

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -89,7 +89,7 @@ static int maybe_new_socket(uv_tcp_t* handle, int domain, unsigned long flags) {
       slen = sizeof(saddr);
       memset(&saddr, 0, sizeof(saddr));
       if (getsockname(uv__stream_fd(handle), (struct sockaddr*) &saddr, &slen))
-        return UV_ERR(errno);
+        return UV__ERR(errno);
 
       if ((saddr.ss_family == AF_INET6 &&
           ((struct sockaddr_in6*) &saddr)->sin6_port != 0) ||
@@ -102,7 +102,7 @@ static int maybe_new_socket(uv_tcp_t* handle, int domain, unsigned long flags) {
 
       /* Bind to arbitrary port */
       if (bind(uv__stream_fd(handle), (struct sockaddr*) &saddr, slen))
-        return UV_ERR(errno);
+        return UV__ERR(errno);
     }
 
     handle->flags |= flags;
@@ -164,7 +164,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 
   on = 1;
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
 #ifdef IPV6_V6ONLY
   if (addr->sa_family == AF_INET6) {
@@ -178,7 +178,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
       if (errno == EOPNOTSUPP)
         return UV_EINVAL;
 #endif
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
   }
 #endif
@@ -189,9 +189,9 @@ int uv__tcp_bind(uv_tcp_t* tcp,
       /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
        * socket created with AF_INET to an AF_INET6 address or vice versa. */
       return UV_EINVAL;
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
-  tcp->delayed_error = UV_ERR(errno);
+  tcp->delayed_error = UV__ERR(errno);
 
   tcp->flags |= UV_HANDLE_BOUND;
   if (addr->sa_family == AF_INET6)
@@ -240,9 +240,9 @@ int uv__tcp_connect(uv_connect_t* req,
      * error. Solaris wants to report immediately--other unixes want to
      * wait.
      */
-      handle->delayed_error = UV_ERR(errno);
+      handle->delayed_error = UV__ERR(errno);
     else
-      return UV_ERR(errno);
+      return UV__ERR(errno);
   }
 
   uv__req_init(handle->loop, req, UV_CONNECT);
@@ -288,7 +288,7 @@ int uv_tcp_getsockname(const uv_tcp_t* handle,
   socklen = (socklen_t) *namelen;
 
   if (getsockname(uv__stream_fd(handle), name, &socklen))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *namelen = (int) socklen;
   return 0;
@@ -310,7 +310,7 @@ int uv_tcp_getpeername(const uv_tcp_t* handle,
   socklen = (socklen_t) *namelen;
 
   if (getpeername(uv__stream_fd(handle), name, &socklen))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *namelen = (int) socklen;
   return 0;
@@ -346,7 +346,7 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
     return err;
 
   if (listen(tcp->io_watcher.fd, backlog))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   tcp->connection_cb = cb;
   tcp->flags |= UV_HANDLE_BOUND;
@@ -361,18 +361,18 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
 
 int uv__tcp_nodelay(int fd, int on) {
   if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   return 0;
 }
 
 
 int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
   if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
 #ifdef TCP_KEEPIDLE
   if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &delay, sizeof(delay)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 #endif
 
   /* Solaris/SmartOS, if you don't support keep-alive,
@@ -381,7 +381,7 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
   /* FIXME(bnoordhuis) That's possibly because sizeof(delay) should be 1. */
 #if defined(TCP_KEEPALIVE) && !defined(__sun)
   if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &delay, sizeof(delay)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 #endif
 
   return 0;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -200,7 +200,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   if (attr != NULL)
     pthread_attr_destroy(attr);
 
-  return -err;
+  return UV_ERR(err);
 }
 
 
@@ -209,7 +209,7 @@ uv_thread_t uv_thread_self(void) {
 }
 
 int uv_thread_join(uv_thread_t *tid) {
-  return -pthread_join(*tid, NULL);
+  return UV_ERR(pthread_join(*tid, NULL));
 }
 
 
@@ -220,7 +220,7 @@ int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
 
 int uv_mutex_init(uv_mutex_t* mutex) {
 #if defined(NDEBUG) || !defined(PTHREAD_MUTEX_ERRORCHECK)
-  return -pthread_mutex_init(mutex, NULL);
+  return UV_ERR(pthread_mutex_init(mutex, NULL));
 #else
   pthread_mutexattr_t attr;
   int err;
@@ -236,7 +236,7 @@ int uv_mutex_init(uv_mutex_t* mutex) {
   if (pthread_mutexattr_destroy(&attr))
     abort();
 
-  return -err;
+  return UV_ERR(err);
 #endif
 }
 
@@ -256,7 +256,7 @@ int uv_mutex_init_recursive(uv_mutex_t* mutex) {
   if (pthread_mutexattr_destroy(&attr))
     abort();
 
-  return -err;
+  return UV_ERR(err);
 }
 
 
@@ -279,7 +279,7 @@ int uv_mutex_trylock(uv_mutex_t* mutex) {
   if (err) {
     if (err != EBUSY && err != EAGAIN)
       abort();
-    return -EBUSY;
+    return UV_EBUSY;
   }
 
   return 0;
@@ -293,7 +293,7 @@ void uv_mutex_unlock(uv_mutex_t* mutex) {
 
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
-  return -pthread_rwlock_init(rwlock, NULL);
+  return UV_ERR(pthread_rwlock_init(rwlock, NULL));
 }
 
 
@@ -316,7 +316,7 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
   if (err) {
     if (err != EBUSY && err != EAGAIN)
       abort();
-    return -EBUSY;
+    return UV_EBUSY;
   }
 
   return 0;
@@ -342,7 +342,7 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
   if (err) {
     if (err != EBUSY && err != EAGAIN)
       abort();
-    return -EBUSY;
+    return UV_EBUSY;
   }
 
   return 0;
@@ -369,12 +369,12 @@ int uv_sem_init(uv_sem_t* sem, unsigned int value) {
   if (err == KERN_SUCCESS)
     return 0;
   if (err == KERN_INVALID_ARGUMENT)
-    return -EINVAL;
+    return UV_EINVAL;
   if (err == KERN_RESOURCE_SHORTAGE)
-    return -ENOMEM;
+    return UV_ENOMEM;
 
   abort();
-  return -EINVAL;  /* Satisfy the compiler. */
+  return UV_EINVAL;  /* Satisfy the compiler. */
 }
 
 
@@ -413,10 +413,10 @@ int uv_sem_trywait(uv_sem_t* sem) {
   if (err == KERN_SUCCESS)
     return 0;
   if (err == KERN_OPERATION_TIMED_OUT)
-    return -EAGAIN;
+    return UV_EAGAIN;
 
   abort();
-  return -EINVAL;  /* Satisfy the compiler. */
+  return UV_EINVAL;  /* Satisfy the compiler. */
 }
 
 #elif defined(__MVS__)
@@ -433,14 +433,14 @@ int uv_sem_init(uv_sem_t* sem, unsigned int value) {
 
   semid = semget(IPC_PRIVATE, 1, S_IRUSR | S_IWUSR);
   if (semid == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   arg.val = value;
   if (-1 == semctl(semid, 0, SETVAL, arg)) {
     err = errno;
     if (-1 == semctl(*sem, 0, IPC_RMID))
       abort();
-    return -err;
+    return UV_ERR(err);
   }
 
   *sem = semid;
@@ -493,7 +493,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 
   if (op_status) {
     if (errno == EAGAIN)
-      return -EAGAIN;
+      return UV_EAGAIN;
     abort();
   }
 
@@ -504,7 +504,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 
 int uv_sem_init(uv_sem_t* sem, unsigned int value) {
   if (sem_init(sem, 0, value))
-    return -errno;
+    return UV_ERR(errno);
   return 0;
 }
 
@@ -542,7 +542,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 
   if (r) {
     if (errno == EAGAIN)
-      return -EAGAIN;
+      return UV_EAGAIN;
     abort();
   }
 
@@ -555,7 +555,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 #if defined(__APPLE__) && defined(__MACH__) || defined(__MVS__)
 
 int uv_cond_init(uv_cond_t* cond) {
-  return -pthread_cond_init(cond, NULL);
+  return UV_ERR(pthread_cond_init(cond, NULL));
 }
 
 #else /* !(defined(__APPLE__) && defined(__MACH__)) */
@@ -566,7 +566,7 @@ int uv_cond_init(uv_cond_t* cond) {
 
   err = pthread_condattr_init(&attr);
   if (err)
-    return -err;
+    return UV_ERR(err);
 
 #if !(defined(__ANDROID_API__) && __ANDROID_API__ < 21)
   err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
@@ -588,7 +588,7 @@ error:
   pthread_cond_destroy(cond);
 error2:
   pthread_condattr_destroy(&attr);
-  return -err;
+  return UV_ERR(err);
 }
 
 #endif /* defined(__APPLE__) && defined(__MACH__) */
@@ -672,15 +672,15 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
     return 0;
 
   if (r == ETIMEDOUT)
-    return -ETIMEDOUT;
+    return UV_ETIMEDOUT;
 
   abort();
-  return -EINVAL;  /* Satisfy the compiler. */
+  return UV_EINVAL;  /* Satisfy the compiler. */
 }
 
 
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
-  return -pthread_barrier_init(barrier, NULL, count);
+  return UV_ERR(pthread_barrier_init(barrier, NULL, count));
 }
 
 
@@ -699,7 +699,7 @@ int uv_barrier_wait(uv_barrier_t* barrier) {
 
 
 int uv_key_create(uv_key_t* key) {
-  return -pthread_key_create(key, NULL);
+  return UV_ERR(pthread_key_create(key, NULL));
 }
 
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -200,7 +200,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   if (attr != NULL)
     pthread_attr_destroy(attr);
 
-  return UV_ERR(err);
+  return UV__ERR(err);
 }
 
 
@@ -209,7 +209,7 @@ uv_thread_t uv_thread_self(void) {
 }
 
 int uv_thread_join(uv_thread_t *tid) {
-  return UV_ERR(pthread_join(*tid, NULL));
+  return UV__ERR(pthread_join(*tid, NULL));
 }
 
 
@@ -220,7 +220,7 @@ int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
 
 int uv_mutex_init(uv_mutex_t* mutex) {
 #if defined(NDEBUG) || !defined(PTHREAD_MUTEX_ERRORCHECK)
-  return UV_ERR(pthread_mutex_init(mutex, NULL));
+  return UV__ERR(pthread_mutex_init(mutex, NULL));
 #else
   pthread_mutexattr_t attr;
   int err;
@@ -236,7 +236,7 @@ int uv_mutex_init(uv_mutex_t* mutex) {
   if (pthread_mutexattr_destroy(&attr))
     abort();
 
-  return UV_ERR(err);
+  return UV__ERR(err);
 #endif
 }
 
@@ -256,7 +256,7 @@ int uv_mutex_init_recursive(uv_mutex_t* mutex) {
   if (pthread_mutexattr_destroy(&attr))
     abort();
 
-  return UV_ERR(err);
+  return UV__ERR(err);
 }
 
 
@@ -293,7 +293,7 @@ void uv_mutex_unlock(uv_mutex_t* mutex) {
 
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
-  return UV_ERR(pthread_rwlock_init(rwlock, NULL));
+  return UV__ERR(pthread_rwlock_init(rwlock, NULL));
 }
 
 
@@ -433,14 +433,14 @@ int uv_sem_init(uv_sem_t* sem, unsigned int value) {
 
   semid = semget(IPC_PRIVATE, 1, S_IRUSR | S_IWUSR);
   if (semid == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   arg.val = value;
   if (-1 == semctl(semid, 0, SETVAL, arg)) {
     err = errno;
     if (-1 == semctl(*sem, 0, IPC_RMID))
       abort();
-    return UV_ERR(err);
+    return UV__ERR(err);
   }
 
   *sem = semid;
@@ -504,7 +504,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 
 int uv_sem_init(uv_sem_t* sem, unsigned int value) {
   if (sem_init(sem, 0, value))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   return 0;
 }
 
@@ -555,7 +555,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 #if defined(__APPLE__) && defined(__MACH__) || defined(__MVS__)
 
 int uv_cond_init(uv_cond_t* cond) {
-  return UV_ERR(pthread_cond_init(cond, NULL));
+  return UV__ERR(pthread_cond_init(cond, NULL));
 }
 
 #else /* !(defined(__APPLE__) && defined(__MACH__)) */
@@ -566,7 +566,7 @@ int uv_cond_init(uv_cond_t* cond) {
 
   err = pthread_condattr_init(&attr);
   if (err)
-    return UV_ERR(err);
+    return UV__ERR(err);
 
 #if !(defined(__ANDROID_API__) && __ANDROID_API__ < 21)
   err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
@@ -588,7 +588,7 @@ error:
   pthread_cond_destroy(cond);
 error2:
   pthread_condattr_destroy(&attr);
-  return UV_ERR(err);
+  return UV__ERR(err);
 }
 
 #endif /* defined(__APPLE__) && defined(__MACH__) */
@@ -680,7 +680,7 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
 
 
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
-  return UV_ERR(pthread_barrier_init(barrier, NULL, count));
+  return UV__ERR(pthread_barrier_init(barrier, NULL, count));
 }
 
 
@@ -699,7 +699,7 @@ int uv_barrier_wait(uv_barrier_t* barrier) {
 
 
 int uv_key_create(uv_key_t* key) {
-  return UV_ERR(pthread_key_create(key, NULL));
+  return UV__ERR(pthread_key_create(key, NULL));
 }
 
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -66,7 +66,7 @@ int uv_timer_start(uv_timer_t* handle,
   uint64_t clamped_timeout;
 
   if (cb == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (uv__is_active(handle))
     uv_timer_stop(handle);
@@ -105,7 +105,7 @@ int uv_timer_stop(uv_timer_t* handle) {
 
 int uv_timer_again(uv_timer_t* handle) {
   if (handle->timer_cb == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (handle->repeat) {
     uv_timer_stop(handle);

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -106,7 +106,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int readable) {
    */
   type = uv_guess_handle(fd);
   if (type == UV_FILE || type == UV_UNKNOWN_HANDLE)
-    return -EINVAL;
+    return UV_EINVAL;
 
   flags = 0;
   newfd = -1;
@@ -142,7 +142,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int readable) {
     newfd = r;
 
     r = uv__dup2_cloexec(newfd, fd);
-    if (r < 0 && r != -EINVAL) {
+    if (r < 0 && r != UV_EINVAL) {
       /* EINVAL means newfd == fd which could conceivably happen if another
        * thread called close(fd) between our calls to isatty() and open().
        * That's a rather unlikely event but let's handle it anyway.
@@ -163,7 +163,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int readable) {
   if (saved_flags == -1) {
     if (newfd != -1)
       uv__close(newfd);
-    return -errno;
+    return UV_ERR(errno);
   }
 #endif
 
@@ -234,7 +234,7 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   fd = uv__stream_fd(tty);
   if (tty->mode == UV_TTY_MODE_NORMAL && mode != UV_TTY_MODE_NORMAL) {
     if (tcgetattr(fd, &tty->orig_termios))
-      return -errno;
+      return UV_ERR(errno);
 
     /* This is used for uv_tty_reset_mode() */
     uv_spinlock_lock(&termios_spinlock);
@@ -264,7 +264,7 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
 
   /* Apply changes after draining */
   if (tcsetattr(fd, TCSADRAIN, &tmp))
-    return -errno;
+    return UV_ERR(errno);
 
   tty->mode = mode;
   return 0;
@@ -280,7 +280,7 @@ int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
   while (err == -1 && errno == EINTR);
 
   if (err == -1)
-    return -errno;
+    return UV_ERR(errno);
 
   *width = ws.ws_col;
   *height = ws.ws_row;
@@ -358,12 +358,12 @@ int uv_tty_reset_mode(void) {
 
   saved_errno = errno;
   if (!uv_spinlock_trylock(&termios_spinlock))
-    return -EBUSY;  /* In uv_tty_set_mode(). */
+    return UV_EBUSY;  /* In uv_tty_set_mode(). */
 
   err = 0;
   if (orig_termios_fd != -1)
     if (tcsetattr(orig_termios_fd, TCSANOW, &orig_termios))
-      err = -errno;
+      err = UV_ERR(errno);
 
   uv_spinlock_unlock(&termios_spinlock);
   errno = saved_errno;

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -163,7 +163,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int readable) {
   if (saved_flags == -1) {
     if (newfd != -1)
       uv__close(newfd);
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 #endif
 
@@ -234,7 +234,7 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   fd = uv__stream_fd(tty);
   if (tty->mode == UV_TTY_MODE_NORMAL && mode != UV_TTY_MODE_NORMAL) {
     if (tcgetattr(fd, &tty->orig_termios))
-      return UV_ERR(errno);
+      return UV__ERR(errno);
 
     /* This is used for uv_tty_reset_mode() */
     uv_spinlock_lock(&termios_spinlock);
@@ -264,7 +264,7 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
 
   /* Apply changes after draining */
   if (tcsetattr(fd, TCSADRAIN, &tmp))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   tty->mode = mode;
   return 0;
@@ -280,7 +280,7 @@ int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
   while (err == -1 && errno == EINTR);
 
   if (err == -1)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *width = ws.ws_col;
   *height = ws.ws_row;
@@ -363,7 +363,7 @@ int uv_tty_reset_mode(void) {
   err = 0;
   if (orig_termios_fd != -1)
     if (tcsetattr(orig_termios_fd, TCSANOW, &orig_termios))
-      err = UV_ERR(errno);
+      err = UV__ERR(errno);
 
   uv_spinlock_unlock(&termios_spinlock);
   errno = saved_errno;

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -72,7 +72,7 @@ void uv__udp_finish_close(uv_udp_t* handle) {
     QUEUE_REMOVE(q);
 
     req = QUEUE_DATA(q, uv_udp_send_t, queue);
-    req->status = -ECANCELED;
+    req->status = UV_ECANCELED;
     QUEUE_INSERT_TAIL(&handle->write_completed_queue, &req->queue);
   }
 
@@ -189,7 +189,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
       if (errno == EAGAIN || errno == EWOULDBLOCK)
         handle->recv_cb(handle, 0, &buf, NULL, 0);
       else
-        handle->recv_cb(handle, -errno, &buf, NULL, 0);
+        handle->recv_cb(handle, UV_ERR(errno), &buf, NULL, 0);
     }
     else {
       const struct sockaddr *addr;
@@ -242,7 +242,7 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
         break;
     }
 
-    req->status = (size == -1 ? -errno : size);
+    req->status = (size == -1 ? UV_ERR(errno) : size);
 
     /* Sending a datagram is an atomic operation: either all data
      * is written or nothing is (and EMSGSIZE is raised). That is
@@ -270,11 +270,11 @@ static int uv__set_reuse(int fd) {
 #if defined(SO_REUSEPORT) && !defined(__linux__)
   yes = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
-    return -errno;
+    return UV_ERR(errno);
 #else
   yes = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)))
-    return -errno;
+    return UV_ERR(errno);
 #endif
 
   return 0;
@@ -291,11 +291,11 @@ int uv__udp_bind(uv_udp_t* handle,
 
   /* Check for bad flags. */
   if (flags & ~(UV_UDP_IPV6ONLY | UV_UDP_REUSEADDR))
-    return -EINVAL;
+    return UV_EINVAL;
 
   /* Cannot set IPv6-only mode on non-IPv6 socket. */
   if ((flags & UV_UDP_IPV6ONLY) && addr->sa_family != AF_INET6)
-    return -EINVAL;
+    return UV_EINVAL;
 
   fd = handle->io_watcher.fd;
   if (fd == -1) {
@@ -316,21 +316,21 @@ int uv__udp_bind(uv_udp_t* handle,
 #ifdef IPV6_V6ONLY
     yes = 1;
     if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof yes) == -1) {
-      err = -errno;
+      err = UV_ERR(errno);
       return err;
     }
 #else
-    err = -ENOTSUP;
+    err = UV_ENOTSUP;
     return err;
 #endif
   }
 
   if (bind(fd, addr, addrlen)) {
-    err = -errno;
+    err = UV_ERR(errno);
     if (errno == EAFNOSUPPORT)
       /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
        * socket created with AF_INET to an AF_INET6 address or vice versa. */
-      err = -EINVAL;
+      err = UV_EINVAL;
     return err;
   }
 
@@ -418,7 +418,7 @@ int uv__udp_send(uv_udp_send_t* req,
 
   if (req->bufs == NULL) {
     uv__req_unregister(handle->loop, req);
-    return -ENOMEM;
+    return UV_ENOMEM;
   }
 
   memcpy(req->bufs, bufs, nbufs * sizeof(bufs[0]));
@@ -457,7 +457,7 @@ int uv__udp_try_send(uv_udp_t* handle,
 
   /* already sending a message */
   if (handle->send_queue_count != 0)
-    return -EAGAIN;
+    return UV_EAGAIN;
 
   err = uv__udp_maybe_deferred_bind(handle, addr->sa_family, 0);
   if (err)
@@ -475,9 +475,9 @@ int uv__udp_try_send(uv_udp_t* handle,
 
   if (size == -1) {
     if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
-      return -EAGAIN;
+      return UV_EAGAIN;
     else
-      return -errno;
+      return UV_ERR(errno);
   }
 
   return size;
@@ -512,7 +512,7 @@ static int uv__udp_set_membership4(uv_udp_t* handle,
     optname = IP_DROP_MEMBERSHIP;
     break;
   default:
-    return -EINVAL;
+    return UV_EINVAL;
   }
 
   if (setsockopt(handle->io_watcher.fd,
@@ -522,9 +522,9 @@ static int uv__udp_set_membership4(uv_udp_t* handle,
                  sizeof(mreq))) {
 #if defined(__MVS__)
   if (errno == ENXIO)
-    return -ENODEV;
+    return UV_ENODEV;
 #endif
-    return -errno;
+    return UV_ERR(errno);
   }
 
   return 0;
@@ -543,7 +543,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
 
   if (interface_addr) {
     if (uv_ip6_addr(interface_addr, 0, &addr6))
-      return -EINVAL;
+      return UV_EINVAL;
     mreq.ipv6mr_interface = addr6.sin6_scope_id;
   } else {
     mreq.ipv6mr_interface = 0;
@@ -559,7 +559,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
     optname = IPV6_DROP_MEMBERSHIP;
     break;
   default:
-    return -EINVAL;
+    return UV_EINVAL;
   }
 
   if (setsockopt(handle->io_watcher.fd,
@@ -569,9 +569,9 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
                  sizeof(mreq))) {
 #if defined(__MVS__)
   if (errno == ENXIO)
-    return -ENODEV;
+    return UV_ENODEV;
 #endif
-    return -errno;
+    return UV_ERR(errno);
   }
 
   return 0;
@@ -586,10 +586,10 @@ int uv_udp_init_ex(uv_loop_t* loop, uv_udp_t* handle, unsigned int flags) {
   /* Use the lower 8 bits for the domain */
   domain = flags & 0xFF;
   if (domain != AF_INET && domain != AF_INET6 && domain != AF_UNSPEC)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (flags & ~0xFF)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (domain != AF_UNSPEC) {
     err = uv__socket(domain, SOCK_DGRAM, 0);
@@ -622,7 +622,7 @@ int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock) {
 
   /* Check for already active socket. */
   if (handle->io_watcher.fd != -1)
-    return -EBUSY;
+    return UV_EBUSY;
 
   err = uv__nonblock(sock, 1);
   if (err)
@@ -656,7 +656,7 @@ int uv_udp_set_membership(uv_udp_t* handle,
       return err;
     return uv__udp_set_membership6(handle, &addr6, interface_addr, membership);
   } else {
-    return -EINVAL;
+    return UV_EINVAL;
   }
 }
 
@@ -680,7 +680,7 @@ static int uv__setsockopt(uv_udp_t* handle,
                    val,
                    size);
   if (r)
-    return -errno;
+    return UV_ERR(errno);
 
   return 0;
 }
@@ -698,7 +698,7 @@ static int uv__setsockopt_maybe_char(uv_udp_t* handle,
 #endif
 
   if (val < 0 || val > 255)
-    return -EINVAL;
+    return UV_EINVAL;
 
   return uv__setsockopt(handle, option4, option6, &arg, sizeof(arg));
 }
@@ -710,7 +710,7 @@ int uv_udp_set_broadcast(uv_udp_t* handle, int on) {
                  SO_BROADCAST,
                  &on,
                  sizeof(on))) {
-    return -errno;
+    return UV_ERR(errno);
   }
 
   return 0;
@@ -719,11 +719,11 @@ int uv_udp_set_broadcast(uv_udp_t* handle, int on) {
 
 int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
   if (ttl < 1 || ttl > 255)
-    return -EINVAL;
+    return UV_EINVAL;
 
 #if defined(__MVS__)
   if (!(handle->flags & UV_HANDLE_IPV6))
-    return -ENOTSUP;  /* zOS does not support setting ttl for IPv4 */
+    return UV_ENOTSUP;  /* zOS does not support setting ttl for IPv4 */
 #endif
 
 /*
@@ -817,7 +817,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
   } else if (uv_ip6_addr(interface_addr, 0, addr6) == 0) {
     /* nothing, address was parsed */
   } else {
-    return -EINVAL;
+    return UV_EINVAL;
   }
 
   if (addr_st.ss_family == AF_INET) {
@@ -826,7 +826,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
                    IP_MULTICAST_IF,
                    (void*) &addr4->sin_addr,
                    sizeof(addr4->sin_addr)) == -1) {
-      return -errno;
+      return UV_ERR(errno);
     }
   } else if (addr_st.ss_family == AF_INET6) {
     if (setsockopt(handle->io_watcher.fd,
@@ -834,7 +834,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
                    IPV6_MULTICAST_IF,
                    &addr6->sin6_scope_id,
                    sizeof(addr6->sin6_scope_id)) == -1) {
-      return -errno;
+      return UV_ERR(errno);
     }
   } else {
     assert(0 && "unexpected address family");
@@ -851,13 +851,13 @@ int uv_udp_getsockname(const uv_udp_t* handle,
   socklen_t socklen;
 
   if (handle->io_watcher.fd == -1)
-    return -EINVAL;  /* FIXME(bnoordhuis) -EBADF */
+    return UV_EINVAL;  /* FIXME(bnoordhuis) UV_EBADF */
 
   /* sizeof(socklen_t) != sizeof(int) on some systems. */
   socklen = (socklen_t) *namelen;
 
   if (getsockname(handle->io_watcher.fd, name, &socklen))
-    return -errno;
+    return UV_ERR(errno);
 
   *namelen = (int) socklen;
   return 0;
@@ -870,10 +870,10 @@ int uv__udp_recv_start(uv_udp_t* handle,
   int err;
 
   if (alloc_cb == NULL || recv_cb == NULL)
-    return -EINVAL;
+    return UV_EINVAL;
 
   if (uv__io_active(&handle->io_watcher, POLLIN))
-    return -EALREADY;  /* FIXME(bnoordhuis) Should be -EBUSY. */
+    return UV_EALREADY;  /* FIXME(bnoordhuis) Should be UV_EBUSY. */
 
   err = uv__udp_maybe_deferred_bind(handle, AF_INET, 0);
   if (err)

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -189,7 +189,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
       if (errno == EAGAIN || errno == EWOULDBLOCK)
         handle->recv_cb(handle, 0, &buf, NULL, 0);
       else
-        handle->recv_cb(handle, UV_ERR(errno), &buf, NULL, 0);
+        handle->recv_cb(handle, UV__ERR(errno), &buf, NULL, 0);
     }
     else {
       const struct sockaddr *addr;
@@ -242,7 +242,7 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
         break;
     }
 
-    req->status = (size == -1 ? UV_ERR(errno) : size);
+    req->status = (size == -1 ? UV__ERR(errno) : size);
 
     /* Sending a datagram is an atomic operation: either all data
      * is written or nothing is (and EMSGSIZE is raised). That is
@@ -270,11 +270,11 @@ static int uv__set_reuse(int fd) {
 #if defined(SO_REUSEPORT) && !defined(__linux__)
   yes = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 #else
   yes = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 #endif
 
   return 0;
@@ -316,7 +316,7 @@ int uv__udp_bind(uv_udp_t* handle,
 #ifdef IPV6_V6ONLY
     yes = 1;
     if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof yes) == -1) {
-      err = UV_ERR(errno);
+      err = UV__ERR(errno);
       return err;
     }
 #else
@@ -326,7 +326,7 @@ int uv__udp_bind(uv_udp_t* handle,
   }
 
   if (bind(fd, addr, addrlen)) {
-    err = UV_ERR(errno);
+    err = UV__ERR(errno);
     if (errno == EAFNOSUPPORT)
       /* OSX, other BSDs and SunoS fail with EAFNOSUPPORT when binding a
        * socket created with AF_INET to an AF_INET6 address or vice versa. */
@@ -477,7 +477,7 @@ int uv__udp_try_send(uv_udp_t* handle,
     if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)
       return UV_EAGAIN;
     else
-      return UV_ERR(errno);
+      return UV__ERR(errno);
   }
 
   return size;
@@ -524,7 +524,7 @@ static int uv__udp_set_membership4(uv_udp_t* handle,
   if (errno == ENXIO)
     return UV_ENODEV;
 #endif
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   return 0;
@@ -571,7 +571,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
   if (errno == ENXIO)
     return UV_ENODEV;
 #endif
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   return 0;
@@ -680,7 +680,7 @@ static int uv__setsockopt(uv_udp_t* handle,
                    val,
                    size);
   if (r)
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   return 0;
 }
@@ -710,7 +710,7 @@ int uv_udp_set_broadcast(uv_udp_t* handle, int on) {
                  SO_BROADCAST,
                  &on,
                  sizeof(on))) {
-    return UV_ERR(errno);
+    return UV__ERR(errno);
   }
 
   return 0;
@@ -826,7 +826,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
                    IP_MULTICAST_IF,
                    (void*) &addr4->sin_addr,
                    sizeof(addr4->sin_addr)) == -1) {
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
   } else if (addr_st.ss_family == AF_INET6) {
     if (setsockopt(handle->io_watcher.fd,
@@ -834,7 +834,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
                    IPV6_MULTICAST_IF,
                    &addr6->sin6_scope_id,
                    sizeof(addr6->sin6_scope_id)) == -1) {
-      return UV_ERR(errno);
+      return UV__ERR(errno);
     }
   } else {
     assert(0 && "unexpected address family");
@@ -857,7 +857,7 @@ int uv_udp_getsockname(const uv_udp_t* handle,
   socklen = (socklen_t) *namelen;
 
   if (getsockname(handle->io_watcher.fd, name, &socklen))
-    return UV_ERR(errno);
+    return UV__ERR(errno);
 
   *namelen = (int) socklen;
   return 0;

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -41,6 +41,12 @@
 #include "tree.h"
 #include "queue.h"
 
+#if EDOM > 0
+# define UV__ERR(x) (-(x))
+#else
+# define UV__ERR(x) (x)
+#endif
+
 #if !defined(snprintf) && defined(_MSC_VER) && _MSC_VER < 1900
 extern int snprintf(char*, size_t, const char*, ...);
 #endif

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -304,7 +304,7 @@ static void read_cb(uv_stream_t* handle,
   union handles* recv;
   uv_write_t* write_req;
 
-  if (nread == UV__EOF || nread == UV__ECONNABORTED) {
+  if (nread == UV_EOF || nread == UV_ECONNABORTED) {
     return;
   }
 


### PR DESCRIPTION
using `-errno`, `-E**`, and `-pthread_function()` can be error-prone and breaks compatibility with some operating systems (e.g. Haiku).

Using UV_ERR() can prevent possible future errors and fix compatibility with operating systems that use already-negated errno's.

Refer to discussion in https://github.com/libuv/help/issues/39

I have tested this on 64-bit Ubuntu 17.04 using `gcc version 6.3.0 20170406 (Ubuntu 6.3.0-12ubuntu2)` and 64-bit macOS 10.13.2 using `Apple LLVM version 9.0.0 (clang-900.0.38)`. Unfortunately, I don't have a FreeBSD machine on hand to test things on. There are no changes to the windows code, so I did not test with Windows.