### PR TITLE
test: allow net unreachable status in udp test

### DIFF
--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -67,7 +67,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT(status == 0 || status == UV_ENETUNREACH);
   CHECK_OBJECT(req->handle, uv_udp_t, client);
   CHECK_OBJECT(req, uv_udp_send_t, send_req);
   req->handle = NULL;


### PR DESCRIPTION
Since the destination address may not be routable, UV_ENETUNREACH is
an error that can happen and should be handled.

Fixes: https://github.com/libuv/libuv/issues/1680
CI: https://ci.nodejs.org/job/libuv-test-commit/647/