### PR TITLE
unix: restart syscalls interrupted by our signal handler

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -28,6 +28,9 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifndef SA_RESTART
+# define SA_RESTART 0
+#endif
 
 typedef struct {
   uv_signal_t* handle;
@@ -216,7 +219,9 @@ static int uv__signal_register_handler(int signum, int oneshot) {
   if (sigfillset(&sa.sa_mask))
     abort();
   sa.sa_handler = uv__signal_handler;
-  sa.sa_flags = oneshot ? SA_RESETHAND : 0;
+  sa.sa_flags = SA_RESTART;
+  if (oneshot)
+    sa.sa_flags |= SA_RESETHAND;
 
   /* XXX save old action so we can restore it later on? */
   if (sigaction(signum, &sa, NULL))


### PR DESCRIPTION
BSD `signal(2)` semantics make some system calls (e.g. for `write`)
restartable when interrupted by a signal handler.  Use `SA_RESTART` to
enable these semantics everywhere that supports them.

This was done by libev back when we used it.  In addition to being
common practice, this is required by C++ stream libraries that interpret
`EINTR` as any other error, set `badbit`, and stop writing.  I've
observed this with `libstdc++` during a `std::cout.flush()` call
interrupted by `SIGCHLD`.