### PR TITLE
win: use RemoveDirectoryW() instead of _wmrmdir()

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -131,7 +131,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENETUNREACH:                    return UV_ENETUNREACH;
     case WSAENOBUFS:                        return UV_ENOBUFS;
     case ERROR_BAD_PATHNAME:                return UV_ENOENT;
-    case ERROR_DIRECTORY:                   return UV_ENOENT;
+    case ERROR_DIRECTORY:                   return UV_ENOTDIR;
     case ERROR_FILE_NOT_FOUND:              return UV_ENOENT;
     case ERROR_INVALID_NAME:                return UV_ENOENT;
     case ERROR_INVALID_DRIVE:               return UV_ENOENT;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -723,8 +723,11 @@ void fs__write(uv_fs_t* req) {
 
 
 void fs__rmdir(uv_fs_t* req) {
-  int result = _wrmdir(req->file.pathw);
-  SET_REQ_RESULT(req, result);
+  if (RemoveDirectoryW(req->file.pathw)) {
+    SET_REQ_SUCCESS(req);
+  } else {
+    SET_REQ_WIN32_ERROR(req, GetLastError());
+  }
 }
 
 


### PR DESCRIPTION
Use RemoveDirectoryW() and remap ERROR_DIRECTORY from UV_ENOENT
to UV_ENOTDIR so that attempted removal of a non-directory produces
the right (and legible) error message.

Fixes: https://github.com/nodejs/node/issues/18014
CI: https://ci.nodejs.org/job/libuv-test-commit/653/