### PR TITLE
zos,test: free system resources on process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ describes the package in more detail.
 
 AIX support for filesystem events is not compiled when building with `gyp`.
 
+### z/OS Notes
+
+z/OS creates System V semaphores and message queues. These persist on the system
+after the process terminates unless the event loop is closed.
+
+Use the ipcrm command to manually clear up System V resources.
+
 ## Patches
 
 See the [guidelines for contributing][].

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -341,6 +341,7 @@ HELPER_IMPL(tcp4_echo_server) {
     return 1;
 
   uv_run(loop, UV_RUN_DEFAULT);
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }
 
@@ -352,6 +353,7 @@ HELPER_IMPL(tcp6_echo_server) {
     return 1;
 
   uv_run(loop, UV_RUN_DEFAULT);
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }
 
@@ -363,6 +365,7 @@ HELPER_IMPL(pipe_echo_server) {
     return 1;
 
   uv_run(loop, UV_RUN_DEFAULT);
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }
 
@@ -374,5 +377,6 @@ HELPER_IMPL(udp4_echo_server) {
     return 1;
 
   uv_run(loop, UV_RUN_DEFAULT);
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-connect-unspecified.c
+++ b/test/test-connect-unspecified.c
@@ -57,5 +57,6 @@ TEST_IMPL(connect_unspecified) {
 
   ASSERT(uv_run(loop, UV_RUN_DEFAULT) == 0);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -278,6 +278,9 @@ TEST_IMPL(fork_signal_to_child_closed) {
   /* A signal handler installed before forking
      doesn't get received anywhere when the child is signalled,
      but isnt running the loop. */
+#ifdef __MVS__
+  RETURN_SKIP("This test leaks system resources on z/OS");
+#endif
   uv_signal_t signal_handle;
   pid_t child_pid;
   int sync_pipe[2];

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -176,5 +176,6 @@ TEST_IMPL(fs_copyfile) {
   handle_result(&req);
 
   unlink(dst); /* Cleanup */
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -704,9 +704,15 @@ TASK_LIST_START
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
   TEST_ENTRY  (getaddrinfo_fail_sync)
 
+#ifdef __MVS__
+  TEST_ENTRY_CUSTOM  (getaddrinfo_basic, 0, 0, 10000)
+  TEST_ENTRY_CUSTOM  (getaddrinfo_basic_sync, 0, 0, 10000)
+  TEST_ENTRY_CUSTOM  (getaddrinfo_concurrent, 0, 0, 10000)
+#else
   TEST_ENTRY  (getaddrinfo_basic)
   TEST_ENTRY  (getaddrinfo_basic_sync)
   TEST_ENTRY  (getaddrinfo_concurrent)
+#endif
 
   TEST_ENTRY  (gethostname)
 

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -63,5 +63,6 @@ TEST_IMPL(loop_alive) {
   ASSERT(r == 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -67,5 +67,6 @@ TEST_IMPL(loop_stop) {
   ASSERT(timer_called == 10);
   ASSERT(prepare_called == 10);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -41,5 +41,6 @@ TEST_IMPL(run_nowait) {
   ASSERT(r != 0);
   ASSERT(timer_called == 0);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -645,6 +645,7 @@ int spawn_tcp_server_helper(void) {
   r = uv_listen((uv_stream_t*)&tcp, SOMAXCONN, NULL);
   ASSERT(r == 0);
 
+  MAKE_VALGRIND_HAPPY();
   return 1;
 }
 


### PR DESCRIPTION
The libuv tests are leaving behind semaphore and message queues which persist on z/OS after process termination if not cleaned up. This code change ensures that the tests clean up on exit and
on abornal termination via signals.

This is to address the problems being seen on the z/OS test machine which runs out of system semaphores/messagequeues after a few test runs.