### PR TITLE
Don't crash on OOM whenever possible

### DIFF
--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -164,8 +164,7 @@ static void timer_cb(uv_timer_t* timer) {
   assert(ctx->parent_handle->poll_ctx == ctx);
   ctx->start_time = uv_now(ctx->loop);
 
-  if (uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb))
-    abort();
+  uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb);
 }
 
 
@@ -214,8 +213,8 @@ out:
   interval = ctx->interval;
   interval -= (uv_now(ctx->loop) - ctx->start_time) % interval;
 
-  if (uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0))
-    abort();
+  uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0);
+  return;
 }
 
 

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -698,7 +698,7 @@ void uv__fsevents_loop_delete(uv_loop_t* loop) {
     return;
 
   if (uv__cf_loop_signal(loop, NULL, kUVCFLoopSignalRegular) != 0)
-    abort();
+    return;
 
   uv_thread_join(&loop->cf_thread);
   uv_sem_destroy(&loop->cf_sem);

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -198,13 +198,13 @@ void uv__make_close_pending(uv_handle_t* handle);
 int uv__getiovmax(void);
 
 void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd);
-void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events);
+int uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 void uv__io_close(uv_loop_t* loop, uv__io_t* w);
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w);
 int uv__io_active(const uv__io_t* w, unsigned int events);
 int uv__io_check_fd(uv_loop_t* loop, int fd);
-void uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
+int uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
 int uv__io_fork(uv_loop_t* loop);
 
 /* async */

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -429,7 +429,7 @@ static void uv__signal_event(uv_loop_t* loop,
     if (r == -1 && errno == EINTR)
       continue;
 
-    if (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    if (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOMEM)) {
       /* If there are bytes in the buffer already (which really is extremely
        * unlikely if possible at all) we can't exit the function here. We'll
        * spin until more bytes are read instead.

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -73,7 +73,7 @@ static int uv__tty_is_slave(const int fd) {
 
   /* Lookup stat structure behind the file descriptor. */
   if (fstat(fd, &sb) != 0)
-    abort();
+    return 0;
 
   /* Assert character device. */
   if (!S_ISCHR(sb.st_mode))

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -113,10 +113,10 @@ void uv__fs_poll_close(uv_fs_poll_t* handle);
 
 int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
-void uv__work_submit(uv_loop_t* loop,
-                     struct uv__work *w,
-                     void (*work)(struct uv__work *w),
-                     void (*done)(struct uv__work *w, int status));
+int uv__work_submit(uv_loop_t* loop,
+                    struct uv__work *w,
+                    void (*work)(struct uv__work *w),
+                    void (*done)(struct uv__work *w, int status));
 
 void uv__work_done(uv_async_t* handle);
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1411,7 +1411,8 @@ static void fs__sendfile(uv_fs_t* req) {
   int64_t result_offset = 0;
   char* buf = (char*) uv__malloc(buf_size);
   if (!buf) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    SET_REQ_WIN32_ERROR(req, ERROR_OUTOFMEMORY);
+    return;
   }
 
   if (offset != -1) {
@@ -1634,7 +1635,8 @@ static void fs__create_junction(uv_fs_t* req, const WCHAR* path,
   /* Allocate the buffer */
   buffer = (REPARSE_DATA_BUFFER*)uv__malloc(needed_buf_size);
   if (!buffer) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
+    return;
   }
 
   /* Grab a pointer to the part of the buffer where filenames go */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -389,7 +389,8 @@ int uv_set_process_title(const char* title) {
   /* Convert to wide-char string */
   title_w = (WCHAR*)uv__malloc(sizeof(WCHAR) * length);
   if (!title_w) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    err = ERROR_OUTOFMEMORY;
+    goto done;
   }
 
   length = MultiByteToWideChar(CP_UTF8, 0, title, -1, title_w, length);


### PR DESCRIPTION
Out of memory can actually happen in some situations, and libuv should
not crash, at least not after initialization.