### PR TITLE
win: allow directory symlinks to be created in a non-elevated context

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1785,7 +1785,7 @@ static void fs__symlink(uv_fs_t* req) {
   }
 
   if (req->fs.info.file_flags & UV_FS_SYMLINK_DIR)
-    flags = SYMBOLIC_LINK_FLAG_DIRECTORY;
+    flags = SYMBOLIC_LINK_FLAG_DIRECTORY | uv__file_symlink_usermode_flag;
   else
     flags = uv__file_symlink_usermode_flag;
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -289,6 +289,7 @@ TEST_DECLARE   (fs_realpath)
 TEST_DECLARE   (fs_symlink)
 TEST_DECLARE   (fs_symlink_dir)
 #ifdef _WIN32
+TEST_DECLARE   (fs_symlink_junction)
 TEST_DECLARE   (fs_non_symlink_reparse_point)
 #endif
 TEST_DECLARE   (fs_utime)
@@ -817,6 +818,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_symlink)
   TEST_ENTRY  (fs_symlink_dir)
 #ifdef _WIN32
+  TEST_ENTRY  (fs_symlink_junction)
   TEST_ENTRY  (fs_non_symlink_reparse_point)
 #endif
   TEST_ENTRY  (fs_stat_missing_path)


### PR DESCRIPTION
Title should be self-explanatory.

cc @cjihrig 
hi @saghul, @bnoordhuis 