### PR TITLE
doc: README: add note on installing gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ $ make check
 $ make install
 ```
 
+To build with GYP, first run:
+
+```bash
+$ git clone https://chromium.googlesource.com/external/gyp build/gyp
+```
+
 ### Windows
 
 Prerequisites:


### PR DESCRIPTION
Problem:
The instructions assume you have already installed gyp to
build/gyp.

If you run 'make' without doing so, it asks you to read the README,
which does not actually tell you about installing gyp.

Solution:
Add a one-liner `git clone` command to the setup instructions.