### PR TITLE
cygwin: fix compilation of ifaddrs impl

### DIFF
--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -36,6 +36,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
     return 1;
   if (ent->ifa_addr == NULL)
     return 1;
+#if !defined(__CYGWIN__) && !defined(__MSYS__)
   /*
    * If `exclude_type` is `UV__EXCLUDE_IFPHYS`, just see whether `sa_family`
    * equals to `AF_LINK` or not. Otherwise, the result depends on the operation
@@ -43,6 +44,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
    */
   if (exclude_type == UV__EXCLUDE_IFPHYS)
     return (ent->ifa_addr->sa_family != AF_LINK);
+#endif
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
   /*
    * On BSD getifaddrs returns information related to the raw underlying


### PR DESCRIPTION
On cygwin there is no `AF_LINK`.  Skip the check for it since
we just zero the physical addresses on this platform anyway.

Fixes: https://github.com/libuv/libuv/issues/1448