### PR TITLE
Don’t crash on OOM where possible

### DIFF
--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -164,8 +164,7 @@ static void timer_cb(uv_timer_t* timer) {
   assert(ctx->parent_handle->poll_ctx == ctx);
   ctx->start_time = uv_now(ctx->loop);
 
-  if (uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb))
-    abort();
+  uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb);
 }
 
 
@@ -214,8 +213,8 @@ out:
   interval = ctx->interval;
   interval -= (uv_now(ctx->loop) - ctx->start_time) % interval;
 
-  if (uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0))
-    abort();
+  uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0);
+  return;
 }
 
 

--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -164,7 +164,8 @@ static void timer_cb(uv_timer_t* timer) {
   assert(ctx->parent_handle->poll_ctx == ctx);
   ctx->start_time = uv_now(ctx->loop);
 
-  uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb);
+  if (uv_fs_stat(ctx->loop, &ctx->fs_req, ctx->path, poll_cb))
+    abort();
 }
 
 
@@ -213,8 +214,8 @@ out:
   interval = ctx->interval;
   interval -= (uv_now(ctx->loop) - ctx->start_time) % interval;
 
-  uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0);
-  return;
+  if (uv_timer_start(&ctx->timer_handle, timer_cb, interval, 0))
+    abort();
 }
 
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -197,9 +197,9 @@ int uv__work_submit(uv_loop_t* loop,
                     struct uv__work* w,
                     void (*work)(struct uv__work* w),
                     void (*done)(struct uv__work* w, int status)) {
+  uv_once(&once, init_once);
   if (init_error)
     return UV_ENOMEM;
-  uv_once(&once, init_once);
   w->loop = loop;
   w->work = work;
   w->done = done;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -767,9 +767,8 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   handle->cb = cb;
   handle->dir_filename = NULL;
 
-  uv__io_start(handle->loop, &handle->event_watcher, POLLIN);
+  return uv__io_start(handle->loop, &handle->event_watcher, POLLIN);
 
-  return 0;
 #else
   return -ENOSYS;
 #endif

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -177,7 +177,8 @@ static int uv__async_start(uv_loop_t* loop) {
       char buf[32];
       int fd;
 
-      snprintf(buf, sizeof(buf), "/proc/self/fd/%d", pipefd[0]);
+      if (snprintf(buf, sizeof(buf), "/proc/self/fd/%d", pipefd[0]) < 0)
+        return -errno;
       fd = uv__open_cloexec(buf, O_RDWR);
       if (fd >= 0) {
         uv__close(pipefd[0]);
@@ -193,7 +194,8 @@ static int uv__async_start(uv_loop_t* loop) {
     return err;
 
   uv__io_init(&loop->async_io_watcher, uv__async_io, pipefd[0]);
-  uv__io_start(loop, &loop->async_io_watcher, POLLIN);
+  if (uv__io_start(loop, &loop->async_io_watcher, POLLIN))
+    return UV_ENOMEM;
   loop->async_wfd = pipefd[1];
 
   return 0;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -852,9 +852,9 @@ int uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   assert(w->fd >= 0);
   assert(w->fd < INT_MAX);
 
-  w->pevents |= events;
   if (maybe_resize(loop, w->fd + 1))
     return UV_ENOMEM;
+  w->pevents |= events;
 
 #if !defined(__sun)
   /* The event ports backend needs to rearm all file descriptors on each and

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -698,7 +698,7 @@ void uv__fsevents_loop_delete(uv_loop_t* loop) {
     return;
 
   if (uv__cf_loop_signal(loop, NULL, kUVCFLoopSignalRegular) != 0)
-    abort();
+    return;
 
   uv_thread_join(&loop->cf_thread);
   uv_sem_destroy(&loop->cf_sem);

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -198,13 +198,13 @@ void uv__make_close_pending(uv_handle_t* handle);
 int uv__getiovmax(void);
 
 void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd);
-void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events);
+int uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 void uv__io_close(uv_loop_t* loop, uv__io_t* w);
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w);
 int uv__io_active(const uv__io_t* w, unsigned int events);
 int uv__io_check_fd(uv_loop_t* loop, int fd);
-void uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
+int uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
 int uv__io_fork(uv_loop_t* loop);
 
 /* async */

--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -104,9 +104,7 @@ static int init_inotify(uv_loop_t* loop) {
 
   loop->inotify_fd = err;
   uv__io_init(&loop->inotify_read_watcher, uv__inotify_read, loop->inotify_fd);
-  uv__io_start(loop, &loop->inotify_read_watcher, POLLIN);
-
-  return 0;
+  return uv__io_start(loop, &loop->inotify_read_watcher, POLLIN);
 }
 
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -109,8 +109,7 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
 
   handle->connection_cb = cb;
   handle->io_watcher.cb = uv__server_io;
-  uv__io_start(handle->loop, &handle->io_watcher, POLLIN);
-  return 0;
+  return uv__io_start(handle->loop, &handle->io_watcher, POLLIN);
 }
 
 
@@ -199,8 +198,11 @@ void uv_pipe_connect(uv_connect_t* req,
                           UV_STREAM_READABLE | UV_STREAM_WRITABLE);
   }
 
-  if (err == 0)
-    uv__io_start(handle->loop, &handle->io_watcher, POLLIN | POLLOUT);
+  if (err == 0) {
+    err = uv__io_start(handle->loop, &handle->io_watcher, POLLIN | POLLOUT);
+    if (err)
+      uv__stream_close(handle);
+  }
 
 out:
   handle->delayed_error = err;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -134,7 +134,8 @@ int uv_poll_start(uv_poll_t* handle, int pevents, uv_poll_cb poll_cb) {
   if (pevents & UV_DISCONNECT)
     events |= UV__POLLRDHUP;
 
-  uv__io_start(handle->loop, &handle->io_watcher, events);
+  if (uv__io_start(handle->loop, &handle->io_watcher, events))
+    return UV_ENOMEM;
   uv__handle_start(handle);
   handle->poll_cb = poll_cb;
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -261,9 +261,7 @@ static int uv__signal_loop_once_init(uv_loop_t* loop) {
   uv__io_init(&loop->signal_io_watcher,
               uv__signal_event,
               loop->signal_pipefd[0]);
-  uv__io_start(loop, &loop->signal_io_watcher, POLLIN);
-
-  return 0;
+  return uv__io_start(loop, &loop->signal_io_watcher, POLLIN);
 }
 
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -429,7 +429,7 @@ static void uv__signal_event(uv_loop_t* loop,
     if (r == -1 && errno == EINTR)
       continue;
 
-    if (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    if (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOMEM)) {
       /* If there are bytes in the buffer already (which really is extremely
        * unlikely if possible at all) we can't exit the function here. We'll
        * spin until more bytes are read instead.

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -491,7 +491,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
   if (first_run) {
     uv__io_init(&handle->loop->fs_event_watcher, uv__fs_event_read, portfd);
-    uv__io_start(handle->loop, &handle->loop->fs_event_watcher, POLLIN);
+    return uv__io_start(handle->loop, &handle->loop->fs_event_watcher, POLLIN);
   }
 
   return 0;

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -251,7 +251,8 @@ int uv__tcp_connect(uv_connect_t* req,
   QUEUE_INIT(&req->queue);
   handle->connect_req = req;
 
-  uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
+  if (uv__io_start(handle->loop, &handle->io_watcher, POLLOUT))
+    return UV_ENOMEM;
 
   if (handle->delayed_error)
     uv__io_feed(handle->loop, &handle->io_watcher);
@@ -353,9 +354,7 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
 
   /* Start listening for connections. */
   tcp->io_watcher.cb = uv__server_io;
-  uv__io_start(tcp->loop, &tcp->io_watcher, POLLIN);
-
-  return 0;
+  return uv__io_start(tcp->loop, &tcp->io_watcher, POLLIN);
 }
 
 

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -73,7 +73,7 @@ static int uv__tty_is_slave(const int fd) {
 
   /* Lookup stat structure behind the file descriptor. */
   if (fstat(fd, &sb) != 0)
-    abort();
+    return 0;
 
   /* Assert character device. */
   if (!S_ISCHR(sb.st_mode))

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -435,9 +435,9 @@ int uv__udp_send(uv_udp_send_t* req,
      * write.
      */
     if (!QUEUE_EMPTY(&handle->write_queue))
-      uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
+      return uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
   } else {
-    uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
+    return uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
   }
 
   return 0;
@@ -873,7 +873,7 @@ int uv__udp_recv_start(uv_udp_t* handle,
     return -EINVAL;
 
   if (uv__io_active(&handle->io_watcher, POLLIN))
-    return -EALREADY;  /* FIXME(bnoordhuis) Should be -EBUSY. */
+    return -EBUSY;  /* FIXME(bnoordhuis) Should be -EBUSY. */
 
   err = uv__udp_maybe_deferred_bind(handle, AF_INET, 0);
   if (err)
@@ -882,7 +882,8 @@ int uv__udp_recv_start(uv_udp_t* handle,
   handle->alloc_cb = alloc_cb;
   handle->recv_cb = recv_cb;
 
-  uv__io_start(handle->loop, &handle->io_watcher, POLLIN);
+  if ((err = uv__io_start(handle->loop, &handle->io_watcher, POLLIN)))
+    return err;
   uv__handle_start(handle);
 
   return 0;

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -113,10 +113,10 @@ void uv__fs_poll_close(uv_fs_poll_t* handle);
 
 int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
-void uv__work_submit(uv_loop_t* loop,
-                     struct uv__work *w,
-                     void (*work)(struct uv__work *w),
-                     void (*done)(struct uv__work *w, int status));
+int uv__work_submit(uv_loop_t* loop,
+                    struct uv__work *w,
+                    void (*work)(struct uv__work *w),
+                    void (*done)(struct uv__work *w, int status));
 
 void uv__work_done(uv_async_t* handle);
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1411,7 +1411,8 @@ static void fs__sendfile(uv_fs_t* req) {
   int64_t result_offset = 0;
   char* buf = (char*) uv__malloc(buf_size);
   if (!buf) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    SET_REQ_WIN32_ERROR(req, ERROR_OUTOFMEMORY);
+    return;
   }
 
   if (offset != -1) {
@@ -1634,7 +1635,8 @@ static void fs__create_junction(uv_fs_t* req, const WCHAR* path,
   /* Allocate the buffer */
   buffer = (REPARSE_DATA_BUFFER*)uv__malloc(needed_buf_size);
   if (!buffer) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
+    return;
   }
 
   /* Grab a pointer to the part of the buffer where filenames go */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -389,7 +389,8 @@ int uv_set_process_title(const char* title) {
   /* Convert to wide-char string */
   title_w = (WCHAR*)uv__malloc(sizeof(WCHAR) * length);
   if (!title_w) {
-    uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
+    err = ERROR_OUTOFMEMORY;
+    goto done;
   }
 
   length = MultiByteToWideChar(CP_UTF8, 0, title, -1, title_w, length);


### PR DESCRIPTION
This improves libuv’s handling of out-of-memory situations.