### PR TITLE
src: unregister requests on invalid input

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1319,8 +1319,11 @@ int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
                uv_fs_cb cb) {
   INIT(READ);
 
-  if (bufs == NULL || nbufs == 0)
+  if (bufs == NULL || nbufs == 0) {
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return UV_EINVAL;
+  }
 
   req->file = file;
 
@@ -1458,8 +1461,11 @@ int uv_fs_write(uv_loop_t* loop,
                 uv_fs_cb cb) {
   INIT(WRITE);
 
-  if (bufs == NULL || nbufs == 0)
+  if (bufs == NULL || nbufs == 0) {
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return UV_EINVAL;
+  }
 
   req->file = file;
 
@@ -1513,8 +1519,11 @@ int uv_fs_copyfile(uv_loop_t* loop,
                    uv_fs_cb cb) {
   INIT(COPYFILE);
 
-  if (flags & ~UV_FS_COPYFILE_EXCL)
+  if (flags & ~UV_FS_COPYFILE_EXCL) {
+    if (cb != NULL)
+      uv__req_unregister(loop, req);
     return UV_EINVAL;
+  }
 
   PATH2;
   req->flags = flags;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -36,6 +36,10 @@ static const char dst[] = "test_file_dst";
 static int result_check_count;
 
 
+static void fail_cb(uv_fs_t* req) {
+  FATAL("fail_cb should not have been called");
+}
+
 static void handle_result(uv_fs_t* req) {
   uv_fs_t stat_req;
   uint64_t size;
@@ -158,7 +162,12 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(result_check_count == 5);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 6);
-  unlink(dst); /* Cleanup */
 
+  /* If the flags are invalid, the loop should not be kept open */
+  unlink(dst);
+  r = uv_fs_copyfile(loop, &req, fixture, dst, -1, fail_cb);
+  ASSERT(r == UV_EINVAL);
+  uv_run(loop, UV_RUN_DEFAULT);
+  unlink(dst); /* Cleanup */
   return 0;
 }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -319,6 +319,9 @@ static void ftruncate_cb(uv_fs_t* req) {
   ASSERT(r == 0);
 }
 
+static void fail_cb(uv_fs_t* req) {
+  FATAL("fail_cb should not have been called");
+}
 
 static void read_cb(uv_fs_t* req) {
   int r;
@@ -2895,6 +2898,31 @@ TEST_IMPL(fs_read_write_null_arguments) {
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, 0, &iov, 0, -1, NULL);
   ASSERT(r == UV_EINVAL);
+  uv_fs_req_cleanup(&write_req);
+
+  /* If the arguments are invalid, the loop should not be kept open */
+  loop = uv_default_loop();
+
+  r = uv_fs_read(loop, &read_req, 0, NULL, 0, -1, fail_cb);
+  ASSERT(r == UV_EINVAL);
+  uv_run(loop, UV_RUN_DEFAULT);
+  uv_fs_req_cleanup(&read_req);
+
+  r = uv_fs_write(loop, &write_req, 0, NULL, 0, -1, fail_cb);
+  ASSERT(r == UV_EINVAL);
+  uv_run(loop, UV_RUN_DEFAULT);
+  uv_fs_req_cleanup(&write_req);
+
+  iov = uv_buf_init(NULL, 0);
+  r = uv_fs_read(loop, &read_req, 0, &iov, 0, -1, fail_cb);
+  ASSERT(r == UV_EINVAL);
+  uv_run(loop, UV_RUN_DEFAULT);
+  uv_fs_req_cleanup(&read_req);
+
+  iov = uv_buf_init(NULL, 0);
+  r = uv_fs_write(loop, &write_req, 0, &iov, 0, -1, fail_cb);
+  ASSERT(r == UV_EINVAL);
+  uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
   return 0;


### PR DESCRIPTION
Check the flags before calling INIT so the loop won't be kept
open if the flags are invalid.

Refs: https://github.com/nodejs/node/pull/18811

cc @bnoordhuis 