### PR TITLE
unix: delay fs req register until after validation

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -68,9 +68,7 @@
   do {                                                                        \
     if (req == NULL)                                                          \
       return UV_EINVAL;                                                       \
-    req->type = UV_FS;                                                        \
-    if (cb != NULL)                                                           \
-      uv__req_init(loop, req, UV_FS);                                         \
+    UV_REQ_INIT(req, UV_FS);                                                  \
     req->fs_type = UV_FS_ ## subtype;                                         \
     req->result = 0;                                                          \
     req->ptr = NULL;                                                          \
@@ -88,10 +86,8 @@
       req->path = path;                                                       \
     } else {                                                                  \
       req->path = uv__strdup(path);                                           \
-      if (req->path == NULL) {                                                \
-        uv__req_unregister(loop, req);                                        \
+      if (req->path == NULL)                                                  \
         return UV_ENOMEM;                                                     \
-      }                                                                       \
     }                                                                         \
   }                                                                           \
   while (0)
@@ -107,10 +103,8 @@
       path_len = strlen(path) + 1;                                            \
       new_path_len = strlen(new_path) + 1;                                    \
       req->path = uv__malloc(path_len + new_path_len);                        \
-      if (req->path == NULL) {                                                \
-        uv__req_unregister(loop, req);                                        \
+      if (req->path == NULL)                                                  \
         return UV_ENOMEM;                                                     \
-      }                                                                       \
       req->new_path = req->path + path_len;                                   \
       memcpy((void*) req->path, path, path_len);                              \
       memcpy((void*) req->new_path, new_path, new_path_len);                  \
@@ -121,6 +115,7 @@
 #define POST                                                                  \
   do {                                                                        \
     if (cb != NULL) {                                                         \
+      uv__req_register(loop, req);                                            \
       uv__work_submit(loop, &req->work_req, uv__fs_work, uv__fs_done);        \
       return 0;                                                               \
     }                                                                         \
@@ -1288,11 +1283,8 @@ int uv_fs_mkdtemp(uv_loop_t* loop,
                   uv_fs_cb cb) {
   INIT(MKDTEMP);
   req->path = uv__strdup(tpl);
-  if (req->path == NULL) {
-    if (cb != NULL)
-      uv__req_unregister(loop, req);
+  if (req->path == NULL)
     return UV_ENOMEM;
-  }
   POST;
 }
 
@@ -1329,11 +1321,8 @@ int uv_fs_read(uv_loop_t* loop, uv_fs_t* req,
   if (nbufs > ARRAY_SIZE(req->bufsml))
     req->bufs = uv__malloc(nbufs * sizeof(*bufs));
 
-  if (req->bufs == NULL) {
-    if (cb != NULL)
-      uv__req_unregister(loop, req);
+  if (req->bufs == NULL)
     return UV_ENOMEM;
-  }
 
   memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
 
@@ -1468,11 +1457,8 @@ int uv_fs_write(uv_loop_t* loop,
   if (nbufs > ARRAY_SIZE(req->bufsml))
     req->bufs = uv__malloc(nbufs * sizeof(*bufs));
 
-  if (req->bufs == NULL) {
-    if (cb != NULL)
-      uv__req_unregister(loop, req);
+  if (req->bufs == NULL)
     return UV_ENOMEM;
-  }
 
   memcpy(req->bufs, bufs, nbufs * sizeof(*bufs));
 


### PR DESCRIPTION
On Unix, if a fs function fails validation after `INIT` but before sending the work to the thread pool, then is is necessary to manually unregister the request. This commit moves the registration to just before the work submission. This also makes Unix match the Windows behavior.

Refs: https://github.com/libuv/libuv/pull/1747