### PR TITLE
 unix,win: ensure req->bufs is freed

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -75,6 +75,7 @@
     req->loop = loop;                                                         \
     req->path = NULL;                                                         \
     req->new_path = NULL;                                                     \
+    req->bufs = NULL;                                                         \
     req->cb = cb;                                                             \
   }                                                                           \
   while (0)
@@ -1484,6 +1485,10 @@ void uv_fs_req_cleanup(uv_fs_t* req) {
 
   if (req->fs_type == UV_FS_SCANDIR && req->ptr != NULL)
     uv__fs_scandir_cleanup(req);
+
+  if (req->bufs != req->bufsml)
+    uv__free(req->bufs);
+  req->bufs = NULL;
 
   if (req->ptr != &req->statbuf)
     uv__free(req->ptr);

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -245,6 +245,7 @@ INLINE static void uv_fs_req_init(uv_loop_t* loop, uv_fs_t* req,
   req->ptr = NULL;
   req->path = NULL;
   req->cb = cb;
+  req->fs.info.bufs = NULL;
   memset(&req->fs, 0, sizeof(req->fs));
 }
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2887,7 +2887,19 @@ TEST_IMPL(fs_read_write_null_arguments) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_write(NULL, &write_req, 0, NULL, 0, -1, NULL);
+  /* Validate some memory management on failed input validation before sending
+     fs work to the thread pool. */
   ASSERT(r == UV_EINVAL);
+  ASSERT(write_req.path == NULL);
+  ASSERT(write_req.ptr == NULL);
+#ifdef _WIN32
+  ASSERT(write_req.file.pathw == NULL);
+  ASSERT(write_req.fs.info.new_pathw == NULL);
+  ASSERT(write_req.fs.info.bufs == NULL);
+#else
+  ASSERT(write_req.new_path == NULL);
+  ASSERT(write_req.bufs == NULL);
+#endif
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(NULL, 0);
@@ -3112,7 +3124,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   unlink("test_file");
 
   ASSERT(UV_FS_O_EXLOCK > 0);
-  
+
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/pull/1751#discussion_r169645330

I added a commit that checks the fs req fields when erroring before the work is sent to the thread pool. It would probably be useful to have similar checks on errors after the work is sent to the thread pool at some point.