### PR TITLE
win: remove unnecessary initialization

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -245,7 +245,6 @@ INLINE static void uv_fs_req_init(uv_loop_t* loop, uv_fs_t* req,
   req->ptr = NULL;
   req->path = NULL;
   req->cb = cb;
-  req->fs.info.bufs = NULL;
   memset(&req->fs, 0, sizeof(req->fs));
 }
 


### PR DESCRIPTION
There is no need to set `req->fs.info.bufs` to `NULL` and then `memset()` the entire `req->fs` struct on the next line.

Refs: https://github.com/libuv/libuv/pull/1752#discussion_r169953154

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/734/