### PR TITLE
unix,win: add UV_FS_COPYFILE_FICLONE_FORCE support

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -252,6 +252,9 @@ API
     - `UV_FS_COPYFILE_FICLONE`: If present, `uv_fs_copyfile()` will attempt to
       create a copy-on-write reflink. If the underlying platform does not
       support copy-on-write, then a fallback copy mechanism is used.
+    - `UV_FS_COPYFILE_FICLONE_FORCE`: If present, `uv_fs_copyfile()` will
+      attempt to create a copy-on-write reflink. If the underlying platform does
+      not support copy-on-write, then an error is returned.
 
     .. warning::
         If the destination path is created, but an error occurs while copying
@@ -261,7 +264,8 @@ API
 
     .. versionadded:: 1.14.0
 
-    .. versionchanged:: 1.20.0 `UV_FS_COPYFILE_FICLONE` is supported.
+    .. versionchanged:: 1.20.0 `UV_FS_COPYFILE_FICLONE` and
+        `UV_FS_COPYFILE_FICLONE_FORCE` are supported.
 
 .. c:function:: int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_file out_fd, uv_file in_fd, int64_t in_offset, size_t length, uv_fs_cb cb)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1196,6 +1196,12 @@ UV_EXTERN int uv_fs_write(uv_loop_t* loop,
  */
 #define UV_FS_COPYFILE_FICLONE 0x0002
 
+/*
+ * This flag can be used with uv_fs_copyfile() to attempt to create a reflink.
+ * If copy-on-write is not supported, an error is returned.
+ */
+#define UV_FS_COPYFILE_FICLONE_FORCE 0x0004
+
 UV_EXTERN int uv_fs_copyfile(uv_loop_t* loop,
                              uv_fs_t* req,
                              const char* path,

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1390,6 +1390,12 @@ static void fs__copyfile(uv_fs_t* req) {
   int overwrite;
 
   flags = req->fs.info.file_flags;
+
+  if (flags & UV_FS_COPYFILE_FICLONE_FORCE) {
+    SET_REQ_UV_ERROR(req, UV_ENOSYS, ERROR_NOT_SUPPORTED);
+    return;
+  }
+
   overwrite = flags & UV_FS_COPYFILE_EXCL;
 
   if (CopyFileW(req->file.pathw, req->fs.info.new_pathw, overwrite) == 0) {
@@ -2334,8 +2340,11 @@ int uv_fs_copyfile(uv_loop_t* loop,
 
   INIT(UV_FS_COPYFILE);
 
-  if (flags & ~(UV_FS_COPYFILE_EXCL | UV_FS_COPYFILE_FICLONE))
+  if (flags & ~(UV_FS_COPYFILE_EXCL |
+                UV_FS_COPYFILE_FICLONE |
+                UV_FS_COPYFILE_FICLONE_FORCE)) {
     return UV_EINVAL;
+  }
 
   err = fs__capture_path(req, path, new_path, cb != NULL);
 

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -175,6 +175,15 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(r == 0);
   handle_result(&req);
 
+  /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */
+  unlink(dst);
+  r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE_FORCE,
+                     NULL);
+  ASSERT(r == 0 || r == UV_ENOSYS || r == UV_ENOTSUP || r == UV_ENOTTY);
+
+  if (r == 0)
+    handle_result(&req);
+
   unlink(dst); /* Cleanup */
   return 0;
 }


### PR DESCRIPTION
`UV_FS_COPYFILE_FICLONE_FORCE` attempts to use copy-on-write semantics in `uv_fs_copyfile()`. If CoW is not available, an error is returned.