### PR TITLE
win: use long directory name for handle->dirw

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -301,6 +301,9 @@ TEST_DECLARE   (fs_stat_missing_path)
 TEST_DECLARE   (fs_read_file_eof)
 TEST_DECLARE   (fs_event_watch_dir)
 TEST_DECLARE   (fs_event_watch_dir_recursive)
+#ifdef _WIN32
+TEST_DECLARE   (fs_event_watch_dir_short_path)
+#endif
 TEST_DECLARE   (fs_event_watch_file)
 TEST_DECLARE   (fs_event_watch_file_exact_path)
 TEST_DECLARE   (fs_event_watch_file_twice)
@@ -828,6 +831,9 @@ TASK_LIST_START
   TEST_ENTRY  (fs_file_open_append)
   TEST_ENTRY  (fs_event_watch_dir)
   TEST_ENTRY  (fs_event_watch_dir_recursive)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_event_watch_dir_short_path)
+#endif
   TEST_ENTRY  (fs_event_watch_file)
   TEST_ENTRY  (fs_event_watch_file_exact_path)
   TEST_ENTRY  (fs_event_watch_file_twice)


### PR DESCRIPTION
`uv_relative_path` assumes `dir` is a prefix of `filename`, which is not
the case when `handle->dirw` is a short path.

Fixes: https://github.com/nodejs/node/issues/19170