### PR TITLE
[WIP] Allow to compile libuv as a Universal Windows library (UWP)

### DIFF
--- a/src/stubs/dl.c
+++ b/src/stubs/dl.c
@@ -1,0 +1,41 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+int uv_dlopen(const char* filename, uv_lib_t* lib) {
+	return UV_ENOSYS;
+}
+
+
+void uv_dlclose(uv_lib_t* lib) {
+}
+
+
+int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr) {
+	return UV_ENOSYS;
+}
+
+
+const char* uv_dlerror(const uv_lib_t* lib) {
+  return "not implemented";
+}
+

--- a/src/stubs/fs-event.c
+++ b/src/stubs/fs-event.c
@@ -1,0 +1,55 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_event_start(uv_fs_event_t* handle,
+                      uv_fs_event_cb cb,
+                      const char* path,
+                      unsigned int flags) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_event_stop(uv_fs_event_t* handle) {
+	return UV_ENOSYS;
+}
+
+
+void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
+    uv_fs_event_t* handle) {
+  
+}
+
+
+void uv_fs_event_close(uv_loop_t* loop, uv_fs_event_t* handle) {
+
+}
+
+
+void uv_fs_event_endgame(uv_loop_t* loop, uv_fs_event_t* handle) {
+
+}

--- a/src/stubs/fs.c
+++ b/src/stubs/fs.c
@@ -1,0 +1,244 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+void fs__open(uv_fs_t* req) {
+  
+}
+
+void fs__close(uv_fs_t* req) {
+
+}
+
+
+void fs__read(uv_fs_t* req) {
+  
+}
+
+
+void fs__write(uv_fs_t* req) {
+  
+}
+
+
+void fs__rmdir(uv_fs_t* req) {
+
+}
+
+
+void fs__unlink(uv_fs_t* req) {
+  
+}
+
+
+void fs__mkdir(uv_fs_t* req) {
+
+}
+
+
+void fs__mkdtemp(uv_fs_t* req) {
+
+}
+
+
+void fs__scandir(uv_fs_t* req) {
+
+}
+
+
+void uv_fs_req_cleanup(uv_fs_t* req) {
+}
+
+
+int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
+    int mode, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_read(uv_loop_t* loop,
+               uv_fs_t* req,
+               uv_os_fd_t handle,
+               const uv_buf_t bufs[],
+               unsigned int nbufs,
+               int64_t offset,
+               uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_write(uv_loop_t* loop,
+                uv_fs_t* req,
+                uv_os_fd_t handle,
+                const uv_buf_t bufs[],
+                unsigned int nbufs,
+                int64_t offset,
+                uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, const char* tpl,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_link(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    const char* new_path, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_symlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    const char* new_path, int flags, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_readlink(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_realpath(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_chown(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_uid_t uid,
+    uv_gid_t gid, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t hFile, uv_uid_t uid,
+    uv_gid_t gid, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, const char* path,
+    const char* new_path, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle,
+    int64_t offset, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+
+int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t fd_out,
+    uv_os_fd_t fd_in, int64_t in_offset, size_t length, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_access(uv_loop_t* loop,
+                 uv_fs_t* req,
+                 const char* path,
+                 int flags,
+                 uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, int mode,
+    uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime,
+    double mtime, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_os_fd_t handle, double atime,
+    double mtime, uv_fs_cb cb) {
+	return UV_ENOSYS;
+}

--- a/src/stubs/fs.c
+++ b/src/stubs/fs.c
@@ -66,6 +66,11 @@ void fs__scandir(uv_fs_t* req) {
 
 
 void uv_fs_req_cleanup(uv_fs_t* req) {
+
+}
+
+void uv_fs_init(void) {
+
 }
 
 

--- a/src/stubs/pipe.c
+++ b/src/stubs/pipe.c
@@ -1,0 +1,147 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int ipc) {
+	return UV_ENOSYS;
+}
+
+int uv_stdio_pipe_server(uv_loop_t* loop, uv_pipe_t* handle, DWORD access,
+    char* name, size_t nameSize) {
+	return UV_ENOSYS;
+}
+
+void uv_pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
+}
+
+
+void uv_pipe_pending_instances(uv_pipe_t* handle, int count) {
+}
+
+/* Creates a pipe server. */
+int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
+	return UV_ENOSYS;
+}
+
+
+void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle,
+    const char* name, uv_connect_cb cb) {
+}
+
+
+void uv__pipe_pause_read(uv_pipe_t* handle) {
+}
+
+
+void uv__pipe_unpause_read(uv_pipe_t* handle) {
+}
+
+
+void uv__pipe_stop_read(uv_pipe_t* handle) {
+}
+
+void uv_pipe_cleanup(uv_loop_t* loop, uv_pipe_t* handle) {
+}
+
+
+void uv_pipe_close(uv_loop_t* loop, uv_pipe_t* handle) {
+}
+
+int uv_pipe_accept(uv_pipe_t* server, uv_stream_t* client) {
+	return UV_ENOSYS;
+}
+
+
+/* Starts listening for connections for the given pipe. */
+int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
+	return UV_ENOSYS;
+}
+
+int uv_pipe_read_start(uv_pipe_t* handle,
+                       uv_alloc_cb alloc_cb,
+                       uv_read_cb read_cb) {
+	return UV_ENOSYS;
+}
+
+int uv_pipe_write(uv_loop_t* loop,
+                  uv_write_t* req,
+                  uv_pipe_t* handle,
+                  const uv_buf_t bufs[],
+                  unsigned int nbufs,
+                  uv_write_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_pipe_write2(uv_loop_t* loop,
+                   uv_write_t* req,
+                   uv_pipe_t* handle,
+                   const uv_buf_t bufs[],
+                   unsigned int nbufs,
+                   uv_stream_t* send_handle,
+                   uv_write_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+void uv_process_pipe_read_req(uv_loop_t* loop, uv_pipe_t* handle, uv_req_t* req) {
+}
+
+
+void uv_process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
+    uv_write_t* req) {
+}
+
+
+void uv_process_pipe_accept_req(uv_loop_t* loop, uv_pipe_t* handle,
+    uv_req_t* raw_req) {
+}
+
+
+void uv_process_pipe_connect_req(uv_loop_t* loop, uv_pipe_t* handle,
+    uv_connect_t* req) {
+}
+
+
+void uv_process_pipe_shutdown_req(uv_loop_t* loop, uv_pipe_t* handle,
+    uv_shutdown_t* req) {
+}
+
+int uv_pipe_open(uv_pipe_t* pipe, uv_os_fd_t os_handle) {
+	return UV_ENOSYS;
+}
+
+int uv_pipe_pending_count(uv_pipe_t* handle) {
+	return UV_ENOSYS;
+}
+
+int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size) {
+	return UV_ENOSYS;
+}
+
+int uv_pipe_getpeername(const uv_pipe_t* handle, char* buffer, size_t* size) {
+	return UV_ENOSYS;
+}
+
+uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
+	return UV_ENOSYS;
+}

--- a/src/stubs/poll.c
+++ b/src/stubs/poll.c
@@ -1,0 +1,50 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle,
+    uv_os_sock_t socket) {
+	return UV_ENOSYS;
+}
+
+
+int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb) {
+  return UV_ENOSYS;
+}
+
+
+int uv_poll_stop(uv_poll_t* handle) {
+  return UV_ENOSYS;
+}
+
+void uv_process_poll_req(uv_loop_t* loop, uv_poll_t* handle, uv_req_t* req) {
+
+}
+
+int uv_poll_close(uv_loop_t* loop, uv_poll_t* handle) {
+	return UV_ENOSYS;
+}
+
+
+void uv_poll_endgame(uv_loop_t* loop, uv_poll_t* handle) {
+
+}

--- a/src/stubs/process-stdio.c
+++ b/src/stubs/process-stdio.c
@@ -1,0 +1,61 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+void uv_disable_stdio_inheritance(void) {
+}
+
+
+int uv__create_nul_handle(HANDLE* handle_ptr,
+    DWORD access) {
+	return UV_ENOSYS;
+}
+
+
+int uv__stdio_create(uv_loop_t* loop,
+                     const uv_process_options_t* options,
+                     BYTE** buffer_ptr) {
+	return UV_ENOSYS;
+}
+
+
+void uv__stdio_destroy(BYTE* buffer) {
+}
+
+
+void uv__stdio_noinherit(BYTE* buffer) {
+}
+
+
+int uv__stdio_verify(BYTE* buffer, WORD size) {
+	return UV_ENOSYS;
+}
+
+
+WORD uv__stdio_size(BYTE* buffer) {
+	return 0;
+}
+
+
+HANDLE uv__stdio_handle(BYTE* buffer, int fd) {
+	return NULL;
+}

--- a/src/stubs/process.c
+++ b/src/stubs/process.c
@@ -1,0 +1,53 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+/* Called on main thread after a child process has exited. */
+void uv_process_proc_exit(uv_loop_t* loop, uv_process_t* handle) {
+
+}
+
+
+void uv_process_close(uv_loop_t* loop, uv_process_t* handle) {
+
+}
+
+
+void uv_process_endgame(uv_loop_t* loop, uv_process_t* handle) {
+
+}
+
+
+int uv_spawn(uv_loop_t* loop,
+             uv_process_t* process,
+             const uv_process_options_t* options) {
+	return UV_ENOSYS;
+}
+
+int uv_process_kill(uv_process_t* process, int signum) {
+	return UV_ENOSYS;
+}
+
+
+int uv_kill(int pid, int signum) {
+	return UV_ENOSYS;
+}

--- a/src/stubs/tty.c
+++ b/src/stubs/tty.c
@@ -1,0 +1,125 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+void uv_console_init(void) {
+}
+
+
+int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_os_fd_t handle, int readable) {
+	return UV_ENOSYS;
+}
+
+int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
+	return UV_ENOSYS;
+}
+
+
+int uv_is_tty(uv_os_fd_t file) {
+	return UV_ENOSYS;
+}
+
+
+int uv_tty_get_winsize(uv_tty_t* tty, int* width, int* height) {
+	return UV_ENOSYS;
+}
+
+void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
+    uv_req_t* req) {
+}
+
+
+
+void uv_process_tty_read_line_req(uv_loop_t* loop, uv_tty_t* handle,
+    uv_req_t* req) {
+}
+
+
+void uv_process_tty_read_req(uv_loop_t* loop, uv_tty_t* handle,
+    uv_req_t* req) {
+
+}
+
+
+int uv_tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
+    uv_read_cb read_cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv_tty_read_stop(uv_tty_t* handle) {
+	return UV_ENOSYS;
+}
+
+int uv_tty_write(uv_loop_t* loop,
+                 uv_write_t* req,
+                 uv_tty_t* handle,
+                 const uv_buf_t bufs[],
+                 unsigned int nbufs,
+                 uv_write_cb cb) {
+	return UV_ENOSYS;
+}
+
+
+int uv__tty_try_write(uv_tty_t* handle,
+                      const uv_buf_t bufs[],
+                      unsigned int nbufs) {
+	return UV_ENOSYS;
+}
+
+
+void uv_process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
+  uv_write_t* req) {
+	return UV_ENOSYS;
+}
+
+
+void uv_tty_close(uv_tty_t* handle) {
+
+}
+
+
+void uv_tty_endgame(uv_loop_t* loop, uv_tty_t* handle) {
+
+}
+
+
+/* TODO: remove me */
+void uv_process_tty_accept_req(uv_loop_t* loop, uv_tty_t* handle,
+    uv_req_t* raw_req) {
+}
+
+
+/* TODO: remove me */
+void uv_process_tty_connect_req(uv_loop_t* loop, uv_tty_t* handle,
+    uv_connect_t* req) {
+}
+
+
+int uv_tty_reset_mode(void) {
+  /* Not necessary to do anything. */
+  return 0;
+}
+
+static void uv__determine_vterm_state(HANDLE handle) {
+	return UV_ENOSYS;
+}

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -195,10 +195,12 @@ static void uv_init(void) {
   /* Initialize tracking of all uv loops */
   uv__loops_init();
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Fetch winapi function pointers. This must be done first because other
    * initialization code might need these function pointers to be loaded.
    */
   uv_winapi_init();
+#endif
 
   /* Initialize winsock */
   uv_winsock_init();
@@ -215,8 +217,10 @@ static void uv_init(void) {
   /* Initialize utilities */
   uv__util_init();
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Initialize system wakeup detection */
   uv__init_detect_system_wakeup();
+#endif
 }
 
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -195,12 +195,10 @@ static void uv_init(void) {
   /* Initialize tracking of all uv loops */
   uv__loops_init();
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Fetch winapi function pointers. This must be done first because other
    * initialization code might need these function pointers to be loaded.
    */
   uv_winapi_init();
-#endif
 
   /* Initialize winsock */
   uv_winsock_init();

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -188,7 +188,7 @@ static void uv_init(void) {
    * functions (eg _get_osfhandle) raise an assert when called with invalid
    * FDs even though they return the proper error code in the release build.
    */
-#if defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && defined(_DEBUG) && (defined(_MSC_VER) || defined(__MINGW64_VERSION_MAJOR))
   _CrtSetReportHook(uv__crt_dbg_report_handler);
 #endif
 

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -58,7 +58,9 @@ void uv_fatal_error(const int errorno, const char* syscall) {
     LocalFree(buf);
   }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   DebugBreak();
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
   abort();
 }
 

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -386,6 +386,7 @@ error:
   return uv_translate_sys_error(err);
 }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
   NET_LUID luid;
   wchar_t wname[NDIS_IF_MAX_STRING_SIZE + 1]; /* Add one for the NUL. */
@@ -451,3 +452,4 @@ int uv_if_indextoiid(unsigned int ifindex, char* buffer, size_t* size) {
   *size = r;
   return 0;
 }
+#endif

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -351,12 +351,10 @@ int uv__stdio_verify(BYTE* buffer, WORD size);
 WORD uv__stdio_size(BYTE* buffer);
 HANDLE uv__stdio_handle(BYTE* buffer, int fd);
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 /*
  * Winapi and ntapi utility functions
  */
 void uv_winapi_init(void);
-#endif
 
 /*
  * Winsock utility functions

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -368,6 +368,7 @@ int uv_ntstatus_to_winsock_error(NTSTATUS status);
 BOOL uv_get_acceptex_function(SOCKET socket, LPFN_ACCEPTEX* target);
 BOOL uv_get_connectex_function(SOCKET socket, LPFN_CONNECTEX* target);
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 int WSAAPI uv_wsarecv_workaround(SOCKET socket, WSABUF* buffers,
     DWORD buffer_count, DWORD* bytes, DWORD* flags, WSAOVERLAPPED *overlapped,
     LPWSAOVERLAPPED_COMPLETION_ROUTINE completion_routine);
@@ -378,6 +379,7 @@ int WSAAPI uv_wsarecvfrom_workaround(SOCKET socket, WSABUF* buffers,
 
 int WSAAPI uv_msafd_poll(SOCKET socket, AFD_POLL_INFO* info_in,
     AFD_POLL_INFO* info_out, OVERLAPPED* overlapped);
+#endif
 
 /* Whether there are any non-IFS LSPs stacked on TCP */
 extern int uv_tcp_non_ifs_lsp_ipv4;

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -351,12 +351,12 @@ int uv__stdio_verify(BYTE* buffer, WORD size);
 WORD uv__stdio_size(BYTE* buffer);
 HANDLE uv__stdio_handle(BYTE* buffer, int fd);
 
-
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 /*
  * Winapi and ntapi utility functions
  */
 void uv_winapi_init(void);
-
+#endif
 
 /*
  * Winsock utility functions

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -95,9 +95,11 @@ static int uv_tcp_set_socket(uv_loop_t* loop,
     return WSAGetLastError();
   }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Make the socket non-inheritable */
   if (!SetHandleInformation((HANDLE) socket, HANDLE_FLAG_INHERIT, 0))
     return GetLastError();
+#endif
 
   /* Associate it with the I/O completion port. */
   /* Use uv_handle_t pointer as completion key. */
@@ -419,6 +421,7 @@ static void uv_tcp_queue_accept(uv_tcp_t* handle, uv_tcp_accept_t* req) {
     return;
   }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Make the socket non-inheritable */
   if (!SetHandleInformation((HANDLE) accept_socket, HANDLE_FLAG_INHERIT, 0)) {
     SET_REQ_ERROR(req, GetLastError());
@@ -427,6 +430,7 @@ static void uv_tcp_queue_accept(uv_tcp_t* handle, uv_tcp_accept_t* req) {
     closesocket(accept_socket);
     return;
   }
+#endif
 
   /* Prepare the overlapped structure. */
   memset(&(req->u.io.overlapped), 0, sizeof(req->u.io.overlapped));

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1341,6 +1341,8 @@ int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable) {
 
 static int uv_tcp_try_cancel_io(uv_tcp_t* tcp) {
   SOCKET socket = tcp->socket;
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   int non_ifs_lsp;
 
   /* Check if we have any non-IFS LSPs stacked on top of TCP */
@@ -1364,6 +1366,7 @@ static int uv_tcp_try_cancel_io(uv_tcp_t* tcp) {
       return -1;
     }
   }
+#endif
 
   assert(socket != 0 && socket != INVALID_SOCKET);
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1416,7 +1416,7 @@ void uv_tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
       for (i = 0; i < uv_simultaneous_server_accepts; i++) {
         uv_tcp_accept_t* req = &tcp->tcp.serv.accept_reqs[i];
         if (req->accept_socket != INVALID_SOCKET &&
-            !HasOverlappedIoCompleted(&req->u.io.overlapped)) {
+            req->u.io.overlapped.Internal == STATUS_PENDING) {
           closesocket(req->accept_socket);
           req->accept_socket = INVALID_SOCKET;
         }

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -69,10 +69,12 @@ static int uv_udp_set_socket(uv_loop_t* loop, uv_udp_t* handle, SOCKET socket,
     return WSAGetLastError();
   }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   /* Make the socket non-inheritable */
   if (!SetHandleInformation((HANDLE)socket, HANDLE_FLAG_INHERIT, 0)) {
     return GetLastError();
   }
+#endif
 
   /* Associate it with the I/O completion port. */
   /* Use uv_handle_t pointer as completion key. */

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -85,6 +85,7 @@ static int uv_udp_set_socket(uv_loop_t* loop, uv_udp_t* handle, SOCKET socket,
     return GetLastError();
   }
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)  
   if (pSetFileCompletionNotificationModes) {
     /* All known Windows that support SetFileCompletionNotificationModes */
     /* have a bug that makes it impossible to use this function in */
@@ -112,6 +113,7 @@ static int uv_udp_set_socket(uv_loop_t* loop, uv_udp_t* handle, SOCKET socket,
       }
     }
   }
+#endif
 
   handle->socket = socket;
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -767,7 +767,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   uv__free(cpu_infos);
 }
 
-
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 static int is_windows_version_or_greater(DWORD os_major,
                                          DWORD os_minor,
                                          WORD service_pack_major,
@@ -797,7 +797,7 @@ static int is_windows_version_or_greater(DWORD os_major,
     VER_SERVICEPACKMAJOR | VER_SERVICEPACKMINOR,
     condition_mask);
 }
-
+#endif
 
 static int address_prefix_match(int family,
                                 struct sockaddr* address,
@@ -849,6 +849,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
   int is_vista_or_greater;
   ULONG flags;
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   is_vista_or_greater = is_windows_version_or_greater(6, 0, 0, 0);
   if (is_vista_or_greater) {
     flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
@@ -861,7 +862,12 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
     flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
       GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_INCLUDE_PREFIX;
   }
-
+#else
+  /* We assume that WinRT apps are >= Vista */
+  is_vista_or_greater = TRUE;
+  flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+	  GAA_FLAG_SKIP_DNS_SERVER;
+#endif
 
   /* Fetch the size of the adapters reported by windows, and then get the */
   /* list itself. */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -337,6 +337,7 @@ uv_pid_t uv_os_getpid(void) {
 
 
 uv_pid_t uv_os_getppid(void) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   int parent_pid = -1;
   HANDLE handle;
   PROCESSENTRY32 pe;
@@ -356,6 +357,9 @@ uv_pid_t uv_os_getppid(void) {
 
   CloseHandle(handle);
   return parent_pid;
+#else
+	return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
@@ -373,6 +377,7 @@ char** uv_setup_args(int argc, char** argv) {
 
 
 int uv_set_process_title(const char* title) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   int err;
   int length;
   WCHAR* title_w = NULL;
@@ -418,10 +423,14 @@ int uv_set_process_title(const char* title) {
 done:
   uv__free(title_w);
   return uv_translate_sys_error(err);
+#else
+	return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
 static int uv__get_process_title(void) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   WCHAR title_w[MAX_TITLE_LENGTH];
 
   if (!GetConsoleTitleW(title_w, sizeof(title_w) / sizeof(WCHAR))) {
@@ -432,6 +441,9 @@ static int uv__get_process_title(void) {
     return -1;
 
   return 0;
+#else
+	return -1;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
@@ -510,6 +522,7 @@ int uv_resident_set_memory(size_t* rss) {
 
 
 int uv_uptime(double* uptime) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   BYTE stack_buffer[4096];
   BYTE* malloced_buffer = NULL;
   BYTE* buffer = (BYTE*) stack_buffer;
@@ -607,10 +620,14 @@ int uv_uptime(double* uptime) {
   uv__free(malloced_buffer);
   *uptime = 0;
   return UV_EIO;
+#else
+  return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
 int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   uv_cpu_info_t* cpu_infos;
   SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION* sppi;
   DWORD sppi_size;
@@ -734,6 +751,9 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   uv__free(sppi);
 
   return uv_translate_sys_error(err);
+#else
+  return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
@@ -1091,6 +1111,7 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
 
 
 int uv_getrusage(uv_rusage_t *uv_rusage) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   FILETIME createTime, exitTime, kernelTime, userTime;
   SYSTEMTIME kernelSystemTime, userSystemTime;
   PROCESS_MEMORY_COUNTERS memCounters;
@@ -1143,6 +1164,9 @@ int uv_getrusage(uv_rusage_t *uv_rusage) {
   uv_rusage->ru_inblock = (uint64_t) ioCounters.ReadOperationCount;
 
   return 0;
+#else
+	return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 
@@ -1344,6 +1368,7 @@ int uv__convert_utf8_to_utf16(const char* utf8, int utf8len, WCHAR** utf16) {
 
 
 int uv__getpwuid_r(uv_passwd_t* pwd) {
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   HANDLE token;
   wchar_t username[UNLEN + 1];
   wchar_t path[MAX_PATH];
@@ -1402,6 +1427,9 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
   pwd->gid = -1;
 
   return 0;
+#else
+	return UV_ENOSYS;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -24,6 +24,25 @@
 
 #include <windows.h>
 
+/*
+ * Missing defines on UWP partition
+ */
+#ifndef SEM_FAILCRITICALERRORS
+#define SEM_FAILCRITICALERRORS      0x0001
+#endif // !SEM_FAILCRITICALERRORS
+
+#ifndef SEM_NOGPFAULTERRORBOX
+#define SEM_NOGPFAULTERRORBOX       0x0002
+#endif // !SEM_NOGPFAULTERRORBOX
+
+#ifndef SEM_NOALIGNMENTFAULTEXCEPT
+#define SEM_NOALIGNMENTFAULTEXCEPT  0x0004
+#endif // !SEM_NOALIGNMENTFAULTEXCEPT
+
+#ifndef SEM_NOOPENFILEERRORBOX
+#define SEM_NOOPENFILEERRORBOX      0x8000
+#endif // !SEM_NOOPENFILEERRORBOX
+
 
 /*
  * Ntdll headers
@@ -4085,6 +4104,7 @@
         ((NTSTATUS) (error)) : ((NTSTATUS) (((error) & 0x0000FFFF) | \
         (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_WARNING)))
 
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #ifndef JOB_OBJECT_LIMIT_PROCESS_MEMORY
 # define JOB_OBJECT_LIMIT_PROCESS_MEMORY             0x00000100
 #endif
@@ -4771,6 +4791,7 @@ extern sGetFinalPathNameByHandleW pGetFinalPathNameByHandleW;
 
 /* Powrprof.dll function pointer */
 extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4104,7 +4104,6 @@
         ((NTSTATUS) (error)) : ((NTSTATUS) (((error) & 0x0000FFFF) | \
         (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_WARNING)))
 
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #ifndef JOB_OBJECT_LIMIT_PROCESS_MEMORY
 # define JOB_OBJECT_LIMIT_PROCESS_MEMORY             0x00000100
 #endif
@@ -4764,8 +4763,8 @@ typedef HWINEVENTHOOK (WINAPI *sSetWinEventHook)
                        DWORD        idThread,
                        UINT         dwflags);
 
-
 /* Ntdll function pointers */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 extern sRtlNtStatusToDosError pRtlNtStatusToDosError;
 extern sNtDeviceIoControlFile pNtDeviceIoControlFile;
 extern sNtQueryInformationFile pNtQueryInformationFile;
@@ -4773,12 +4772,14 @@ extern sNtSetInformationFile pNtSetInformationFile;
 extern sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 extern sNtQueryDirectoryFile pNtQueryDirectoryFile;
 extern sNtQuerySystemInformation pNtQuerySystemInformation;
-
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 
 /* Kernel32 function pointers */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+extern sCreateSymbolicLinkW pCreateSymbolicLinkW;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 extern sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;
 extern sSetFileCompletionNotificationModes pSetFileCompletionNotificationModes;
-extern sCreateSymbolicLinkW pCreateSymbolicLinkW;
 extern sCancelIoEx pCancelIoEx;
 extern sInitializeConditionVariable pInitializeConditionVariable;
 extern sSleepConditionVariableCS pSleepConditionVariableCS;
@@ -4788,11 +4789,13 @@ extern sWakeConditionVariable pWakeConditionVariable;
 extern sCancelSynchronousIo pCancelSynchronousIo;
 extern sGetFinalPathNameByHandleW pGetFinalPathNameByHandleW;
 
-
 /* Powrprof.dll function pointer */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 
 /* User32.dll function pointer */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 extern sSetWinEventHook pSetWinEventHook;
 #endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4791,9 +4791,9 @@ extern sGetFinalPathNameByHandleW pGetFinalPathNameByHandleW;
 
 /* Powrprof.dll function pointer */
 extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
-#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 
 #endif /* UV_WIN_WINAPI_H_ */

--- a/src/win/winapi_app.c
+++ b/src/win/winapi_app.c
@@ -1,0 +1,48 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
+
+#include "uv.h"
+#include "internal.h"
+
+/* Kernel32 function pointers */
+sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;
+sSetFileCompletionNotificationModes pSetFileCompletionNotificationModes;
+sCancelIoEx pCancelIoEx;
+sInitializeConditionVariable pInitializeConditionVariable;
+sSleepConditionVariableCS pSleepConditionVariableCS;
+sSleepConditionVariableSRW pSleepConditionVariableSRW;
+sWakeAllConditionVariable pWakeAllConditionVariable;
+sWakeConditionVariable pWakeConditionVariable;
+sGetFinalPathNameByHandleW pGetFinalPathNameByHandleW;
+
+void uv_winapi_init(void) {
+  pGetQueuedCompletionStatusEx = GetQueuedCompletionStatusEx;
+  pSetFileCompletionNotificationModes = SetFileCompletionNotificationModes;
+  pCancelIoEx = CancelIoEx;
+  pInitializeConditionVariable = InitializeConditionVariable;
+  pSleepConditionVariableCS = SleepConditionVariableCS;
+  pSleepConditionVariableSRW = SleepConditionVariableSRW;
+  pWakeAllConditionVariable = WakeAllConditionVariable;
+  pWakeConditionVariable = WakeConditionVariable;
+  pGetFinalPathNameByHandleW = GetFinalPathNameByHandleW;
+}

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -266,7 +266,7 @@ int uv_ntstatus_to_winsock_error(NTSTATUS status) {
   }
 }
 
-
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 /*
  * This function provides a workaround for a bug in the winsock implementation
  * of WSARecv. The problem is that when SetFileCompletionNotificationModes is
@@ -559,6 +559,7 @@ int WSAAPI uv_msafd_poll(SOCKET socket, AFD_POLL_INFO* info_in,
     return SOCKET_ERROR;
   }
 }
+#endif
 
 int uv__convert_to_localhost_if_unspecified(const struct sockaddr* addr,
                                             struct sockaddr_storage* storage) {


### PR DESCRIPTION
Hi, this is my first real contribution, so I'm looking for any advices or tips on how to improve 💯 

_this is a very early stage and i would recommand not to us it as-it_ 

The main goal of this contribution is to port libuv to XBOX One
In order to archive this, I had to disable some modules and features of libuv and replace them by stubs.
I did that by either replacing the whole files with empty ones where each methods returns UV_ENOSYS

**Disabled modules:**
- Dynamic Library linking (dl.c)
- File, File systems and files systems events (fs.c & fs-event.c)
- Pipes (pipe.c)
- Multi-purpose polling (poll.c) [ASF polling is not available on UWP, slow mode could be done]
- Process handling (process.c & process-stdio.c)
- TTY, there is not terminal associated to UWP (tty.c)

**Disabled utils:**
- uv_getrusage(...)
- uv_os_get_passwd(...)
- uv_os_getppid(...)
- uv_set_process_title(...)
- uv_get_process_title(...)
- uv_uptime(...)
- uv_cpu_info(...)
- uv_getrusage(...)
- uv_os_get_passwd(...)

**Workaround needed:**
UDP, TCP: Disable handle inheritance.
UDP: Disable the WSARecv Workaround on SetFileCompletionNotificationModes because ASF polling is not available
TCP: Disable IOCP Emulation
Some other workaround not available APIs in UWP

**What's left:**
- Integrate the build in the vcbuild.bat tool (add a store or uwp option to compile as a UWP lib)
- Add the tests backs (still need to figure out how ;) )
- Make sure I didn't broke anything 👍 