### PR TITLE
zos: use BPX4AIO call for async connect

### DIFF
--- a/include/uv-os390.h
+++ b/include/uv-os390.h
@@ -22,6 +22,9 @@
 #ifndef UV_MVS_H
 #define UV_MVS_H
 
+#define _AIO_OS390
+#include <aio.h>
+
 #define UV_PLATFORM_SEM_T int
 
 #define UV_PLATFORM_LOOP_FIELDS                                               \
@@ -29,5 +32,8 @@
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
   char rfis_rftok[8];                                                         \
+
+#define UV_CONNECT_PRIVATE_PLATFORM_FIELDS                                    \
+  struct aiocb aio;                                                           \
 
 #endif /* UV_MVS_H */

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -116,6 +116,10 @@ struct uv__io_s {
 # define UV_STREAM_PRIVATE_PLATFORM_FIELDS /* empty */
 #endif
 
+#ifndef UV_CONNECT_PRIVATE_PLATFORM_FIELDS
+# define UV_CONNECT_PRIVATE_PLATFORM_FIELDS /* empty */
+#endif
+
 /* Note: May be cast to struct iovec. See writev(2). */
 typedef struct uv_buf_t {
   char* base;
@@ -241,6 +245,7 @@ typedef struct {
 
 #define UV_CONNECT_PRIVATE_FIELDS                                             \
   void* queue[2];                                                             \
+  UV_CONNECT_PRIVATE_PLATFORM_FIELDS                                          \
 
 #define UV_SHUTDOWN_PRIVATE_FIELDS /* empty */
 

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -49,7 +49,7 @@ struct epoll_event {
 typedef struct {
   QUEUE member;
   struct pollfd* items;
-  unsigned long size;
+  int size;
   int msg_queue;
 } uv__os390_epoll;
 

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -27,6 +27,14 @@
 #include <assert.h>
 #include <errno.h>
 
+#ifdef __MVS__
+# define platform_connect(req, handle, addr, addrlen) \
+         uv__os390_connect(req, handle, addr, addrlen)
+#else
+# define platform_connect(req, handle, addr, addrlen) \
+         connect(uv__stream_fd(handle), addr, addrlen)
+#endif
+
 
 static int new_socket(uv_tcp_t* handle, int domain, unsigned long flags) {
   struct sockaddr_storage saddr;
@@ -222,7 +230,7 @@ int uv__tcp_connect(uv_connect_t* req,
 
   do {
     errno = 0;
-    r = connect(uv__stream_fd(handle), addr, addrlen);
+    r = platform_connect(req, handle, addr, addrlen);
   } while (r == -1 && errno == EINTR);
 
   /* We not only check the return value, but also check the errno != 0.


### PR DESCRIPTION
z/OS has a faster way to do async io using message queues (instead of poll).
This PR only applies that to tcp connects for now. Poll will continue to be used for other operations like read/write/accept/listen.
Once this PR goes through, using the other operations should be easier.
I thought it would be easier for code reviewers to do it in stages.