### PR TITLE
build: build with -D_FILE_OFFSET_BITS=64 again

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -2,12 +2,12 @@
   'variables': {
     'conditions': [
       ['OS=="win"', {
+        'shared_unix_defines': [ ],
+      }, {
         'shared_unix_defines': [
           '_LARGEFILE_SOURCE',
           '_FILE_OFFSET_BITS=64',
         ],
-      }, {
-        'shared_unix_defines': [ ],
       }],
       ['OS in "mac ios"', {
         'shared_mac_defines': [ '_DARWIN_USE_64_BIT_INODE=1' ],


### PR DESCRIPTION
Faulty logic in commit fdf7c2a ("build: split off tests into separate
gyp file") accidentally disabled `-D_FILE_OFFSET_BITS=64` on Unices,
breaking file operations on files > 2 GB on 32 bits platforms.

Fixes: https://github.com/nodejs/node/issues/19455
CI: https://ci.nodejs.org/job/libuv-test-commit/760/