### PR TITLE
test,freebsd: fix flaky poll tests

### DIFF
--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -134,7 +134,10 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT(r == 0);
+  /* On FreeBSD close() can fail with ECONNRESET if the socket was shutdown by
+   * the peer before all pending data was delivered.
+   */
+  ASSERT(r == 0 || errno == ECONNRESET);
 }
 
 


### PR DESCRIPTION
On FreeBSD `close()` can return `ECONNRESET` if the socket was shutdown
by the peer before all pending data was delivered.

Last seen on: https://ci.nodejs.org/job/libuv-test-commit-freebsd/727/nodes=freebsd11-x64/console
```
not ok 170 - poll_unidirectional
# exit code 134
# Output from process `poll_unidirectional`:
# Assertion failed in test/test-poll.c on line 137: r == 0
```