### PR TITLE
Cleanup to rely on compiler definition __PASE__ for IBM i platform (GCC 6.3.0+)

### DIFF
--- a/checksparse.sh
+++ b/checksparse.sh
@@ -184,7 +184,7 @@ AIX)
            src/unix/aix.c"
   ;;
 OS400)
-  SPARSE_FLAGS="$SPARSE_FLAGS -D_PASE=1"
+  SPARSE_FLAGS="$SPARSE_FLAGS -D__PASE__=1"
   SOURCES="$SOURCES
            src/unix/aix-common.c
            src/unix/ibmi.c

--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -48,7 +48,7 @@
 # include "uv-linux.h"
 #elif defined (__MVS__)
 # include "uv-os390.h"
-#elif defined(_PASE)
+#elif defined(__PASE__)
 # include "uv-posix.h"
 #elif defined(_AIX)
 # include "uv-aix.h"

--- a/uv.gyp
+++ b/uv.gyp
@@ -300,9 +300,6 @@
                 'src/unix/no-fsevents.c',
                 'src/unix/no-proctitle.c',
               ],
-              'defines': [
-                '_PASE=1'
-              ],
             }, {
               'sources': [
                 'src/unix/aix.c'


### PR DESCRIPTION
IBM i compilers now predefine __PASE__, so cleaning up code to rely on
that rather than manually setting (or relying on) a _PASE definition