### PR TITLE
win, tcp: handle canceled connect with ECANCELED status, like unix

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1171,11 +1171,14 @@ void uv_process_tcp_connect_req(uv_loop_t* loop, uv_tcp_t* handle,
 
   err = 0;
   if (REQ_SUCCESS(req)) {
-    if (setsockopt(handle->socket,
-                    SOL_SOCKET,
-                    SO_UPDATE_CONNECT_CONTEXT,
-                    NULL,
-                    0) == 0) {
+    if (handle->flags & UV__HANDLE_CLOSING) {
+      /* use UV_ECANCELED for consistency with Unix */
+      err = ERROR_OPERATION_ABORTED;
+    } else if (setsockopt(handle->socket,
+                          SOL_SOCKET,
+                          SO_UPDATE_CONNECT_CONTEXT,
+                          NULL,
+                          0) == 0) {
       uv_connection_init((uv_stream_t*)handle);
       handle->flags |= UV_HANDLE_READABLE | UV_HANDLE_WRITABLE;
       loop->active_tcp_streams++;


### PR DESCRIPTION
(As discovered when testing this sequence of events in https://github.com/JuliaLang/julia/pull/26545)

Previously, this would return ENOTSOCK (since handle->socket was set to INVALID_HANDLE after closesocket). This detects if that case is occurring and instead returns ECANCELED.

In nodejs, I assumed this example would correspond to something like:
```
net.connect(80, "1.1.1.1").end()
```
(or `destroy` instead of `end`), but those seem to either skip running the callbacks (connect or error) or don't actually call `uv_close` on the stream.