### PR TITLE
WIP: win, stdio: allow child pipe handles to be opened in overlapped mode

### DIFF
--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -109,6 +109,11 @@ Data types
             */
             UV_READABLE_PIPE = 0x10,
             UV_WRITABLE_PIPE = 0x20
+            /*
+             * Open the child pipe handle in overlapped mode on Windows.
+             * On Unix it is silently ignored.
+             */
+            UV_OVERLAPPED_PIPE = 0x40
         } uv_stdio_flags;
 
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -865,7 +865,13 @@ typedef enum {
    * flags may be specified to create a duplex data stream.
    */
   UV_READABLE_PIPE  = 0x10,
-  UV_WRITABLE_PIPE  = 0x20
+  UV_WRITABLE_PIPE  = 0x20,
+
+  /*
+   * Open the child pipe handle in overlapped mode on Windows.
+   * On Unix it is silently ignored.
+   */
+  UV_OVERLAPPED_PIPE = 0x40
 } uv_stdio_flags;
 
 typedef struct uv_stdio_container_s {

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -131,12 +131,13 @@ static int uv__create_stdio_pipe_pair(uv_loop_t* loop,
   sa.lpSecurityDescriptor = NULL;
   sa.bInheritHandle = TRUE;
 
+  BOOL overlap = server_pipe->ipc || (flags & UV_OVERLAPPED_PIPE);
   child_pipe = CreateFileA(pipe_name,
                            client_access,
                            0,
                            &sa,
                            OPEN_EXISTING,
-                           server_pipe->ipc ? FILE_FLAG_OVERLAPPED : 0,
+                           overlap ? FILE_FLAG_OVERLAPPED : 0,
                            NULL);
   if (child_pipe == INVALID_HANDLE_VALUE) {
     err = GetLastError();


### PR DESCRIPTION
Context: in neovim, which uses libuv for subprocess management, we run a python interpreter as a child process to implement python plugins. We would like to use asyncio in python to communicate with neovim and handle other event sources. However on windows, asyncio with the bulitin proactor event loop, can only use pipes for stdio handles if they were opened in overlapped mode by the parent.

There might be some black magic that can be used to transmute an ordinary pipe end into an overlapped pipe end on the subprocess side, but it would be more convenient if libuv could open stdio pipes in overlapped mode directly. This PR adds a flag to `process_options->stdio[i].flags` that requests a pipe to be opened in overlapped mode for the child process. An alternative could be to do this unconditionally, but I know to little about winNT IO to know if this could cause problems for some other potential child process.

If any option makes sense to you, I could look into adding documentation and tests.

Ref https://github.com/neovim/neovim/pull/8113