### PR TITLE
unix,win: add gecos field to uv_passwd_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AM_CONDITIONAL([OS390],    [AS_CASE([$host_os],[openedition*],  [true], [false])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [
-    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
+    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -lsecur32 -luserenv -luser32"
 ])
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -140,6 +140,7 @@ Data types
             long gid;
             char* shell;
             char* homedir;
+            char* gecos;
         } uv_passwd_t;
 
 
@@ -421,6 +422,8 @@ API
     :c:func:`uv_os_free_passwd`.
 
     .. versionadded:: 1.9.0
+
+    .. versionchanged:: 2.0.0 `gecos` support is added.
 
 .. c:function:: void uv_os_free_passwd(uv_passwd_t* pwd)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1096,6 +1096,7 @@ struct uv_passwd_s {
   long gid;
   char* shell;
   char* homedir;
+  char* gecos;
 };
 
 typedef enum {

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -70,6 +70,7 @@ TEST_IMPL(get_passwd) {
   ASSERT(pwd.username == NULL);
   ASSERT(pwd.shell == NULL);
   ASSERT(pwd.homedir == NULL);
+  ASSERT(pwd.gecos == NULL);
 
   /* Test a double free */
   uv_os_free_passwd(&pwd);
@@ -77,6 +78,7 @@ TEST_IMPL(get_passwd) {
   ASSERT(pwd.username == NULL);
   ASSERT(pwd.shell == NULL);
   ASSERT(pwd.homedir == NULL);
+  ASSERT(pwd.gecos == NULL);
 
   /* Test invalid input */
   r = uv_os_get_passwd(NULL);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -145,6 +145,7 @@ TEST_IMPL(platform_output) {
   printf("  username: %s\n", pwd.username);
   printf("  shell: %s\n", pwd.shell);
   printf("  home directory: %s\n", pwd.homedir);
+  printf("  gecos: %s\n", pwd.gecos);
 
   pid = uv_os_getpid();
   ASSERT(pid > 0);

--- a/uv.gyp
+++ b/uv.gyp
@@ -135,6 +135,7 @@
               '-liphlpapi',
               '-lpsapi',
               '-lshell32',
+              '-lsecur32',
               '-luser32',
               '-luserenv',
               '-lws2_32'


### PR DESCRIPTION
On Unix the `gecos` field usually contains the full name of the user. This is returned by `getpwuid_r()` on Unix and `GetUserNameExW` on Windows (falling back to `NameSamCompatible` if the users display name is not set).

This is a reworking of https://github.com/libuv/libuv/pull/834. I kept @kthelgason as the author, but added @saghul (for the original Windows implementation) and myself (because this PR is different enough, especially on Windows) as co-authors.

Successful CI run: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/788/