### PR TITLE
unix: work around glibc semaphore race condition

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -561,7 +561,7 @@ static int uv__custom_sem_init(uv_sem_t* sem_, unsigned int value) {
   }
 
   sem->value = value;
-  *(uv_semaphore_t**) sem_ = sem;
+  *(uv_semaphore_t**)sem_ = sem;
   return 0;
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -37,10 +37,6 @@
 #include <sys/sem.h>
 #endif
 
-#ifdef __GLIBC__
-#include <features.h>  /* __GLIBC_MINOR__ */
-#endif
-
 #undef NANOSEC
 #define NANOSEC ((uint64_t) 1e9)
 
@@ -504,7 +500,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
   return 0;
 }
 
-#elif defined(__GLIBC__) && __GLIBC_MINOR__ < 21
+#elif defined(__GLIBC__)
 
 /* Hack around https://sourceware.org/bugzilla/show_bug.cgi?id=12674
  * by providing a custom implementation for glibc < 2.21 in terms of other

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -522,11 +522,12 @@ typedef struct uv_semaphore_s {
 } uv_semaphore_t;
 
 
+STATIC_ASSERT(sizeof(uv_sem_t) >= sizeof(uv_semaphore_t*));
 int uv_sem_init(uv_sem_t* sem_, unsigned int value) {
   int err;
   uv_semaphore_t* sem;
 
-  sem = uv__malloc(sizeof(uv_semaphore_t));
+  sem = uv__malloc(sizeof(*sem));
   if (sem == NULL)
     return UV_ENOMEM;
 
@@ -541,7 +542,6 @@ int uv_sem_init(uv_sem_t* sem_, unsigned int value) {
     return err;
   }
 
-  assert(sizeof(uv_sem_t) >= sizeof(uv_semaphore_t*));
   sem->value = value;
   *(uv_semaphore_t**) sem_ = sem;
   return 0;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -564,7 +564,8 @@ void uv_sem_post(uv_sem_t* sem_) {
   sem = *(uv_semaphore_t**)sem_;
   uv_mutex_lock(&sem->mutex);
   sem->value++;
-  uv_cond_signal(&sem->cond);
+  if (sem->value == 1)
+    uv_cond_signal(&sem->cond);
   uv_mutex_unlock(&sem->mutex);
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -526,18 +526,18 @@ int uv_sem_init(uv_sem_t* sem_, unsigned int value) {
   int err;
   uv_semaphore_t* sem;
 
-  sem = malloc(sizeof(uv_semaphore_t));
+  sem = uv__malloc(sizeof(uv_semaphore_t));
   if (sem == NULL)
     return UV_ENOMEM;
 
   if ((err = uv_mutex_init(&sem->mutex)) != 0) {
-    free(sem);
+    uv__free(sem);
     return err;
   }
 
   if ((err = uv_cond_init(&sem->cond)) != 0) {
     uv_mutex_destroy(&sem->mutex);
-    free(sem);
+    uv__free(sem);
     return err;
   }
 
@@ -554,7 +554,7 @@ void uv_sem_destroy(uv_sem_t* sem_) {
   sem = *(uv_semaphore_t**)sem_;
   uv_cond_destroy(&sem->cond);
   uv_mutex_destroy(&sem->mutex);
-  free(sem);
+  uv__free(sem);
 }
 
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -519,7 +519,7 @@ int uv_sem_trywait(uv_sem_t* sem) {
 static uv_once_t glibc_version_check_once = UV_ONCE_INIT;
 static int glibc_needs_custom_semaphore = 0;
 
-void glibc_version_check(void) {
+static void glibc_version_check(void) {
   const char* version = gnu_get_libc_version();
   glibc_needs_custom_semaphore =
       version[0] == '2' && version[1] == '.' &&


### PR DESCRIPTION
Hack around https://sourceware.org/bugzilla/show_bug.cgi?id=12674
by providing a custom implementation for glibc < 2.21 in terms of other
concurrency primitives.

The glibc implementation on these versions is inherently unsafe.
So, while libuv and Node.js support those versions, it seems to make
sense for libuv in its functionality as a platform abstraction library
to provide a working version.

Fixes: https://github.com/nodejs/node/issues/19903

/cc @bnoordhuis 