### PR TITLE
Fix build and some tests on OpenBSD

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -164,6 +164,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
     return UV__ERR(errno);
 
+#ifndef __OpenBSD__
 #ifdef IPV6_V6ONLY
   if (addr->sa_family == AF_INET6) {
     on = (flags & UV_TCP_IPV6ONLY) != 0;
@@ -179,6 +180,7 @@ int uv__tcp_bind(uv_tcp_t* tcp,
       return UV__ERR(errno);
     }
   }
+#endif
 #endif
 
   errno = 0;

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -174,6 +174,8 @@ TEST_IMPL(udp_dual_stack) {
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
   if (!can_ipv6_ipv4_dual())
     RETURN_SKIP("IPv6-IPv4 dual stack not supported");
+#elif defined(__OpenBSD__)
+  RETURN_SKIP("IPv6-IPv4 dual stack not supported");
 #endif
 
   do_test(ipv6_recv_ok, 0);

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -123,7 +123,8 @@ TEST_IMPL(udp_multicast_join6) {
     defined(_AIX)               || \
     defined(__MVS__)            || \
     defined(__FreeBSD_kernel__) || \
-    defined(__NetBSD__)
+    defined(__NetBSD__)         || \
+    defined(__OpenBSD__)
   r = uv_udp_set_membership(&client, "ff02::1", "::1%lo0", UV_JOIN_GROUP);
 #else
   r = uv_udp_set_membership(&client, "ff02::1", NULL, UV_JOIN_GROUP);


### PR DESCRIPTION
This PR upstreams the patches in the OpenBSD Ports Collection so that libuv can be built from source on OpenBSD. There are still a couple of test failures which I believe do not apply to the version of libuv in the OpenBSD port, so no fixes for those are included here. I can report them as a separate issue.