### PR TITLE
zos: use custom semaphore

### DIFF
--- a/include/uv-os390.h
+++ b/include/uv-os390.h
@@ -22,7 +22,7 @@
 #ifndef UV_MVS_H
 #define UV_MVS_H
 
-#define UV_PLATFORM_SEM_T int
+#define UV_PLATFORM_SEM_T long
 
 #define UV_PLATFORM_LOOP_FIELDS                                               \
   void* ep;                                                                   \


### PR DESCRIPTION
The System V semaphores on z/OS require explicit ending of the worker threads
and cleanup at process exit. The user will have to manually cleanup these
resources that are left behind. Instead use the custom semaphore implementation
which uses posix mutexes and condition variables which are cleaned up automatically
on process exit.