### PR TITLE
build: add support for 64-bit AIX

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -134,7 +134,7 @@
           }]
         ]
       }],
-      ['OS in "freebsd dragonflybsd linux openbsd solaris android"', {
+      ['OS in "freebsd dragonflybsd linux openbsd solaris android aix"', {
         'cflags': [ '-Wall' ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'target_conditions': [
@@ -161,6 +161,10 @@
           [ 'OS not in "solaris android zos"', {
             'cflags': [ '-pthread' ],
             'ldflags': [ '-pthread' ],
+          }],
+          [ 'OS=="aix" and target_arch=="ppc64"', {
+            'cflags': [ '-maix64' ],
+            'ldflags': [ '-maix64' ],
           }],
         ],
       }],


### PR DESCRIPTION
Support building 64-bit binaries on AIX via gyp. At the moment there's no automatic detection as `platform.machine()`/`uname -m` on AIX is a bit useless (e.g., on an AIX system I have access to `uname -m` outputs `00F460A94C00`) so you need to pass `-Dtarget_arch=ppc64` to `gyp_uv.py` to activate.

Note however that https://github.com/libuv/libuv/pull/1795 actually fails to compile on 64-bit AIX due to incorrect assumptions about the size of `uv_sem_t`, see https://github.com/nodejs/node/pull/20129#issuecomment-382858256.
