### PR TITLE
Make libuv can running in Windows XP.

### DIFF
--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -395,12 +395,16 @@ int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  r = ConvertInterfaceIndexToLuid(ifindex, &luid);
+  if (pConvertInterfaceIndexToLuid == NULL)
+    return UV_ENOSYS;
+  r = pConvertInterfaceIndexToLuid(ifindex, &luid);
 
   if (r != 0)
     return uv_translate_sys_error(r);
 
-  r = ConvertInterfaceLuidToNameW(&luid, wname, ARRAY_SIZE(wname));
+  if (pConvertInterfaceLuidToNameW == NULL)
+    return UV_ENOSYS;
+  r = pConvertInterfaceLuidToNameW(&luid, wname, ARRAY_SIZE(wname));
 
   if (r != 0)
     return uv_translate_sys_error(r);

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -392,6 +392,8 @@ int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
   DWORD bufsize;
   int r;
 
+  uv__once_init();
+
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -55,13 +55,17 @@ sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
 /* User32.dll function pointer */
 sSetWinEventHook pSetWinEventHook;
 
+/* iphlpapi.dll function pointer */
+sConvertInterfaceIndexToLuid pConvertInterfaceIndexToLuid = NULL;
+sConvertInterfaceLuidToNameW pConvertInterfaceLuidToNameW = NULL;
 
 void uv_winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE kernel32_module;
   HMODULE powrprof_module;
   HMODULE user32_module;
-
+  HMODULE iphlpapi_module;
+  
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
     uv_fatal_error(GetLastError(), "GetModuleHandleA");
@@ -166,4 +170,11 @@ void uv_winapi_init(void) {
       GetProcAddress(user32_module, "SetWinEventHook");
   }
 
+  iphlpapi_module = LoadLibraryA("iphlpapi.dll");
+  if (iphlpapi_module != NULL) {
+    pConvertInterfaceIndexToLuid = (sConvertInterfaceIndexToLuid)
+      GetProcAddress(iphlpapi_module, "ConvertInterfaceIndexToLuid");
+    pConvertInterfaceLuidToNameW = (sConvertInterfaceLuidToNameW)
+      GetProcAddress(iphlpapi_module, "ConvertInterfaceLuidToNameW");
+  }
 }

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4775,4 +4775,19 @@ extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotifi
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;
 
+/* iphlpapi.dll function pointer */
+union _NET_LUID_LH;
+typedef DWORD (WINAPI *sConvertInterfaceIndexToLuid)(
+    ULONG InterfaceIndex,
+    union _NET_LUID_LH *InterfaceLuid);
+
+typedef DWORD (WINAPI *sConvertInterfaceLuidToNameW)(
+    const union _NET_LUID_LH *InterfaceLuid,
+    PWSTR InterfaceName,
+    size_t Length);
+
+extern sConvertInterfaceIndexToLuid pConvertInterfaceIndexToLuid;
+extern sConvertInterfaceLuidToNameW pConvertInterfaceLuidToNameW;
+
+
 #endif /* UV_WIN_WINAPI_H_ */

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -51,8 +51,6 @@ TEST_IMPL(ip6_addr_link_local) {
   int ix;
   int r;
 
-  uv_default_loop();
-
   ASSERT(0 == uv_interface_addresses(&addresses, &count));
 
   for (ix = 0; ix < count; ix++) {

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -51,6 +51,8 @@ TEST_IMPL(ip6_addr_link_local) {
   int ix;
   int r;
 
+  uv_default_loop();
+
   ASSERT(0 == uv_interface_addresses(&addresses, &count));
 
   for (ix = 0; ix < count; ix++) {


### PR DESCRIPTION
Since there is no ConvertInterfaceLuidToNameW function in the Windows XP operating system, in order for libuv to run smoothly on Widnwos XP, we use the pointer of the ConvertInterfaceLuidToNameW function.