### PR TITLE
util,win: fix registry API error handling

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -676,28 +676,30 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
                       KEY_QUERY_VALUE,
                       &processor_key);
     if (r != ERROR_SUCCESS) {
-      err = GetLastError();
+      err = r;
       goto error;
     }
 
-    if (RegQueryValueExW(processor_key,
-                         L"~MHz",
-                         NULL,
-                         NULL,
-                         (BYTE*) &cpu_speed,
-                         &cpu_speed_size) != ERROR_SUCCESS) {
-      err = GetLastError();
+    r = RegQueryValueExW(processor_key,
+        L"~MHz",
+        NULL,
+        NULL,
+        (BYTE*)&cpu_speed,
+        &cpu_speed_size);
+    if (r != ERROR_SUCCESS) {
+      err = r;
       RegCloseKey(processor_key);
       goto error;
     }
 
-    if (RegQueryValueExW(processor_key,
-                         L"ProcessorNameString",
-                         NULL,
-                         NULL,
-                         (BYTE*) &cpu_brand,
-                         &cpu_brand_size) != ERROR_SUCCESS) {
-      err = GetLastError();
+    r = RegQueryValueExW(processor_key,
+        L"ProcessorNameString",
+        NULL,
+        NULL,
+        (BYTE*)&cpu_brand,
+        &cpu_brand_size);
+    if (r != ERROR_SUCCESS) {
+      err = r;
       RegCloseKey(processor_key);
       goto error;
     }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -615,7 +615,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION* sppi;
   DWORD sppi_size;
   SYSTEM_INFO system_info;
-  DWORD cpu_count, r, i;
+  DWORD cpu_count, i;
   NTSTATUS status;
   ULONG result_size;
   int err;
@@ -670,36 +670,33 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
 
     assert(len > 0 && len < ARRAY_SIZE(key_name));
 
-    r = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                      key_name,
-                      0,
-                      KEY_QUERY_VALUE,
-                      &processor_key);
-    if (r != ERROR_SUCCESS) {
-      err = r;
+    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                        key_name,
+                        0,
+                        KEY_QUERY_VALUE,
+                        &processor_key);
+    if (err != ERROR_SUCCESS) {
       goto error;
     }
 
-    r = RegQueryValueExW(processor_key,
-        L"~MHz",
-        NULL,
-        NULL,
-        (BYTE*)&cpu_speed,
-        &cpu_speed_size);
-    if (r != ERROR_SUCCESS) {
-      err = r;
+    err = RegQueryValueExW(processor_key,
+                           L"~MHz",
+                           NULL,
+                           NULL,
+                           (BYTE*)&cpu_speed,
+                           &cpu_speed_size);
+    if (err != ERROR_SUCCESS) {
       RegCloseKey(processor_key);
       goto error;
     }
 
-    r = RegQueryValueExW(processor_key,
-        L"ProcessorNameString",
-        NULL,
-        NULL,
-        (BYTE*)&cpu_brand,
-        &cpu_brand_size);
-    if (r != ERROR_SUCCESS) {
-      err = r;
+    err = RegQueryValueExW(processor_key,
+                           L"ProcessorNameString",
+                           NULL,
+                           NULL,
+                           (BYTE*)&cpu_brand,
+                           &cpu_brand_size);
+    if (err != ERROR_SUCCESS) {
       RegCloseKey(processor_key);
       goto error;
     }


### PR DESCRIPTION
The `Reg*` APIs on Windows don't use `GetLastError` to report failures.
The errors are returned directly from the call.

For systems which don't have one of the values `GetLastError` can end
up returning `0` to the caller, indicating success. The caller then
assumes that the data is valid and can attempt to execute on garbage
data. This change fixes the flow to correctly return the error to the
caller.