### PR TITLE
To avoid ` 'floor' undefined ` warnning.

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -37,7 +37,7 @@
 #include <tlhelp32.h>
 #include <windows.h>
 #include <userenv.h>
-
+#include <math.h>
 
 /*
  * Max title length; the only thing MSDN tells us about the maximum length


### PR DESCRIPTION
In VS2010 debug build, output message is `libuv\src\win\util.c(590): warning C4013: 'floor' undefined; assuming extern returning int`.