### PR TITLE
Windows: Fix Visual studio 2015 + Windows kit 10 compile warnings.

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -141,7 +141,7 @@ int uv__next_timeout(const uv_loop_t* loop) {
   if (diff > INT_MAX)
     diff = INT_MAX;
 
-  return diff;
+  return (int)diff;
 }
 
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -46,7 +46,10 @@ TEST_IMPL(kill_invalid_signum) {
 
 /* For Windows we test only signum handling */
 #ifdef _WIN32
+
+#ifndef NSIG
 #define NSIG 32
+#endif
 
 static void signum_test_cb(uv_signal_t* handle, int signum) {
   FATAL("signum_test_cb should not be called");


### PR DESCRIPTION
src\timer.c(144): warning C4244: 'return': conversion from 'uint64_t' to 
'int', possible loss of data
Explicit cast to int added.

test-signal.c(49): warning C4005: 'NSIG': macro redefinition
This happens with Windows kit 10, NSIG is already defined in signal.h and
the value in test-signal.c is out of range.