### PR TITLE
WIP: add uv_thread_set_name

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -180,6 +180,18 @@ static size_t thread_stack_size(void) {
 }
 
 
+void uv_thread_set_name(const char* name) {
+#if defined(__APPLE__) && defined(__MACH__)
+  pthread_setname_np(name);
+#elif defined(__NetBSD__) || ((__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 12))
+  pthread_setname_np(pthread_self(), name);
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+  pthread_set_name_np(pthread_self(), name);
+#else
+  /* nothing */
+#endif
+}
+
 int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   int err;
   size_t stack_size;

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -124,6 +124,33 @@ static UINT __stdcall uv__thread_start(void* arg) {
   return 0;
 }
 
+const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push, 8)
+  typedef struct tagTHREADNAME_INFO
+  {
+    DWORD dwType;     // Must be 0x1000.
+    LPCSTR szName;    // Pointer to name (in user addr space).
+    DWORD dwThreadID; // Thread ID (-1=caller thread).
+    DWORD dwFlags;    // Reserved for future use, must be zero.
+  } THREADNAME_INFO;
+#pragma pack(pop)
+
+void uv_thread_set_name(const char *threadName) {
+  THREADNAME_INFO info;
+  info.dwType = 0x1000;
+  info.szName = threadName;
+  info.dwThreadID = -1;
+  info.dwFlags = 0;
+
+#pragma warning(push)
+#pragma warning(disable : 6320 6322)
+  __try {
+    RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR *)&info);
+  }
+  __except (EXCEPTION_EXECUTE_HANDLER) {}
+#pragma warning(pop)
+}
+
 
 int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   struct thread_ctx* ctx;


### PR DESCRIPTION
Opening a PR early in case there is early feedback, and to check availability of `pthread_setname_np` across supported platforms through the CI.

For debugging and diagnostics it would be quite useful if users could name threads. I propose to add `uv_thread_set_name` and `uv_thread_get_name`, which would {set,get} the thread name for the currently active thread. On platforms that have no equivalent of this functionality, these functions will be no-ops. We can make this clear in the docs.

TODO:
- [ ] Look at the CI result to see where all `pthread_setname_np` may be unavailable.
- [ ] Add uv_thread_get_name()
- [ ] docs
- [ ] tests
