### PR TITLE
unix,windows: map EFTYPE errno

### DIFF
--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -433,5 +433,11 @@
 # define UV__ENOTTY (-4029)
 #endif
 
+#if defined(EFTYPE) && !defined(_WIN32)
+# define UV__EFTYPE UV__ERR(EFTYPE)
+#else
+# define UV__EFTYPE (-4028)
+#endif
+
 
 #endif /* UV_ERRNO_H_ */

--- a/include/uv.h
+++ b/include/uv.h
@@ -142,6 +142,7 @@ extern "C" {
   XX(EHOSTDOWN, "host is down")                                               \
   XX(EREMOTEIO, "remote I/O error")                                           \
   XX(ENOTTY, "inappropriate ioctl for device")                                \
+  XX(EFTYPE, "inappropriate file type or format")                             \
 
 #define UV_HANDLE_TYPE_MAP(XX)                                                \
   XX(ASYNC, async)                                                            \


### PR DESCRIPTION
I was able to generate this error in https://github.com/nodejs/node/pull/20588 on FreeBSD. Without it being defined, Node crashed with:

```
TypeError: errmap.get is not a function or its return value is not iterable
  at Object.uvException (internal/errors.js:521:34)
```

After defining it, I got a proper exception.