### PR TITLE
unix,win: limit concurrent DNS calls to nthreads/2

### DIFF
--- a/include/uv-threadpool.h
+++ b/include/uv-threadpool.h
@@ -27,11 +27,18 @@
 #ifndef UV_THREADPOOL_H_
 #define UV_THREADPOOL_H_
 
+enum uv__work_kind {
+  UV__WORK_CPU,
+  UV__WORK_FAST_IO,
+  UV__WORK_SLOW_IO
+};
+
 struct uv__work {
   void (*work)(struct uv__work *w);
   void (*done)(struct uv__work *w, int status);
   struct uv_loop_s* loop;
   void* wq[2];
+  enum uv__work_kind kind;
 };
 
 #endif /* UV_THREADPOOL_H_ */

--- a/include/uv-threadpool.h
+++ b/include/uv-threadpool.h
@@ -27,18 +27,11 @@
 #ifndef UV_THREADPOOL_H_
 #define UV_THREADPOOL_H_
 
-enum uv__work_kind {
-  UV__WORK_CPU,
-  UV__WORK_FAST_IO,
-  UV__WORK_SLOW_IO
-};
-
 struct uv__work {
   void (*work)(struct uv__work *w);
   void (*done)(struct uv__work *w, int status);
   struct uv_loop_s* loop;
   void* wq[2];
-  enum uv__work_kind kind;
 };
 
 #endif /* UV_THREADPOOL_H_ */

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -304,7 +304,6 @@ void uv__work_done(uv_async_t* handle) {
 
     w = container_of(q, struct uv__work, wq);
     err = (w->work == uv__cancelled) ? UV_ECANCELED : 0;
-
     w->done(w, err);
   }
 }

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -120,7 +120,11 @@
   do {                                                                        \
     if (cb != NULL) {                                                         \
       uv__req_register(loop, req);                                            \
-      uv__work_submit(loop, &req->work_req, uv__fs_work, uv__fs_done);        \
+      uv__work_submit(loop,                                                   \
+                      &req->work_req,                                         \
+                      UV__WORK_FAST_IO,                                       \
+                      uv__fs_work,                                            \
+                      uv__fs_done);                                           \
       return 0;                                                               \
     }                                                                         \
     else {                                                                    \
@@ -129,7 +133,6 @@
     }                                                                         \
   }                                                                           \
   while (0)
-
 
 static ssize_t uv__fs_fsync(uv_fs_t* req) {
 #if defined(__APPLE__)

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -134,6 +134,7 @@
   }                                                                           \
   while (0)
 
+
 static ssize_t uv__fs_fsync(uv_fs_t* req) {
 #if defined(__APPLE__)
   /* Apple's fdatasync and fsync explicitly do NOT flush the drive write cache

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -186,6 +186,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   if (cb) {
     uv__work_submit(loop,
                     &req->work_req,
+                    UV__WORK_SLOW_IO,
                     uv__getaddrinfo_work,
                     uv__getaddrinfo_done);
     return 0;

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -109,6 +109,7 @@ int uv_getnameinfo(uv_loop_t* loop,
   if (getnameinfo_cb) {
     uv__work_submit(loop,
                     &req->work_req,
+                    UV__WORK_SLOW_IO,
                     uv__getnameinfo_work,
                     uv__getnameinfo_done);
     return 0;

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -121,6 +121,7 @@ int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
 void uv__work_submit(uv_loop_t* loop,
                      struct uv__work *w,
+                     enum uv__work_kind kind,
                      void (*work)(struct uv__work *w),
                      void (*done)(struct uv__work *w, int status));
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -119,6 +119,12 @@ void uv__fs_poll_close(uv_fs_poll_t* handle);
 
 int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
 
+enum uv__work_kind {
+  UV__WORK_CPU,
+  UV__WORK_FAST_IO,
+  UV__WORK_SLOW_IO
+};
+
 void uv__work_submit(uv_loop_t* loop,
                      struct uv__work *w,
                      enum uv__work_kind kind,

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1517,10 +1517,10 @@ static void fs__fchmod(uv_fs_t* req) {
     SET_REQ_WIN32_ERROR(req, pRtlNtStatusToDosError(nt_status));
     goto fchmod_cleanup;
   }
-
+ 
   /* Test if the Archive attribute is cleared */
   if ((file_info.FileAttributes & FILE_ATTRIBUTE_ARCHIVE) == 0) {
-      /* Set Archive flag, otherwise setting or clearing the read-only
+      /* Set Archive flag, otherwise setting or clearing the read-only 
          flag will not work */
       file_info.FileAttributes |= FILE_ATTRIBUTE_ARCHIVE;
       nt_status = pNtSetInformationFile(handle,

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -55,7 +55,11 @@
   do {                                                                        \
     if (cb != NULL) {                                                         \
       uv__req_register(loop, req);                                            \
-      uv__work_submit(loop, &req->work_req, uv__fs_work, uv__fs_done);        \
+      uv__work_submit(loop,                                                   \
+                      &req->work_req,                                         \
+                      UV__WORK_FAST_IO,                                       \
+                      uv__fs_work,                                            \
+                      uv__fs_done);                                           \
       return 0;                                                               \
     } else {                                                                  \
       uv__fs_work(&req->work_req);                                            \
@@ -1513,10 +1517,10 @@ static void fs__fchmod(uv_fs_t* req) {
     SET_REQ_WIN32_ERROR(req, pRtlNtStatusToDosError(nt_status));
     goto fchmod_cleanup;
   }
- 
+
   /* Test if the Archive attribute is cleared */
   if ((file_info.FileAttributes & FILE_ATTRIBUTE_ARCHIVE) == 0) {
-      /* Set Archive flag, otherwise setting or clearing the read-only 
+      /* Set Archive flag, otherwise setting or clearing the read-only
          flag will not work */
       file_info.FileAttributes |= FILE_ATTRIBUTE_ARCHIVE;
       nt_status = pNtSetInformationFile(handle,

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -368,6 +368,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   if (getaddrinfo_cb) {
     uv__work_submit(loop,
                     &req->work_req,
+                    UV__WORK_SLOW_IO,
                     uv__getaddrinfo_work,
                     uv__getaddrinfo_done);
     return 0;

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -138,6 +138,7 @@ int uv_getnameinfo(uv_loop_t* loop,
   if (getnameinfo_cb) {
     uv__work_submit(loop,
                     &req->work_req,
+                    UV__WORK_SLOW_IO,
                     uv__getnameinfo_work,
                     uv__getnameinfo_done);
     return 0;


### PR DESCRIPTION
~~Not sure about semverness here, so I went with PRing against `master` first. Happy to retarget to `v1.x` if that’s deemed okay as well. Also happy to throw this PR in the garbage bin if this approach doesn’t work for people.~~

---

If `nthreads / 2` (rounded up) DNS calls are outstanding,
queue more work of that kind instead of letting it take over
more positions in the thread pool, blocking other work
such as the (usually much faster) file system I/O or
user-scheduled work.

Fixes: https://github.com/nodejs/node/issues/8436