### PR TITLE
Misc fixes

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1517,7 +1517,7 @@ static void fs__fchmod(uv_fs_t* req) {
  
   /* Test if the Archive attribute is cleared */
   if ((file_info.FileAttributes & FILE_ATTRIBUTE_ARCHIVE) == 0) {
-      /* Set Archive flag, otherwise setting or clearing the read-olny 
+      /* Set Archive flag, otherwise setting or clearing the read-only 
          flag will not work */
       file_info.FileAttributes |= FILE_ATTRIBUTE_ARCHIVE;
       nt_status = pNtSetInformationFile(handle,

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3361,5 +3361,6 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     /* Restore Archive flag for rest of the tests */
     r = SetFileAttributes("test_file", FILE_ATTRIBUTE_ARCHIVE);
     ASSERT(r != 0);
+    return 0;
 }
 #endif

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3318,7 +3318,7 @@ TEST_IMPL(fs_open_readonly_acl) {
 #endif
 
 #ifdef _WIN32
-TEST_IMPL(fs_fchmod_archive_readolny) {
+TEST_IMPL(fs_fchmod_archive_readonly) {
     uv_fs_t req;
     uv_file file;
     int r;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -338,7 +338,7 @@ TEST_DECLARE   (fs_null_req)
 #ifdef _WIN32
 TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_open_readonly_acl)
-TEST_DECLARE   (fs_fchmod_archive_readolny)
+TEST_DECLARE   (fs_fchmod_archive_readonly)
 #endif
 TEST_DECLARE   (threadpool_queue_work_simple)
 TEST_DECLARE   (threadpool_queue_work_einval)
@@ -872,7 +872,7 @@ TASK_LIST_START
 #ifdef _WIN32
   TEST_ENTRY  (fs_exclusive_sharing_mode)
   TEST_ENTRY  (fs_open_readonly_acl)
-  TEST_ENTRY  (fs_fchmod_archive_readolny)
+  TEST_ENTRY  (fs_fchmod_archive_readonly)
 #endif
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (threadpool_queue_work_simple)


### PR DESCRIPTION
- The first commit fixes a recurring typo.
- The second commit suppresses a compiler warning by returning a value from a test.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/880/