### PR TITLE
build: fix cygwin install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -344,7 +344,7 @@ libuv_la_SOURCES += src/unix/android-ifaddrs.c \
 endif
 
 if CYGWIN
-include_HEADERS += include/uv-posix.h
+uvinclude_HEADERS += include/uv/posix.h
 libuv_la_CFLAGS += -D_GNU_SOURCE
 libuv_la_SOURCES += src/unix/cygwin.c \
                     src/unix/bsd-ifaddrs.c \


### PR DESCRIPTION
Use the right file path and variable name for the posix.h header file.

Introduced when commit ce41af28 ("cygwin: include uv-posix.h header")
was merged from the v1.x branch, where it is the correct path, into
the master branch.