### PR TITLE
Revert "win: add Windows XP support to uv_if_indextoname()"

### DIFF
--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -391,21 +391,15 @@ int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
   DWORD bufsize;
   int r;
 
-  uv__once_init();
-
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  if (pConvertInterfaceIndexToLuid == NULL)
-    return UV_ENOSYS;
-  r = pConvertInterfaceIndexToLuid(ifindex, &luid);
+  r = ConvertInterfaceIndexToLuid(ifindex, &luid);
 
   if (r != 0)
     return uv_translate_sys_error(r);
 
-  if (pConvertInterfaceLuidToNameW == NULL)
-    return UV_ENOSYS;
-  r = pConvertInterfaceLuidToNameW(&luid, wname, ARRAY_SIZE(wname));
+  r = ConvertInterfaceLuidToNameW(&luid, wname, ARRAY_SIZE(wname));
 
   if (r != 0)
     return uv_translate_sys_error(r);

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -53,16 +53,12 @@ sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
 /* User32.dll function pointer */
 sSetWinEventHook pSetWinEventHook;
 
-/* iphlpapi.dll function pointer */
-sConvertInterfaceIndexToLuid pConvertInterfaceIndexToLuid = NULL;
-sConvertInterfaceLuidToNameW pConvertInterfaceLuidToNameW = NULL;
 
 void uv_winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE kernel32_module;
   HMODULE powrprof_module;
   HMODULE user32_module;
-  HMODULE iphlpapi_module;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
@@ -162,11 +158,4 @@ void uv_winapi_init(void) {
       GetProcAddress(user32_module, "SetWinEventHook");
   }
 
-  iphlpapi_module = LoadLibraryA("iphlpapi.dll");
-  if (iphlpapi_module != NULL) {
-    pConvertInterfaceIndexToLuid = (sConvertInterfaceIndexToLuid)
-      GetProcAddress(iphlpapi_module, "ConvertInterfaceIndexToLuid");
-    pConvertInterfaceLuidToNameW = (sConvertInterfaceLuidToNameW)
-      GetProcAddress(iphlpapi_module, "ConvertInterfaceLuidToNameW");
-  }
 }

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4766,19 +4766,4 @@ extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotifi
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;
 
-/* iphlpapi.dll function pointer */
-union _NET_LUID_LH;
-typedef DWORD (WINAPI *sConvertInterfaceIndexToLuid)(
-    ULONG InterfaceIndex,
-    union _NET_LUID_LH *InterfaceLuid);
-
-typedef DWORD (WINAPI *sConvertInterfaceLuidToNameW)(
-    const union _NET_LUID_LH *InterfaceLuid,
-    PWSTR InterfaceName,
-    size_t Length);
-
-extern sConvertInterfaceIndexToLuid pConvertInterfaceIndexToLuid;
-extern sConvertInterfaceLuidToNameW pConvertInterfaceLuidToNameW;
-
-
 #endif /* UV_WIN_WINAPI_H_ */


### PR DESCRIPTION
Libuv is not supported on Windows XP, as stated in the SUPPORTED_PLATFORMS document. It also can't possibly work because `ReOpenFile()` in src/win/fs.c is not weakly linked, so any executable that links libuv would simply fail to load on XP.

This reverts commit 17eaa956bde35daad99b36b820daf8e8227add74.

Refs: https://github.com/libuv/libuv/pull/1810