### PR TITLE
test: use custom timeout for getaddrinfo_fail_sync

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -724,7 +724,7 @@ TASK_LIST_START
   TEST_ENTRY  (hrtime)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
-  TEST_ENTRY  (getaddrinfo_fail_sync)
+  TEST_ENTRY_CUSTOM (getaddrinfo_fail_sync, 0, 0, 10000)
 
   TEST_ENTRY  (getaddrinfo_basic)
   TEST_ENTRY  (getaddrinfo_basic_sync)


### PR DESCRIPTION
We don't control the running time of the test and as a result it
frequently times out on some of the CI buildbots.

We are already using a custom timeout for getaddrinfo_fail so it only
makes sense to do the same for its synchronous counterpart.