### PR TITLE
unix,win: limit uv_timer_again to repeating timers

### DIFF
--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -51,8 +51,8 @@ The utility function::
 
 applies **only to repeating timers** and is equivalent to stopping the timer
 and then starting it with both initial ``timeout`` and ``repeat`` set to the
-old ``repeat`` value. If the timer hasn't been started it fails (error code
-``UV_EINVAL``) and returns -1.
+old ``repeat`` value. If the timer hasn't been started, or isn't a repeating
+timer, it fails with ``UV_EINVAL``.
 
 An actual timer example is in the :ref:`reference count section
 <reference-count>`.

--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -53,9 +53,9 @@ API
 
 .. c:function:: int uv_timer_again(uv_timer_t* handle)
 
-    Stop the timer, and if it is repeating restart it using the repeat value
-    as the timeout. If the timer has never been started before it returns
-    UV_EINVAL.
+    Stop the timer and restart it using the repeat value as the timeout. If the
+    timer has never been started before, or the timer is not a repeating timer,
+    it returns `UV_EINVAL`.
 
 .. c:function:: void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat)
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -104,11 +104,10 @@ int uv_timer_stop(uv_timer_t* handle) {
 
 
 int uv_timer_again(uv_timer_t* handle) {
-  if (handle->timer_cb == NULL)
+  if (handle->timer_cb == NULL || handle->repeat == 0)
     return UV_EINVAL;
 
-  if (handle->repeat)
-    uv_timer_start(handle, handle->timer_cb, handle->repeat, handle->repeat);
+  uv_timer_start(handle, handle->timer_cb, handle->repeat, handle->repeat);
 
   return 0;
 }

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -112,6 +112,10 @@ TEST_IMPL(timer_again) {
   ASSERT(r == 0);
   ASSERT(uv_timer_get_repeat(&repeat_1) == 0);
 
+  /* Verify that it is not possible to uv_timer_again a non-repeating timer. */
+  r = uv_timer_again(&repeat_1);
+  ASSERT(r == UV_EINVAL);
+
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);
   ASSERT(uv_timer_get_repeat(&repeat_1) == 50);


### PR DESCRIPTION
This commit causes `uv_timer_again()` to return `UV_EINVAL` for non-repeating timers. It also adds clarification to the related documentation.

Fixes: https://github.com/libuv/libuv/issues/1591

This takes the second approach from https://github.com/libuv/libuv/issues/1591#issuecomment-335028066. Because of the new error being returned, I could also see a case for this targeting `master`.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/894/