### PR TITLE
win: allow setting udp socket options before bind

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -741,7 +741,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
     return UV_EINVAL;
   }
 
-  if (!(handle->flags & UV_HANDLE_BOUND))
+  if (handle->socket == INVALID_SOCKET)
     return UV_EBADF;
 
   if (addr_st.ss_family == AF_INET) {
@@ -772,7 +772,7 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
 int uv_udp_set_broadcast(uv_udp_t* handle, int value) {
   BOOL optval = (BOOL) value;
 
-  if (!(handle->flags & UV_HANDLE_BOUND))
+  if (handle->socket == INVALID_SOCKET)
     return UV_EBADF;
 
   if (setsockopt(handle->socket,
@@ -818,7 +818,7 @@ int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock) {
       return UV_EINVAL;                                                       \
     }                                                                         \
                                                                               \
-    if (!(handle->flags & UV_HANDLE_BOUND))                                   \
+    if (handle->socket == INVALID_SOCKET)                                     \
       return UV_EBADF;                                                        \
                                                                               \
     if (!(handle->flags & UV_HANDLE_IPV6)) {                                  \

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -114,9 +114,11 @@ TEST_IMPL(udp_options6) {
 TEST_IMPL(udp_no_autobind) {
   uv_loop_t* loop;
   uv_udp_t h;
+  uv_udp_t h2;
 
   loop = uv_default_loop();
 
+  /* Test a lazy initialized socket. */
   ASSERT(0 == uv_udp_init(loop, &h));
   ASSERT(UV_EBADF == uv_udp_set_multicast_ttl(&h, 32));
   ASSERT(UV_EBADF == uv_udp_set_broadcast(&h, 1));
@@ -129,6 +131,23 @@ TEST_IMPL(udp_no_autobind) {
   ASSERT(UV_EBADF == uv_udp_set_multicast_interface(&h, "0.0.0.0"));
 
   uv_close((uv_handle_t*) &h, NULL);
+
+  /* Test a non-lazily initialized socket. */
+  ASSERT(0 == uv_udp_init_ex(loop, &h2, AF_INET));
+  ASSERT(0 == uv_udp_set_multicast_ttl(&h2, 32));
+  ASSERT(0 == uv_udp_set_broadcast(&h2, 1));
+
+#if defined(__MVS__)
+  /* zOS only supports setting ttl for IPv6 sockets. */
+  ASSERT(UV_ENOTSUP == uv_udp_set_ttl(&h2, 1));
+#else
+  ASSERT(0 == uv_udp_set_ttl(&h2, 1));
+#endif
+
+  ASSERT(0 == uv_udp_set_multicast_loop(&h2, 1));
+  ASSERT(0 == uv_udp_set_multicast_interface(&h2, "0.0.0.0"));
+
+  uv_close((uv_handle_t*) &h2, NULL);
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 


### PR DESCRIPTION
Unix allows socket options to be set prior to binding. This commit aligns Windows with this behavior.

Fixes: https://github.com/libuv/libuv/issues/1842
Refs: https://github.com/joyent/libuv/issues/1205
Refs: https://github.com/joyent/libuv/pull/1270

Green CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/898/