### PR TITLE
unix,windows: map EOPNOTSUPP errno

### DIFF
--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -251,6 +251,10 @@ Error constants
 
     operation not supported on socket
 
+.. c:macro:: UV_EOPNOTSUPP
+
+    operation not supported on transport endpoint
+
 .. c:macro:: UV_EPERM
 
     operation not permitted

--- a/include/uv-errno.h
+++ b/include/uv-errno.h
@@ -439,5 +439,11 @@
 # define UV__EFTYPE (-4028)
 #endif
 
+#if defined(EOPNOTSUPP) && !defined(_WIN32)
+# define UV__EOPNOTSUPP UV__ERR(EOPNOTSUPP)
+#else
+# define UV__EOPNOTSUPP (-4027)
+#endif
+
 
 #endif /* UV_ERRNO_H_ */

--- a/include/uv.h
+++ b/include/uv.h
@@ -143,6 +143,7 @@ extern "C" {
   XX(EREMOTEIO, "remote I/O error")                                           \
   XX(ENOTTY, "inappropriate ioctl for device")                                \
   XX(EFTYPE, "inappropriate file type or format")                             \
+  XX(EOPNOTSUPP, "operation not supported on transport endpoint")             \
 
 #define UV_HANDLE_TYPE_MAP(XX)                                                \
   XX(ASYNC, async)                                                            \

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -166,6 +166,7 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_NOT_SAME_DEVICE:             return UV_EXDEV;
     case ERROR_INVALID_FUNCTION:            return UV_EISDIR;
     case ERROR_META_EXPANSION_TOO_LONG:     return UV_E2BIG;
+    case WSAEOPNOTSUPP:                     return UV_EOPNOTSUPP;
     default:                                return UV_UNKNOWN;
   }
 }


### PR DESCRIPTION
`ENOTSUP` and `EOPNOTSUPP` have different values on some platforms, so I think it may make sense to have distinct constants in libuv.

Refs: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900237#15