### PR TITLE
test: speedup process-title-threadsafe on macOS

### DIFF
--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #ifdef __APPLE__
-# define NUM_ITERATIONS 20
+# define NUM_ITERATIONS 10
 #else
 # define NUM_ITERATIONS 50
 #endif


### PR DESCRIPTION
This test has been timing out on macOS on the CI. Try to avoid that by reducing the number of iterations run. It looks like macOS performance was already a known issue based on the `#ifdef`.

I ran the libuv-test-commit-osx job a handful of times: https://ci.nodejs.org/job/libuv-test-commit-osx/. Builds 905-909 are this change.