### PR TITLE
win,tty: Use ANSI and Xterm processing of ConEmu

### DIFF
--- a/include/uv-win.h
+++ b/include/uv-win.h
@@ -675,3 +675,10 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
 #define UV_FS_O_NONBLOCK     0
 #define UV_FS_O_SYMLINK      0
 #define UV_FS_O_SYNC         0x08000000 /* FILE_FLAG_WRITE_THROUGH */
+
+#define UV_TTY_NONE          0
+#define UV_TTY_VTP           0x02
+#define UV_TTY_LEGACY        0x04
+#define UV_TTY_CONEMU        0x08
+
+UV_EXTERN int uv_guess_tty(uv_file fd);

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2406,10 +2406,14 @@ static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,
 }
 
 int uv_guess_tty(uv_file fd) {
+  int result = UV_TTY_NONE;
   HANDLE handle = _get_osfhandle(fd);
   uv__once_init();
   if (uv_guess_handle(fd) != UV_TTY) {
-    return UV_TTY_NONE;
+    return result;
   }
-  return uv__guess_tty(handle);
+  uv_sem_wait(&uv_tty_output_lock);
+  result = uv__guess_tty(handle);
+  uv_sem_post(&uv_tty_output_lock);
+  return result;
 }

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2306,7 +2306,7 @@ static int uv__guess_tty(HANDLE handle)
       parent_file_name_length =
         GetProcessImageFileNameW(
             process_handle, parent_file_name,
-            sizeof(parent_file_name) / sizeof(parent_file_name[0]));
+            ARRAY_SIZE(parent_file_name));
       if (!parent_file_name_length) {
         break;
       }

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2304,9 +2304,9 @@ static int uv__guess_tty(HANDLE handle)
       }
 
       parent_file_name_length =
-        GetProcessImageFileNameW(process_handle,
-                                 parent_file_name,
-                                 sizeof(parent_file_name));
+        GetProcessImageFileNameW(
+            process_handle, parent_file_name,
+            sizeof(parent_file_name) / sizeof(parent_file_name[0]));
       if (!parent_file_name_length) {
         break;
       }

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -33,6 +33,7 @@ sNtSetInformationFile pNtSetInformationFile;
 sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 sNtQueryDirectoryFile pNtQueryDirectoryFile;
 sNtQuerySystemInformation pNtQuerySystemInformation;
+sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Powrprof.dll function pointer */
 sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
@@ -95,6 +96,13 @@ void uv_winapi_init(void) {
       ntdll_module,
       "NtQuerySystemInformation");
   if (pNtQuerySystemInformation == NULL) {
+    uv_fatal_error(GetLastError(), "GetProcAddress");
+  }
+
+  pNtQueryInformationProcess = (sNtQueryInformationProcess) GetProcAddress(
+      ntdll_module,
+      "NtQueryInformationProcess");
+  if (pNtQueryInformationProcess == NULL) {
     uv_fatal_error(GetLastError(), "GetProcAddress");
   }
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4117,6 +4117,102 @@ typedef struct _UNICODE_STRING {
 
 typedef const UNICODE_STRING *PCUNICODE_STRING;
 
+typedef struct _PEB_LDR_DATA {
+  BYTE Reserved1[8];
+  PVOID Reserved2[3];
+  LIST_ENTRY InMemoryOrderModuleList;
+} PEB_LDR_DATA,*PPEB_LDR_DATA;
+
+typedef struct _RTL_USER_PROCESS_PARAMETERS {
+  BYTE Reserved1[16];
+  PVOID Reserved2[10];
+  UNICODE_STRING ImagePathName;
+  UNICODE_STRING CommandLine;
+} RTL_USER_PROCESS_PARAMETERS,*PRTL_USER_PROCESS_PARAMETERS;
+
+typedef VOID (NTAPI *PPS_POST_PROCESS_INIT_ROUTINE)(VOID);
+
+typedef struct _PEB {
+  BYTE Reserved1[2];
+  BYTE BeingDebugged;
+  BYTE Reserved2[1];
+  PVOID Reserved3[2];
+  PPEB_LDR_DATA Ldr;
+  PRTL_USER_PROCESS_PARAMETERS ProcessParameters;
+  BYTE Reserved4[104];
+  PVOID Reserved5[52];
+  PPS_POST_PROCESS_INIT_ROUTINE PostProcessInitRoutine;
+  BYTE Reserved6[128];
+  PVOID Reserved7[1];
+  ULONG SessionId;
+} PEB,*PPEB;
+
+typedef LONG KPRIORITY;
+
+typedef struct _PROCESS_BASIC_INFORMATION {
+  NTSTATUS ExitStatus;
+  PPEB PebBaseAddress;
+  KAFFINITY AffinityMask;
+  KPRIORITY BasePriority;
+  ULONG_PTR UniqueProcessId;
+  ULONG_PTR InheritedFromUniqueProcessId;
+} PROCESS_BASIC_INFORMATION, *PPROCESS_BASIC_INFORMATION;
+
+typedef enum _PROCESSINFOCLASS {
+  ProcessBasicInformation,
+  ProcessQuotaLimits,
+  ProcessIoCounters,
+  ProcessVmCounters,
+  ProcessTimes,
+  ProcessBasePriority,
+  ProcessRaisePriority,
+  ProcessDebugPort,
+  ProcessExceptionPort,
+  ProcessAccessToken,
+  ProcessLdtInformation,
+  ProcessLdtSize,
+  ProcessDefaultHardErrorMode,
+  ProcessIoPortHandlers,
+  ProcessPooledUsageAndLimits,
+  ProcessWorkingSetWatch,
+  ProcessUserModeIOPL,
+  ProcessEnableAlignmentFaultFixup,
+  ProcessPriorityClass,
+  ProcessWx86Information,
+  ProcessHandleCount,
+  ProcessAffinityMask,
+  ProcessPriorityBoost,
+  ProcessDeviceMap,
+  ProcessSessionInformation,
+  ProcessForegroundInformation,
+  ProcessWow64Information,
+  ProcessImageFileName,
+  ProcessLUIDDeviceMapsEnabled,
+  ProcessBreakOnTermination,
+  ProcessDebugObjectHandle,
+  ProcessDebugFlags,
+  ProcessHandleTracing,
+  ProcessIoPriority,
+  ProcessExecuteFlags,
+  ProcessTlsInformation,
+  ProcessCookie,
+  ProcessImageInformation,
+  ProcessCycleTime,
+  ProcessPagePriority,
+  ProcessInstrumentationCallback,
+  ProcessThreadStackAllocation,
+  ProcessWorkingSetWatchEx,
+  ProcessImageFileNameWin32,
+  ProcessImageFileMapping,
+  ProcessAffinityUpdateMode,
+  ProcessMemoryAllocationMode,
+  ProcessGroupInformation,
+  ProcessTokenVirtualizationEnabled,
+  ProcessConsoleHostProcess,
+  ProcessWindowInformation,
+  MaxProcessInfoClass
+} PROCESSINFOCLASS;
+
 /* from ntifs.h */
 #ifndef DEVICE_TYPE
 # define DEVICE_TYPE DWORD
@@ -4572,6 +4668,13 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
                   BOOLEAN RestartScan
                 );
 
+typedef NTSTATUS (NTAPI *sNtQueryInformationProcess)
+                 (HANDLE PorcessHandle,
+                  PROCESSINFOCLASS ProcessInformationClass,
+                  PVOID ProcessInformation,
+                  ULONG ProcessInformationLength,
+                  PULONG ReturnLength);
+
 /*
  * Kernel32 headers
  */
@@ -4703,6 +4806,7 @@ extern sNtSetInformationFile pNtSetInformationFile;
 extern sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 extern sNtQueryDirectoryFile pNtQueryDirectoryFile;
 extern sNtQuerySystemInformation pNtQuerySystemInformation;
+extern sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Powrprof.dll function pointer */
 extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;


### PR DESCRIPTION
ConEmu has its own [ANSI X3.64 and and its extension xterm 256 color mode processing](https://conemu.github.io/en/AnsiEscapeCodes.html). But, currently libuv does not use it.

I have created a patch that uses it in libuv to improve TUI of neovim on Windows. If there is no problem, I would like you to merge it upstream. 

Ref neovim/neovim#8462