### PR TITLE
src: enable uv_spawn without creating console window

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -934,9 +934,9 @@ void uv_process_endgame(uv_loop_t* loop, uv_process_t* handle) {
 }
 
 
-int uv_spawn(uv_loop_t* loop,
+int uv_spawn_default(uv_loop_t* loop,
              uv_process_t* process,
-             const uv_process_options_t* options) {
+             const uv_process_options_t* options, bool windowless) {
   int i;
   int err = 0;
   WCHAR* path = NULL, *alloc_path = NULL;
@@ -1094,6 +1094,10 @@ int uv_spawn(uv_loop_t* loop,
     process_flags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
   }
 
+  if (windowless) {
+    process_flags |= CREATE_NO_WINDOW;
+  }
+
   if (!CreateProcessW(application_path,
                      arguments,
                      NULL,
@@ -1179,6 +1183,19 @@ int uv_spawn(uv_loop_t* loop,
   }
 
   return uv_translate_sys_error(err);
+}
+
+
+int uv_spawn(uv_loop_t* loop,
+             uv_process_t* process,
+             const uv_process_options_t* options) {
+  return uv_spawn_default(loop, process, options, false);
+}
+
+int uv_spawn_windowless(uv_loop_t* loop,
+             uv_process_t* process,
+             const uv_process_options_t* options) {
+  return uv_spawn_default(loop, process, options, true);
 }
 
 


### PR DESCRIPTION
This PR will enable embedders to spawn new processes cleanly without opening a new console window. It adds two new methods: `uv_spawn_default` and `uv_spawn_windowless`. 

Current behavior doesn't change, as the signature for the original method `uv_spawn` is unchanged. 

However, embedders would now be able to call `uv_spawn_windowless` to achieve desired behavior. At present, Electron is simply [patching the dependency](https://github.com/electron/node/commit/5e8eef9e9e9533a1d1bc17d86d0c46d9195f172c) in Node, but this would be a cleaner and more maintainable way both for us and others to do this into the future.

