### PR TITLE
unix: set errno in uv_fs_copyfile()

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -929,7 +929,11 @@ out:
     }
   }
 
-  return result;
+  if (result == 0)
+    return 0;
+
+  errno = UV__ERR(result);
+  return -1;
 #endif
 }
 


### PR DESCRIPTION
When the specific value of -1 is returned, `uv__fs_work()` uses the value of `errno`. This commit sets `errno` in `uv__fs_copyfile()`.

Fixes: https://github.com/nodejs/node/issues/21329