### PR TITLE
uv.h: Move uv_cpu_times_s structure declaration to global level.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1004,16 +1004,18 @@ UV_EXTERN int uv_queue_work(uv_loop_t* loop,
 UV_EXTERN int uv_cancel(uv_req_t* req);
 
 
+struct uv_cpu_times_s {
+  uint64_t user;
+  uint64_t nice;
+  uint64_t sys;
+  uint64_t idle;
+  uint64_t irq;
+};
+
 struct uv_cpu_info_s {
   char* model;
   int speed;
-  struct uv_cpu_times_s {
-    uint64_t user;
-    uint64_t nice;
-    uint64_t sys;
-    uint64_t idle;
-    uint64_t irq;
-  } cpu_times;
+  struct uv_cpu_times_s cpu_times;
 };
 
 struct uv_interface_address_s {


### PR DESCRIPTION
This fixes a C++ / C ambiguity about whether this structure is scoped
or global.