### PR TITLE
poll.c: Avoid a compiler warning "conditional always true".

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -180,9 +180,11 @@ struct uv__stream_queued_fds_s {
     defined(__NetBSD__)
 #define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
+#define UV__NONBLOCK_IS_IOCTL
 #else
 #define uv__cloexec uv__cloexec_fcntl
 #define uv__nonblock uv__nonblock_fcntl
+#define UV__NONBLOCK_IS_FCNTL
 #endif
 
 /* On Linux, uv__nonblock_fcntl() and uv__nonblock_ioctl() do not commute
@@ -195,6 +197,8 @@ struct uv__stream_queued_fds_s {
 #if defined(__linux__) && O_NDELAY != O_NONBLOCK
 #undef uv__nonblock
 #define uv__nonblock uv__nonblock_fcntl
+#undef UV__NONBLOCK_IS_IOCTL
+#define UV__NONBLOCK_IS_FCNTL
 #endif
 
 /* core */

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -79,9 +79,10 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    * Workaround for e.g. kqueue fds not supporting ioctls.
    */
   err = uv__nonblock(fd, 1);
+#ifdef UV__NONBLOCK_IS_IOCTL
   if (err == UV_ENOTTY)
-    if (uv__nonblock == uv__nonblock_ioctl)
-      err = uv__nonblock_fcntl(fd, 1);
+    err = uv__nonblock_fcntl(fd, 1);
+#endif
 
   if (err)
     return err;


### PR DESCRIPTION
The current implementation compares a macro define to what it is defined
to, which results in some compilers warning that this is equivalent to
if (true).  This patch works around that warning by instead using a
preprocessor macro to comment out the code in question.