### PR TITLE
win: Add pragmas to pull in windows library dependencies.

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -37,6 +37,7 @@
 
 #include <wincrypt.h>
 
+#pragma comment(lib, "Advapi32.lib")
 
 #define UV_FS_FREE_PATHS         0x0002
 #define UV_FS_FREE_PTR           0x0008

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -40,6 +40,8 @@
 #include "stream-inl.h"
 #include "req-inl.h"
 
+#pragma comment(lib, "User32.lib")
+
 #ifndef InterlockedOr
 # define InterlockedOr _InterlockedOr
 #endif

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -77,6 +77,11 @@ static CRITICAL_SECTION process_title_lock;
 /* Interval (in seconds) of the high-resolution clock. */
 static double hrtime_interval_ = 0;
 
+#pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "IPHLPAPI.lib")
+#pragma comment(lib, "Psapi.lib")
+#pragma comment(lib, "Userenv.lib")
+#pragma comment(lib, "kernel32.lib")
 
 /*
  * One-time initialization code for functionality defined in util.c.

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -26,6 +26,8 @@
 #include "internal.h"
 
 
+#pragma comment(lib, "Ws2_32.lib")
+
 /* Whether there are any non-IFS LSPs stacked on TCP */
 int uv_tcp_non_ifs_lsp_ipv4;
 int uv_tcp_non_ifs_lsp_ipv6;


### PR DESCRIPTION
The Windows compiler provides these pragmas as way to pull in dependent
system libraries without requiring users of the library to explicitly
include them when linking the user application.