### PR TITLE
win: pipe.c: Use comparison instead of min() macro.

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1658,7 +1658,8 @@ static DWORD uv__pipe_read_data(uv_loop_t* loop,
    *   (a) the length of the user-allocated buffer.
    *   (b) the maximum data length as specified by the `max_bytes` argument.
    */
-  max_bytes = min(buf.len, max_bytes);
+  if (max_bytes > buf.len)
+    max_bytes = buf.len;
 
   /* Read into the user buffer. */
   if (!ReadFile(handle->handle, buf.base, max_bytes, &bytes_read, NULL)) {


### PR DESCRIPTION
NOMINMAX is commonly defined on larger projects on Windows to avoid
the C++ std::min() conflicting with the C/Windows min() macro.  When
libuv is built as part of a larger project, this macro can sometimes
be defined when compiling libuv as well, so if it is defined, go ahead
and define min() ourselves.