### PR TITLE
linux: handle exclusive POLLHUP when looking for UV_DISCONNECT

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -388,7 +388,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
        * free when we switch over to edge-triggered I/O.
        */
       if (pe->events == POLLERR || pe->events == POLLHUP)
-        pe->events |= w->pevents & (POLLIN | POLLOUT | UV__POLLPRI);
+        pe->events |=
+          w->pevents & (POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI);
 
       if (pe->events != 0) {
         /* Run signal watchers last.  This also affects child process watchers


### PR DESCRIPTION
In #691 we forgot to update the workaround added by commit 24bfef2ef4b5ac3e47f037f0f6759ad63b5d1e96.  On linux-sparc64, epoll returns just POLLHUP during part of our `poll_duplex` and `poll_unidirectional` tests, triggering the need for the workaround to recognize UV_DISCONNECT.

Fixes: #1859  
