### PR TITLE
src: add new mem apis to prevent memory leaks

### DIFF
--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -331,7 +331,9 @@ API
 .. c:function:: char* uv_strerror_r(int err, char* buf, size_t buflen)
 
     Returns the error message for the given error code. The zero-terminated
-    message is stored the user-supplied buffer buf of at most buflen bytes.
+    message is stored in the user-supplied buffer `buf` of at most `buflen` bytes.
+
+    .. versionadded:: 1.22.0
 
 .. c:function:: const char* uv_err_name(int err)
 
@@ -341,7 +343,9 @@ API
 .. c:function:: char* uv_err_name_r(int err, char* buf, size_t buflen)
 
     Returns the error name for the given error code. The zero-terminated
-    name is stored the user-supplied buffer buf of at most buflen bytes.
+    name is stored in the user-supplied buffer `buf` of at most `buflen` bytes.
+
+    .. versionadded:: 1.22.0
 
 .. c:function:: int uv_translate_sys_error(int sys_errno)
 

--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -328,10 +328,20 @@ API
     Returns the error message for the given error code.  Leaks a few bytes
     of memory when you call it with an unknown error code.
 
+.. c:function:: char* uv_strerror_r(int err, char* buf, size_t buflen)
+
+    Returns the error message for the given error code. The zero-terminated
+    message is stored the user-supplied buffer buf of at most buflen bytes.
+
 .. c:function:: const char* uv_err_name(int err)
 
     Returns the error name for the given error code.  Leaks a few bytes
     of memory when you call it with an unknown error code.
+
+.. c:function:: char* uv_err_name_r(int err, char* buf, size_t buflen)
+
+    Returns the error name for the given error code. The zero-terminated
+    name is stored the user-supplied buffer buf of at most buflen bytes.
 
 .. c:function:: int uv_translate_sys_error(int sys_errno)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -370,10 +370,10 @@ typedef enum {
 UV_EXTERN int uv_translate_sys_error(int sys_errno);
 
 UV_EXTERN const char* uv_strerror(int err);
-UV_EXTERN const char* uv_strerror_r(int err, char *buf, size_t buflen);
+UV_EXTERN char* uv_strerror_r(int err, char* buf, size_t buflen);
 
 UV_EXTERN const char* uv_err_name(int err);
-UV_EXTERN const char* uv_err_name_r(int err, char *buf, size_t buflen);
+UV_EXTERN char* uv_err_name_r(int err, char* buf, size_t buflen);
 
 
 #define UV_REQ_FIELDS                                                         \

--- a/include/uv.h
+++ b/include/uv.h
@@ -370,7 +370,10 @@ typedef enum {
 UV_EXTERN int uv_translate_sys_error(int sys_errno);
 
 UV_EXTERN const char* uv_strerror(int err);
+UV_EXTERN const char* uv_strerror_r(int err, char *buf, size_t buflen);
+
 UV_EXTERN const char* uv_err_name(int err);
+UV_EXTERN const char* uv_err_name_r(int err, char *buf, size_t buflen);
 
 
 #define UV_REQ_FIELDS                                                         \

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -155,19 +155,14 @@ static const char* uv__unknown_err_code(int err) {
   return copy != NULL ? copy : "Unknown system error";
 }
 
-#define UV_ERR_NAME_GEN_R(name, _) case UV_ ## name: { strncpy(buf, #name, buflen); break; }
-const char* uv_err_name_r(int err, char *buf, size_t buflen) {
+#define UV_ERR_NAME_GEN_R(name, _) case UV_ ## name: { snprintf(buf, #name, buflen); break; }
+char* uv_err_name_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_ERR_NAME_GEN_R)
-    default: {
+    default:
       snprintf(buf, buflen, "Unknown system error %d", err);
       break;
-    }
   }
-  /* ensure zero-termination */
-  if ((buf != NULL) && (buflen != 0))
-    buf[buflen-1] = '\0';
-  return buf;
 }
 #undef UV_ERR_NAME_GEN_R
 
@@ -182,19 +177,14 @@ const char* uv_err_name(int err) {
 #undef UV_ERR_NAME_GEN
 
 
-#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: { strncpy(buf, msg, buflen); break; }
-const char* uv_strerror_r(int err, char *buf, size_t buflen) {
+#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: { snprintf(buf, msg, buflen); break; }
+char* uv_strerror_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_STRERROR_GEN_R)
-    default: {
+    default:
       snprintf(buf, buflen, "Unknown system error %d", err);
       break;
-    }
   }
-  /* ensure zero-termination */
-  if ((buf != NULL) && (buflen != 0))
-    buf[buflen-1] = '\0';
-  return buf;
 }
 #undef UV_STRERROR_GEN_R
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -155,9 +155,10 @@ static const char* uv__unknown_err_code(int err) {
   return copy != NULL ? copy : "Unknown system error";
 }
 
-#define UV_ERR_NAME_GEN_R(name, _) case UV_## name: \
+#define UV_ERR_NAME_GEN_R(name, _) \
+case UV_## name: \
   snprintf(buf, buflen, "%s", #name); break;
-char * uv_err_name_r(int err, char* buf, size_t buflen) {
+char* uv_err_name_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_ERR_NAME_GEN_R)
     default: snprintf(buf, buflen, "Unknown system error %d", err);
@@ -177,12 +178,13 @@ const char* uv_err_name(int err) {
 #undef UV_ERR_NAME_GEN
 
 
-#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: \
+#define UV_STRERROR_GEN_R(name, msg) \
+case UV_ ## name: \
   snprintf(buf, buflen, "%s", msg); break;
 char* uv_strerror_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_STRERROR_GEN_R)
-    default: snprintf(buf, buflen, "Unknown system error %d", err); break;
+    default: snprintf(buf, buflen, "Unknown system error %d", err);
   }
   return buf;
 }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -155,6 +155,22 @@ static const char* uv__unknown_err_code(int err) {
   return copy != NULL ? copy : "Unknown system error";
 }
 
+#define UV_ERR_NAME_GEN_R(name, _) case UV_ ## name: { strncpy(buf, #name, buflen); break; }
+const char* uv_err_name_r(int err, char *buf, size_t buflen) {
+  switch (err) {
+    UV_ERRNO_MAP(UV_ERR_NAME_GEN_R)
+    default: {
+      snprintf(buf, buflen, "Unknown system error %d", err);
+      break;
+    }
+  }
+  /* ensure zero-termination */
+  if ((buf != NULL) && (buflen != 0))
+    buf[buflen-1] = '\0';
+  return buf;
+}
+#undef UV_ERR_NAME_GEN_R
+
 
 #define UV_ERR_NAME_GEN(name, _) case UV_ ## name: return #name;
 const char* uv_err_name(int err) {
@@ -164,6 +180,23 @@ const char* uv_err_name(int err) {
   return uv__unknown_err_code(err);
 }
 #undef UV_ERR_NAME_GEN
+
+
+#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: { strncpy(buf, msg, buflen); break; }
+const char* uv_strerror_r(int err, char *buf, size_t buflen) {
+  switch (err) {
+    UV_ERRNO_MAP(UV_STRERROR_GEN_R)
+    default: {
+      snprintf(buf, buflen, "Unknown system error %d", err);
+      break;
+    }
+  }
+  /* ensure zero-termination */
+  if ((buf != NULL) && (buflen != 0))
+    buf[buflen-1] = '\0';
+  return buf;
+}
+#undef UV_STRERROR_GEN_R
 
 
 #define UV_STRERROR_GEN(name, msg) case UV_ ## name: return msg;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -155,14 +155,14 @@ static const char* uv__unknown_err_code(int err) {
   return copy != NULL ? copy : "Unknown system error";
 }
 
-#define UV_ERR_NAME_GEN_R(name, _) case UV_ ## name: { snprintf(buf, #name, buflen); break; }
-char* uv_err_name_r(int err, char* buf, size_t buflen) {
+#define UV_ERR_NAME_GEN_R(name, _) case UV_## name: \
+  snprintf(buf, buflen, "%s", #name); break;
+char * uv_err_name_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_ERR_NAME_GEN_R)
-    default:
-      snprintf(buf, buflen, "Unknown system error %d", err);
-      break;
+    default: snprintf(buf, buflen, "Unknown system error %d", err);
   }
+  return buf;
 }
 #undef UV_ERR_NAME_GEN_R
 
@@ -177,14 +177,14 @@ const char* uv_err_name(int err) {
 #undef UV_ERR_NAME_GEN
 
 
-#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: { snprintf(buf, msg, buflen); break; }
+#define UV_STRERROR_GEN_R(name, msg) case UV_ ## name: \
+  snprintf(buf, buflen, "%s", msg); break;
 char* uv_strerror_r(int err, char* buf, size_t buflen) {
   switch (err) {
     UV_ERRNO_MAP(UV_STRERROR_GEN_R)
-    default:
-      snprintf(buf, buflen, "Unknown system error %d", err);
-      break;
+    default: snprintf(buf, buflen, "Unknown system error %d", err); break;
   }
+  return buf;
 }
 #undef UV_STRERROR_GEN_R
 

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -49,6 +49,11 @@ TEST_IMPL(error_message) {
   ASSERT(strcmp(uv_strerror(1337), "Unknown error") == 0);
   ASSERT(strcmp(uv_strerror(-1337), "Unknown error") == 0);
 
+  char buf[32];
+  ASSERT(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success") == NULL);
+  ASSERT(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337") != NULL);
+  ASSERT(strstr(uv_strerror_r(-1337, buf, sizeof(buf)), "-1337") != NULL);
+
   return 0;
 }
 

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -39,7 +39,9 @@
 TEST_IMPL(error_message) {
   char buf[32];
 
-  // Cop out. Can't do proper checks on systems with i18n-ized error messages...
+  /* Cop out. Can't do proper checks on systems with
+   * i18n-ized error messages...
+   */
   if (strcmp(uv_strerror(0), "Success") != 0) {
     printf("i18n error messages detected, skipping test.\n");
     return 0;

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -37,9 +37,9 @@
  * See https://github.com/joyent/libuv/issues/210
  */
 TEST_IMPL(error_message) {
-  /* Cop out. Can't do proper checks on systems with
-   * i18n-ized error messages...
-   */
+  char buf[32];
+
+  // Cop out. Can't do proper checks on systems with i18n-ized error messages...
   if (strcmp(uv_strerror(0), "Success") != 0) {
     printf("i18n error messages detected, skipping test.\n");
     return 0;
@@ -49,7 +49,6 @@ TEST_IMPL(error_message) {
   ASSERT(strcmp(uv_strerror(1337), "Unknown error") == 0);
   ASSERT(strcmp(uv_strerror(-1337), "Unknown error") == 0);
 
-  char buf[32];
   ASSERT(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success") == NULL);
   ASSERT(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337") != NULL);
   ASSERT(strstr(uv_strerror_r(-1337, buf, sizeof(buf)), "-1337") != NULL);


### PR DESCRIPTION
This PR creates two new externally-facing APIs, `uv_err_name_r()` and `uv_strerror_r()`. 

In keeping with the precedent set by POSIX, the `*_r()` suffix of these two new methods indicate that the caller does the memory management and passes in the memory that the output will be stored in, which provides an alternative for the two existent methods (`uv_err_name()` and `uv_strerror()`), which, when called with an unknown error code, leak a few bytes of memory. 

For reference, I used POSIX [`strerror_r()`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html). I need to add documentation, but chose to open this as a WIP to discuss implementation prior to doing that. I'm also not sure how you might prefer me to add tests for `uv_err_name_r()`. 

h/t @ckerr for assistance with this!
 
TODO:
- [x] Documentation