### PR TITLE
fix  UV__UNUSED usage

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -372,9 +372,8 @@ int uv_cond_init(uv_cond_t* cond) {
 }
 
 
-void uv_cond_destroy(uv_cond_t* cond) {
+void uv_cond_destroy(uv_cond_t* UV__UNUSED cond) {
   /* nothing to do */
-  UV__UNUSED(cond);
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -26,15 +26,6 @@
 #include "uv.h"
 #include "internal.h"
 
-static int uv_cond_condvar_init(uv_cond_t* cond);
-static void uv_cond_condvar_destroy(uv_cond_t* cond);
-static void uv_cond_condvar_signal(uv_cond_t* cond);
-static void uv_cond_condvar_broadcast(uv_cond_t* cond);
-static void uv_cond_condvar_wait(uv_cond_t* cond, uv_mutex_t* mutex);
-static int uv_cond_condvar_timedwait(uv_cond_t* cond,
-    uv_mutex_t* mutex, uint64_t timeout);
-
-
 static void uv__once_inner(uv_once_t* guard, void (*callback)(void)) {
   DWORD result;
   HANDLE existing_event, created_event;


### PR DESCRIPTION
The usage of `UV__UNUSED` inside src/win/thread.c is wrong.
Macro definition: 
https://github.com/libuv/libuv/blob/07955ed3737cc59bc4d586b34222669ca87de755/include/uv/tree.h#L31
So it resolves to something like:
```c
void uv_cond_destroy(uv_cond_t* cond) {
    __attribute__((unused))(cond);
}
```

This declares a new variable of implicit type int. But cond already exists and has a different type.

I've also removed the function declarations of the functions that were removed in 13e8b15eb7e73ed624e88033950e691745a90c6a