### PR TITLE
win: avoid uninitialized memory access in uv_getnameinfo

### DIFF
--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -42,7 +42,7 @@ static void uv__getnameinfo_work(struct uv__work* w) {
   uv_getnameinfo_t* req;
   WCHAR host[NI_MAXHOST];
   WCHAR service[NI_MAXSERV];
-  int ret = 0;
+  int ret;
 
   req = container_of(w, uv_getnameinfo_t, work_req);
   if (GetNameInfoW((struct sockaddr*)&req->storage,
@@ -53,27 +53,34 @@ static void uv__getnameinfo_work(struct uv__work* w) {
                    ARRAY_SIZE(service),
                    req->flags)) {
     ret = WSAGetLastError();
+    req->retcode = uv__getaddrinfo_translate_error(ret);
+    return;
   }
-  req->retcode = uv__getaddrinfo_translate_error(ret);
 
-  /* convert results to UTF-8 */
-  WideCharToMultiByte(CP_UTF8,
-                      0,
-                      host,
-                      -1,
-                      req->host,
-                      sizeof(req->host),
-                      NULL,
-                      NULL);
+  ret = WideCharToMultiByte(CP_UTF8,
+                            0,
+                            host,
+                            -1,
+                            req->host,
+                            sizeof(req->host),
+                            NULL,
+                            NULL);
+  if (ret == 0) {
+    req->retcode = uv_translate_sys_error(GetLastError());
+    return ;
+  }
 
-  WideCharToMultiByte(CP_UTF8,
-                      0,
-                      service,
-                      -1,
-                      req->service,
-                      sizeof(req->service),
-                      NULL,
-                      NULL);
+  ret = WideCharToMultiByte(CP_UTF8,
+                            0,
+                            service,
+                            -1,
+                            req->service,
+                            sizeof(req->service),
+                            NULL,
+                            NULL);
+  if (ret == 0) {
+    req->retcode = uv_translate_sys_error(GetLastError());
+  }
 }
 
 


### PR DESCRIPTION
1) If `GetNameInfoW` fails, `host` and `service` are passed to `WideCharToMultiByte` that will then access uninitialized memory.
2) The result of `WideCharToMultiByte` is ignored. I don't know, if `to_utf8(WCHAR host[NI_MAXHOST])` will always fit into `char host[NI_MAXHOST]` for this special case.
