### PR TITLE
Make apple frameworks optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin|DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
   list(APPEND uv_test_libraries util)
 endif()
 
+check_include_file(CoreServices/CoreServices.h HAVE_CORESERVICES_CORESERVICES_H)
+check_include_file(ApplicationServices/ApplicationServices.h HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H)
+
 add_library(uv SHARED ${uv_sources})
 target_compile_definitions(uv PRIVATE ${uv_defines} BUILDING_UV_SHARED=1)
 target_compile_options(uv PRIVATE ${uv_cflags})

--- a/configure.ac
+++ b/configure.ac
@@ -69,4 +69,6 @@ AS_CASE([$host_os],[mingw*], [
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])
+AC_CHECK_HEADERS(ApplicationServices/ApplicationServices.h)
+AC_CHECK_HEADERS(CoreServices/CoreServices.h)
 AC_OUTPUT

--- a/src/unix/darwin-proctitle.c
+++ b/src/unix/darwin-proctitle.c
@@ -26,9 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <TargetConditionals.h>
-
-#if !TARGET_OS_IPHONE
+#if HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H
 # include <CoreFoundation/CoreFoundation.h>
 # include <ApplicationServices/ApplicationServices.h>
 #endif
@@ -58,7 +56,7 @@ static int uv__pthread_setname_np(const char* name) {
 
 
 int uv__set_process_title(const char* title) {
-#if TARGET_OS_IPHONE
+#if !HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H
   return uv__pthread_setname_np(title);
 #else
   CFStringRef (*pCFStringCreateWithCString)(CFAllocatorRef,
@@ -205,5 +203,5 @@ out:
     dlclose(application_services_handle);
 
   return err;
-#endif  /* !TARGET_OS_IPHONE */
+#endif  /* HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H */
 }

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -21,7 +21,7 @@
 #include "uv.h"
 #include "internal.h"
 
-#if TARGET_OS_IPHONE
+#if !HAVE_CORESERVICES_CORESERVICES_H
 
 /* iOS (currently) doesn't provide the FSEvents-API (nor CoreServices) */
 
@@ -38,7 +38,7 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
 void uv__fsevents_loop_delete(uv_loop_t* loop) {
 }
 
-#else /* TARGET_OS_IPHONE */
+#else /* !HAVE_CORESERVICES_CORESERVICES_H */
 
 #include <dlfcn.h>
 #include <assert.h>
@@ -916,4 +916,4 @@ int uv__fsevents_close(uv_fs_event_t* handle) {
   return 0;
 }
 
-#endif /* TARGET_OS_IPHONE */
+#endif /* !HAVE_CORESERVICES_CORESERVICES_H */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -229,7 +229,9 @@ TEST_DECLARE   (get_passwd)
 TEST_DECLARE   (handle_fileno)
 TEST_DECLARE   (homedir)
 TEST_DECLARE   (tmpdir)
+#if !__APPLE__
 TEST_DECLARE   (hrtime)
+#endif
 TEST_DECLARE   (getaddrinfo_fail)
 TEST_DECLARE   (getaddrinfo_fail_sync)
 TEST_DECLARE   (getaddrinfo_basic)
@@ -306,6 +308,7 @@ TEST_DECLARE   (fs_futime)
 TEST_DECLARE   (fs_file_open_append)
 TEST_DECLARE   (fs_stat_missing_path)
 TEST_DECLARE   (fs_read_file_eof)
+#if !__APPLE__ || HAVE_CORESERVICES_CORESERVICES_H
 TEST_DECLARE   (fs_event_watch_dir)
 TEST_DECLARE   (fs_event_watch_dir_recursive)
 #ifdef _WIN32
@@ -327,6 +330,7 @@ TEST_DECLARE   (fs_event_close_in_callback)
 TEST_DECLARE   (fs_event_start_and_close)
 TEST_DECLARE   (fs_event_error_reporting)
 TEST_DECLARE   (fs_event_getpath)
+#endif
 TEST_DECLARE   (fs_scandir_empty_dir)
 TEST_DECLARE   (fs_scandir_non_existent_dir)
 TEST_DECLARE   (fs_scandir_file)
@@ -426,9 +430,11 @@ TEST_DECLARE  (fork_socketpair)
 TEST_DECLARE  (fork_socketpair_started)
 TEST_DECLARE  (fork_signal_to_child)
 TEST_DECLARE  (fork_signal_to_child_closed)
+#if !__APPLE__ || HAVE_CORESERVICES_CORESERVICES_H
 TEST_DECLARE  (fork_fs_events_child)
 TEST_DECLARE  (fork_fs_events_child_dir)
 TEST_DECLARE  (fork_fs_events_file_parent_child)
+#endif
 #ifndef __MVS__
 TEST_DECLARE  (fork_threadpool_queue_work_simple)
 #endif
@@ -721,7 +727,9 @@ TASK_LIST_START
 
   TEST_ENTRY  (tmpdir)
 
+#if !__APPLE__
   TEST_ENTRY  (hrtime)
+#endif
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
   TEST_ENTRY_CUSTOM (getaddrinfo_fail_sync, 0, 0, 10000)
@@ -851,6 +859,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_stat_missing_path)
   TEST_ENTRY  (fs_read_file_eof)
   TEST_ENTRY  (fs_file_open_append)
+#if !__APPLE__ || HAVE_CORESERVICES_CORESERVICES_H
   TEST_ENTRY  (fs_event_watch_dir)
   TEST_ENTRY  (fs_event_watch_dir_recursive)
 #ifdef _WIN32
@@ -872,6 +881,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_event_start_and_close)
   TEST_ENTRY  (fs_event_error_reporting)
   TEST_ENTRY  (fs_event_getpath)
+#endif
   TEST_ENTRY  (fs_scandir_empty_dir)
   TEST_ENTRY  (fs_scandir_non_existent_dir)
   TEST_ENTRY  (fs_scandir_file)
@@ -921,9 +931,11 @@ TASK_LIST_START
   TEST_ENTRY  (fork_socketpair_started)
   TEST_ENTRY  (fork_signal_to_child)
   TEST_ENTRY  (fork_signal_to_child_closed)
+#if !__APPLE__ || HAVE_CORESERVICES_CORESERVICES_H
   TEST_ENTRY  (fork_fs_events_child)
   TEST_ENTRY  (fork_fs_events_child_dir)
   TEST_ENTRY  (fork_fs_events_file_parent_child)
+#endif
 #ifndef __MVS__
   TEST_ENTRY  (fork_threadpool_queue_work_simple)
 #endif

--- a/uv.gyp
+++ b/uv.gyp
@@ -229,6 +229,12 @@
             '_DARWIN_UNLIMITED_SELECT=1',
           ]
         }],
+        [ 'OS in "mac"', {
+              'defines': [
+                'HAVE_CORESERVICES_CORESERVICES_H',
+		'HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H'
+              ],
+        }],
         [ 'OS=="linux"', {
           'defines': [ '_GNU_SOURCE' ],
           'sources': [


### PR DESCRIPTION
Previously, you had to have the apple sdk frameworks downloaded to
build on “Darwin”. There are certain cases where this is not desired,
so an Autoconf conditional is added to check for their availability.
When they are not available, proctitle & fsevents are unavailable.

These frameworks are proprietary- owned and developed by Apple Inc.
They have never been released publically so we should not make
everyone use it in a core library like libuv.

Also could not get hrtime test to work on my macOS - so had to disable it.