### PR TITLE
unix, win: change position of uv_fs_lchown

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -92,9 +92,9 @@ Data types
             UV_FS_READLINK,
             UV_FS_CHOWN,
             UV_FS_FCHOWN,
-            UV_FS_LCHOWN,
             UV_FS_REALPATH,
-            UV_FS_COPYFILE
+            UV_FS_COPYFILE,
+            UV_FS_LCHOWN
         } uv_fs_type;
 
 .. c:type:: uv_dirent_t

--- a/include/uv.h
+++ b/include/uv.h
@@ -1141,9 +1141,9 @@ typedef enum {
   UV_FS_READLINK,
   UV_FS_CHOWN,
   UV_FS_FCHOWN,
-  UV_FS_LCHOWN,
   UV_FS_REALPATH,
-  UV_FS_COPYFILE
+  UV_FS_COPYFILE,
+  UV_FS_LCHOWN
 } uv_fs_type;
 
 /* uv_fs_t is a subclass of uv_req_t. */


### PR DESCRIPTION
Change the position of UV_LS_LCHOWN, moving it to the end in order to go
around a bug due to it's initial position.

Fixes: https://github.com/libuv/libuv/issues/1908

/cc @cjihrig do you want me to add regression tests for this? I'd be glad to.