### PR TITLE
Fixed compiler warning caused by uninitialized variables.

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -223,7 +223,7 @@ static void uv_init(void) {
 
 int uv_loop_init(uv_loop_t* loop) {
   struct heap* timer_heap;
-  int err;
+  int err = 0;
 
   /* Initialize libuv itself first */
   uv__once_init();

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -156,7 +156,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   DWORD attr, last_error;
   WCHAR* dir = NULL, *dir_to_watch, *pathw = NULL;
   WCHAR short_path_buffer[MAX_PATH];
-  WCHAR* short_path, *long_path;
+  WCHAR* short_path, *long_path = NULL;
 
   if (uv__is_active(handle))
     return UV_EINVAL;


### PR DESCRIPTION
Clang with -Wall
```
src/win/core.c:252:7: warning: variable 'err' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]

src/win/fs-event.c:205:9: warning: variable 'long_path' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
```