### PR TITLE
src: add uv_loop watcher_queue update apis

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -228,6 +228,15 @@ API
        invalid. That function must be called again to determine the
        correct backend file descriptor.
 
+.. c:function:: uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop)
+
+    Returns `loop->watcher_queue_updated_cb`.
+
+.. c:function:: void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                                uv_loop_cb cb)
+
+    Sets `loop->watcher_queue_updated_cb` to `cb`.
+
 .. c:function:: void* uv_loop_get_data(const uv_loop_t* loop)
 
     Returns `loop->data`.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1741,6 +1741,7 @@ union uv_any_req {
 };
 #undef XX
 
+typedef void (*uv_loop_cb)(uv_loop_t*);
 
 struct uv_loop_s {
   /* User data - use this for whatever. */
@@ -1754,9 +1755,14 @@ struct uv_loop_s {
   } active_reqs;
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
-  void* reserved[4];
+  uv_loop_cb watcher_queue_updated_cb;
+  void* reserved[3];
   UV_LOOP_PRIVATE_FIELDS
 };
+
+UV_EXTERN uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop);
+UV_EXTERN void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                          uv_loop_cb cb);
 
 UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
 UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -856,8 +856,12 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     return;
 #endif
 
-  if (QUEUE_EMPTY(&w->watcher_queue))
+  if (QUEUE_EMPTY(&w->watcher_queue)) {
     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+    if (loop->watcher_queue_updated_cb != NULL)
+      loop->watcher_queue_updated_cb(loop);
+  }
+
 
   if (loop->watchers[w->fd] == NULL) {
     loop->watchers[w->fd] = w;
@@ -893,8 +897,12 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
       w->events = 0;
     }
   }
-  else if (QUEUE_EMPTY(&w->watcher_queue))
+  else if (QUEUE_EMPTY(&w->watcher_queue)) {
     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+    if (loop->watcher_queue_updated_cb != NULL)
+      loop->watcher_queue_updated_cb(loop);
+  }
+
 }
 
 
@@ -911,6 +919,8 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w) {
   if (QUEUE_EMPTY(&w->pending_queue))
     QUEUE_INSERT_TAIL(&loop->pending_queue, &w->pending_queue);
+  if (loop->watcher_queue_updated_cb != NULL)
+    loop->watcher_queue_updated_cb(loop);
 }
 
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -46,6 +46,7 @@ int uv_loop_init(uv_loop_t* loop) {
 
   loop->active_handles = 0;
   loop->active_reqs.count = 0;
+  loop->watcher_queue_updated_cb = NULL;
   loop->nfds = 0;
   loop->watchers = NULL;
   loop->nwatchers = 0;

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -96,3 +96,13 @@ void* uv_loop_get_data(const uv_loop_t* loop) {
 void uv_loop_set_data(uv_loop_t* loop, void* data) {
   loop->data = data;
 }
+
+uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop) {
+  return loop->watcher_queue_updated_cb;
+}
+
+void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                uv_loop_cb cb) {
+  loop->watcher_queue_updated_cb = cb;
+}
+

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -127,6 +127,10 @@ int uv_loop_init(uv_loop_t* loop) {
   QUEUE_INIT(&loop->wq);
   QUEUE_INIT(&loop->handle_queue);
   loop->active_reqs.count = 0;
+  QUEUE_INIT(&loop->active_reqs);
+
+  loop->watcher_queue_updated_cb = NULL;
+
   loop->active_handles = 0;
 
   loop->pending_reqs_tail = NULL;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -33,6 +33,7 @@ TEST_DECLARE   (loop_stop)
 TEST_DECLARE   (loop_update_time)
 TEST_DECLARE   (loop_backend_timeout)
 TEST_DECLARE   (loop_configure)
+TEST_DECLARE   (loop_queue_watcher_test)
 TEST_DECLARE   (default_loop_close)
 TEST_DECLARE   (barrier_1)
 TEST_DECLARE   (barrier_2)
@@ -495,6 +496,7 @@ TASK_LIST_START
 #if 0
   TEST_ENTRY  (callback_order)
 #endif
+
   TEST_ENTRY  (close_order)
   TEST_ENTRY  (run_once)
   TEST_ENTRY  (run_nowait)
@@ -505,6 +507,7 @@ TASK_LIST_START
   TEST_ENTRY  (loop_update_time)
   TEST_ENTRY  (loop_backend_timeout)
   TEST_ENTRY  (loop_configure)
+  TEST_ENTRY  (loop_queue_watcher_test)
   TEST_ENTRY  (default_loop_close)
   TEST_ENTRY  (barrier_1)
   TEST_ENTRY  (barrier_2)
@@ -1049,4 +1052,5 @@ TASK_LIST_START
   TEST_ENTRY  (fail_always)
   TEST_ENTRY  (pass_always)
 #endif
+
 TASK_LIST_END


### PR DESCRIPTION
This PR adds to` uv_loop_t` a callback field `on_queue_watcher_updated` which is called whenever the loop's watcher queue changes. It also adds a public getter and setter for this field.

Electron's Node Integration works by listening to Node's backend file descriptor in a separate thread; when an event is ready the backend file descriptor will trigger a new event for it, and the main thread will then iterate the libuv loop. For certain operations (ex. adding a timeout task) the backend file descriptor isn't informed, & as a result the main thread doesn't know it needs to iterate the libuv loop so  the timeout task will never execute until something else trigger a new event. This PR mitigates that problem.

I didn't add a test for the initial iteration of this API addition, but I can go ahead and add one if need be!