### PR TITLE
Added uv_open_osfhandle (counterpart of uv_get_osfhandle)

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -403,6 +403,16 @@ Helper functions
 
     .. versionadded:: 1.12.0
 
+
+.. c:function:: int uv_open_osfhandle(uv_os_fd_t handle)
+
+   For an OS-dependent handle, get the file descriptor in the C runtime.
+   On UNIX, returns the ``fd`` intact. On Windows, this calls `_open_osfhandle <https://msdn.microsoft.com/en-us/library/bdts1c9x.aspx>`_.
+   Note that the return value will be owned by the C runtime,
+   any attempts to close the handle use it after libuv closes the fd may lead to malfunction.
+
+    .. versionadded:: 1.22.1
+
 File open constants
 -------------------
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1065,6 +1065,7 @@ UV_EXTERN int uv_set_process_title(const char* title);
 UV_EXTERN int uv_resident_set_memory(size_t* rss);
 UV_EXTERN int uv_uptime(double* uptime);
 UV_EXTERN uv_os_fd_t uv_get_osfhandle(int fd);
+UV_EXTERN int uv_open_osfhandle(uv_os_fd_t handle);
 
 typedef struct {
   long tv_sec;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1339,6 +1339,11 @@ uv_os_fd_t uv_get_osfhandle(int fd) {
 }
 
 
+int uv_open_osfhandle(uv_os_fd_t handle) {
+  return handle;
+}
+
+
 uv_pid_t uv_os_getpid(void) {
   return getpid();
 }

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -157,3 +157,8 @@ int uv_is_closing(const uv_handle_t* handle) {
 uv_os_fd_t uv_get_osfhandle(int fd) {
   return uv__get_osfhandle(fd);
 }
+
+
+int uv_open_osfhandle(uv_os_fd_t handle) {
+  return _open_osfhandle((HANDLE)handle);
+}


### PR DESCRIPTION
I do not know why `uv_get_osfhandle` was implemented without its counterpart to begin with,
But when fiddling with node.js native addons this looks like a major oversight.

This PR is a very basic wrapper for get_osfhandle, which allows us to pass `fd`s to node.js from a native addon. (Scenario: We create a `HANDLE` to a file or another compatible object, and pass it to node to do something with it)

Closes https://github.com/nodejs/node-addon-api/issues/304