### PR TITLE
ibmi: uv_resident_set_memory() returns 0

### DIFF
--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -72,7 +72,8 @@ void uv_loadavg(double avg[3]) {
 
 
 int uv_resident_set_memory(size_t* rss) {
-  return UV_ENOSYS;
+  *rss = 0;
+  return 0;
 }
 
 


### PR DESCRIPTION
On IBM i we can not get the resident set memory size of a process. 
Current code does not support **yarn** --
> yarn version
Error: ENOSYS: function not implemented, uv_resident_set_memory

So return 0 just like what the **ps** command does on IBM i and make **yarn** work.