### PR TITLE
doc: Path encoding in uv_fs_XX is UTF-8[Windows]

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -13,7 +13,7 @@ All file operations are run on the threadpool. See :ref:`threadpool` for informa
 on the threadpool size.
 
 .. note::
-     On Windows `uv_fs_XXX` functions use utf-8 encoding.
+     On Windows `uv_fs_*` functions use utf-8 encoding.
 
 Data types
 ----------

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -175,6 +175,7 @@ API
         On Windows libuv uses `CreateFileW` and thus the file is always opened
         in binary mode. Because of this the O_BINARY and O_TEXT flags are not
         supported.
+        On Windows `uv_fs_XXX` functions use utf-8 encoding.
 
 .. c:function:: int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -176,7 +176,7 @@ API
     .. note::
         On Windows libuv uses `CreateFileW` and thus the file is always opened
         in binary mode. Because of this the O_BINARY and O_TEXT flags are not
-        supported.  
+        supported.
 
 .. c:function:: int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -12,6 +12,8 @@ otherwise it will be performed asynchronously.
 All file operations are run on the threadpool. See :ref:`threadpool` for information
 on the threadpool size.
 
+.. note::
+     On Windows `uv_fs_XXX` functions use utf-8 encoding.
 
 Data types
 ----------

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -176,8 +176,7 @@ API
     .. note::
         On Windows libuv uses `CreateFileW` and thus the file is always opened
         in binary mode. Because of this the O_BINARY and O_TEXT flags are not
-        supported.
-        On Windows `uv_fs_XXX` functions use utf-8 encoding.
+        supported.  
 
 .. c:function:: int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 


### PR DESCRIPTION
#1554 
Modified the documentation to mention that uv_fs_XXX functions use utf-8 encoding on Windows.
Native unicode encoding on Windows is UTF-16