### PR TITLE
win: return UV_ENOMEM from uv_loop_init()

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -249,8 +249,10 @@ int uv_loop_init(uv_loop_t* loop) {
   loop->endgame_handles = NULL;
 
   loop->timer_heap = timer_heap = uv__malloc(sizeof(*timer_heap));
-  if (timer_heap == NULL)
+  if (timer_heap == NULL) {
+    err = UV_ENOMEM;
     goto fail_timers_alloc;
+  }
 
   heap_init(timer_heap);
 


### PR DESCRIPTION
This commit sets the error returned by `uv_loop_init()` to `UV_ENOMEM` in the case of a failed timer heap malloc.