### PR TITLE
test: fix warning in test-tcp-open

### DIFF
--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -176,7 +176,7 @@ static void timer_cb(uv_timer_t* handle) {
   int r;
 
   /* Shutdown on drain. */
-  r = uv_shutdown(&shutdown_req, &client, shutdown_cb);
+  r = uv_shutdown(&shutdown_req, (uv_stream_t*) &client, shutdown_cb);
   ASSERT(r == 0);
   shutdown_requested++;
 }


### PR DESCRIPTION
```

```test/test-tcp-open.c: In function ‘timer_cb’:
test/test-tcp-open.c:179:34: warning: passing argument 2 of ‘uv_shutdown’ from incompatible pointer type
   r = uv_shutdown(&shutdown_req, &client, shutdown_cb);
                                  ^
In file included from test/test-tcp-open.c:22:0:
./include/uv.h:398:15: note: expected ‘struct uv_stream_t *’ but argument is of type ‘struct uv_tcp_t *’
 UV_EXTERN int uv_shutdown(uv_shutdown_t* req,