### PR TITLE
Avoid selective syscalls() to support userspace stack integration with Node.js runtime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,12 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects] UV_EXTRA_AUTOMAKE_FLAGS)
 AC_CANONICAL_HOST
 AC_ENABLE_SHARED
 AC_ENABLE_STATIC
+AC_ARG_ENABLE([syscall],
+  AS_HELP_STRING([--disable-syscall], [Disable syscall api [default=no]]))
+AS_IF([test "x$enable_syscall" = "xno"], [
+  dnl Set macro to override syscall api as needed
+  CFLAGS="$CFLAGS -DAVOID_SYSCALL_API"
+])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AS_IF([AS_CASE([$host_os],[openedition*],  [false], [true])], [

--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -260,7 +260,11 @@ int uv__accept4(int fd, struct sockaddr* addr, socklen_t* addrlen, int flags) {
 
   return r;
 #elif defined(__NR_accept4)
+#if defined(AVOID_SYSCALL_API)
+  return accept4(fd, addr, addrlen, flags);
+#else
   return syscall(__NR_accept4, fd, addr, addrlen, flags);
+#endif
 #else
   return errno = ENOSYS, -1;
 #endif
@@ -287,7 +291,11 @@ int uv__eventfd2(unsigned int count, int flags) {
 
 int uv__epoll_create(int size) {
 #if defined(__NR_epoll_create)
+#if defined(AVOID_SYSCALL_API)
+  return epoll_create(size);
+#else
   return syscall(__NR_epoll_create, size);
+#endif
 #else
   return errno = ENOSYS, -1;
 #endif
@@ -296,7 +304,11 @@ int uv__epoll_create(int size) {
 
 int uv__epoll_create1(int flags) {
 #if defined(__NR_epoll_create1)
+#if defined(AVOID_SYSCALL_API)
+  return epoll_create1(flags);
+#else
   return syscall(__NR_epoll_create1, flags);
+#endif
 #else
   return errno = ENOSYS, -1;
 #endif
@@ -305,7 +317,11 @@ int uv__epoll_create1(int flags) {
 
 int uv__epoll_ctl(int epfd, int op, int fd, struct uv__epoll_event* events) {
 #if defined(__NR_epoll_ctl)
+#if defined(AVOID_SYSCALL_API)
+  return epoll_ctl(epfd, op, fd, (struct epoll_event*)events);
+#else
   return syscall(__NR_epoll_ctl, epfd, op, fd, events);
+#endif
 #else
   return errno = ENOSYS, -1;
 #endif
@@ -318,7 +334,11 @@ int uv__epoll_wait(int epfd,
                    int timeout) {
 #if defined(__NR_epoll_wait)
   int result;
+#if defined(AVOID_SYSCALL_API)
+  result = epoll_wait(epfd, (struct epoll_event *)events, nevents, timeout);
+#else
   result = syscall(__NR_epoll_wait, epfd, events, nevents, timeout);
+#endif
 #if MSAN_ACTIVE
   if (result > 0)
     __msan_unpoison(events, sizeof(events[0]) * result);

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -30,6 +30,9 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#if defined(AVOID_SYSCALL_API)
+#include <sys/epoll.h>
+#endif
 
 #if defined(__alpha__)
 # define UV__O_CLOEXEC        0x200000


### PR DESCRIPTION
I've successfully enabled use of userspace TCP/IP stack with Node.js runtime showing improved performance. In order to support that work I needed to update libuv codebase. The change is to avoid syscall() api for few low level system calls namely, accept4(), epoll_create(), epoll_create1(), epoll_ctl() and epoll_wait(). This change enables intercepting of these calls in the external code in this case "mTCP" stack as needed.
With suggestions from @bnoordhuis (see issue #1880), I'd tried intercepting "syscall()" directly, but it turned out not to be as simple as I imagined. Change had broad functional impact (negative) on mTCP as well as DPDK userspace driver stack with increased complexity, hence this patch. I also understand this is going to be a temporary patch till libuv v2.0, where syscall() api has been removed for the Linux platform. This patch helps my work to integrate userspace stack (mTCP with DPDK or netmap driver) into Node.js runtime and continue my experiment to improve overall network performance for Node.js applications.
I'm looking forward to community suggestions, feedback.