### PR TITLE
Specify less greedy flags when connecting to named pipes

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -137,10 +137,12 @@ static HANDLE open_named_pipe(const WCHAR* name, DWORD* duplex_flags) {
 
   /*
    * Assume that we have a duplex pipe first, so attempt to
-   * connect with GENERIC_READ | GENERIC_WRITE.
+   * connect with GENERIC_READ | FILE_WRITE_DATA. No reason
+   * to ask for GENERIC_WRITE, FILE_WRITE_DATA is enough
+   * to write data to a pipe.
    */
   pipeHandle = CreateFileW(name,
-                           GENERIC_READ | GENERIC_WRITE,
+                           GENERIC_READ | FILE_WRITE_DATA,
                            0,
                            NULL,
                            OPEN_EXISTING,


### PR DESCRIPTION
Whilst working with named pipes on Node, I came across an issue where I wouldn't be able to connect to a pipe which had it's access permissions set to `GENERIC_READ | FILE_WRITE_DATA`. If the pipe had it's permissions set to `GENERIC_READ | GENERIC_WRITE`, any process that would be able to connect to the pipe would also be capable of spawning new server ends of the pipe. Or at least that's my interpretation of the [docs](https://docs.microsoft.com/en-us/windows/desktop/ipc/named-pipe-security-and-access-rights) on this.

Maybe this is would be best handled the same way read-only and write-only pipes are handled, i.e. try for `GENERIC_READ | GENERIC_WRITE` first and then attempt `GENERIC_READ | GENERIC_WRITE` ?