### PR TITLE
win,fs: retry if uv_fs_rename fails

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -233,6 +233,15 @@ API
 
     Equivalent to :man:`rename(2)`.
 
+    .. note::
+        On Windows if this function fails with ``UV_EBUSY``, ``UV_EPERM`` or
+        ``UV_EACCES``, it will retry to rename the file up to four times with
+        250ms wait between attempts before giving up. If both `path` and
+        `new_path` are existing directories this function will work only if
+        target directory is empty.
+
+    .. versionchanged:: 1.24.0 Added retrying and directory move support on Windows.
+
 .. c:function:: int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
 
     Equivalent to :man:`fsync(2)`.

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1335,7 +1335,7 @@ static void fs__rename(uv_fs_t* req) {
   int sys_errno;
   int result;
   int try_rmdir;
-  WCHAR *src, *dst;
+  WCHAR* src, *dst;
   DWORD src_attrib, dst_attrib;
 
   src = req->file.pathw;
@@ -1358,9 +1358,8 @@ static void fs__rename(uv_fs_t* req) {
      * Windows. We will try to delete target folder first.
      */
     if (src_attrib & FILE_ATTRIBUTE_DIRECTORY &&
-        dst_attrib & FILE_ATTRIBUTE_DIRECTORY) {
+        dst_attrib & FILE_ATTRIBUTE_DIRECTORY)
         try_rmdir = 1;
-    }
   }
 
   /* Sometimes an antivirus or indexing software can lock the target or the
@@ -1368,15 +1367,11 @@ static void fs__rename(uv_fs_t* req) {
    * retry couple of times with some delay before failing.
    */
   for (tries = 0; tries < UV__RENAME_RETRIES; ++tries) {
-    if (tries > 0) {
+    if (tries > 0)
       Sleep(UV__RENAME_WAIT);
-    }
+
     if (try_rmdir) {
-      if (_wrmdir(dst) == 0) {
-        result = 0;
-      } else {
-        result = uv_translate_sys_error(_doserrno);
-      }
+      result = _wrmdir(dst) == 0 ? 0 : uv_translate_sys_error(_doserrno);
       switch (result)
       {
       case 0:
@@ -1403,13 +1398,11 @@ static void fs__rename(uv_fs_t* req) {
 
     sys_errno = GetLastError();
     result = uv_translate_sys_error(sys_errno);
-    if (result != UV_EBUSY && result != UV_EPERM && result != UV_EACCES) {
+    if (result != UV_EBUSY && result != UV_EPERM && result != UV_EACCES)
       break;
-    }
   }
   req->sys_errno_ = sys_errno;
   req->result = result;
-  return;
 }
 
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -42,6 +42,8 @@
 #define UV_FS_FREE_PTR           0x0008
 #define UV_FS_CLEANEDUP          0x0010
 
+#define UV__RENAME_RETRIES       4
+#define UV__RENAME_WAIT          250
 
 #define INIT(subtype)                                                         \
   do {                                                                        \
@@ -1329,12 +1331,85 @@ static void fs__fstat(uv_fs_t* req) {
 
 
 static void fs__rename(uv_fs_t* req) {
-  if (!MoveFileExW(req->file.pathw, req->fs.info.new_pathw, MOVEFILE_REPLACE_EXISTING)) {
+  int tries;
+  int sys_errno;
+  int result;
+  int try_rmdir;
+  WCHAR *src, *dst;
+  DWORD src_attrib, dst_attrib;
+
+  src = req->file.pathw;
+  dst = req->fs.info.new_pathw;
+  try_rmdir = 0;
+
+  /* Do some checks to fail early. */
+  src_attrib = GetFileAttributesW(src);
+  if (src_attrib == INVALID_FILE_ATTRIBUTES) {
     SET_REQ_WIN32_ERROR(req, GetLastError());
     return;
   }
+  dst_attrib = GetFileAttributesW(dst);
+  if (dst_attrib != INVALID_FILE_ATTRIBUTES) {
+    if (dst_attrib & FILE_ATTRIBUTE_READONLY) {
+      req->result = UV_EPERM;
+      return;
+    }
+    /* Renaming folder to a folder name that already exist will fail on
+     * Windows. We will try to delete target folder first.
+     */
+    if (src_attrib & FILE_ATTRIBUTE_DIRECTORY &&
+        dst_attrib & FILE_ATTRIBUTE_DIRECTORY) {
+        try_rmdir = 1;
+    }
+  }
 
-  SET_REQ_RESULT(req, 0);
+  /* Sometimes an antivirus or indexing software can lock the target or the
+   * source file/directory. This is annoying for users, in such cases we will
+   * retry couple of times with some delay before failing.
+   */
+  for (tries = 0; tries < UV__RENAME_RETRIES; ++tries) {
+    if (tries > 0) {
+      Sleep(UV__RENAME_WAIT);
+    }
+    if (try_rmdir) {
+      if (_wrmdir(dst) == 0) {
+        result = 0;
+      } else {
+        result = uv_translate_sys_error(_doserrno);
+      }
+      switch (result)
+      {
+      case 0:
+      case UV_ENOENT:
+        /* Folder removed or did not exist at all. */
+        try_rmdir = 0;
+        break;
+      case UV_ENOTEMPTY:
+        /* Non-empty target folder, fail instantly. */
+        SET_REQ_RESULT(req, -1);
+        return;
+      default:
+        /* All other errors - try to move file anyway and handle the error
+         * there, retrying folder deletion next time around.
+         */
+        break;
+      }
+    }
+
+    if (MoveFileExW(src, dst, MOVEFILE_REPLACE_EXISTING) != 0) {
+      SET_REQ_RESULT(req, 0);
+      return;
+    }
+
+    sys_errno = GetLastError();
+    result = uv_translate_sys_error(sys_errno);
+    if (result != UV_EBUSY && result != UV_EPERM && result != UV_EACCES) {
+      break;
+    }
+  }
+  req->sys_errno_ = sys_errno;
+  req->result = result;
+  return;
 }
 
 


### PR DESCRIPTION
On Windows rename operation can fail randomly in presence of antivirus or indexing software. Popular workaround is to retry the operation after small delay, like in [graceful-fs](https://github.com/isaacs/node-graceful-fs/blob/master/polyfills.js#L88-L116), it also appear in other places, like [here](https://github.com/davidmarkclements/0x/pull/128/files) and [here](https://stackoverflow.com/questions/964920/is-it-possible-to-reasonably-workaround-an-antivirus-scanning-the-working-direct).

This PR implements this workaround in libuv. It makes `uv_fs_rename` retry up to four times with 250ms delay between attempts before giving up.