### PR TITLE
libuv cant get uv_threadpool_size i put on windows 10

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -181,7 +181,7 @@ UV_DESTRUCTOR(static void cleanup(void)) {
 
 static void init_threads(void) {
   unsigned int i;
-  const char* val;
+  //const char* val;
   uv_sem_t sem;
   // Check UV_THREADPOOL_SIZE
   char buf[16];

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -188,14 +188,12 @@ static void init_threads(void) {
   size_t buf_size = sizeof(buf);
   
   nthreads = ARRAY_SIZE(default_threads);
-#ifdef _WIN32
   if (uv_os_getenv("UV_THREADPOOL_SIZE", buf, &buf_size) == 0) {
     nthreads = atoi(buf);
   }
-#endif
-  val = getenv("UV_THREADPOOL_SIZE");
-  if (val != NULL)
-    nthreads = atoi(val);
+  //val = getenv("UV_THREADPOOL_SIZE");
+  //if (val != NULL)
+  //  nthreads = atoi(val);
   if (nthreads == 0)
     nthreads = 1;
   if (nthreads > MAX_THREADPOOL_SIZE)

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 
 #define MAX_THREADPOOL_SIZE 128
-#define MAX_THREADPOOL_SIZE_IN_STR 4
 
 static uv_once_t once = UV_ONCE_INIT;
 static uv_cond_t cond;
@@ -184,23 +183,14 @@ static void init_threads(void) {
   unsigned int i;
   const char* val;
   uv_sem_t sem;
-  char* pbuf;
-  size_t szbuf;
-
+  // Check UV_THREADPOOL_SIZE
+  char buf[16];
+  size_t buf_size = sizeof(buf);
+  
   nthreads = ARRAY_SIZE(default_threads);
-  pbuf = uv__malloc(MAX_THREADPOOL_SIZE_IN_STR * sizeof(char));
-  if (pbuf) {
-	  szbuf = MAX_THREADPOOL_SIZE_IN_STR;
-	  memset(pbuf, 0, MAX_THREADPOOL_SIZE_IN_STR * sizeof(char));
-	  uv_os_getenv("UV_THREADPOOL_SIZE", pbuf, &szbuf);
-	  if (szbuf > 0 && szbuf < MAX_THREADPOOL_SIZE_IN_STR)
-	  {
-		  pbuf[szbuf] = 0;
-		  nthreads = atoi(pbuf);
-	  }
-	  uv__free(pbuf);
-	  pbuf = NULL;
-  }
+  if (uv_os_getenv("UV_THREADPOOL_SIZE", buf, &buf_size) == 0) {
+    nthreads = atoi(buf);
+  }   
   val = getenv("UV_THREADPOOL_SIZE");
   if (val != NULL)
     nthreads = atoi(val);

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 
 #define MAX_THREADPOOL_SIZE 128
+#define MAX_THREADPOOL_SIZE_IN_STR 4
 
 static uv_once_t once = UV_ONCE_INIT;
 static uv_cond_t cond;
@@ -183,8 +184,23 @@ static void init_threads(void) {
   unsigned int i;
   const char* val;
   uv_sem_t sem;
+  char* pbuf;
+  size_t szbuf;
 
   nthreads = ARRAY_SIZE(default_threads);
+  pbuf = uv__malloc(MAX_THREADPOOL_SIZE_IN_STR * sizeof(char));
+  if (pbuf) {
+	  szbuf = MAX_THREADPOOL_SIZE_IN_STR;
+	  memset(pbuf, 0, MAX_THREADPOOL_SIZE_IN_STR * sizeof(char));
+	  uv_os_getenv("UV_THREADPOOL_SIZE", pbuf, &szbuf);
+	  if (szbuf > 0 && szbuf < MAX_THREADPOOL_SIZE_IN_STR)
+	  {
+		  pbuf[szbuf] = 0;
+		  nthreads = atoi(pbuf);
+	  }
+	  uv__free(pbuf);
+	  pbuf = NULL;
+  }
   val = getenv("UV_THREADPOOL_SIZE");
   if (val != NULL)
     nthreads = atoi(val);

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -188,9 +188,11 @@ static void init_threads(void) {
   size_t buf_size = sizeof(buf);
   
   nthreads = ARRAY_SIZE(default_threads);
+#ifdef _WIN32
   if (uv_os_getenv("UV_THREADPOOL_SIZE", buf, &buf_size) == 0) {
     nthreads = atoi(buf);
-  }   
+  }
+#endif
   val = getenv("UV_THREADPOOL_SIZE");
   if (val != NULL)
     nthreads = atoi(val);


### PR DESCRIPTION
hi,
the following program wont mix character 'm' and 'Q' if putenv works.
calling putenv directly doesnot work in my program,
loadlibrary and getprocaddress and then calling putenv works.

on my machine,
libuv is built with ms visual studio 2012 as a dynamic library(dll),the following piece of code is compile and built with ms visual studio 2017. for both of them ,i selected Multi-threaded (Debug) DLL for run time library.i believe if u build libuv and the following code with different version of ms visual studio ,this issue appears. see here http://siomsystems.com/mixing-visual-studio-versions/

```
#include<iostream>
#include<uv.h>
#include<Windows.h>

#pragma comment(lib,"C:\\apis\\libuv-1.18.0\\Debug\\libuv.lib")
void uv_work_cb_test(uv_work_t* req)
{
	char c = (char)req->data;
	for (int i = 0; i < 100; i++)
		std::cout << c;
}

int main(int c,char *v[])
{
	putenv("UV_THREADPOOL_SIZE=1");
	HMODULE hdll = LoadLibraryA(
#ifdef _DEBUG
		"msvcr110d.dll"
#else
		"msvcr110.dll"
#endif
	);
	FARPROC proc = GetProcAddress(hdll, "_putenv");
	typedef int(*pf)(const char *);
	pf _pf = (pf)proc;
	//comment next line,character 'm' mixed with character 'Q'
	//_pf("UV_THREADPOOL_SIZE=1");
	
	uv_work_t vts[2];
	vts[0].data = (void *)'m';
	vts[1].data = (void *)'Q';
	for (auto &a : vts)
	{
		uv_queue_work(uv_default_loop(), &a, uv_work_cb_test, nullptr);
	}
	uv_run(uv_default_loop(), UV_RUN_DEFAULT);	
	FreeLibrary(hdll);
	return 0;
}
```

i have opened  issue https://github.com/libuv/libuv/issues/1977   for this