### PR TITLE
unix: return 0 retrieving rss on cygwin

### DIFF
--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -38,7 +38,7 @@ int uv_uptime(double* uptime) {
 int uv_resident_set_memory(size_t* rss) {
   /* FIXME: read /proc/meminfo? */
   *rss = 0;
-  return UV_ENOSYS;
+  return 0;
 }
 
 int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {


### PR DESCRIPTION
I didn't want to make this change while landing https://github.com/libuv/libuv/pull/1939, so I split it out.

Refs: https://github.com/libuv/libuv/pull/1939#issuecomment-421353357