### PR TITLE
unix: zero epoll_event before use

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -228,6 +228,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     assert(w->fd >= 0);
     assert(w->fd < (int) loop->nwatchers);
 
+    memset(&e, 0, sizeof(e));
     e.events = w->pevents;
     e.data.fd = w->fd;
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -170,6 +170,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   struct epoll_event e;
   int rc;
 
+  memset(&e, 0, sizeof(e));
   e.events = POLLIN;
   e.data.fd = -1;
 
@@ -218,6 +219,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     return;
   }
 
+  memset(&e, 0, sizeof(e));
+
   while (!QUEUE_EMPTY(&loop->watcher_queue)) {
     q = QUEUE_HEAD(&loop->watcher_queue);
     QUEUE_REMOVE(q);
@@ -228,7 +231,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     assert(w->fd >= 0);
     assert(w->fd < (int) loop->nwatchers);
 
-    memset(&e, 0, sizeof(e));
     e.events = w->pevents;
     e.data.fd = w->fd;
 


### PR DESCRIPTION
Valgrind will emit the following error on a system where `int` is 32 bits:

```
==21616== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==21616==    at 0x693E06A: epoll_ctl (syscall-template.S:84)
==21616==    by 0x529F35B: uv__io_poll (in .../libuv/libuv.so)
==21616==    by 0x528AE62: uv_run (in .../libuv/libuv.so)
[...]
==21616==  Address 0x1ffeffc8ec is on thread 1's stack
==21616==  in frame #1, created by uv__io_poll (???:)
```

We only initialise `e.events` and `e.data.fd`, meaning half of `e.data` (the 32 bits not covered by the 4-byte `fd`) is uninitialised.