### PR TITLE
test: more generous hrtime range asserts

### DIFF
--- a/test/test-hrtime.c
+++ b/test/test-hrtime.c
@@ -33,7 +33,8 @@
 
 TEST_IMPL(hrtime) {
   uint64_t a, b, diff;
-  int i = 75;
+  /* 50 iterations * 300 ms max (assert-enforced) = 15 seconds. */
+  int i = 50;
   while (i > 0) {
     a = uv_hrtime();
     uv_sleep(45);
@@ -41,14 +42,14 @@ TEST_IMPL(hrtime) {
 
     diff = b - a;
 
-    printf("i= %d diff = %llu\n", i, (unsigned long long int) diff);
+    /* printf("i= %d diff = %llu\n", i, (unsigned long long int) diff); */
 
-    /* The Windows Sleep() function has a resolution of 10-20 ms.
-     * The MacOS sleep resolution is XXX.
-     * So be a bit generous with assertions about the difference between the
-     * two hrtime values. */
+    /* Be generous with assertions about the difference between the
+     * two hrtime values.
+     * - The Windows Sleep() function has a resolution of 10-20 ms.
+     * - On MacOSX 12 CI we observed diff values between (48, 195) ms. */
     ASSERT(diff > (uint64_t) 20 * NANOSEC / MILLISEC);
-    ASSERT(diff < (uint64_t) 200 * NANOSEC / MILLISEC);
+    ASSERT(diff < (uint64_t) 300 * NANOSEC / MILLISEC);
     --i;
   }
   return 0;

--- a/test/test-hrtime.c
+++ b/test/test-hrtime.c
@@ -41,13 +41,14 @@ TEST_IMPL(hrtime) {
 
     diff = b - a;
 
-    /*  printf("i= %d diff = %llu\n", i, (unsigned long long int) diff); */
+    printf("i= %d diff = %llu\n", i, (unsigned long long int) diff);
 
-    /* The windows Sleep() function has only a resolution of 10-20 ms. Check
-     * that the difference between the two hrtime values is somewhat in the
-     * range we expect it to be. */
-    ASSERT(diff > (uint64_t) 25 * NANOSEC / MILLISEC);
-    ASSERT(diff < (uint64_t) 80 * NANOSEC / MILLISEC);
+    /* The Windows Sleep() function has a resolution of 10-20 ms.
+     * The MacOS sleep resolution is XXX.
+     * So be a bit generous with assertions about the difference between the
+     * two hrtime values. */
+    ASSERT(diff > (uint64_t) 20 * NANOSEC / MILLISEC);
+    ASSERT(diff < (uint64_t) 200 * NANOSEC / MILLISEC);
     --i;
   }
   return 0;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -725,7 +725,7 @@ TASK_LIST_START
 
   TEST_ENTRY  (tmpdir)
 
-  TEST_ENTRY  (hrtime)
+  TEST_ENTRY_CUSTOM  (hrtime, 0, 1, 16000)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
   TEST_ENTRY_CUSTOM (getaddrinfo_fail_sync, 0, 0, 10000)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -725,7 +725,7 @@ TASK_LIST_START
 
   TEST_ENTRY  (tmpdir)
 
-  TEST_ENTRY_CUSTOM  (hrtime, 0, 1, 16000)
+  TEST_ENTRY_CUSTOM  (hrtime, 0, 0, 16000)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
   TEST_ENTRY_CUSTOM (getaddrinfo_fail_sync, 0, 0, 10000)


### PR DESCRIPTION
For MacOSX support.
Has a printf for debugging.

Partial fix for #1910.