### PR TITLE
unix: initialize uv_interface_address_t.phys_addr

### DIFF
--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -119,16 +119,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       continue;
 
     address = *addresses;
+    memset(address->phys_addr, 0, sizeof(address->phys_addr));
 
     for (i = 0; i < *count; i++) {
       if (strcmp(address->name, ent->ifa_name) == 0) {
-#if defined(__CYGWIN__) || defined(__MSYS__)
-        memset(address->phys_addr, 0, sizeof(address->phys_addr));
-#else
         struct sockaddr_dl* sa_addr;
         sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
         memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
-#endif
       }
       address++;
     }

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -890,6 +890,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
       continue;
 
     address = *addresses;
+    memset(address->phys_addr, 0, sizeof(address->phys_addr));
 
     for (i = 0; i < (*count); i++) {
       if (strcmp(address->name, ent->ifa_name) == 0) {

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -512,7 +512,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
     /* TODO: Retrieve netmask using SIOCGIFNETMASK ioctl */
 
     address->is_internal = flg.__nif6e_flags & _NIF6E_FLAGS_LOOPBACK ? 1 : 0;
-
+    memset(address->phys_addr, 0, sizeof(address->phys_addr));
     address++;
   }
 
@@ -624,6 +624,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     }
 
     address->is_internal = flg.ifr_flags & IFF_LOOPBACK ? 1 : 0;
+    memset(address->phys_addr, 0, sizeof(address->phys_addr));
     address++;
   }
 


### PR DESCRIPTION
This commit ensures that the memory of the `phys_addr` field is initialized on all platforms.

Refs: https://github.com/nodejs/node/issues/23043
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1033/ (one unrelated failure)