### PR TITLE
barrier: make destroy match spec

### DIFF
--- a/docs/src/threading.rst
+++ b/docs/src/threading.rst
@@ -155,14 +155,17 @@ Functions return 0 on success or an error code < 0 (unless the
 return type is void, of course).
 
 .. note::
-    :c:func:`uv_barrier_wait` returns a value > 0 to an arbitrarily chosen "serializer" thread
-    to facilitate cleanup, i.e.
+    1. :c:func:`uv_barrier_wait` returns a value > 0 to
+       an arbitrarily chosen "serializer" thread to facilitate cleanup.
 
-    ::
+       ::
 
-        if (uv_barrier_wait(&barrier) > 0)
-            uv_barrier_destroy(&barrier);
+           if (uv_barrier_wait(&barrier) > 0)
+               uv_barrier_destroy(&barrier);
+    2. :c:func:`uv_barrier_destroy` may fail silently.
+       Use `:c:func:`uv_barrier_try_destroy` instead.
 
 .. c:function:: int uv_barrier_init(uv_barrier_t* barrier, unsigned int count)
 .. c:function:: void uv_barrier_destroy(uv_barrier_t* barrier)
+.. c:function:: int uv_barrier_try_destroy(uv_barrier_t* barrier)
 .. c:function:: int uv_barrier_wait(uv_barrier_t* barrier)

--- a/include/uv.h
+++ b/include/uv.h
@@ -1533,6 +1533,7 @@ UV_EXTERN void uv_cond_broadcast(uv_cond_t* cond);
 
 UV_EXTERN int uv_barrier_init(uv_barrier_t* barrier, unsigned int count);
 UV_EXTERN void uv_barrier_destroy(uv_barrier_t* barrier);
+UV_EXTERN int uv_barrier_try_destroy(uv_barrier_t* barrier);
 UV_EXTERN int uv_barrier_wait(uv_barrier_t* barrier);
 
 UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex);


### PR DESCRIPTION
Problem:
uv_barrier_destroy asserts that pthread_barrier_destroy returns 0.
This is incorrect according to the spec.

Solution:
1. Remove the abort in uv_barrier_destroy.
2. Introduce a new API uv_barrier_try_destroy which propagates
   any failure (translating POSIX error codes to libuv ones).