### PR TITLE
Explicitly mark message queue events on os390

### DIFF
--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -269,6 +269,8 @@ int epoll_ctl(uv__os390_epoll* lst,
   return 0;
 }
 
+#define EP_MAX_PFDS (ULONG_MAX / sizeof(struct pollfd))
+#define EP_MAX_EVENTS (INT_MAX / sizeof(struct epoll_event))
 
 int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
                int maxevents, int timeout) {
@@ -280,11 +282,31 @@ int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
   struct pollfd msg_fd;
   int i;
 
-  _SET_FDS_MSGS(size, 1, lst->size - 1);
+  if (!lst || !lst->items || !events) {
+    errno = EFAULT;
+    return -1;
+  }
+
+  if (lst->size > EP_MAX_PFDS) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (maxevents <= 0 || maxevents > EP_MAX_EVENTS) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (lst->size > 0)
+    _SET_FDS_MSGS(size, 1, lst->size - 1);
+  else
+    _SET_FDS_MSGS(size, 0, 0);
   pfds = lst->items;
   pollret = poll(pfds, size, timeout);
   if (pollret <= 0)
     return pollret;
+
+  assert(lst->size > 0);
 
   pollret = _NFDS(pollret) + _NMSGS(pollret);
 

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -299,6 +299,11 @@ int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
 
     ev.fd = pfd->fd;
     ev.events = pfd->revents;
+    if (i == lst->size - 1)
+      ev.is_msg = 1;
+    else
+      ev.is_msg = 0;
+
     if (pfd->revents & POLLIN && pfd->revents & POLLOUT)
       reventcount += 2;
     else if (pfd->revents & (POLLIN | POLLOUT))

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -40,6 +40,7 @@
 struct epoll_event {
   int events;
   int fd;
+  int is_msg;
 };
 
 typedef struct {

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -919,7 +919,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;
 
       ep = loop->ep;
-      if (fd == ep->msg_queue) {
+      if (pe->is_msg) {
         os390_message_queue_handler(ep);
         continue;
       }


### PR DESCRIPTION
This fix was originally made for https://github.com/ibmruntimes/node/issues/104. Per @bnoordhuis request, I'm making a PR against this repo, reviewers are @bnoordhuis and @jBarz . There are differences between this version and [the one for the IBM fork](https://github.com/ibmruntimes/node/pull/109) because the latter has diverged. 

The os390 epoll_wait implementation uses poll() to detect events in
both file descriptors and the message queue used for file system
events. The only message queue ID is always placed at the end of the
array passed to the poll() call. When the poll() call returns all FDs
and the message queue are checked for events by iterating through that
array. In order to distinguish the message queue from the FDs its ID
value is compared with the only message queue ID we have and if it
matches the message queue handler function is called.

When the message queue ID is relatively small, it may have the same
value as the value of one of the file descriptors. If this happens,
the message queue handler is called for the matching file descriptor,
and this call fails. The file descriptor ends up being unhandled and
this makes the next poll() call to return immediately. Eventually this
will happen again and again, leading to an infinite busy loop and high
CPU usage.

To prevent the incorrect interpretation of file descriptors as the
message queue, a new field has been added to the epoll event struct.
This field is checked instead of the ID value and the message queue
handler function is never called for file descriptors.

_To compile this on z/OS I had to provide src/unix/csrsic.h used in src/unix/os390.c. I copied it from https://github.com/ibmruntimes/node/tree/v6.x.zos/deps/uv/src/unix_