### PR TITLE
fail read request if the file is a directory

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -272,7 +272,7 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
     goto done;
   if (S_ISDIR(buf.st_mode)) {
     errno = EISDIR;
-    result -1;
+    result = -1;
     goto done;
   }
 #endif /* defined(_AIX) */

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -265,7 +265,7 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
   unsigned int iovmax;
   ssize_t result;
 
-#if defined(_AIX)
+  /* Make sure that the read request is not for a directory */
   struct stat buf;
   result = fstat(req->file, &buf);
   if (result)
@@ -275,7 +275,6 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
     result = -1;
     goto done;
   }
-#endif /* defined(_AIX) */
 
   iovmax = uv__getiovmax();
   if (req->nbufs > iovmax)

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3037,6 +3037,45 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   return 0;
 }
 
+TEST_IMPL(fs_read_dir_failure) {
+  int r;
+  int buf[2];
+  loop = uv_default_loop();
+
+  /* Setup */
+  rmdir("test_dir");
+  r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(mkdir_cb_count == 1);
+  /* Setup Done Here */
+
+  /* Get a file descriptor for the directory */
+  r = uv_fs_open(loop,
+                 &open_req1,
+                 "test_dir",
+                 O_RDONLY | O_DIRECTORY,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
+  ASSERT(r > 0);
+  uv_fs_req_cleanup(&open_req1);
+
+  /* Try to read data from the directory */
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, 0, NULL);
+  ASSERT(r == -EISDIR);
+  uv_fs_req_cleanup(&read_req);
+
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+  ASSERT(r == 0);
+  uv_fs_req_cleanup(&close_req);
+
+  /* Cleanup */
+  rmdir("test_dir");
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
 
 #ifdef _WIN32
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -344,6 +344,7 @@ TEST_DECLARE   (fs_partial_read)
 TEST_DECLARE   (fs_partial_write)
 TEST_DECLARE   (fs_file_pos_after_op_with_offset)
 TEST_DECLARE   (fs_null_req)
+TEST_DECLARE   (fs_read_dir_failure)
 #ifdef _WIN32
 TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_open_readonly_acl)
@@ -893,6 +894,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_read_write_null_arguments)
   TEST_ENTRY  (fs_file_pos_after_op_with_offset)
   TEST_ENTRY  (fs_null_req)
+  TEST_ENTRY  (fs_read_dir_failure)
 #ifdef _WIN32
   TEST_ENTRY  (fs_exclusive_sharing_mode)
   TEST_ENTRY  (fs_open_readonly_acl)


### PR DESCRIPTION
1. unix,fs: return failure if a directory is read in AIX
This is most likely a typo from https://github.com/libuv/libuv/pull/1742, if I am not wrong (cc @vtjnash). If the file is a directory, `result` should be assigned `-1`, so that the `errno` will be checked and the result will be propagated properly.

2. unix,fs: do directory check before read in all OSes
`#if defined(_AIX)` makes sure that only AIX checks if the file is a directory before actually reading it. This commit removes the guard so that all the OSes will do the same. I believe this was introduced because AIX did not return `EISDIR` if it is a directory during read. If it is an over-optimization for other OSes, this commit can be removed.

3. A test to make sure that reading a directory fails with `EISDIR`