### PR TITLE
aix: don't EISDIR on read from directory fd

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -265,18 +265,6 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
   unsigned int iovmax;
   ssize_t result;
 
-#if defined(_AIX)
-  struct stat buf;
-  result = fstat(req->file, &buf);
-  if (result)
-    goto done;
-  if (S_ISDIR(buf.st_mode)) {
-    errno = EISDIR;
-    result -1;
-    goto done;
-  }
-#endif /* defined(_AIX) */
-
   iovmax = uv__getiovmax();
   if (req->nbufs > iovmax)
     req->nbufs = iovmax;


### PR DESCRIPTION
Remove the artificial EISDIR that was generated when trying to
uv_fs_read() from a file descriptor that refers to a directory.

We don't do that on the BSDs either (where reading from a directory
is allowed) and it introduces an extra stat() call for every read.

Refs: https://github.com/libuv/libuv/pull/2023#issuecomment-427759265