### PR TITLE
win: Redefine NSIG to consider SIGWINCH

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -87,11 +87,11 @@ typedef struct pollfd {
 #define SIGWINCH             28
 
 /* Redefine NSIG to take SIGWINCH into consideration */
-#if defined(NSIG) && NSIG < 29
+#if defined(NSIG) && NSIG <= SIGWINCH
 # undef NSIG
 #endif
 #ifndef NSIG
-# define NSIG 29
+# define NSIG SIGWINCH + 1
 #endif
 
 /* The CRT defines SIGABRT_COMPAT as 6, which equals SIGABRT on many unix-like

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -86,6 +86,14 @@ typedef struct pollfd {
 #define SIGKILL               9
 #define SIGWINCH             28
 
+/* Redefine NSIG to take SIGWINCH into consideration */
+#if defined(NSIG) && NSIG < 29
+# undef NSIG
+#endif
+#ifndef NSIG
+# define NSIG 29
+#endif
+
 /* The CRT defines SIGABRT_COMPAT as 6, which equals SIGABRT on many unix-like
  * platforms. However MinGW doesn't define it, so we do. */
 #ifndef SIGABRT_COMPAT

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -190,7 +190,7 @@ int uv__signal_start(uv_signal_t* handle,
                             int signum,
                             int oneshot) {
   /* Test for invalid signal values. */
-  if (signum != SIGWINCH && (signum <= 0 || signum >= NSIG))
+  if (signum <= 0 || signum >= NSIG)
     return UV_EINVAL;
 
   /* Short circuit: if the signal watcher is already watching {signum} don't go


### PR DESCRIPTION
Since SIGWINCH is being defined with a value above the existing NSIG,
redefine NSIG on WIN32.

Not a large change, but one less thing to have to consider in signal-centric
conditionals.