### PR TITLE
libuv: expose broadcast address on interfaces

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -154,6 +154,9 @@ Data types
                 struct sockaddr_in netmask4;
                 struct sockaddr_in6 netmask6;
             } netmask;
+            union {
+                struct sockaddr_in broadcast4;
+            } broadcast;
         } uv_interface_address_t;
 
 .. c:type:: uv_passwd_t

--- a/include/uv.h
+++ b/include/uv.h
@@ -1178,6 +1178,11 @@ struct uv_cpu_info_s {
   struct uv_cpu_times_s cpu_times;
 };
 
+/*
+ * IPv6 doesn't support broadcast but this is the closest thing
+ */
+#define UV_IN6ADDR_ALLHOSTS_GROUP	{ { { 0xff,2,0,0,0,0,0,0,0,0,0,0,0,0,0,1 } } }
+
 struct uv_interface_address_s {
   char* name;
   char phys_addr[6];
@@ -1190,6 +1195,9 @@ struct uv_interface_address_s {
     struct sockaddr_in netmask4;
     struct sockaddr_in6 netmask6;
   } netmask;
+  union {
+    struct sockaddr_in broadcast4;
+  } broadcast;
 };
 
 struct uv_passwd_s {

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1219,6 +1219,9 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       address->netmask.netmask4 = *((struct sockaddr_in*) &p->ifr_addr);
       /* Explicitly set family as the ioctl call appears to return it as 0. */
       address->netmask.netmask4.sin_family = AF_INET;
+
+      if ((flg.ifr_flags & IFF_BROADCAST) != 0 && p->ifr_broadaddr != NULL)
+	address->broadcast.broadcast4 = *((struct sockaddr_in*) &p->ifr_broadaddr);
     }
 
     address->is_internal = flg.ifr_flags & IFF_LOOPBACK ? 1 : 0;

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -121,6 +121,11 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       address->netmask.netmask4 = *((struct sockaddr_in*) ent->ifa_netmask);
     }
 
+    if ((ent->ifa_flags & IFF_BROADCAST) != 0 && ent->ifa_broadaddr != NULL) {
+      if (ent->ifa_broadaddr->sa_family == AF_INET)
+        address->broadcast.broadcast4 = *((struct sockaddr_in*) ent->ifa_broadaddr);
+    }
+
     address->is_internal = !!(ent->ifa_flags & IFF_LOOPBACK);
 
     address++;

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -621,6 +621,11 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       address->netmask.netmask4 = *((struct sockaddr_in*) ent->ifa_netmask);
     }
 
+    if (ent->ifa_flags & IFF_BROADCAST && ent->ifa_broadaddr != NULL) {
+      if (ent->ifa_broadaddr->sa_family == AF_INET)
+        address->broadcast.broadcast4 = *((struct sockaddr_in*) ent->ifa_broadaddr);
+    }
+
     address->is_internal = !!(ent->ifa_flags & IFF_LOOPBACK);
 
     address++;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -842,6 +842,11 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       address->netmask.netmask4 = *((struct sockaddr_in*) ent->ifa_netmask);
     }
 
+    if (ent->ifa_flags & IFF_BROADCAST && ent->ifa_broadaddr != NULL) {
+      if (ent->ifa_broadaddr->sa_family == AF_INET)
+        address->broadcast.broadcast4 = *((struct sockaddr_in*) ent->ifa_broadaddr);
+    }
+
     address->is_internal = !!((ent->ifa_flags & IFF_PRIVATE) ||
                            (ent->ifa_flags & IFF_LOOPBACK));
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -974,6 +974,15 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
         uv_address->netmask.netmask4.sin_family = AF_INET;
         uv_address->netmask.netmask4.sin_addr.s_addr = (prefix_len > 0) ?
             htonl(0xffffffff << (32 - prefix_len)) : 0;
+
+        /*
+         * This assumes contiguous bits in the netmask, which is asserted
+	 * in the calculation of the netmask above.
+         */
+        uv_address->broadcast.broadcast4.sin_family = AF_INET;
+        uv_address->broadcast.broadcast4.sin_addr.s_addr =
+             uv_address->address.address4.sin_addr.s_addr |
+            ~uv_address->netmask.netmask4.sin_addr.s_addr;
       }
 
       uv_address++;

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -143,6 +143,13 @@ TEST_IMPL(platform_output) {
     } else {
       printf("  netmask: none\n");
     }
+
+    if (interfaces[i].broadcast.broadcast4.sin_family == AF_INET) {
+      uv_ip4_name(&interfaces[i].broadcast.broadcast4, buffer, sizeof(buffer));
+      printf("  broadcast: %s\n", buffer);
+    } else {
+      printf("  broadcast: none\n");
+    }
   }
   uv_free_interface_addresses(interfaces, count);
 


### PR DESCRIPTION
Not using the correct broadcast address in applications can cause
disasterous results. Rather than letting the programmer guess at
the broadcast address and try to derive it correctly, allow him to
query the system instead for the correctly configured state.

This addresses compliance per Host Requirements, "Broadcasts"
(RFC-1122, Section 3.3.6).