### PR TITLE
unix: restore skipping of phys_addr copy

### DIFF
--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -119,14 +119,19 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       continue;
 
     address = *addresses;
-    memset(address->phys_addr, 0, sizeof(address->phys_addr));
 
     for (i = 0; i < *count; i++) {
+#if defined(__CYGWIN__) || defined(__MSYS__)
+      memset(address->phys_addr, 0, sizeof(address->phys_addr));
+#else
       if (strcmp(address->name, ent->ifa_name) == 0) {
         struct sockaddr_dl* sa_addr;
         sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
         memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
+      } else {
+        memset(address->phys_addr, 0, sizeof(address->phys_addr));
       }
+#endif
       address++;
     }
   }

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -890,12 +890,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses,
       continue;
 
     address = *addresses;
-    memset(address->phys_addr, 0, sizeof(address->phys_addr));
 
     for (i = 0; i < (*count); i++) {
       if (strcmp(address->name, ent->ifa_name) == 0) {
         sll = (struct sockaddr_ll*)ent->ifa_addr;
         memcpy(address->phys_addr, sll->sll_addr, sizeof(address->phys_addr));
+      } else {
+        memset(address->phys_addr, 0, sizeof(address->phys_addr));
       }
       address++;
     }


### PR DESCRIPTION
Prior to https://github.com/libuv/libuv/pull/1999, `uv_interface_addresses()` did not populate the `phys_addr` field on Cygwin or MinGW. This commit restores that behavior, which was mistakenly changed.

Fixes: https://github.com/libuv/libuv/issues/2034

EDIT: Passing CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1063/