### PR TITLE
win,spawn: add .attribute_list property for uv_spawn

### DIFF
--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -34,6 +34,7 @@ Data types
             uv_gid_t gid;
             char* cpumask;
             size_t cpumask_size;
+            void *attribute_list;
         } uv_process_options_t;
 
 .. c:type:: void (*uv_exit_cb)(uv_process_t*, int64_t exit_status, int term_signal)
@@ -193,6 +194,17 @@ Public members
 
         If enabled on an unsupported platform, :c:func:`uv_spawn` will fail
         with ``UV_ENOTSUP``.
+
+    .. versionadded:: 2.0.0
+
+.. c:member:: uv_process_options_t.attribute_list
+
+    Represents a set of attributes that passed with STARTUPINFOEXW
+    on Windows.
+
+    .. note::
+        This is not supported on *nix, :c:func:`uv_spawn` will fail and set the error
+        to ``UV_ENOTSUP`` if this property is anything but ``NULL``.
 
     .. versionadded:: 2.0.0
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1000,6 +1000,12 @@ typedef struct uv_process_options_s {
    */
   char* cpumask;
   size_t cpumask_size;
+  /*
+   * Represents a set of attributes that passed with STARTUPINFOEXW
+   * on Windows. This is not supported on unix; uv_spawn() will fail
+   * and set the error to UV_ENOTSUP.
+  */
+  void *attribute_list;
 } uv_process_options_t;
 
 /*

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -471,6 +471,10 @@ int uv_spawn(uv_loop_t* loop,
 #endif
   }
 
+  if (options->attribute_list != NULL) {
+    return UV_ENOTSUP;
+  }
+
   assert(options->file != NULL);
   assert(!(options->flags & ~(UV_PROCESS_DETACHED |
                               UV_PROCESS_SETGID |


### PR DESCRIPTION
Sometimes we need to pass extended attributes to child processes on Windows.
For example, to pass AppContainer attributes.
See: https://github.com/MalwareTech/AppContainerSandbox/blob/master/ContainerCreate.cpp#L85

To do this we need additional field of unknown type: `attribute_list`.

This PR:
1. adds `attribute_list` to `uv_process_options_s` struct.
2. changes `startup` var from `STARTUPINFOW` to `STARTUPINFOEXW`.