### PR TITLE
win, tcp: avoid starving the loop

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -945,6 +945,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
     uv_req_t* req) {
   DWORD bytes, flags, err;
   uv_buf_t buf;
+  int count;
 
   assert(handle->type == UV_TCP);
 
@@ -999,7 +1000,8 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
     }
 
     /* Do nonblocking reads until the buffer is empty */
-    while (handle->flags & UV_HANDLE_READING) {
+    count = 32;
+    while (handle->flags & UV_HANDLE_READING && count-- > 0) {
       buf = uv_buf_init(NULL, 0);
       handle->alloc_cb((uv_handle_t*) handle, 65536, &buf);
       if (buf.base == NULL || buf.len == 0) {

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1001,7 +1001,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
 
     /* Do nonblocking reads until the buffer is empty */
     count = 32;
-    while (handle->flags & UV_HANDLE_READING && count-- > 0) {
+    while ((handle->flags & UV_HANDLE_READING) && (count-- > 0)) {
       buf = uv_buf_init(NULL, 0);
       handle->alloc_cb((uv_handle_t*) handle, 65536, &buf);
       if (buf.base == NULL || buf.len == 0) {


### PR DESCRIPTION
Limit the time a TCP read callback can be called on a single loop iteration to 32.

Ref: https://github.com/libuv/libuv/commit/738b31eb3aff440ae75ff9f32ba61086a948c3f4
Fixes: https://github.com/libuv/libuv/issues/2027