### PR TITLE
 test,unix: fix race in test runner

### DIFF
--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -340,6 +340,7 @@ HELPER_IMPL(tcp4_echo_server) {
   if (tcp4_echo_start(TEST_PORT))
     return 1;
 
+  notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
   return 0;
 }
@@ -351,6 +352,7 @@ HELPER_IMPL(tcp6_echo_server) {
   if (tcp6_echo_start(TEST_PORT))
     return 1;
 
+  notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
   return 0;
 }
@@ -362,6 +364,7 @@ HELPER_IMPL(pipe_echo_server) {
   if (pipe_echo_start(TEST_PIPENAME))
     return 1;
 
+  notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
   return 0;
 }
@@ -373,6 +376,7 @@ HELPER_IMPL(udp4_echo_server) {
   if (udp4_echo_start(TEST_PORT))
     return 1;
 
+  notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
   return 0;
 }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -109,20 +109,24 @@ static int maybe_run_test(int argc, char **argv) {
   }
 
   if (strcmp(argv[1], "spawn_helper1") == 0) {
+    notify_parent_process();
     return 1;
   }
 
   if (strcmp(argv[1], "spawn_helper2") == 0) {
+    notify_parent_process();
     printf("hello world\n");
     return 1;
   }
 
   if (strcmp(argv[1], "spawn_tcp_server_helper") == 0) {
+    notify_parent_process();
     return spawn_tcp_server_helper();
   }
 
   if (strcmp(argv[1], "spawn_helper3") == 0) {
     char buffer[256];
+    notify_parent_process();
     ASSERT(buffer == fgets(buffer, sizeof(buffer) - 1, stdin));
     buffer[sizeof(buffer) - 1] = '\0';
     fputs(buffer, stdout);
@@ -130,12 +134,14 @@ static int maybe_run_test(int argc, char **argv) {
   }
 
   if (strcmp(argv[1], "spawn_helper4") == 0) {
+    notify_parent_process();
     /* Never surrender, never return! */
     while (1) uv_sleep(10000);
   }
 
   if (strcmp(argv[1], "spawn_helper5") == 0) {
     const char out[] = "fourth stdio!\n";
+    notify_parent_process();
 #ifdef _WIN32
     DWORD bytes;
     WriteFile((HANDLE) _get_osfhandle(3), out, sizeof(out) - 1, &bytes, NULL);
@@ -156,6 +162,8 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper6") == 0) {
     int r;
 
+    notify_parent_process();
+
     r = fprintf(stdout, "hello world\n");
     ASSERT(r > 0);
 
@@ -168,6 +176,9 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper7") == 0) {
     int r;
     char *test;
+
+    notify_parent_process();
+
     /* Test if the test value from the parent is still set */
     test = getenv("ENV_TEST");
     ASSERT(test != NULL);
@@ -181,6 +192,8 @@ static int maybe_run_test(int argc, char **argv) {
 #ifndef _WIN32
   if (strcmp(argv[1], "spawn_helper8") == 0) {
     int fd;
+
+    notify_parent_process();
     ASSERT(sizeof(fd) == read(0, &fd, sizeof(fd)));
     ASSERT(fd > 2);
     ASSERT(-1 == write(fd, "x", 1));
@@ -190,6 +203,7 @@ static int maybe_run_test(int argc, char **argv) {
 #endif  /* !_WIN32 */
 
   if (strcmp(argv[1], "spawn_helper9") == 0) {
+    notify_parent_process();
     return spawn_stdin_stdout();
   }
 
@@ -200,6 +214,7 @@ static int maybe_run_test(int argc, char **argv) {
 
     ASSERT(uid == getuid());
     ASSERT(gid == getgid());
+    notify_parent_process();
 
     return 1;
   }

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -40,6 +40,7 @@
 #include <sys/time.h>
 #include <pthread.h>
 
+extern char** environ;
 
 /* Do platform-specific initialization. */
 int platform_init(int argc, char **argv) {
@@ -107,8 +108,8 @@ int process_start(char* name, char* part, process_info_t* p, int is_helper) {
     /* child */
     dup2(stdout_fd, STDOUT_FILENO);
     dup2(stdout_fd, STDERR_FILENO);
-    execvp(args[0], args);
-    perror("execvp()");
+    execve(args[0], args, environ);
+    perror("execve()");
     _exit(127);
   }
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -76,6 +76,11 @@ int process_start(char *name, char *part, process_info_t *p, int is_helper) {
   PROCESS_INFORMATION pi;
   DWORD result;
 
+  if (!is_helper) {
+    /* Give the helpers time to settle. Race-y, fix this. */
+    uv_sleep(250);
+  }
+
   if (GetTempPathW(sizeof(path) / sizeof(WCHAR), (WCHAR*)&path) == 0)
     goto error;
   if (GetTempFileNameW((WCHAR*)&path, L"uv", 0, (WCHAR*)&filename) == 0)

--- a/test/runner.c
+++ b/test/runner.c
@@ -215,9 +215,6 @@ int run_test(const char* test,
     process_count++;
   }
 
-  /* Give the helpers time to settle. Race-y, fix this. */
-  uv_sleep(250);
-
   /* Now start the test itself. */
   for (task = TASKS; task->main; task++) {
     if (strcmp(test, task->task_name) != 0) {

--- a/test/task.h
+++ b/test/task.h
@@ -181,6 +181,12 @@ extern int snprintf(char*, size_t, const char*, ...);
 # define UNUSED
 #endif
 
+#if defined(_WIN32)
+#define notify_parent_process() ((void) 0)
+#else
+extern void notify_parent_process(void);
+#endif
+
 /* Fully close a loop */
 static void close_walk_cb(uv_handle_t* handle, void* arg) {
   if (!uv_is_closing(handle))

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -150,6 +150,7 @@ int ipc_helper_heavy_traffic_deadlock_bug(void) {
   r = uv_pipe_open(&pipe, 0);
   ASSERT(r == 0);
 
+  notify_parent_process();
   do_writes_and_reads((uv_stream_t*) &pipe);
   uv_sleep(100);
 

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -397,6 +397,7 @@ int run_ipc_send_recv_helper(uv_loop_t* loop, int inprocess) {
     send_recv_start();
   }
 
+  notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -724,6 +724,7 @@ int ipc_helper(int listen_after_write) {
     ASSERT(r == 0);
   }
 
+  notify_parent_process();
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
 

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -232,6 +232,7 @@ int stdio_over_pipes_helper(void) {
     ASSERT(r == 0);
   }
 
+  notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(after_write_called == 7);


### PR DESCRIPTION
The test runner inserted a 250 ms delay to give helper processes time to
settle. That's intrinsically race-y and caused tests to intermittently
fail on platforms like AIX.

Instead of a fixed delay, pass a file descriptor to the helper process
and wait until it closes the descriptor. That way we know for sure the
process has started.

Incidentally, this change reduces the running time of the test suite
from 112 to 26 seconds on my machine.

Fixes: #2041

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1086/