### PR TITLE
warnings: fix code that emits compiler warnings

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -152,7 +152,7 @@ int uv__next_timeout(const uv_loop_t* loop) {
   if (diff > INT_MAX)
     diff = INT_MAX;
 
-  return diff;
+  return (int) diff;
 }
 
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -71,6 +71,10 @@
 # include <utime.h>
 #endif
 
+#if defined(_AIX) && _XOPEN_SOURCE <= 600
+extern char *mkdtemp(char *template); /* See issue #740 on AIX < 7 */
+#endif
+
 #define INIT(subtype)                                                         \
   do {                                                                        \
     if (req == NULL)                                                          \
@@ -723,7 +727,7 @@ static ssize_t uv__fs_utime(uv_fs_t* req) {
   atr.att_atimechg = 1;
   atr.att_mtime = req->mtime;
   atr.att_atime = req->atime;
-  return __lchattr(req->path, &atr, sizeof(atr));
+  return __lchattr((char*) req->path, &atr, sizeof(atr));
 #else
   errno = ENOSYS;
   return -1;

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -229,8 +229,8 @@ static int getexe(const int pid, char* buf, size_t len) {
   assert(((Output_buf.Output_data.offsetPath >>24) & 0xFF) == 'A');
 
   /* Get the offset from the lowest 3 bytes */
-  Output_path = (char*)(&Output_buf) +
-                (Output_buf.Output_data.offsetPath & 0x00FFFFFF);
+  Output_path = (struct Output_path_type*) ((char*) (&Output_buf) +
+      (Output_buf.Output_data.offsetPath & 0x00FFFFFF));
 
   if (Output_path->len >= len) {
     errno = ENOBUFS;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -707,13 +707,14 @@ static int uv__set_phys_addr(uv_interface_address_t* address,
 
   struct sockaddr_dl* sa_addr;
   int sockfd;
-  int i;
+  size_t i;
   struct arpreq arpreq;
 
   /* This appears to only work as root */
   sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
   memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
   for (i = 0; i < sizeof(address->phys_addr); i++) {
+    /* Check that all bytes of phys_addr are zero. */
     if (address->phys_addr[i] != 0)
       return 0;
   }

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -3,11 +3,11 @@
 const char* uv_handle_type_name(uv_handle_type type) {
   switch (type) {
 #define XX(uc,lc) case UV_##uc: return #lc;
-    UV_HANDLE_TYPE_MAP(XX)
+  UV_HANDLE_TYPE_MAP(XX)
 #undef XX
-    case UV_FILE: return "file";
-    case UV_HANDLE_TYPE_MAX:
-    case UV_UNKNOWN_HANDLE: return NULL;
+  case UV_FILE: return "file";
+  case UV_HANDLE_TYPE_MAX:
+  case UV_UNKNOWN_HANDLE: return NULL;
   }
   return NULL;
 }
@@ -31,10 +31,12 @@ void uv_handle_set_data(uv_handle_t* handle, void* data) {
 const char* uv_req_type_name(uv_req_type type) {
   switch (type) {
 #define XX(uc,lc) case UV_##uc: return #lc;
-    UV_REQ_TYPE_MAP(XX)
+  UV_REQ_TYPE_MAP(XX)
 #undef XX
-    case UV_REQ_TYPE_MAX:
-    case UV_UNKNOWN_REQ: return NULL;
+  case UV_REQ_TYPE_MAX:
+  case UV_UNKNOWN_REQ:
+  default: /* UV_REQ_TYPE_PRIVATE */
+     return NULL;
   }
   return NULL;
 }

--- a/src/win/dl.c
+++ b/src/win/dl.c
@@ -64,7 +64,8 @@ void uv_dlclose(uv_lib_t* lib) {
 
 
 int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr) {
-  *ptr = (void*) GetProcAddress(lib->handle, name);
+  /* Cast though integer to suppress pedantic warning about forbidden cast. */
+  *ptr = (void*)(uintptr_t) GetProcAddress(lib->handle, name);
   return uv__dlerror(lib, "", *ptr ? 0 : GetLastError());
 }
 
@@ -75,8 +76,9 @@ const char* uv_dlerror(const uv_lib_t* lib) {
 
 
 static void uv__format_fallback_error(uv_lib_t* lib, int errorno){
-  DWORD_PTR args[1] = { (DWORD_PTR) errorno };
-  LPSTR fallback_error = "error: %1!d!";
+  static const CHAR fallback_error[] = "error: %1!d!";
+  DWORD_PTR args[1];
+  args[0] = (DWORD_PTR) errorno;
 
   FormatMessageA(FORMAT_MESSAGE_FROM_STRING |
                  FORMAT_MESSAGE_ARGUMENT_ARRAY |

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -215,11 +215,11 @@ int uv_fs_event_start(uv_fs_event_t* handle,
         uv__free(long_path);
         long_path = NULL;
       }
-    }
 
-    if (long_path) {
-      uv__free(pathw);
-      pathw = long_path;
+      if (long_path) {
+        uv__free(pathw);
+        pathw = long_path;
+      }
     }
 
     dir_to_watch = pathw;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -98,14 +98,17 @@
     return;                                                                 \
   }
 
+#define MILLIONu (1000U * 1000U)
+#define BILLIONu (1000U * 1000U * 1000U)
+
 #define FILETIME_TO_UINT(filetime)                                          \
-   (*((uint64_t*) &(filetime)) - 116444736000000000ULL)
+   (*((uint64_t*) &(filetime)) - (uint64_t) 116444736 * BILLIONu)
 
 #define FILETIME_TO_TIME_T(filetime)                                        \
-   (FILETIME_TO_UINT(filetime) / 10000000ULL)
+   (FILETIME_TO_UINT(filetime) / (10u * MILLIONu))
 
 #define FILETIME_TO_TIME_NS(filetime, secs)                                 \
-   ((FILETIME_TO_UINT(filetime) - (secs * 10000000ULL)) * 100)
+   ((FILETIME_TO_UINT(filetime) - (secs * (uint64_t) 10 * MILLIONu)) * 100U)
 
 #define FILETIME_TO_TIMESPEC(ts, filetime)                                  \
    do {                                                                     \
@@ -115,8 +118,8 @@
 
 #define TIME_T_TO_FILETIME(time, filetime_ptr)                              \
   do {                                                                      \
-    uint64_t bigtime = ((uint64_t) ((time) * 10000000ULL)) +                \
-                                  116444736000000000ULL;                    \
+    uint64_t bigtime = ((uint64_t) ((time) * (uint64_t) 10 * MILLIONu)) +   \
+                       (uint64_t) 116444736 * BILLIONu;                     \
     (filetime_ptr)->dwLowDateTime = bigtime & 0xFFFFFFFF;                   \
     (filetime_ptr)->dwHighDateTime = bigtime >> 32;                         \
   } while(0)
@@ -788,9 +791,8 @@ void fs__unlink(uv_fs_t* req) {
     /* Remove read-only attribute */
     FILE_BASIC_INFORMATION basic = { 0 };
 
-    basic.FileAttributes = info.dwFileAttributes
-                           & ~(FILE_ATTRIBUTE_READONLY)
-                           | FILE_ATTRIBUTE_ARCHIVE;
+    basic.FileAttributes = (info.dwFileAttributes & ~FILE_ATTRIBUTE_READONLY) |
+                           FILE_ATTRIBUTE_ARCHIVE;
 
     status = pNtSetInformationFile(handle,
                                    &iosb,
@@ -1201,7 +1203,7 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf,
 
   /* st_blocks contains the on-disk allocation size in 512-byte units. */
   statbuf->st_blocks =
-      file_info.StandardInformation.AllocationSize.QuadPart >> 9ULL;
+      (uint64_t) file_info.StandardInformation.AllocationSize.QuadPart >> 9;
 
   statbuf->st_nlink = file_info.StandardInformation.NumberOfLinks;
 
@@ -1958,7 +1960,7 @@ static void fs__readlink(uv_fs_t* req) {
 }
 
 
-static size_t fs__realpath_handle(HANDLE handle, char** realpath_ptr) {
+static ssize_t fs__realpath_handle(HANDLE handle, char** realpath_ptr) {
   int r;
   DWORD w_realpath_len;
   WCHAR* w_realpath_ptr = NULL;

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1541,7 +1541,7 @@ int uv__pipe_write_ipc(uv_loop_t* loop,
         frame_header.flags |= UV__IPC_FRAME_HAS_SOCKET_XFER;
         break;
       default:
-        assert(0);  // Unreachable.
+        assert(0);  /* Unreachable. */
     }
     /* Add xfer info buffer. */
     bufs[buf_index++] = uv_buf_init((char*) &xfer_info, sizeof xfer_info);
@@ -2141,7 +2141,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
   if (pipe->ipc) {
     assert(!(pipe->flags & UV_HANDLE_NON_OVERLAPPED_PIPE));
     pipe->pipe.conn.ipc_remote_pid = uv_os_getppid();
-    assert(pipe->pipe.conn.ipc_remote_pid != -1);
+    assert(pipe->pipe.conn.ipc_remote_pid != (DWORD) -1);
   }
   return 0;
 }
@@ -2312,7 +2312,7 @@ uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle) {
 }
 
 int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
-  SID_IDENTIFIER_AUTHORITY sid_world = SECURITY_WORLD_SID_AUTHORITY;
+  SID_IDENTIFIER_AUTHORITY sid_world = { SECURITY_WORLD_SID_AUTHORITY };
   PACL old_dacl, new_dacl;
   PSECURITY_DESCRIPTOR sd;
   EXPLICIT_ACCESS ea;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -75,7 +75,7 @@ static AFD_POLL_INFO* uv__get_afd_poll_info_dummy(void) {
 static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
   uv_req_t* req;
   AFD_POLL_INFO* afd_poll_info;
-  DWORD result;
+  int result;
 
   /* Find a yet unsubmitted req to submit. */
   if (handle->submitted_events_1 == 0) {
@@ -136,7 +136,7 @@ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
 
 static int uv__fast_poll_cancel_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
   AFD_POLL_INFO afd_poll_info;
-  DWORD result;
+  int result;
 
   afd_poll_info.Exclusive = TRUE;
   afd_poll_info.NumberOfHandles = 1;

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -739,7 +739,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
     }
   }
   *ptr_copy = NULL;
-  assert(env_len == ptr - dst_copy);
+  assert(env_len == (size_t) (ptr - dst_copy));
 
   /* sort our (UTF-16) copy */
   qsort(env_copy, env_block_count-1, sizeof(wchar_t*), qsort_wcscmp);
@@ -799,7 +799,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
         var_size = GetEnvironmentVariableW(required_vars[i].wide,
                                            ptr,
                                            (int) (env_len - (ptr - dst)));
-        if (var_size != len-1) { /* race condition? */
+        if (var_size != (DWORD) (len - 1)) { /* TODO: handle race condition? */
           uv_fatal_error(GetLastError(), "GetEnvironmentVariableW");
         }
       }
@@ -815,7 +815,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   }
 
   /* Terminate with an extra NULL. */
-  assert(env_len == (ptr - dst));
+  assert(env_len == (size_t) (ptr - dst));
   *ptr = L'\0';
 
   uv__free(dst_copy);

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -791,8 +791,9 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
         if (KEV.uChar.UnicodeChar >= 0xDC00 &&
             KEV.uChar.UnicodeChar < 0xE000) {
           /* UTF-16 surrogate pair */
-          WCHAR utf16_buffer[2] = { handle->tty.rd.last_utf16_high_surrogate,
-                                    KEV.uChar.UnicodeChar};
+          WCHAR utf16_buffer[2];
+          utf16_buffer[0] = handle->tty.rd.last_utf16_high_surrogate;
+          utf16_buffer[1] = KEV.uChar.UnicodeChar;
           char_len = WideCharToMultiByte(CP_UTF8,
                                          0,
                                          utf16_buffer,

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4109,6 +4109,9 @@
 #endif
 
 /* from winternl.h */
+#if !defined(__UNICODE_STRING_DEFINED) && defined(__MINGW32_)
+#define __UNICODE_STRING_DEFINED
+#endif
 typedef struct _UNICODE_STRING {
   USHORT Length;
   USHORT MaximumLength;

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -142,11 +142,11 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper5") == 0) {
     const char out[] = "fourth stdio!\n";
     notify_parent_process();
-#ifdef _WIN32
-    DWORD bytes;
-    WriteFile((HANDLE) _get_osfhandle(3), out, sizeof(out) - 1, &bytes, NULL);
-#else
     {
+#ifdef _WIN32
+      DWORD bytes;
+      WriteFile((HANDLE) _get_osfhandle(3), out, sizeof(out) - 1, &bytes, NULL);
+#else
       ssize_t r;
 
       do
@@ -154,8 +154,8 @@ static int maybe_run_test(int argc, char **argv) {
       while (r == -1 && errno == EINTR);
 
       fsync(3);
-    }
 #endif
+    }
     return 1;
   }
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -194,7 +194,7 @@ int process_wait(process_info_t *vec, int n, int timeout) {
 
   result = WaitForMultipleObjects(n, handles, TRUE, timeout_api);
 
-  if (result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + n) {
+  if (result < WAIT_OBJECT_0 + n) {
     /* All processes are terminated. */
     return 0;
   }
@@ -268,7 +268,8 @@ int process_read_last_line(process_info_t *p,
   if (!ReadFile(p->stdio_out, buffer, buffer_len - 1, &read, &overlapped))
     return -1;
 
-  for (start = read - 1; start >= 0; start--) {
+  start = read;
+  while (start-- > 0) {
     if (buffer[start] == '\n' || buffer[start] == '\r')
       break;
   }
@@ -308,7 +309,7 @@ void process_cleanup(process_info_t *p) {
 }
 
 
-static int clear_line() {
+static int clear_line(void) {
   HANDLE handle;
   CONSOLE_SCREEN_BUFFER_INFO info;
   COORD coord;

--- a/test/runner-win.h
+++ b/test/runner-win.h
@@ -20,7 +20,9 @@
  */
 
 /* Don't complain about write(), fileno() etc. being deprecated. */
+#ifdef _MSC_VER
 #pragma warning(disable : 4996)
+#endif
 
 
 #include <winsock2.h>

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -73,4 +73,8 @@ TEST_IMPL(close_fd) {
   return 0;
 }
 
-#endif  /* !defined(_WIN32) */
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -235,7 +235,7 @@ TEST_IMPL(condvar_5) {
   uint64_t elapsed;
   uint64_t timeout;
 
-  timeout = 100 * 1e6; /* 100 ms in ns */
+  timeout = 100 * 1000 * 1000; /* 100 ms in ns */
 
   /* Mostly irrelevant. We need cond and mutex initialized. */
   worker_config_init(&wc, 0, NULL, NULL);

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -38,6 +38,11 @@ static uv_tcp_t client_handle;
 
 
 TEST_IMPL(emfile) {
+  struct sockaddr_in addr;
+  struct rlimit limits;
+  uv_connect_t connect_req;
+  uv_loop_t* loop;
+  int first_fd;
 #if defined(_AIX) || defined(__MVS__)
   /* On AIX, if a 'accept' call fails ECONNRESET is set on the socket
    * which causes uv__emfile_trick to not work as intended and this test
@@ -45,11 +50,6 @@ TEST_IMPL(emfile) {
    */
   RETURN_SKIP("uv__emfile_trick does not work on this OS");
 #endif
-  struct sockaddr_in addr;
-  struct rlimit limits;
-  uv_connect_t connect_req;
-  uv_loop_t* loop;
-  int first_fd;
 
   /* Lower the file descriptor limit and use up all fds save one. */
   limits.rlim_cur = limits.rlim_max = maxfd + 1;
@@ -114,4 +114,8 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_close((uv_handle_t*) &client_handle, NULL);
 }
 
-#endif  /* !defined(_WIN32) */
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -676,5 +676,8 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
 }
 #endif /* !__MVS__ */
 
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
 
 #endif /* !_WIN32 */

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -154,7 +154,7 @@ int uv_test_getiovmax(void) {
 static unsigned REPARSE_TAG = 0x9913;
 static GUID REPARSE_GUID = {
   0x1bf6205f, 0x46ae, 0x4527,
-  0xb1, 0x0c, 0xc5, 0x09, 0xb7, 0x55, 0x22, 0x80 };
+  { 0xb1, 0x0c, 0xc5, 0x09, 0xb7, 0x55, 0x22, 0x80 }};
 #endif
 
 static void check_permission(const char* filename, unsigned int mode) {
@@ -2331,9 +2331,6 @@ TEST_IMPL(fs_stat_root) {
 
 
 TEST_IMPL(fs_futime) {
-#if defined(_AIX) && !defined(_AIX71)
-  RETURN_SKIP("futime is not implemented for AIX versions below 7.1");
-#else
   utime_check_t checkme;
   const char* path = "test_file";
   double atime;
@@ -2341,6 +2338,9 @@ TEST_IMPL(fs_futime) {
   uv_file file;
   uv_fs_t req;
   int r;
+#if defined(_AIX) && !defined(_AIX71)
+  RETURN_SKIP("futime is not implemented for AIX versions below 7.1");
+#endif
 
   /* Setup. */
   loop = uv_default_loop();
@@ -2402,7 +2402,6 @@ TEST_IMPL(fs_futime) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
-#endif
 }
 
 

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -83,7 +83,7 @@ TEST_IMPL(ip6_addr_link_local) {
     ASSERT(0 == r);
 #ifdef _WIN32
     /* On Windows, the interface identifier is the numeric string of the index. */
-    ASSERT(strtol(interface_id, NULL, 10) == iface_index);
+    ASSERT(strtoul(interface_id, NULL, 10) == iface_index);
 #else
     /* On Unix/Linux, the interface identifier is the interface device name. */
     ASSERT(0 == strcmp(device_name, interface_id));

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -105,4 +105,8 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
   return 0;
 }
 
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
 #endif /* ifndef _WIN32 */

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -49,7 +49,7 @@ static void poll_cb(uv_poll_t* h, int status, int events) {
 }
 
 
-static void NO_INLINE close_socket_and_verify_stack() {
+static void NO_INLINE close_socket_and_verify_stack(void) {
   const uint32_t MARKER = 0xDEADBEEF;
   const int VERIFY_AFTER = 10; /* ms */
   int r;

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -202,4 +202,9 @@ TEST_IMPL(poll_oob) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
 #endif

--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -70,7 +70,7 @@ TEST_IMPL(process_title_threadsafe) {
 #if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__) || \
     defined(__MVS__)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
-#else
+#endif
 
   ASSERT(0 == uv_set_process_title(titles[0]));
   ASSERT(0 == uv_thread_create(&getter_thread, getter_thread_body, NULL));
@@ -82,5 +82,4 @@ TEST_IMPL(process_title_threadsafe) {
     ASSERT(0 == uv_thread_join(&setter_threads[i]));
 
   return 0;
-#endif
 }

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -62,7 +62,8 @@ static void uv_get_process_title_edge_cases(void) {
 TEST_IMPL(process_title) {
 #if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
-#else
+#endif
+
   /* Check for format string vulnerabilities. */
   set_title("%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s");
   set_title("new title");
@@ -71,5 +72,4 @@ TEST_IMPL(process_title) {
   uv_get_process_title_edge_cases();
 
   return 0;
-#endif
 }

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -295,4 +295,8 @@ TEST_IMPL(signal_multiple_loops) {
   return 0;
 }
 
-#endif  /* !_WIN32 */
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -49,7 +49,9 @@ static char exepath[1024];
 static size_t exepath_size = 1024;
 static char* args[5];
 static int no_term_signal;
+#ifndef _WIN32
 static int timer_counter;
+#endif
 static uv_tcp_t tcp_server;
 
 #define OUTPUT_SIZE 1024
@@ -138,10 +140,12 @@ static void on_read(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 }
 
 
+#ifndef _WIN32
 static void on_read_once(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   uv_read_stop(tcp);
   on_read(tcp, nread, buf);
 }
+#endif
 
 
 static void write_cb(uv_write_t* req, int status) {
@@ -173,9 +177,11 @@ static void timer_cb(uv_timer_t* handle) {
 }
 
 
+#ifndef _WIN32
 static void timer_counter_cb(uv_timer_t* handle) {
   ++timer_counter;
 }
+#endif
 
 
 TEST_IMPL(spawn_fails) {
@@ -1198,7 +1204,7 @@ TEST_IMPL(argument_escaping) {
 int make_program_env(char** env_block, WCHAR** dst_ptr);
 
 TEST_IMPL(environment_creation) {
-  int i;
+  size_t i;
   char* environment[] = {
     "FOO=BAR",
     "SYSTEM=ROOT", /* substring of a supplied var name */

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -191,4 +191,8 @@ TEST_IMPL(tcp_close_accept) {
   return 0;
 }
 
-#endif  /* !_WIN32 */
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -138,4 +138,9 @@ TEST_IMPL(tcp_oob) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
-#endif
+
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -65,4 +65,8 @@ TEST_IMPL(tcp_write_after_connect) {
   return 0;
 }
 
-#endif
+#else
+
+typedef int file_has_no_tests; /* ISO C forbids an empty translation unit. */
+
+#endif /* !_WIN32 */

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -315,10 +315,8 @@ TEST_IMPL(tty_raw_cancel) {
   int r;
   int ttyin_fd;
   uv_tty_t tty_in;
-  uv_loop_t* loop;
   HANDLE handle;
 
-  loop = uv_default_loop();
   /* Make sure we have an FD that refers to a tty */
   handle = CreateFileA("conin$",
                        GENERIC_READ | GENERIC_WRITE,


### PR DESCRIPTION
Added `-Wno-long-long` on Windows to disable warning about ULL constants (in the filetime code). This flag was already being used for the test suite.

Not many real bugs were uncovered, but does make compilation a bit less noisy.