### PR TITLE
win, process: more fine-grain windows hiding

### DIFF
--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -70,11 +70,22 @@ Data types
             */
             UV_PROCESS_DETACHED = (1 << 3),
             /*
-            * Hide the subprocess console window that would normally be created. This
+            * Hide the subprocess window that would normally be created. This option is
+            * only meaningful on Windows systems. On Unix it is silently ignored.
+            */
+            UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+            /*
+            * Hide the subprocess console window that would normally be created. This 
             * option is only meaningful on Windows systems. On Unix it is silently
             * ignored.
             */
-            UV_PROCESS_WINDOWS_HIDE = (1 << 4)
+            UV_PROCESS_WINDOWS_HIDE_CONSOLE = (1 << 5),
+            /*
+            * Hide the subprocess GUI window that would normally be created. This 
+            * option is only meaningful on Windows systems. On Unix it is silently
+            * ignored.
+            */
+            UV_PROCESS_WINDOWS_HIDE_GUI = (1 << 6)
         };
 
 .. c:type:: uv_stdio_container_t
@@ -216,6 +227,9 @@ API
     the file to execute not existing, not having permissions to use the setuid or
     setgid specified, or not having enough memory to allocate for the new
     process.
+
+    .. versionchanged:: 1.24.0 Added `UV_PROCESS_WINDOWS_HIDE_CONSOLE` and
+                        `UV_PROCESS_WINDOWS_HIDE_GUI` flags.
 
 .. c:function:: int uv_process_kill(uv_process_t* handle, int signum)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -963,11 +963,22 @@ enum uv_process_flags {
    */
   UV_PROCESS_DETACHED = (1 << 3),
   /*
-   * Hide the subprocess console window that would normally be created. This
+   * Hide the subprocess window that would normally be created. This option is
+   * only meaningful on Windows systems. On Unix it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+  /*
+   * Hide the subprocess console window that would normally be created. This 
    * option is only meaningful on Windows systems. On Unix it is silently
    * ignored.
    */
-  UV_PROCESS_WINDOWS_HIDE = (1 << 4)
+  UV_PROCESS_WINDOWS_HIDE_CONSOLE = (1 << 5),
+  /*
+   * Hide the subprocess GUI window that would normally be created. This 
+   * option is only meaningful on Windows systems. On Unix it is silently
+   * ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE_GUI = (1 << 6)
 };
 
 /*

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -964,6 +964,8 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_SETGID |
                               UV_PROCESS_SETUID |
                               UV_PROCESS_WINDOWS_HIDE |
+                              UV_PROCESS_WINDOWS_HIDE_CONSOLE |
+                              UV_PROCESS_WINDOWS_HIDE_GUI |
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
 
   err = uv_utf8_to_utf16_alloc(options->file, &application);
@@ -1065,7 +1067,8 @@ int uv_spawn(uv_loop_t* loop,
 
   process_flags = CREATE_UNICODE_ENVIRONMENT;
 
-  if (options->flags & UV_PROCESS_WINDOWS_HIDE) {
+  if ((options->flags & UV_PROCESS_WINDOWS_HIDE_CONSOLE) ||
+      (options->flags & UV_PROCESS_WINDOWS_HIDE)) {
     /* Avoid creating console window if stdio is not inherited. */
     for (i = 0; i < options->stdio_count; i++) {
       if (options->stdio[i].flags & UV_INHERIT_FD)
@@ -1073,7 +1076,9 @@ int uv_spawn(uv_loop_t* loop,
       if (i == options->stdio_count - 1)
         process_flags |= CREATE_NO_WINDOW;
     }
-
+  }
+  if ((options->flags & UV_PROCESS_WINDOWS_HIDE_GUI) ||
+      (options->flags & UV_PROCESS_WINDOWS_HIDE)) {
     /* Use SW_HIDE to avoid any potential process window. */
     startup.wShowWindow = SW_HIDE;
   } else {


### PR DESCRIPTION
Added `UV_PROCESS_WINDOWS_HIDE_CONSOLE` that only hides console windows and `UV_PROCESS_WINDOWS_HIDE_GUI` that only hides GUI windows. The `UV_PROCESS_WINDOWS_HIDE` flag works as before.

Ref: https://github.com/nodejs/node/pull/24034