### PR TITLE
thread,mingw64: need intrin.h header for SSE2 MemoryBarrier

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -23,6 +23,12 @@
 #include <limits.h>
 #include <stdlib.h>
 
+#if defined(__MINGW64_VERSION_MAJOR)
+/* MemoryBarrier expands to __mm_mfence in some cases (x86+sse2), which may
+ * require this header in some versions of mingw64. */
+#include <intrin.h>
+#endif
+
 #include "uv.h"
 #include "internal.h"
 


### PR DESCRIPTION
Appears to be needed for compile with `-msse2` (such as implied by `-march=pentium4`)
for the i686-w64-mingw64 target triple. This seems like a header mistake, but
we can work-around it here by including the header explicitly. (this call was added in #1634)