### PR TITLE
API: Pull up loop to uv_req_t.

### DIFF
--- a/docs/src/dns.rst
+++ b/docs/src/dns.rst
@@ -34,11 +34,6 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
-.. c:member:: uv_loop_t* uv_getaddrinfo_t.loop
-
-    Loop that started this getaddrinfo request and where completion will be
-    reported. Readonly.
-
 .. c:member:: struct addrinfo* uv_getaddrinfo_t.addrinfo
 
     Pointer to a `struct addrinfo` containing the result. Must be freed by the user

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -164,11 +164,6 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
-.. c:member:: uv_loop_t* uv_fs_t.loop
-
-    Loop that started this request and where completion will be reported.
-    Readonly.
-
 .. c:member:: uv_fs_type uv_fs_t.fs_type
 
     FS request type.

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -25,6 +25,14 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
+.. c:member:: uv_loop_t* uv_req_t.loop
+
+    Loop that started this request and where completion will be reported.
+    Readonly.
+    
+    .. versionadded:: 2.0.0
+       Moved from derived types (uv_connect_t, uv_fs_t, etc.) to uv_req_t.
+
 .. c:member:: void* uv_req_t.data
 
     Space for user-defined arbitrary data. libuv does not use this field.

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -97,6 +97,12 @@ API
     Returns the size of the given request type. Useful for FFI binding writers
     who don't want to know the structure layout.
 
+.. c:function:: uv_loop_t* uv_req_get_loop(const uv_req_t* req)
+
+    Returns `req->loop`.
+
+    .. versionadded:: 2.0.0
+
 .. c:function:: void* uv_req_get_data(const uv_req_t* req)
 
     Returns `req->data`.

--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -47,11 +47,6 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
-.. c:member:: uv_loop_t* uv_work_t.loop
-
-    Loop that started this request and where completion will be reported.
-    Readonly.
-
 .. seealso:: The :c:type:`uv_req_t` members also apply.
 
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -394,6 +394,7 @@ UV_EXTERN char* uv_err_name_r(int err, char* buf, size_t buflen);
   /* public */                                                                \
   void* data;                                                                 \
   /* read-only */                                                             \
+  uv_loop_t* loop;                                                            \
   uv_req_type type;                                                           \
   /* private */                                                               \
   void* reserved[6];                                                          \
@@ -925,7 +926,6 @@ UV_EXTERN uint64_t uv_timer_get_repeat(const uv_timer_t* handle);
 struct uv_getaddrinfo_s {
   UV_REQ_FIELDS
   /* read-only */
-  uv_loop_t* loop;
   /* struct addrinfo* addrinfo is marked as private, but it really isn't. */
   UV_GETADDRINFO_PRIVATE_FIELDS
 };
@@ -948,7 +948,6 @@ UV_EXTERN void uv_freeaddrinfo(struct addrinfo* ai);
 struct uv_getnameinfo_s {
   UV_REQ_FIELDS
   /* read-only */
-  uv_loop_t* loop;
   /* host and service are marked as private, but they really aren't. */
   UV_GETNAMEINFO_PRIVATE_FIELDS
 };
@@ -1121,7 +1120,6 @@ UV_EXTERN uv_pid_t uv_process_get_pid(const uv_process_t*);
  */
 struct uv_work_s {
   UV_REQ_FIELDS
-  uv_loop_t* loop;
   uv_work_cb work_cb;
   uv_after_work_cb after_work_cb;
   UV_WORK_PRIVATE_FIELDS
@@ -1361,7 +1359,6 @@ struct uv_dir_s {
 struct uv_fs_s {
   UV_REQ_FIELDS
   uv_fs_type fs_type;
-  uv_loop_t* loop;
   uv_fs_cb cb;
   ssize_t result;
   void* ptr;
@@ -1712,8 +1709,6 @@ UV_EXTERN int uv_inet_pton(int af, const char* src, void* dst);
 
 struct uv_random_s {
   UV_REQ_FIELDS
-  /* read-only */
-  uv_loop_t* loop;
   /* private */
   int status;
   void* buf;

--- a/include/uv.h
+++ b/include/uv.h
@@ -448,6 +448,7 @@ UV_EXTERN void uv_handle_set_data(uv_handle_t* handle, void* data);
 UV_EXTERN size_t uv_req_size(uv_req_type type);
 UV_EXTERN void* uv_req_get_data(const uv_req_t* req);
 UV_EXTERN void uv_req_set_data(uv_req_t* req, void* data);
+UV_EXTERN uv_loop_t* uv_req_get_loop(const uv_req_t* handle);
 UV_EXTERN uv_req_type uv_req_get_type(const uv_req_t* req);
 UV_EXTERN const char* uv_req_type_name(uv_req_type type);
 

--- a/src/random.c
+++ b/src/random.c
@@ -107,7 +107,6 @@ int uv_random(uv_loop_t* loop,
     return uv__random(buf, buflen);
 
   uv__req_init(loop, req, UV_RANDOM);
-  req->loop = loop;
   req->status = 0;
   req->cb = cb;
   req->buf = buf;

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -343,7 +343,6 @@ int uv_queue_work(uv_loop_t* loop,
     return UV_EINVAL;
 
   uv__req_init(loop, req, UV_WORK);
-  req->loop = loop;
   req->work_cb = work_cb;
   req->after_work_cb = after_work_cb;
   uv__work_submit(loop,

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -136,11 +136,10 @@ extern char *mkdtemp(char *template); /* See issue #740 on AIX < 7 */
   do {                                                                        \
     if (req == NULL)                                                          \
       return UV_EINVAL;                                                       \
-    UV_REQ_INIT(req, UV_FS);                                                  \
+    UV_REQ_INIT(loop, req, UV_FS);                                            \
     req->fs_type = UV_FS_ ## subtype;                                         \
     req->result = 0;                                                          \
     req->ptr = NULL;                                                          \
-    req->loop = loop;                                                         \
     req->path = NULL;                                                         \
     req->new_path = NULL;                                                     \
     req->bufs = NULL;                                                         \

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -181,7 +181,6 @@ int uv_getaddrinfo(uv_loop_t* loop,
     return UV_ENOMEM;
 
   uv__req_init(loop, req, UV_GETADDRINFO);
-  req->loop = loop;
   req->cb = cb;
   req->addrinfo = NULL;
   req->hints = NULL;

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -103,7 +103,6 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->getnameinfo_cb = getnameinfo_cb;
   req->flags = flags;
   req->type = UV_GETNAMEINFO;
-  req->loop = loop;
   req->retcode = 0;
 
   if (getnameinfo_cb) {

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -303,15 +303,17 @@ void uv__threadpool_cleanup(void);
  * a circular dependency between src/uv-common.h and src/win/internal.h.
  */
 #if defined(_WIN32)
-# define UV_REQ_INIT(req, typ)                                                \
+# define UV_REQ_INIT(loop_, req, typ)                                         \
   do {                                                                        \
+    (req)->loop = (loop_);                                                    \
     (req)->type = (typ);                                                      \
     (req)->u.io.overlapped.Internal = 0;  /* SET_REQ_SUCCESS() */             \
   }                                                                           \
   while (0)
 #else
-# define UV_REQ_INIT(req, typ)                                                \
+# define UV_REQ_INIT(loop_, req, typ)                                         \
   do {                                                                        \
+    (req)->loop = (loop_);                                                    \
     (req)->type = (typ);                                                      \
   }                                                                           \
   while (0)
@@ -319,7 +321,7 @@ void uv__threadpool_cleanup(void);
 
 #define uv__req_init(loop, req, typ)                                          \
   do {                                                                        \
-    UV_REQ_INIT(req, typ);                                                    \
+    UV_REQ_INIT(loop, req, typ);                                              \
     uv__req_register(loop, req);                                              \
   }                                                                           \
   while (0)

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -49,6 +49,10 @@ void* uv_req_get_data(const uv_req_t* req) {
   return req->data;
 }
 
+uv_loop_t* uv_req_get_loop(const uv_req_t* req) {
+  return req->loop;
+}
+
 void uv_req_set_data(uv_req_t* req, void* data) {
   req->data = data;
 }

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -144,7 +144,7 @@ int uv_loop_init(uv_loop_t* loop) {
   QUEUE_INIT(&loop->idle_handles);
 
   QUEUE_INIT(&loop->async_handles);
-  UV_REQ_INIT(&loop->async_req, UV_WAKEUP);
+  UV_REQ_INIT(loop, &loop->async_req, UV_WAKEUP);
 
   memset(&loop->poll_peer_sockets, 0, sizeof loop->poll_peer_sockets);
 

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -144,7 +144,7 @@ int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle) {
   handle->short_filew = NULL;
   handle->dirw = NULL;
 
-  UV_REQ_INIT(&handle->req, UV_FS_EVENT_REQ);
+  UV_REQ_INIT(loop, &handle->req, UV_FS_EVENT_REQ);
   handle->req.data = handle;
 
   return 0;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -278,8 +278,7 @@ INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
 INLINE static void uv_fs_req_init(uv_loop_t* loop, uv_fs_t* req,
     uv_fs_type fs_type, const uv_fs_cb cb) {
   uv__once_init();
-  UV_REQ_INIT(req, UV_FS);
-  req->loop = loop;
+  UV_REQ_INIT(loop, req, UV_FS);
   req->flags = 0;
   req->fs_type = fs_type;
   req->sys_errno_ = 0;

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -249,10 +249,9 @@ int uv_getaddrinfo(uv_loop_t* loop,
     return UV_EINVAL;
   }
 
-  UV_REQ_INIT(req, UV_GETADDRINFO);
+  UV_REQ_INIT(loop, req, UV_GETADDRINFO);
   req->getaddrinfo_cb = getaddrinfo_cb;
   req->addrinfo = NULL;
-  req->loop = loop;
   req->retcode = 0;
 
   /* calculate required memory size for all input values */

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -133,12 +133,11 @@ int uv_getnameinfo(uv_loop_t* loop,
     return UV_EINVAL;
   }
 
-  UV_REQ_INIT(req, UV_GETNAMEINFO);
+  UV_REQ_INIT(loop, req, UV_GETNAMEINFO);
   uv__req_register(loop, req);
 
   req->getnameinfo_cb = getnameinfo_cb;
   req->flags = flags;
-  req->loop = loop;
   req->retcode = 0;
 
   if (getnameinfo_cb) {

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -537,7 +537,7 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
 
   for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
     req = &handle->pipe.serv.accept_reqs[i];
-    UV_REQ_INIT(req, UV_ACCEPT);
+    UV_REQ_INIT(loop, req, UV_ACCEPT);
     req->data = handle;
     req->pipeHandle = INVALID_HANDLE_VALUE;
     req->next_pending = NULL;
@@ -640,7 +640,7 @@ void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle,
   HANDLE pipeHandle = INVALID_HANDLE_VALUE;
   DWORD duplex_flags;
 
-  UV_REQ_INIT(req, UV_CONNECT);
+  UV_REQ_INIT(loop, req, UV_CONNECT);
   req->handle = (uv_stream_t*) handle;
   req->cb = cb;
 
@@ -1314,7 +1314,7 @@ static int uv__pipe_write_data(uv_loop_t* loop,
 
   assert(handle->handle != INVALID_HANDLE_VALUE);
 
-  UV_REQ_INIT(req, UV_WRITE);
+  UV_REQ_INIT(loop, req, UV_WRITE);
   req->handle = (uv_stream_t*) handle;
   req->send_handle = NULL;
   req->cb = cb;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -464,11 +464,11 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle,
 
   /* Initialize 2 poll reqs. */
   handle->submitted_events_1 = 0;
-  UV_REQ_INIT(&handle->poll_req_1, UV_POLL_REQ);
+  UV_REQ_INIT(loop, &handle->poll_req_1, UV_POLL_REQ);
   handle->poll_req_1.data = handle;
 
   handle->submitted_events_2 = 0;
-  UV_REQ_INIT(&handle->poll_req_2, UV_POLL_REQ);
+  UV_REQ_INIT(loop, &handle->poll_req_2, UV_POLL_REQ);
   handle->poll_req_2.data = handle;
 
   return 0;

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -142,7 +142,7 @@ static void uv_process_init(uv_loop_t* loop, uv_process_t* handle) {
   handle->child_stdio_buffer = NULL;
   handle->exit_cb_pending = 0;
 
-  UV_REQ_INIT(&handle->exit_req, UV_PROCESS_EXIT);
+  UV_REQ_INIT(loop, &handle->exit_req, UV_PROCESS_EXIT);
   handle->exit_req.data = handle;
 }
 

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -150,7 +150,7 @@ int uv_signal_init(uv_loop_t* loop, uv_signal_t* handle) {
   handle->signum = 0;
   handle->signal_cb = NULL;
 
-  UV_REQ_INIT(&handle->signal_req, UV_SIGNAL_REQ);
+  UV_REQ_INIT(loop, &handle->signal_req, UV_SIGNAL_REQ);
   handle->signal_req.data = handle;
 
   return 0;

--- a/src/win/stream-inl.h
+++ b/src/win/stream-inl.h
@@ -39,7 +39,7 @@ INLINE static void uv_stream_init(uv_loop_t* loop,
   handle->stream.conn.shutdown_req = NULL;
   handle->stream.conn.write_reqs_pending = 0;
 
-  UV_REQ_INIT(&handle->read_req, UV_READ);
+  UV_REQ_INIT(loop, &handle->read_req, UV_READ);
   handle->read_req.event_handle = NULL;
   handle->read_req.wait_handle = INVALID_HANDLE_VALUE;
   handle->read_req.data = handle;

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -204,7 +204,7 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
     return UV_ENOTCONN;
   }
 
-  UV_REQ_INIT(req, UV_SHUTDOWN);
+  UV_REQ_INIT(loop, req, UV_SHUTDOWN);
   req->handle = handle;
   req->cb = cb;
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -591,7 +591,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
 
     for (i = 0; i < simultaneous_accepts; i++) {
       req = &handle->tcp.serv.accept_reqs[i];
-      UV_REQ_INIT(req, UV_ACCEPT);
+      UV_REQ_INIT(handle->loop, req, UV_ACCEPT);
       req->accept_socket = INVALID_SOCKET;
       req->data = handle;
 
@@ -613,7 +613,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
      * {uv_simultaneous_server_accepts} requests. */
     for (i = simultaneous_accepts; i < uv_simultaneous_server_accepts; i++) {
       req = &handle->tcp.serv.accept_reqs[i];
-      UV_REQ_INIT(req, UV_ACCEPT);
+      UV_REQ_INIT(handle->loop, req, UV_ACCEPT);
       req->accept_socket = INVALID_SOCKET;
       req->data = handle;
       req->wait_handle = INVALID_HANDLE_VALUE;
@@ -758,7 +758,7 @@ static int uv_tcp_try_connect(uv_connect_t* req,
     }
   }
 
-  UV_REQ_INIT(req, UV_CONNECT);
+  UV_REQ_INIT(loop, req, UV_CONNECT);
   req->handle = (uv_stream_t*) handle;
   req->cb = cb;
   memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));
@@ -821,7 +821,7 @@ int uv_tcp_write(uv_loop_t* loop,
   int result;
   DWORD bytes;
 
-  UV_REQ_INIT(req, UV_WRITE);
+  UV_REQ_INIT(loop, req, UV_WRITE);
   req->handle = (uv_stream_t*) handle;
   req->cb = cb;
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2166,7 +2166,7 @@ int uv_tty_write(uv_loop_t* loop,
                  uv_write_cb cb) {
   DWORD error;
 
-  UV_REQ_INIT(req, UV_WRITE);
+  UV_REQ_INIT(loop, req, UV_WRITE);
   req->handle = (uv_stream_t*) handle;
   req->cb = cb;
 

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -137,7 +137,7 @@ int uv__udp_init_ex(uv_loop_t* loop,
   handle->func_wsarecvfrom = WSARecvFrom;
   handle->send_queue_size = 0;
   handle->send_queue_count = 0;
-  UV_REQ_INIT(&handle->recv_req, UV_UDP_RECV);
+  UV_REQ_INIT(loop, &handle->recv_req, UV_UDP_RECV);
   handle->recv_req.data = handle;
 
   /* If anything fails beyond this point we need to remove the handle from
@@ -351,7 +351,7 @@ static int uv__send(uv_udp_send_t* req,
   uv_loop_t* loop = handle->loop;
   DWORD result, bytes;
 
-  UV_REQ_INIT(req, UV_UDP_SEND);
+  UV_REQ_INIT(loop, req, UV_UDP_SEND);
   req->handle = handle;
   req->cb = cb;
   memset(&req->u.io.overlapped, 0, sizeof(req->u.io.overlapped));

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -71,6 +71,7 @@ TEST_IMPL(getters_setters) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
+  ASSERT(uv_req_get_loop((uv_req_t*)fs) == loop);
   ASSERT(uv_fs_get_type(fs) == UV_FS_STAT);
   ASSERT(uv_fs_get_result(fs) == 0);
   ASSERT(uv_fs_get_ptr(fs) == uv_fs_get_statbuf(fs));


### PR DESCRIPTION
Hi,

The rationale of this patch is pretty simple: Being able to easily access the loop from an uv_req_t.
Most of the uv_req_t expose a loop member, and there is room inside uv_req_t to get the pointer without breaking binary compatibility.

Documentation and source is updated accordingly, aiming this patch to land in 1.25.0 release because of the new symbol.

Change was build and tested on linux (need real world testing for binary compatibility). Windows platform was blindly edited without any compile checking.

Please review/comment.

Thanks.