### PR TITLE
doc: clarify the expected memory management strategy

### DIFF
--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -140,6 +140,8 @@ API
 
     Request handle to be closed. `close_cb` will be called asynchronously after
     this call. This MUST be called on each handle before memory is released.
+    Moreover, the memory can only be released in `close_cb` or after it has
+    returned.
 
     Handles that wrap file descriptors are closed immediately but
     `close_cb` will still be deferred to the next iteration of the event loop.


### PR DESCRIPTION
Right now, docs don't make it clear when exactly does it become okay to
free memory belonging to `uv_handle_t`. It's only stated that
`uv_close` must be called before freeing the memory, which is a source
of confusion for new users: they call `uv_close(handle, NULL)`, then
free the memory (see e.g. #2078, https://stackoverflow.com/q/25615340).

Is it okay to call `free` at the last line of `close_cb`? Is `uv_walk(loop, call_close_handle, NULL)` followed by another `uv_run(loop, UV_RUN_DEFAULT)` the only true way to prepare the loop to shut down cleanly? (doesn't seem to me to play well with RAII...)

Let's make it as clear as possible.