### PR TITLE
doc: replace deprecated build command on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,7 @@ Run:
 
 ```bash
 $ ./gyp_uv.py -f xcode
-$ xcodebuild -ARCHS="x86_64" -project uv.xcodeproj \
-     -configuration Release -target All
+$ xcodebuild -ARCHS="x86_64" -project out/uv.xcodeproj -configuration Release -alltargets
 ```
 
 Using Homebrew:


### PR DESCRIPTION
origin README about build command is not suit for current code.
1. gyp_uv.py generated uv.xcodeproj file in directory 'out' instead of repository root directory
2. xcode build target params use '-alltargets' instead of '-target All'.(https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-WHAT_KEYS_CAN_I_PASS_TO_THE_EXPORTOPTIONSPLIST_FLAG_)