### PR TITLE
build: support running tests in out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,4 +73,6 @@ AS_CASE([$host_os], [kfreebsd*], [
 ])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])
+AC_CONFIG_LINKS([test/fixtures/empty_file:test/fixtures/empty_file])
+AC_CONFIG_LINKS([test/fixtures/load_error.node:test/fixtures/load_error.node])
 AC_OUTPUT


### PR DESCRIPTION
With this simple addition, libuv now passes tests when built out-of-tree! This asks `config.status` to generate links (or copies) of these files in the expected place in the build tree.
```
 /bin/bash ./config.status
config.status: creating Makefile
config.status: creating libuv.pc
config.status: linking /data/vtjnash/libuv/test/fixtures/empty_file to test/fixtures/empty_file
config.status: linking /data/vtjnash/libuv/test/fixtures/load_error.node to test/fixtures/load_error.node
config.status: executing depfiles commands
config.status: executing libtool commands
```