### PR TITLE
allow 2 io completion threads on singlecore windows

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -108,22 +108,23 @@ void uv_update_time(uv_loop_t* loop) {
 
 
 int uv_loop_init(uv_loop_t* loop) {
-  int err;
+  int err, ioCompletionThreads = 1;
+  char *numProcessors = NULL;
 
   /* Initialize libuv itself first */
   uv__once_init();
 
-  /* determine NumberOfConcurrentThreads for I/O completion port, 2 works better for single core */
-  int coreCount = -1, ioCompletionThreads = 1;
-  char *coreCountStr = getenv("NUMBER_OF_PROCESSORS");
-  if (coreCountStr) {
-    coreCount = atoi(coreCountStr);
-    if (coreCount == 1)
-      ioCompletionThreads = 2;
-  }
+  /* determine NumberOfConcurrentThreads for I/O completion port, 2 works better
+     for single core */
+  numProcessors = getenv("NUMBER_OF_PROCESSORS");
+  if (numProcessors && strcmp(numProcessors, "1") == 0)
+    ioCompletionThreads = 2;
 
   /* Create an I/O completion port */
-  loop->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, ioCompletionThreads);
+  loop->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE,
+                                      NULL,
+                                      0,
+                                      ioCompletionThreads);
   if (loop->iocp == NULL)
     return uv_translate_sys_error(GetLastError());
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -113,8 +113,17 @@ int uv_loop_init(uv_loop_t* loop) {
   /* Initialize libuv itself first */
   uv__once_init();
 
+  /* determine NumberOfConcurrentThreads for I/O completion port, 2 works better for single core */
+  int coreCount = -1, ioCompletionThreads = 1;
+  char *coreCountStr = getenv("NUMBER_OF_PROCESSORS");
+  if (coreCountStr) {
+    coreCount = atoi(coreCountStr);
+    if (coreCount == 1)
+      ioCompletionThreads = 2;
+  }
+
   /* Create an I/O completion port */
-  loop->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
+  loop->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, ioCompletionThreads);
   if (loop->iocp == NULL)
     return uv_translate_sys_error(GetLastError());
 


### PR DESCRIPTION
Electron on single-core windows has a problem with cpu pegging when it should be idle, triggered by (among other things) async io.

- electron/electron#12026
- electron/electron#11699
- electron/electron#14319

There are related issues in downstream projects like vscode.

This PR is the fix proposed by @gshively11 in electron/electron#12026 that resolves these issues.

@zcbenz from electron [suggested](https://github.com/electron/electron/issues/14319#issuecomment-444700047) submitting it to libuv first for your input