### PR TITLE
test: fix test-ipc spawn_helper exit_cb

### DIFF
--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -55,7 +55,7 @@ static void write_cb(uv_write_t* req, int status) {
 }
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT(status == 0 || status == UV_ENOTCONN);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -92,6 +92,7 @@ static void exit_cb(uv_process_t* process,
   printf("exit_cb\n");
   exit_cb_called++;
   ASSERT(exit_status == 0);
+  ASSERT(term_signal == 0);
   uv_close((uv_handle_t*)process, NULL);
 }
 


### PR DESCRIPTION
Make sure an ipc test fails if `term_signal` is not zero. This can
happen on failing assertions in the child process.