### PR TITLE
tty,win: fix Alt+key under WSL

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -733,8 +733,9 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 
       /* Ignore keyup events, unless the left alt key was held and a valid
        * unicode character was emitted. */
-      if (!KEV.bKeyDown && !(((KEV.dwControlKeyState & LEFT_ALT_PRESSED) ||
-          KEV.wVirtualKeyCode==VK_MENU) && KEV.uChar.UnicodeChar != 0)) {
+      if (!KEV.bKeyDown &&
+          KEV.wVirtualKeyCode != VK_MENU &&
+          KEV.uChar.UnicodeChar != 0) {
         continue;
       }
 


### PR DESCRIPTION
When releasing key with `Alt` pressed, the reported event has `LEFT_ALT_PRESSED` state flag set. This confuses libuv, making it think that `Alt+numpad` combination is used. This fixes this issue by removing the check for state flag. Checking if `VirtuakKeyCode` is set to `VK_MENU` is enough to detect the `Alt+numpad` case.

Fixes: https://github.com/libuv/libuv/issues/2111