### PR TITLE
aix: suppress `defined-but-notused` warning

### DIFF
--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 
+#if !defined(__sun) && !defined(_AIX) && !defined(__MVS__)
 static void set_title(const char* title) {
   char buffer[512];
   int err;
@@ -39,6 +40,7 @@ static void set_title(const char* title) {
 
   ASSERT(strcmp(buffer, title) == 0);
 }
+#endif
 
 
 static void uv_get_process_title_edge_cases(void) {


### PR DESCRIPTION
addresses this warning in AIX (and probably in SUN and MVS too)

```error
test/test-process-title.c:27:13: warning: 'set_title' defined but not used [-Wunused-function]
 static void set_title(const char* title) {
```