### PR TITLE
aix: manually trigger fs event monitoring

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -773,10 +773,10 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   /* AHAFS wants someone to poll for it to start mointoring.
    *  so kick-start it so that we don't miss an event in the
    *  eventuality of an event that occurs in the current loop. */
-  FD_ZERO(&pollfd);
-  FD_SET(fd, &pollfd);
   do {
     memset(&zt, 0, sizeof(zt));
+    FD_ZERO(&pollfd);
+    FD_SET(fd, &pollfd);
     rc = select(fd + 1, &pollfd, NULL, NULL, &zt);
   } while (rc == -1 && errno == EINTR);
   return 0;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -555,7 +555,7 @@ static int uv__setup_ahafs(const char* filename, int *fd) {
     sprintf(mon_file_write_string, "CHANGED=YES;WAIT_TYPE=WAIT_IN_SELECT;INFO_LVL=1");
 
   rc = write(*fd, mon_file_write_string, strlen(mon_file_write_string)+1);
-  if (rc < 0)
+  if (rc < 0 && errno != EBUSY)
     return UV__ERR(errno);
 
   return 0;
@@ -777,7 +777,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   FD_SET(fd, &pollfd);
   do {
     memset(&zt, 0, sizeof(zt));
-    rc = select(1, &pollfd, NULL, NULL, &zt);
+    rc = select(fd + 1, &pollfd, NULL, NULL, &zt);
   } while (rc == -1 && errno == EINTR);
   return 0;
 #else

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -728,6 +728,8 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   char cwd[PATH_MAX];
   char absolute_path[PATH_MAX];
   char readlink_cwd[PATH_MAX];
+  struct timeval zt = {0, 0};
+  fd_set pollfd;
 
 
   /* Figure out whether filename is absolute or not */
@@ -767,6 +769,12 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   handle->dir_filename = NULL;
 
   uv__io_start(handle->loop, &handle->event_watcher, POLLIN);
+
+  /* AHAFS wants someone to poll for it to start mointoring.
+     so kick-start it so that we don't miss an event in the
+     eventuality of an event that occurs in the current loop. */
+  pollfd.fds_bits[0] = fd; 
+  select(1, &pollfd, NULL, NULL, &zt);
 
   return 0;
 #else


### PR DESCRIPTION
In AIX, fs watch feature leverages AHAFS function.
According to AHAFS, monitoring of events does not
begin until the monitoring application issues a select()
or a blocking read() call. In edge cases where the watch
request as well as fs event both occurs in single event
loop cycle, we miss the event, as the event monitors are
created but not yet registered in the current cycle,
instead only enqueued into the poll structure, that will
be taken up with the OS on the loop edge only.

Trigger a select call in-line on the monitoring fd, that
tells AHAFS to kick-start the moitoring.

Fixes: https://github.com/libuv/libuv/issues/2118