### PR TITLE
remove abort when detect IPv6 support failed

### DIFF
--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -131,21 +131,14 @@ void uv_winsock_init(void) {
   if (dummy != INVALID_SOCKET) {
     opt_len = (int) sizeof protocol_info;
     if (getsockopt(dummy,
-                   SOL_SOCKET,
-                   SO_PROTOCOL_INFOW,
-                   (char*) &protocol_info,
-                   &opt_len) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "getsockopt");
-
-    if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
-      uv_tcp_non_ifs_lsp_ipv6 = 1;
-
-    if (closesocket(dummy) == SOCKET_ERROR)
-      uv_fatal_error(WSAGetLastError(), "closesocket");
-
-  } else if (!error_means_no_support(WSAGetLastError())) {
-    /* Any error other than "socket type not supported" is fatal. */
-    uv_fatal_error(WSAGetLastError(), "socket");
+        SOL_SOCKET,
+        SO_PROTOCOL_INFOW,
+        (char*)&protocol_info,
+        &opt_len) == 0) {
+        if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
+            uv_tcp_non_ifs_lsp_ipv6 = 1;
+    }
+    closesocket(dummy);
   }
 }
 

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -130,12 +130,12 @@ void uv_winsock_init(void) {
 
   if (dummy != INVALID_SOCKET) {
     opt_len = (int) sizeof protocol_info;
-    if (getsockopt(dummy,
+    errorno = getsockopt(dummy,
         SOL_SOCKET,
         SO_PROTOCOL_INFOW,
         (char*)&protocol_info,
-        &opt_len) == 0) {
-        if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
+        &opt_len);
+    if (errorno == 0 && !(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES)) {
           uv_tcp_non_ifs_lsp_ipv6 = 1;
     }
     closesocket(dummy);

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -136,7 +136,7 @@ void uv_winsock_init(void) {
         (char*)&protocol_info,
         &opt_len) == 0) {
         if (!(protocol_info.dwServiceFlags1 & XP1_IFS_HANDLES))
-            uv_tcp_non_ifs_lsp_ipv6 = 1;
+          uv_tcp_non_ifs_lsp_ipv6 = 1;
     }
     closesocket(dummy);
   }


### PR DESCRIPTION
These's two reasons to avoid abort application since invalid socket check:
1. https://github.com/libuv/libuv/issues/1425


2. google search "create  socket  10106", found many similar issues that create socket failed