### PR TITLE
win,tty: Exposing uv_set_vterm_state

### DIFF
--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -33,6 +33,23 @@ Data types
           UV_TTY_MODE_IO
       } uv_tty_mode_t;
 
+.. c:type:: uv_tty_vtermstate_t
+
+    Console virtual terminal mode type:
+
+    ::
+
+      typedef enum {
+          /* unchecked */
+          UV_TTY_AUTODETEC,
+          /* Legacy conhost */
+          UV_TTY_LEAGCY,
+          /* Modern conhost */
+          UV_TTY_VTP,
+          /* ConEmu, mintty, etc. */
+          uv_TTY_ANSI
+      } uv_tty_vtermstate_t;
+
 
 
 Public members
@@ -96,5 +113,11 @@ API
 .. c:function:: int uv_tty_get_winsize(uv_tty_t* handle, int* width, int* height)
 
     Gets the current Window size. On success it returns 0.
+
+.. c:function:: int uv_tty_set_vterm_state(uv_tty_t* handle, uv_vtermstate_t state)
+
+    Set the Console using the specified virtual terminal mode.
+
+    This function is only implemented on Windows.
 
 .. seealso:: The :c:type:`uv_stream_t` API functions also apply.

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -119,5 +119,7 @@ API
     Set the Console using the specified virtual terminal mode.
 
     This function is only implemented on Windows.
+    .. versionadded:: 1.25.0
+
 
 .. seealso:: The :c:type:`uv_stream_t` API functions also apply.

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -116,7 +116,7 @@ API
 
 .. c:function:: int uv_tty_set_vterm_state(uv_tty_t* handle, uv_vtermstate_t state)
 
-    Set the Console using the specified virtual terminal mode.
+    Set the Console to use the specified virtual terminal mode.
 
     This function is only implemented on Windows.
     .. versionadded:: 1.25.0

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -43,7 +43,7 @@ Data types
           /* unchecked */
           UV_TTY_AUTODETECT,
           /* Legacy conhost */
-          UV_TTY_LEAGCY,
+          UV_TTY_LEGACY,
           /* Modern conhost */
           UV_TTY_VTP,
           /* ConEmu, mintty, etc. */

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -120,7 +120,7 @@ API
 
     This function is only implemented on Windows.
 
-    .. versionadded:: 1.25.0
+    .. versionadded:: 1.31.0
 
 
 .. seealso:: The :c:type:`uv_stream_t` API functions also apply.

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -119,6 +119,7 @@ API
     Set the Console to use the specified virtual terminal mode.
 
     This function is only implemented on Windows.
+
     .. versionadded:: 1.25.0
 
 

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -41,7 +41,7 @@ Data types
 
       typedef enum {
           /* unchecked */
-          UV_TTY_AUTODETEC,
+          UV_TTY_AUTODETECT,
           /* Legacy conhost */
           UV_TTY_LEAGCY,
           /* Modern conhost */

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -47,7 +47,7 @@ Data types
           /* Modern conhost */
           UV_TTY_VTP,
           /* ConEmu, mintty, etc. */
-          uv_TTY_ANSI
+          UV_TTY_ANSI
       } uv_tty_vtermstate_t;
 
 
@@ -114,9 +114,9 @@ API
 
     Gets the current Window size. On success it returns 0.
 
-.. c:function:: int uv_tty_set_vterm_state(uv_tty_t* handle, uv_vtermstate_t state)
+.. c:function:: int uv_tty_set_vterm_state(uv_tty_t* handle, uv_tty_vtermstate_t state)
 
-    Set the Console to use the specified virtual terminal mode.
+    Set the console to use the specified virtual terminal mode.
 
     This function is only implemented on Windows.
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -57,7 +57,6 @@ extern "C" {
 #endif
 
 #if defined(_WIN32)
-typedef struct uv_tty_s uv_tty_t;
 # include "uv/win.h"
 #else
 # include "uv/unix.h"
@@ -207,9 +206,7 @@ typedef struct uv_stream_s uv_stream_t;
 typedef struct uv_tcp_s uv_tcp_t;
 typedef struct uv_udp_s uv_udp_t;
 typedef struct uv_pipe_s uv_pipe_t;
-#ifndef WIN32
 typedef struct uv_tty_s uv_tty_t;
-#endif
 typedef struct uv_poll_s uv_poll_t;
 typedef struct uv_timer_s uv_timer_t;
 typedef struct uv_prepare_s uv_prepare_t;
@@ -684,10 +681,18 @@ typedef enum {
   UV_TTY_MODE_IO
 } uv_tty_mode_t;
 
+typedef enum {
+  UV_TTY_AUTODETECT, /* unchecked */
+  UV_TTY_LEGACY,
+  UV_TTY_VTP, /* modern conhost */
+  UV_TTY_ANSI /* conemu, mintty, etc. */
+} uv_tty_vtermstate_t;
+
 UV_EXTERN int uv_tty_init(uv_loop_t*, uv_tty_t*, uv_file fd, int readable);
 UV_EXTERN int uv_tty_set_mode(uv_tty_t*, uv_tty_mode_t mode);
 UV_EXTERN int uv_tty_reset_mode(void);
 UV_EXTERN int uv_tty_get_winsize(uv_tty_t*, int* width, int* height);
+UV_EXTERN int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state);
 
 #ifdef __cplusplus
 extern "C++" {

--- a/include/uv.h
+++ b/include/uv.h
@@ -57,6 +57,7 @@ extern "C" {
 #endif
 
 #if defined(_WIN32)
+typedef struct uv_tty_s uv_tty_t;
 # include "uv/win.h"
 #else
 # include "uv/unix.h"
@@ -206,7 +207,9 @@ typedef struct uv_stream_s uv_stream_t;
 typedef struct uv_tcp_s uv_tcp_t;
 typedef struct uv_udp_s uv_udp_t;
 typedef struct uv_pipe_s uv_pipe_t;
+#ifndef WIN32
 typedef struct uv_tty_s uv_tty_t;
+#endif
 typedef struct uv_poll_s uv_poll_t;
 typedef struct uv_timer_s uv_timer_t;
 typedef struct uv_prepare_s uv_prepare_t;

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -683,12 +683,3 @@ typedef struct {
 #define UV_FS_O_NONBLOCK     0
 #define UV_FS_O_SYMLINK      0
 #define UV_FS_O_SYNC         0x08000000 /* FILE_FLAG_WRITE_THROUGH */
-
-typedef enum {
-  UV_TTY_AUTODETECT, /* unchecked */
-  UV_TTY_LEGACY,
-  UV_TTY_VTP, /* modern conhost */
-  UV_TTY_ANSI /* conemu, mintty, etc. */
-} uv_tty_vtermstate_t;
-
-UV_EXTERN int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state);

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -683,3 +683,12 @@ typedef struct {
 #define UV_FS_O_NONBLOCK     0
 #define UV_FS_O_SYMLINK      0
 #define UV_FS_O_SYNC         0x08000000 /* FILE_FLAG_WRITE_THROUGH */
+
+typedef enum {
+  UV_TTY_AUTODETECT, /* unchecked */
+  UV_TTY_LEGACY,
+  UV_TTY_VTP, /* modern conhost */
+  UV_TTY_ANSI /* conemu, mintty, etc.*/
+} uv_tty_vtermstate_t;
+
+UV_EXTERN int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state);

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -688,7 +688,7 @@ typedef enum {
   UV_TTY_AUTODETECT, /* unchecked */
   UV_TTY_LEGACY,
   UV_TTY_VTP, /* modern conhost */
-  UV_TTY_ANSI /* conemu, mintty, etc.*/
+  UV_TTY_ANSI /* conemu, mintty, etc. */
 } uv_tty_vtermstate_t;
 
 UV_EXTERN int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state);

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -365,3 +365,7 @@ int uv_tty_reset_mode(void) {
 
   return err;
 }
+
+int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state) {
+  return UV_ENOTSUP;
+}

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2285,6 +2285,10 @@ static void uv__determine_vterm_state(HANDLE handle) {
 int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state) {
   int ret = 0;
 
+  if (!(tty->flags & UV_HANDLE_WRITABLE)) {
+    return UV_EINVAL;
+  }
+
   uv_sem_wait(&uv_tty_output_lock);
   switch (state) {
     case UV_TTY_AUTODETECT:

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -145,13 +145,8 @@ static char uv_tty_default_fg_bright = 0;
 static char uv_tty_default_bg_bright = 0;
 static char uv_tty_default_inverse = 0;
 
-typedef enum {
-  UV_SUPPORTED,
-  UV_UNCHECKED,
-  UV_UNSUPPORTED
-} uv_vtermstate_t;
 /* Determine whether or not ANSI support is enabled. */
-static uv_vtermstate_t uv__vterm_state = UV_UNCHECKED;
+static uv_tty_vtermstate_t uv__vterm_state = UV_TTY_AUTODETECT;
 static void uv__determine_vterm_state(HANDLE handle);
 
 void uv_console_init(void) {
@@ -213,7 +208,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, uv_file fd, int unused) {
      * between all uv_tty_t handles. */
     uv_sem_wait(&uv_tty_output_lock);
 
-    if (uv__vterm_state == UV_UNCHECKED)
+    if (uv__vterm_state == UV_TTY_AUTODETECT)
       uv__determine_vterm_state(handle);
 
     /* Remember the original console text attributes. */
@@ -1657,7 +1652,7 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
     uv_buf_t buf = bufs[i];
     unsigned int j;
 
-    if (uv__vterm_state == UV_SUPPORTED && buf.len > 0) {
+    if (uv__vterm_state != UV_TTY_LEGACY && buf.len > 0) {
       utf16_buf_used = MultiByteToWideChar(CP_UTF8,
                                            0,
                                            buf.base,
@@ -2255,25 +2250,63 @@ int uv_tty_reset_mode(void) {
   return 0;
 }
 
+static int uv__set_vtp(HANDLE handle, BOOL vtp) {
+  DWORD dwMode = 0;
+
+  if (!GetConsoleMode(handle, &dwMode)) {
+    return uv_translate_sys_error(GetLastError());
+  }
+
+  if (vtp) {
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+  } else {
+    dwMode &= ~(ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  }
+  if (!SetConsoleMode(handle, dwMode)) {
+    return uv_translate_sys_error(GetLastError());
+  }
+
+  return 0;
+}
+
 /* Determine whether or not this version of windows supports
  * proper ANSI color codes. Should be supported as of windows
  * 10 version 1511, build number 10.0.10586.
  */
 static void uv__determine_vterm_state(HANDLE handle) {
-  DWORD dwMode = 0;
-
-  if (!GetConsoleMode(handle, &dwMode)) {
-    uv__vterm_state = UV_UNSUPPORTED;
+  if (uv__set_vtp(handle, TRUE)) {
+    uv__vterm_state = UV_TTY_LEGACY;
     return;
   }
 
-  dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-  if (!SetConsoleMode(handle, dwMode)) {
-    uv__vterm_state = UV_UNSUPPORTED;
-    return;
-  }
+  uv__vterm_state = UV_TTY_VTP;
+}
 
-  uv__vterm_state = UV_SUPPORTED;
+int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state) {
+  int ret = 0;
+
+  uv_sem_wait(&uv_tty_output_lock);
+  switch (state) {
+    case UV_TTY_AUTODETECT:
+      uv__determine_vterm_state(tty->handle);
+      break;
+    case UV_TTY_VTP:
+      if (!(ret = uv__set_vtp(tty->handle, TRUE))) {
+        uv__vterm_state = UV_TTY_VTP;
+      }
+      break;
+    case UV_TTY_LEGACY:
+      if (!(ret = uv__set_vtp(tty->handle, FALSE))) {
+        uv__vterm_state = UV_TTY_LEGACY;
+      }
+      break;
+    case UV_TTY_ANSI:
+      uv__vterm_state = UV_TTY_ANSI;
+      break;
+  }
+  uv_sem_post(&uv_tty_output_lock);
+
+  return ret;
 }
 
 static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param) {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2253,18 +2253,16 @@ int uv_tty_reset_mode(void) {
 static int uv__set_vtp(HANDLE handle, BOOL vtp) {
   DWORD dwMode = 0;
 
-  if (!GetConsoleMode(handle, &dwMode)) {
+  if (0 == GetConsoleMode(handle, &dwMode))
     return uv_translate_sys_error(GetLastError());
-  }
 
   if (vtp) {
     dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
   } else {
     dwMode &= ~(ENABLE_VIRTUAL_TERMINAL_PROCESSING);
   }
-  if (!SetConsoleMode(handle, dwMode)) {
+  if (0 == SetConsoleMode(handle, dwMode))
     return uv_translate_sys_error(GetLastError());
-  }
 
   return 0;
 }
@@ -2285,9 +2283,9 @@ static void uv__determine_vterm_state(HANDLE handle) {
 int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state) {
   int ret = 0;
 
-  if (!(tty->flags & UV_HANDLE_WRITABLE)) {
+  if (!(tty->flags & UV_HANDLE_WRITABLE))
     return UV_EINVAL;
-  }
+
 
   uv_sem_wait(&uv_tty_output_lock);
   switch (state) {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2256,11 +2256,11 @@ static int uv__set_vtp(HANDLE handle, BOOL vtp) {
   if (0 == GetConsoleMode(handle, &dwMode))
     return uv_translate_sys_error(GetLastError());
 
-  if (vtp) {
+  if (vtp)
     dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-  } else {
+  else
     dwMode &= ~(ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-  }
+
   if (0 == SetConsoleMode(handle, dwMode))
     return uv_translate_sys_error(GetLastError());
 
@@ -2285,22 +2285,18 @@ int uv_tty_set_vterm_state(uv_tty_t* tty, uv_tty_vtermstate_t state) {
 
   if (!(tty->flags & UV_HANDLE_WRITABLE))
     return UV_EINVAL;
-
-
   uv_sem_wait(&uv_tty_output_lock);
   switch (state) {
     case UV_TTY_AUTODETECT:
       uv__determine_vterm_state(tty->handle);
       break;
     case UV_TTY_VTP:
-      if (!(ret = uv__set_vtp(tty->handle, TRUE))) {
+      if (!(ret = uv__set_vtp(tty->handle, TRUE)))
         uv__vterm_state = UV_TTY_VTP;
-      }
       break;
     case UV_TTY_LEGACY:
-      if (!(ret = uv__set_vtp(tty->handle, FALSE))) {
+      if (!(ret = uv__set_vtp(tty->handle, FALSE)))
         uv__vterm_state = UV_TTY_LEGACY;
-      }
       break;
     case UV_TTY_ANSI:
       uv__vterm_state = UV_TTY_ANSI;


### PR DESCRIPTION
This PR separated the expose of `uv_set_vterm_state` from #1884.

@vtjnash Is this what you intended at https://github.com/libuv/libuv/pull/1873#issuecomment-450944319.