### PR TITLE
Enable IPv6 tests on OpenBSD and fix associated test failures

### DIFF
--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -52,12 +52,9 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
    */
   if (ent->ifa_addr->sa_family == AF_LINK)
     return 1;
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
   if (ent->ifa_addr->sa_family != PF_INET &&
       ent->ifa_addr->sa_family != PF_INET6)
-    return 1;
-#elif defined(__OpenBSD__)
-  if (ent->ifa_addr->sa_family != PF_INET)
     return 1;
 #endif
   return 0;

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -760,14 +760,16 @@ int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
  * IP_MULTICAST_TTL, so hardcode the size of the option in the IPv6 case,
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
-#if defined(__sun) || defined(_AIX) || defined(__MVS__)
+#if defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
+    defined(__MVS__)
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_TTL,
                           IPV6_MULTICAST_HOPS,
                           &ttl,
                           sizeof(ttl));
-#endif /* defined(__sun) || defined(_AIX) || defined(__MVS__) */
+#endif /* defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
+    defined(__MVS__) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_TTL,
@@ -783,14 +785,16 @@ int uv_udp_set_multicast_loop(uv_udp_t* handle, int on) {
  * IP_MULTICAST_LOOP, so hardcode the size of the option in the IPv6 case,
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
-#if defined(__sun) || defined(_AIX) || defined(__MVS__)
+#if defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
+    defined(__MVS__) 
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_LOOP,
                           IPV6_MULTICAST_LOOP,
                           &on,
                           sizeof(on));
-#endif /* defined(__sun) || defined(_AIX) || defined(__MVS__) */
+#endif /* defined(__sun) || defined(_AIX) ||defined(__OpenBSD__) ||
+    defined(__MVS__) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_LOOP,


### PR DESCRIPTION
I noticed IPv6 tests on OpenBSD 6.4 (x86_64) were skipped and decided to look into it. A similar effort was recently done for NetBSD (#1576) but there were some concerns widening these changes to OpenBSD due to test failures, see https://github.com/libuv/libuv/pull/1576#issuecomment-333416082. After enabling the tests, I only observed test failures in the `udp_options6 `test, which I fixed.

There are still some other, unrelated test failures on OpenBSD.