### PR TITLE
win: fix sizeof-pointer-div warning

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -230,8 +230,11 @@ int uv_fs_event_start(uv_fs_event_t* handle,
      */
 
     /* Convert to short path. */
-    short_path = short_path_buffer;
-    if (!GetShortPathNameW(pathw, short_path, ARRAY_SIZE(short_path))) {
+    if (GetShortPathNameW(pathw,
+                          short_path_buffer,
+                          ARRAY_SIZE(short_path_buffer))) {
+      short_path = short_path_buffer;
+    } else {
       short_path = NULL;
     }
 


### PR DESCRIPTION
`short_path`'s type changed from `WCHAR` array to `WCHAR*` in https://github.com/libuv/libuv/pull/1267, leading to a sizeof-pointer-div warning.

Fixes: https://github.com/libuv/libuv/issues/2138