### PR TITLE
unix: fix clang scan-build warning in uv__process_child_init()

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -315,7 +315,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
         use_fd = open("/dev/null", fd == 0 ? O_RDONLY : O_RDWR);
         close_fd = use_fd;
 
-        if (use_fd == -1) {
+        if (use_fd < 0) {
           uv__write_int(error_fd, UV__ERR(errno));
           _exit(127);
         }


### PR DESCRIPTION
When building libuv with clang scan-build, an "Assigned value is
garbage or undefined" warning is emitted unless the return value of
open() is verified to be >= 0. Fix this warning.

See the [CMake build logs](https://open.cdash.org/buildSummary.php?buildid=5704876) for the warning.