### PR TITLE
win, tty: fix CreateFileW return value check

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -164,7 +164,7 @@ void uv_console_init(void) {
                                        OPEN_EXISTING,
                                        0,
                                        0);
-  if (uv__tty_console_handle != NULL) {
+  if (uv__tty_console_handle != INVALID_HANDLE_VALUE) {
     QueueUserWorkItem(uv__tty_console_resize_message_loop_thread,
                       NULL,
                       WT_EXECUTELONGFUNCTION);


### PR DESCRIPTION
CreateFileW returns INVALID_HANDLE_VALUE on failure, not NULL.

Fixes: https://github.com/libuv/libuv/issues/2141