### PR TITLE
OpenBSD: Switch to libuv's barrier implementation

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -136,7 +136,7 @@ typedef pthread_cond_t uv_cond_t;
 typedef pthread_key_t uv_key_t;
 
 /* Note: guard clauses should match uv_barrier_init's in src/unix/thread.c. */
-#if defined(_AIX) || !defined(PTHREAD_BARRIER_SERIAL_THREAD)
+#if defined(_AIX) || defined(__OpenBSD__) || !defined(PTHREAD_BARRIER_SERIAL_THREAD)
 /* TODO(bnoordhuis) Merge into uv_barrier_t in v2. */
 struct _uv_barrier {
   uv_mutex_t mutex;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -48,8 +48,8 @@
 STATIC_ASSERT(sizeof(uv_barrier_t) == sizeof(pthread_barrier_t));
 #endif
 
-/* Note: guard clauses should match uv_barrier_t's in include/uv/uv-unix.h. */
-#if defined(_AIX) || !defined(PTHREAD_BARRIER_SERIAL_THREAD)
+/* Note: guard clauses should match uv_barrier_t's in include/uv/unix.h. */
+#if defined(_AIX) || defined(__OpenBSD__) || !defined(PTHREAD_BARRIER_SERIAL_THREAD)
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
   struct _uv_barrier* b;
   int rc;


### PR DESCRIPTION
On OpenBSD 6.4 barrier_serial_thread test fails:

```
-bash-4.4$ ./build/uv_run_tests barrier_serial_thread
not ok 1 - barrier_serial_thread
# exit code 134
# Output from process `barrier_serial_thread`: (no output)
```

This occurs because the OpenBSD's `pthread_barrier_wait()` implementation returns `PTHREAD_BARRIER_SERIAL_THREAD` from the _first_ thread that releases the wait, which then causes the subsequent call to `pthread_barrier_destroy()` to return `EBUSY` and `uv_barrier_destroy()` to abort!

(I verified this behavior with the OpenBSD source code @ https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/lib/librthread/rthread_barrier.c?rev=1.4&content-type=text/plain)

This PR simply switches to libuv's internal implementation of uv_barrier_xxx on OpenBSD, similar to what has been done for AIX.

After this change the test now passes:

`ok 9 - barrier_serial_thread`

See also #2019 for some background.

Note, I have targeted this for the v1.x branch but I am not sure the change is v1.x ABI compatible due to the possible redefintion of `uv_barrier_t` on OpenBSD... Looks like @bnoordhuis did some magic in the header file to make it still work...