### PR TITLE
src: add uv_loop watcher_queue update apis

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -223,6 +223,19 @@ API
        invalid. That function must be called again to determine the
        correct backend file descriptor.
 
+.. c:function:: uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop)
+
+    Returns `loop->on_watcher_queue_updated`.
+
+    .. versionadded:: 1.26.0
+
+.. c:function:: void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                                uv_loop_cb cb)
+
+    Sets `loop->on_watcher_queue_updated` to `cb`.
+
+    .. versionadded:: 1.26.0
+
 .. c:function:: void* uv_loop_get_data(const uv_loop_t* loop)
 
     Returns `loop->data`.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1589,11 +1589,13 @@ union uv_any_req {
 };
 #undef XX
 
+typedef void(*uv_loop_cb)(uv_loop_t*);
 
 struct uv_loop_s {
   /* User data - use this for whatever. */
   void* data;
   /* Loop reference counting. */
+  uv_loop_cb on_watcher_queue_updated;
   unsigned int active_handles;
   void* handle_queue[2];
   union {
@@ -1604,6 +1606,10 @@ struct uv_loop_s {
   unsigned int stop_flag;
   UV_LOOP_PRIVATE_FIELDS
 };
+
+UV_EXTERN uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop);
+UV_EXTERN void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                          uv_loop_cb cb);
 
 UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
 UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -845,8 +845,12 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     return;
 #endif
 
-  if (QUEUE_EMPTY(&w->watcher_queue))
+  if (QUEUE_EMPTY(&w->watcher_queue)) {
     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+    if (loop->on_watcher_queue_updated)
+      loop->on_watcher_queue_updated(loop);
+  }
+
 
   if (loop->watchers[w->fd] == NULL) {
     loop->watchers[w->fd] = w;
@@ -882,8 +886,12 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
       w->events = 0;
     }
   }
-  else if (QUEUE_EMPTY(&w->watcher_queue))
+  else if (QUEUE_EMPTY(&w->watcher_queue)) {
     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+    if (loop->on_watcher_queue_updated)
+      loop->on_watcher_queue_updated(loop);
+  }
+
 }
 
 
@@ -899,6 +907,8 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w) {
   if (QUEUE_EMPTY(&w->pending_queue))
     QUEUE_INSERT_TAIL(&loop->pending_queue, &w->pending_queue);
+  if (loop->on_watcher_queue_updated)
+    loop->on_watcher_queue_updated(loop);
 }
 
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -46,6 +46,7 @@ int uv_loop_init(uv_loop_t* loop) {
 
   loop->active_handles = 0;
   loop->active_reqs.count = 0;
+  loop->on_watcher_queue_updated = NULL;
   loop->nfds = 0;
   loop->watchers = NULL;
   loop->nwatchers = 0;

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -96,3 +96,13 @@ void* uv_loop_get_data(const uv_loop_t* loop) {
 void uv_loop_set_data(uv_loop_t* loop, void* data) {
   loop->data = data;
 }
+
+uv_loop_cb uv_loop_get_watcher_queue_changed_callback(uv_loop_t* loop) {
+  return loop->on_watcher_queue_updated;
+}
+
+void uv_loop_set_watcher_queue_changed_callback(uv_loop_t* loop,
+                                                uv_loop_cb cb) {
+  loop->on_watcher_queue_updated = cb;
+}
+

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -242,6 +242,10 @@ int uv_loop_init(uv_loop_t* loop) {
   QUEUE_INIT(&loop->wq);
   QUEUE_INIT(&loop->handle_queue);
   loop->active_reqs.count = 0;
+  QUEUE_INIT(&loop->active_reqs);
+
+  loop->on_watcher_queue_updated = NULL;
+
   loop->active_handles = 0;
 
   loop->pending_reqs_tail = NULL;

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -1105,6 +1105,80 @@ TEST_IMPL(fs_event_error_reporting) {
 
 #endif  /* defined(__APPLE__) */
 
+static int lqw_fs_called = 0;
+static int lqw_file_changed = 0;
+static int lqw_watcher_called = 0;
+
+static void lqw_test_fs_cb(uv_fs_t* fst) {
+  lqw_fs_called = 1;
+}
+static void lqw_file_changed_cb(uv_fs_event_t* handle, const char* filename, int events, int status) {
+  uv_fs_event_stop(handle);
+  lqw_file_changed = 1;
+}
+static void lqw_test_watcher_cb(uv_loop_t* loop) {
+  lqw_watcher_called = 1;
+}
+
+TEST_IMPL(loop_queue_watcher_test) {
+
+  /* Create an open temp file */
+  const char * filename = "test.txt";
+  int r;
+  uv_os_fd_t file;
+  uv_fs_t req;
+  r = uv_fs_open(NULL, &req, filename, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  ASSERT(r == 0);
+  file = (uv_os_fd_t)req.result;
+  uv_fs_req_cleanup(&req);
+
+  /* Create the loop. */
+  uv_loop_t loop;
+  r = uv_loop_init(&loop);
+  ASSERT(r == 0);
+
+  /* Listen for watcher queue changes */
+  uv_loop_set_watcher_queue_changed_callback(&loop, lqw_test_watcher_cb);
+
+  /* Watch the file for changes */
+  uv_fs_event_t fs_event;
+  r = uv_fs_event_init(&loop, &fs_event);
+  ASSERT(r == 0);
+  r = uv_fs_event_start(&fs_event, lqw_file_changed_cb, filename, 0);
+  ASSERT(r == 0);
+
+  /* Queue an async write */
+  uv_buf_t buf;
+  buf.base = "Hello, world!";
+  buf.len = strlen(buf.base);
+  r = uv_fs_write(&loop, &req, file, &buf, 1, 0, lqw_test_fs_cb);
+  ASSERT(r == 0);
+
+  /* Run the loop. Confirm that the write finished, fs event fired */
+  r = uv_run(&loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+  ASSERT(lqw_file_changed);
+  ASSERT(lqw_fs_called);
+
+  uv_fs_req_cleanup(&req);
+
+  /* Now for the actual test: confirm the Loop Queue Watcher was called! */
+  ASSERT(lqw_watcher_called);
+
+  /* Cleanup */
+  r = uv_fs_close(NULL, &req, file, NULL);
+  ASSERT(r == 0);
+  uv_fs_req_cleanup(&req);
+  r = uv_fs_unlink(NULL, &req, filename, NULL);
+  ASSERT(r == 0);
+  uv_fs_req_cleanup(&req);
+
+  uv_loop_close(&loop);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
 TEST_IMPL(fs_event_watch_invalid_path) {
 #if defined(NO_FS_EVENTS)
   RETURN_SKIP(NO_FS_EVENTS);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -33,6 +33,7 @@ TEST_DECLARE   (loop_stop)
 TEST_DECLARE   (loop_update_time)
 TEST_DECLARE   (loop_backend_timeout)
 TEST_DECLARE   (loop_configure)
+TEST_DECLARE   (loop_queue_watcher_test)
 TEST_DECLARE   (default_loop_close)
 TEST_DECLARE   (barrier_1)
 TEST_DECLARE   (barrier_2)
@@ -459,6 +460,7 @@ TASK_LIST_START
 #if 0
   TEST_ENTRY  (callback_order)
 #endif
+
   TEST_ENTRY  (close_order)
   TEST_ENTRY  (run_once)
   TEST_ENTRY  (run_nowait)
@@ -469,6 +471,7 @@ TASK_LIST_START
   TEST_ENTRY  (loop_update_time)
   TEST_ENTRY  (loop_backend_timeout)
   TEST_ENTRY  (loop_configure)
+  TEST_ENTRY  (loop_queue_watcher_test)
   TEST_ENTRY  (default_loop_close)
   TEST_ENTRY  (barrier_1)
   TEST_ENTRY  (barrier_2)
@@ -975,4 +978,5 @@ TASK_LIST_START
   TEST_ENTRY  (fail_always)
   TEST_ENTRY  (pass_always)
 #endif
+
 TASK_LIST_END


### PR DESCRIPTION
Supersedes https://github.com/libuv/libuv/pull/1921 and targets `v1.x`.

This PR adds to` uv_loop_t` a callback field `on_queue_watcher_updated` which is called whenever the loop's watcher queue changes. It also adds a public getter and setter for this field.

Electron's Node Integration works by listening to Node's backend file descriptor in a separate thread; when an event is ready the backend file descriptor will trigger a new event for it, and the main thread will then iterate the libuv loop. For certain operations (ex. adding a timeout task) the backend file descriptor isn't informed, & as a result the main thread doesn't know it needs to iterate the libuv loop so  the timeout task will never execute until something else trigger a new event. This PR mitigates that problem.

cc @cjihrig 