### PR TITLE
unix: fix epoll cpu 100% issue

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -215,7 +215,7 @@ void uv_pipe_connect(uv_connect_t* req,
   }
 
   if (err == 0)
-    uv__io_start(handle->loop, &handle->io_watcher, POLLIN | POLLOUT);
+    uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);
 
 out:
   handle->delayed_error = err;


### PR DESCRIPTION
Remove the POLLIN flag at `uv_pipe_connect` to resolve epoll cpu 100% issue.

Fixes: #2162 