### PR TITLE
src,include: define UV_MAXHOSTNAMESIZE

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -534,6 +534,10 @@ API
 
     .. versionadded:: 1.12.0
 
+    .. versionchanged:: 1.26.0 `UV_MAXHOSTNAMESIZE` is available and represents
+                               the maximum `buffer` size required to store a
+                               hostname and terminating `nul` character.
+
 .. c:function:: int uv_os_getpriority(uv_pid_t pid, int* priority)
 
     Retrieves the scheduling priority of the process specified by `pid`. The

--- a/include/uv.h
+++ b/include/uv.h
@@ -1144,6 +1144,17 @@ UV_EXTERN int uv_os_getenv(const char* name, char* buffer, size_t* size);
 UV_EXTERN int uv_os_setenv(const char* name, const char* value);
 UV_EXTERN int uv_os_unsetenv(const char* name);
 
+#ifdef MAXHOSTNAMELEN
+# define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
+#else
+  /*
+    Fallback for the maximum hostname size, including the null terminator. The
+    Windows gethostname() documentation states that 256 bytes will always be
+    large enough to hold the null-terminated hostname.
+  */
+# define UV_MAXHOSTNAMESIZE 256
+#endif
+
 UV_EXTERN int uv_os_gethostname(char* buffer, size_t* size);
 
 UV_EXTERN int uv_os_uname(uv_utsname_t* buffer);

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -31,13 +31,14 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
-#include <netdb.h>
+#include <netdb.h>  /* MAXHOSTNAMELEN on Solaris */
 
 #include <termios.h>
 #include <pwd.h>
 
 #if !defined(__MVS__)
 #include <semaphore.h>
+#include <sys/param.h> /* MAXHOSTNAMELEN on Linux and the BSDs */
 #endif
 #include <pthread.h>
 #include <signal.h>

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -43,7 +43,6 @@
 #include <sys/utsname.h>
 
 #ifdef __sun
-# include <netdb.h> /* MAXHOSTNAMELEN on Solaris */
 # include <sys/filio.h>
 # include <sys/types.h>
 # include <sys/wait.h>
@@ -86,15 +85,6 @@
 
 #if defined(__MVS__)
 #include <sys/ioctl.h>
-#endif
-
-#if !defined(__MVS__)
-#include <sys/param.h> /* MAXHOSTNAMELEN on Linux and the BSDs */
-#endif
-
-/* Fallback for the maximum hostname length */
-#ifndef MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN 256
 #endif
 
 static int uv__run_pending(uv_loop_t* loop);
@@ -1291,7 +1281,7 @@ int uv_os_gethostname(char* buffer, size_t* size) {
     instead by creating a large enough buffer and comparing the hostname length
     to the size input.
   */
-  char buf[MAXHOSTNAMELEN + 1];
+  char buf[UV_MAXHOSTNAMESIZE];
   size_t len;
 
   if (buffer == NULL || size == NULL || *size == 0)

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -59,13 +59,6 @@
 # define UNLEN 256
 #endif
 
-/*
-  Max hostname length. The Windows gethostname() documentation states that 256
-  bytes will always be large enough to hold the null-terminated hostname.
-*/
-#ifndef MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN 256
-#endif
 
 /* Maximum environment variable size, including the terminating null */
 #define MAX_ENV_VAR_LENGTH 32767
@@ -1507,7 +1500,7 @@ int uv_os_unsetenv(const char* name) {
 
 
 int uv_os_gethostname(char* buffer, size_t* size) {
-  char buf[MAXHOSTNAMELEN + 1];
+  char buf[UV_MAXHOSTNAMESIZE];
   size_t len;
 
   if (buffer == NULL || size == NULL || *size == 0)

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -23,12 +23,8 @@
 #include "task.h"
 #include <string.h>
 
-#ifndef MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN 256
-#endif
-
 TEST_IMPL(gethostname) {
-  char buf[MAXHOSTNAMELEN + 1];
+  char buf[UV_MAXHOSTNAMESIZE];
   size_t size;
   size_t enobufs_size;
   int r;
@@ -52,7 +48,7 @@ TEST_IMPL(gethostname) {
   ASSERT(enobufs_size > 1);
 
   /* Successfully get the hostname */
-  size = MAXHOSTNAMELEN + 1;
+  size = UV_MAXHOSTNAMESIZE;
   r = uv_os_gethostname(buf, &size);
   ASSERT(r == 0);
   ASSERT(size > 1 && size == strlen(buf));


### PR DESCRIPTION
This commit adds `UV_MAXHOSTNAMESIZE` for working with `uv_os_gethostname()`. Prior to this commit, this logic was duplicated in several places across libuv and Node.js alone.

Passing CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1193/