### PR TITLE
unix: don't attempt to invalidate invalid fd

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1041,6 +1041,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct poll_ctl pc;
 
   assert(loop->watchers != NULL);
+  assert(fd >= 0);
 
   events = (struct pollfd*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -882,7 +882,8 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
   QUEUE_REMOVE(&w->pending_queue);
 
   /* Remove stale events for this file descriptor */
-  uv__platform_invalidate_fd(loop, w->fd);
+  if (w->fd != -1)
+    uv__platform_invalidate_fd(loop, w->fd);
 }
 
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -387,6 +387,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   uintptr_t nfds;
 
   assert(loop->watchers != NULL);
+  assert(fd >= 0);
 
   events = (struct kevent*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -141,6 +141,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   uintptr_t nfds;
 
   assert(loop->watchers != NULL);
+  assert(fd >= 0);
 
   events = (struct epoll_event*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -657,6 +657,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   uintptr_t nfds;
 
   assert(loop->watchers != NULL);
+  assert(fd >= 0);
 
   events = (struct epoll_event*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];

--- a/src/unix/posix-poll.c
+++ b/src/unix/posix-poll.c
@@ -298,6 +298,8 @@ update_timeout:
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   size_t i;
 
+  assert(fd >= 0);
+
   if (loop->poll_fds_iterating) {
     /* uv__io_poll is currently iterating.  Just invalidate fd.  */
     for (i = 0; i < loop->poll_fds_used; i++)

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -117,6 +117,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   uintptr_t nfds;
 
   assert(loop->watchers != NULL);
+  assert(fd >= 0);
 
   events = (struct port_event*) loop->watchers[loop->nwatchers];
   nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];


### PR DESCRIPTION
Add a missing check in uv__io_close() where it called
uv__platform_invalidate_fd() without checking that the
watcher actually has a valid file descriptor assigned.

Fixes: https://github.com/libuv/libuv/issues/2181
CI: https://ci.nodejs.org/job/libuv-test-commit/1214/