### PR TITLE
test: relax uv_hrtime() test assumptions

### DIFF
--- a/test/test-hrtime.c
+++ b/test/test-hrtime.c
@@ -41,13 +41,11 @@ TEST_IMPL(hrtime) {
 
     diff = b - a;
 
-    /*  printf("i= %d diff = %llu\n", i, (unsigned long long int) diff); */
-
     /* The windows Sleep() function has only a resolution of 10-20 ms. Check
-     * that the difference between the two hrtime values is somewhat in the
-     * range we expect it to be. */
+     * that the difference between the two hrtime values has a reasonable
+     * lower bound.
+     */
     ASSERT(diff > (uint64_t) 25 * NANOSEC / MILLISEC);
-    ASSERT(diff < (uint64_t) 80 * NANOSEC / MILLISEC);
     --i;
   }
   return 0;


### PR DESCRIPTION
Expecting `uv_sleep(45)` to wake up within 80 ms is not a reasonable
assumption: the operating system may not reschedule the process within
that time frame when the system is overloaded.

The test fails intermittently on our own CI and packagers have reported
similar failures.

Fixes: https://github.com/libuv/libuv/issues/2117
CI: https://ci.nodejs.org/job/libuv-test-commit/1230/