### PR TITLE
src: fill sockaddr_in6.sin6_len when it's defined

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -222,6 +222,9 @@ int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
   memset(addr, 0, sizeof(*addr));
   addr->sin6_family = AF_INET6;
   addr->sin6_port = htons(port);
+#ifdef SIN6_LEN
+  addr->sin6_len = sizeof(struct sockaddr_in6);
+#endif
 
   zone_index = strchr(ip, '%');
   if (zone_index != NULL) {


### PR DESCRIPTION
As some calls in some platforms require.

[Example](https://github.com/freebsd/freebsd/blob/312adcd9420d656ceb5941353169e87d0545d6d6/sys/netinet6/in6_mcast.c#L2007)

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1231/