### PR TITLE
fs: use WTF-8 on Windows

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -353,6 +353,7 @@ TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_file_flag_no_buffering)
 TEST_DECLARE   (fs_open_readonly_acl)
 TEST_DECLARE   (fs_fchmod_archive_readonly)
+TEST_DECLARE   (fs_wtf)
 #endif
 TEST_DECLARE   (strscpy)
 TEST_DECLARE   (threadpool_queue_work_simple)
@@ -916,6 +917,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_file_flag_no_buffering)
   TEST_ENTRY  (fs_open_readonly_acl)
   TEST_ENTRY  (fs_fchmod_archive_readonly)
+  TEST_ENTRY  (fs_wtf)
 #endif
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (open_osfhandle_valid_handle)


### PR DESCRIPTION
This allows working with filenames that are not well-formed UTF-16.

Since a `fs__wide_to_utf8` helper function already existed, I adapted it to be used across fs.c, added a similar function for the opposite direction and rewrote them to implement [WTF-8](https://simonsapin.github.io/wtf-8/).