### PR TITLE
bsd: plug uv_fs_event_start() error path fd leak

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -490,8 +490,11 @@ int uv_fs_event_start(uv_fs_event_t* handle,
     return UV__ERR(errno);
 
   handle->path = uv__strdup(path);
-  if (handle->path == NULL)
+  if (handle->path == NULL) {
+    uv__close_nocheckstdio(fd);
     return UV_ENOMEM;
+  }
+
   handle->cb = cb;
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);


### PR DESCRIPTION
Close the watched file's file descriptor when initialization fails due
to out-of-memory conditions.

CI: https://ci.nodejs.org/job/libuv-test-commit/1239/