### PR TITLE
build: add android-configure scripts to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,11 +121,13 @@ EXTRA_DIST = test/fixtures/empty_file \
              docs \
              img \
              samples \
-             android-configure \
+             android-configure-arm \
+             android-configure-arm64 \
+             android-configure-x86 \
+             android-configure-x86_64 \
              CONTRIBUTING.md \
              LICENSE \
              README.md \
-             checksparse.sh \
              vcbuild.bat \
              common.gypi \
              gyp_uv.py \

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ $ make -C out
 The default API level is 24, but a different one can be selected as follows:
 
 ```bash
-$ source ./android-configure ~/android-ndk-r15b gyp 21
+$ source ./android-configure-arm ~/android-ndk-r15b gyp 21
 $ make -C out
 ```
 


### PR DESCRIPTION
Commit baa81465a ("build: add compile for android arm64/x86/x86-64")
introduced a number of new android-configure scripts but didn't add
them to EXTRA_DIST in Makefile.am, causing `make dist` to fail.

This commit also removes checkspare.sh from EXTRA_DIST. I broke that
in commit a7a16219d ("unix: remove checksparse.sh") from last June.
Mea culpa!

Fixes: https://github.com/libuv/libuv/issues/2190
CI: https://ci.nodejs.org/job/libuv-test-commit/1240/