### PR TITLE
winsock: skip initialization in safe mode without network support

### DIFF
--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -87,6 +87,15 @@ void uv_winsock_init(void) {
   WSAPROTOCOL_INFOW protocol_info;
   int opt_len;
 
+  /* Set implicit binding address used by connectEx */
+  if (uv_ip4_addr("0.0.0.0", 0, &uv_addr_ip4_any_)) {
+	  abort();
+  }
+
+  if (uv_ip6_addr("::", 0, &uv_addr_ip6_any_)) {
+	  abort();
+  }
+
   /* Skip initialization in safe mode without network support */
   if (1 == GetSystemMetrics(SM_CLEANBOOT)) return;
 
@@ -94,15 +103,6 @@ void uv_winsock_init(void) {
   errorno = WSAStartup(MAKEWORD(2, 2), &wsa_data);
   if (errorno != 0) {
     uv_fatal_error(errorno, "WSAStartup");
-  }
-
-  /* Set implicit binding address used by connectEx */
-  if (uv_ip4_addr("0.0.0.0", 0, &uv_addr_ip4_any_)) {
-    abort();
-  }
-
-  if (uv_ip6_addr("::", 0, &uv_addr_ip6_any_)) {
-    abort();
   }
 
   /* Detect non-IFS LSPs */

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -79,6 +79,7 @@ static int error_means_no_support(DWORD error) {
          error == WSAEPFNOSUPPORT || error == WSAEAFNOSUPPORT;
 }
 
+
 void uv_winsock_init(void) {
   WSADATA wsa_data;
   int errorno;

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -89,11 +89,11 @@ void uv_winsock_init(void) {
 
   /* Set implicit binding address used by connectEx */
   if (uv_ip4_addr("0.0.0.0", 0, &uv_addr_ip4_any_)) {
-	  abort();
+    abort();
   }
 
   if (uv_ip6_addr("::", 0, &uv_addr_ip6_any_)) {
-	  abort();
+    abort();
   }
 
   /* Skip initialization in safe mode without network support */

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -79,6 +79,9 @@ static int error_means_no_support(DWORD error) {
          error == WSAEPFNOSUPPORT || error == WSAEAFNOSUPPORT;
 }
 
+static BOOL is_fail_safe_boot_without_network() {
+  return 1 == GetSystemMetrics(SM_CLEANBOOT);
+}
 
 void uv_winsock_init(void) {
   WSADATA wsa_data;
@@ -86,6 +89,9 @@ void uv_winsock_init(void) {
   SOCKET dummy;
   WSAPROTOCOL_INFOW protocol_info;
   int opt_len;
+
+  /* Skip initialization in safe mode without network support */
+  if (is_fail_safe_boot_without_network()) return;
 
   /* Initialize winsock */
   errorno = WSAStartup(MAKEWORD(2, 2), &wsa_data);

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -79,10 +79,6 @@ static int error_means_no_support(DWORD error) {
          error == WSAEPFNOSUPPORT || error == WSAEAFNOSUPPORT;
 }
 
-static BOOL is_fail_safe_boot_without_network() {
-  return 1 == GetSystemMetrics(SM_CLEANBOOT);
-}
-
 void uv_winsock_init(void) {
   WSADATA wsa_data;
   int errorno;
@@ -91,7 +87,7 @@ void uv_winsock_init(void) {
   int opt_len;
 
   /* Skip initialization in safe mode without network support */
-  if (is_fail_safe_boot_without_network()) return;
+  if (1 == GetSystemMetrics(SM_CLEANBOOT)) return;
 
   /* Initialize winsock */
   errorno = WSAStartup(MAKEWORD(2, 2), &wsa_data);


### PR DESCRIPTION
uv_winsock_init calls abort() if socket operation failed, which means
all libuv-based applications are not able to start in safe mode without network.
Node.js and Electron are examples of such applications