### PR TITLE
test: fix link errors on smartos

### DIFF
--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -20,7 +20,7 @@
  */
 
 #include "task.h"
-#include "../src/idna.c"
+#include "../src/idna.h"
 #include <string.h>
 
 TEST_IMPL(utf8_decode1) {

--- a/test/test-strscpy.c
+++ b/test/test-strscpy.c
@@ -24,7 +24,6 @@
 #include <string.h>
 
 #include "../src/strscpy.h"
-#include "../src/strscpy.c"
 
 TEST_IMPL(strscpy) {
   char d[4];


### PR DESCRIPTION
Avoid multiply-defined symbol errors by just including the header files.

I was getting these errors when building locally on a `smartos` VM:
```
LINK(target) /home/sgimeno/libuv/out/Debug/run-tests
ld: fatal: symbol 'uv__utf8_decode1' is multiply-defined:
        (file /home/sgimeno/libuv/out/Debug/obj.target/run-tests/test/test-idna.o type=FUNC; file /home/sgimeno/libuv/out/Debug/obj.target/libuv.a(idna.o) type=FUNC);
ld: fatal: symbol 'uv__idna_toascii' is multiply-defined:
        (file /home/sgimeno/libuv/out/Debug/obj.target/run-tests/test/test-idna.o type=FUNC; file /home/sgimeno/libuv/out/Debug/obj.target/libuv.a(idna.o) type=FUNC);
ld: fatal: symbol 'uv__strscpy' is multiply-defined:
        (file /home/sgimeno/libuv/out/Debug/obj.target/run-tests/test/test-strscpy.o type=FUNC; file /home/sgimeno/libuv/out/Debug/obj.target/libuv.a(strscpy.o) type=FUNC);
ld: fatal: file processing errors. No output written to /home/sgimeno/libuv/out/Debug/run-tests
collect2: error: ld returned 1 exit status
gmake: *** [test/run-tests.target.mk:264: /home/sgimeno/libuv/out/Debug/run-tests] Error 1
gmake: Leaving directory '/home/sgimeno/libuv/out'
```