### PR TITLE
test: changing localhost to 127.0.0.1

### DIFF
--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -25,7 +25,7 @@
 
 #define CONCURRENT_COUNT    10
 
-static const char* name = "localhost";
+static const char* name = "127.0.0.1";
 
 static int getaddrinfo_cbs = 0;
 

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -25,7 +25,7 @@
 
 #define CONCURRENT_COUNT    10
 
-static const char* name = "google.com";
+static const char* name = "libuv.org";
 
 static int getaddrinfo_cbs = 0;
 

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -25,7 +25,7 @@
 
 #define CONCURRENT_COUNT    10
 
-static const char* name = "127.0.0.1";
+static const char* name = "google.com";
 
 static int getaddrinfo_cbs = 0;
 

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -68,7 +68,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
   r = uv_getaddrinfo(req->loop,
                      &req->handle,
                      getaddrinfo_cb,
-                     "localhost",
+                     "127.0.0.1",
                      NULL,
                      NULL);
   ASSERT(r == 0);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -68,7 +68,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
   r = uv_getaddrinfo(req->loop,
                      &req->handle,
                      getaddrinfo_cb,
-                     "google.com",
+                     "libuv.org",
                      NULL,
                      NULL);
   ASSERT(r == 0);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -68,7 +68,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
   r = uv_getaddrinfo(req->loop,
                      &req->handle,
                      getaddrinfo_cb,
-                     "google.com",
+                     "127.0.0.1",
                      NULL,
                      NULL);
   ASSERT(r == 0);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -68,7 +68,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
   r = uv_getaddrinfo(req->loop,
                      &req->handle,
                      getaddrinfo_cb,
-                     "127.0.0.1",
+                     "google.com",
                      NULL,
                      NULL);
   ASSERT(r == 0);


### PR DESCRIPTION
"localhost" may go through dns lookup depending on system settings
which may take longer than 5 second and cause a timeout on the test.
using 127.0.0.1 will assure dns lookup never occurs.