### PR TITLE
unix: fix __FreeBSD_kernel__ typo

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -47,7 +47,7 @@
 
 #if defined(__DragonFly__)        ||                                      \
     defined(__FreeBSD__)          ||                                      \
-    defined(__FreeBSD_kernel_)    ||                                      \
+    defined(__FreeBSD_kernel__)   ||                                      \
     defined(__OpenBSD__)          ||                                      \
     defined(__NetBSD__)
 # define HAVE_PREADV 1


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/2212

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1248/

EDIT: CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1249/. zOS failures are unrelated.