### PR TITLE
unix: report bind error in uv_tcp_connect()

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -81,10 +81,9 @@ API
     initialized ``struct sockaddr_in`` or ``struct sockaddr_in6``.
 
     When the port is already taken, you can expect to see an ``UV_EADDRINUSE``
-    error from either :c:func:`uv_tcp_bind`, :c:func:`uv_listen` or
-    :c:func:`uv_tcp_connect`. That is, a successful call to this function does
-    not guarantee that the call to :c:func:`uv_listen` or :c:func:`uv_tcp_connect`
-    will succeed as well.
+    error from :c:func:`uv_listen` or :c:func:`uv_tcp_connect`. That is,
+    a successful call to this function does not guarantee that the call
+    to :c:func:`uv_listen` or :c:func:`uv_tcp_connect` will succeed as well.
 
     `flags` can contain ``UV_TCP_IPV6ONLY``, in which case dual-stack support
     is disabled and only IPv6 is used.

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -214,13 +214,14 @@ int uv__tcp_connect(uv_connect_t* req,
   if (handle->connect_req != NULL)
     return UV_EALREADY;  /* FIXME(bnoordhuis) UV_EINVAL or maybe UV_EBUSY. */
 
+  if (handle->delayed_error != 0)
+    goto out;
+
   err = maybe_new_socket(handle,
                          addr->sa_family,
                          UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
   if (err)
     return err;
-
-  handle->delayed_error = 0;
 
   do {
     errno = 0;
@@ -248,6 +249,8 @@ int uv__tcp_connect(uv_connect_t* req,
     else
       return UV__ERR(errno);
   }
+
+out:
 
   uv__req_init(handle->loop, req, UV_CONNECT);
   req->cb = cb;

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -228,7 +228,7 @@ static int tcp4_echo_start(int port) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", port, &addr));
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", port, &addr));
 
   server = (uv_handle_t*)&tcpServer;
   serverType = TCP;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -116,7 +116,8 @@ TEST_DECLARE   (tcp_open_bound)
 TEST_DECLARE   (tcp_open_connected)
 TEST_DECLARE   (tcp_connect_error_after_write)
 TEST_DECLARE   (tcp_shutdown_after_write)
-TEST_DECLARE   (tcp_bind_error_addrinuse)
+TEST_DECLARE   (tcp_bind_error_addrinuse_connect)
+TEST_DECLARE   (tcp_bind_error_addrinuse_listen)
 TEST_DECLARE   (tcp_bind_error_addrnotavail_1)
 TEST_DECLARE   (tcp_bind_error_addrnotavail_2)
 TEST_DECLARE   (tcp_bind_error_fault)
@@ -671,7 +672,13 @@ TASK_LIST_START
   TEST_HELPER (tcp_shutdown_after_write, tcp4_echo_server)
 
   TEST_ENTRY  (tcp_connect_error_after_write)
-  TEST_ENTRY  (tcp_bind_error_addrinuse)
+  TEST_ENTRY  (tcp_bind_error_addrinuse_connect)
+  /* tcp4_echo_server steals the port. It needs to be a separate process
+   * because libuv sets setsockopt(SO_REUSEADDR) that lets you steal an
+   * existing bind if it originates from the same process.
+   */
+  TEST_HELPER (tcp_bind_error_addrinuse_connect, tcp4_echo_server)
+  TEST_ENTRY  (tcp_bind_error_addrinuse_listen)
   TEST_ENTRY  (tcp_bind_error_addrnotavail_1)
   TEST_ENTRY  (tcp_bind_error_addrnotavail_2)
   TEST_ENTRY  (tcp_bind_error_fault)

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 
+static int connect_cb_called = 0;
 static int close_cb_called = 0;
 
 
@@ -34,7 +35,49 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
-TEST_IMPL(tcp_bind_error_addrinuse) {
+static void connect_cb(uv_connect_t* req, int status) {
+  ASSERT(status == UV_EADDRINUSE);
+  uv_close((uv_handle_t*) req->handle, close_cb);
+  connect_cb_called++;
+}
+
+
+TEST_IMPL(tcp_bind_error_addrinuse_connect) {
+  struct sockaddr_in addr;
+  int addrlen;
+  uv_connect_t req;
+  uv_tcp_t conn;
+
+  /* 127.0.0.1:<TEST_PORT> is already taken by tcp4_echo_server running in
+   * another process. uv_tcp_bind() and uv_tcp_connect() should still succeed
+   * (greatest common denominator across platforms) but the connect callback
+   * should receive an UV_EADDRINUSE error.
+   */
+  ASSERT(0 == uv_tcp_init(uv_default_loop(), &conn));
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT(0 == uv_tcp_bind(&conn, (const struct sockaddr*) &addr, 0));
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT + 1, &addr));
+  ASSERT(0 == uv_tcp_connect(&req,
+                             &conn,
+                             (const struct sockaddr*) &addr,
+                             connect_cb));
+
+  addrlen = sizeof(addr);
+  ASSERT(UV_EADDRINUSE == uv_tcp_getsockname(&conn,
+                                             (struct sockaddr*) &addr,
+                                             &addrlen));
+
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT(connect_cb_called == 1);
+  ASSERT(close_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
+TEST_IMPL(tcp_bind_error_addrinuse_listen) {
   struct sockaddr_in addr;
   uv_tcp_t server1, server2;
   int r;


### PR DESCRIPTION
Fix a bug where libuv forgets about EADDRINUSE errors reported earlier:
uv_tcp_bind() + uv_tcp_connect() seemingly succeed but the socket isn't
actually bound to the requested address.

This bug goes back to at least 2011 if indeed it ever worked at all.

CI: https://ci.nodejs.org/job/libuv-test-commit/1260/