### PR TITLE
Allow uv_udp_send() to accept `sockaddr_un` addresses

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -34,6 +34,7 @@
 # include <malloc.h> /* malloc */
 #else
 # include <net/if.h> /* if_nametoindex */
+# include <sys/un.h> /* AF_UNIX, sockaddr_un */
 #endif
 
 
@@ -376,6 +377,10 @@ int uv__udp_check_before_send(uv_udp_t* handle, const struct sockaddr* addr) {
       addrlen = sizeof(struct sockaddr_in);
     else if (addr->sa_family == AF_INET6)
       addrlen = sizeof(struct sockaddr_in6);
+#if defined(AF_UNIX) && !defined(_WIN32)
+    else if (addr->sa_family == AF_UNIX)
+      addrlen = sizeof(struct sockaddr_un);
+#endif
     else
       return UV_EINVAL;
   } else {

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -155,6 +155,9 @@ TEST_DECLARE   (udp_open)
 TEST_DECLARE   (udp_open_twice)
 TEST_DECLARE   (udp_open_bound)
 TEST_DECLARE   (udp_open_connect)
+#ifndef _WIN32
+TEST_DECLARE   (udp_send_unix)
+#endif
 TEST_DECLARE   (udp_try_send)
 TEST_DECLARE   (pipe_bind_error_addrinuse)
 TEST_DECLARE   (pipe_bind_error_addrnotavail)
@@ -657,6 +660,9 @@ TASK_LIST_START
   TEST_ENTRY  (udp_open_bound)
   TEST_ENTRY  (udp_open_connect)
   TEST_HELPER (udp_open_connect, udp4_echo_server)
+#ifndef _WIN32
+  TEST_ENTRY  (udp_send_unix)
+#endif
 
   TEST_ENTRY  (pipe_bind_error_addrinuse)
   TEST_ENTRY  (pipe_bind_error_addrnotavail)


### PR DESCRIPTION
While working on integrating the new `uv_udp_connect()` into [uvloop](https://github.com/MagicStack/uvloop/pull/238) I've discovered that libuv doesn't allow `uv_udp_send()` to work with Unix sockets.  While libuv doesn't expose any APIs to create `uv_udp_t` handles over a Unix socket, it does have the `uv_udp_open()` function which accepts Unix sockets just fine.  It seems that the inability of `uv_udp_send()` to work with Unix sockets is a simple overlook.

This PR doesn't have any backwards compatibility issues.