### PR TITLE
fs: remove macOS-specific copyfile(3)

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -889,45 +889,6 @@ done:
 }
 
 static ssize_t uv__fs_copyfile(uv_fs_t* req) {
-#if defined(__APPLE__) && !TARGET_OS_IPHONE
-  /* On macOS, use the native copyfile(3). */
-  static int can_clone;
-  copyfile_flags_t flags;
-  char buf[64];
-  size_t len;
-  int major;
-
-  flags = COPYFILE_ALL;
-
-  if (req->flags & UV_FS_COPYFILE_EXCL)
-    flags |= COPYFILE_EXCL;
-
-  /* Check OS version. Cloning is only supported on macOS >= 10.12. */
-  if (req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
-    if (can_clone == 0) {
-      len = sizeof(buf);
-      if (sysctlbyname("kern.osrelease", buf, &len, NULL, 0))
-        return UV__ERR(errno);
-
-      if (1 != sscanf(buf, "%d", &major))
-        abort();
-
-      can_clone = -1 + 2 * (major >= 16);  /* macOS >= 10.12 */
-    }
-
-    if (can_clone < 0)
-      return UV_ENOSYS;
-  }
-
-  /* copyfile() simply ignores COPYFILE_CLONE if it's not supported. */
-  if (req->flags & UV_FS_COPYFILE_FICLONE)
-    flags |= 1 << 24;  /* COPYFILE_CLONE */
-
-  if (req->flags & UV_FS_COPYFILE_FICLONE_FORCE)
-    flags |= 1 << 25;  /* COPYFILE_CLONE_FORCE */
-
-  return copyfile(req->path, req->new_path, NULL, flags);
-#else
   uv_fs_t fs_req;
   uv_file srcfd;
   uv_file dstfd;
@@ -1054,7 +1015,6 @@ out:
 
   errno = UV__ERR(result);
   return -1;
-#endif
 }
 
 static void uv__to_stat(struct stat* src, uv_stat_t* dst) {

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -60,7 +60,6 @@
 #endif
 
 #if defined(__APPLE__)
-# include <copyfile.h>
 # include <sys/sysctl.h>
 #elif defined(__linux__) && !defined(FICLONE)
 # include <sys/ioctl.h>

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -185,6 +185,7 @@ TEST_IMPL(fs_copyfile) {
   if (r == 0)
     handle_result(&req);
 
+#ifndef _WIN32
   /* Copying respects permissions/mode. */
   unlink(dst);
   touch_file(dst, 0);
@@ -193,6 +194,7 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(req.result == UV_EACCES);
   ASSERT(r == UV_EACCES);
   uv_fs_req_cleanup(&req);
+#endif
 
   unlink(dst); /* Cleanup */
   return 0;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -185,6 +185,15 @@ TEST_IMPL(fs_copyfile) {
   if (r == 0)
     handle_result(&req);
 
+  /* Copying respects permissions/mode. */
+  unlink(dst);
+  touch_file(dst, 0);
+  chmod(dst, S_IRUSR|S_IRGRP|S_IROTH); /* Sets file mode to 444 (read-only). */
+  r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
+  ASSERT(req.result == UV_EACCES);
+  ASSERT(r == UV_EACCES);
+  uv_fs_req_cleanup(&req);
+
   unlink(dst); /* Cleanup */
   return 0;
 }


### PR DESCRIPTION
Using copyfile(3) on macOS apparently results in situations where file
permissions are ignored. Using the same code for other UNIX-like
operating systems seems to fix the issue.

Refs: https://github.com/nodejs/node/issues/26936#issuecomment-476992597

@cjihrig 