### PR TITLE
build: partially revert 5234b1c43a

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,11 +45,9 @@ libuv_la_SOURCES = src/fs-poll.c \
                    src/version.c
 
 if SUNOS
-if GCC
 # Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers
 # on other platforms complain that the argument is unused during compilation.
 libuv_la_CFLAGS += -pthreads
-endif
 endif
 
 if WINNT
@@ -143,19 +141,13 @@ check_PROGRAMS = test/run-tests
 if OS390
 test_run_tests_CFLAGS =
 else
-if GCC
 test_run_tests_CFLAGS = -Wno-long-long
-else
-test_run_tests_CFLAGS =
-endif
 endif
 
 if SUNOS
-if GCC
 # Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers
 # on other platforms complain that the argument is unused during compilation.
 test_run_tests_CFLAGS += -pthreads
-endif
 endif
 
 test_run_tests_LDFLAGS =

--- a/configure.ac
+++ b/configure.ac
@@ -24,18 +24,16 @@ AC_ENABLE_SHARED
 AC_ENABLE_STATIC
 AC_PROG_CC
 AM_PROG_CC_C_O
+AS_IF([AS_CASE([$host_os],[openedition*],  [false], [true])], [
+  CC_CHECK_CFLAGS_APPEND([-pedantic])
+])
 CC_FLAG_VISIBILITY #[-fvisibility=hidden]
 CC_CHECK_CFLAGS_APPEND([-g])
-AS_IF([test "x$GCC" = xyes], [
-  AS_IF([AS_CASE([$host_os], [openedition*], [false], [true])], [
-    CC_CHECK_CFLAGS_APPEND([-pedantic])
-  ])
-  CC_CHECK_CFLAGS_APPEND([-std=gnu89])
-  CC_CHECK_CFLAGS_APPEND([-Wall])
-  CC_CHECK_CFLAGS_APPEND([-Wextra])
-  CC_CHECK_CFLAGS_APPEND([-Wno-unused-parameter])
-  CC_CHECK_CFLAGS_APPEND([-Wstrict-prototypes])
-])
+CC_CHECK_CFLAGS_APPEND([-std=gnu89])
+CC_CHECK_CFLAGS_APPEND([-Wall])
+CC_CHECK_CFLAGS_APPEND([-Wextra])
+CC_CHECK_CFLAGS_APPEND([-Wno-unused-parameter])
+CC_CHECK_CFLAGS_APPEND([-Wstrict-prototypes])
 # AM_PROG_AR is not available in automake v0.11 but it's essential in v0.12.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 # autoconf complains if AC_PROG_LIBTOOL precedes AM_PROG_AR.
@@ -52,7 +50,6 @@ AC_CHECK_LIB([rt], [clock_gettime])
 AC_CHECK_LIB([sendfile], [sendfile])
 AC_CHECK_LIB([socket], [socket])
 AC_SYS_LARGEFILE
-AM_CONDITIONAL([GCC],      [AS_IF([test "x$GCC" = xyes],        [true], [false])])
 AM_CONDITIONAL([AIX],      [AS_CASE([$host_os],[aix*],          [true], [false])])
 AM_CONDITIONAL([ANDROID],  [AS_CASE([$host_os],[linux-android*],[true], [false])])
 AM_CONDITIONAL([CYGWIN],   [AS_CASE([$host_os],[cygwin*],       [true], [false])])


### PR DESCRIPTION
This undoes the changes commit 5234b1c4 ("build,sunos: better handling
of non-GCC compiler") makes to configure.ac and Makefile.am because they
break the build on the centos6 buildbots with the following error:

    # <snip>
    checking for _FILE_OFFSET_BITS value needed for large files... no
    ./configure: line 12957: syntax error near unexpected token `;'
    ./configure: line 12957: `; then'
    Build step 'Execute shell' marked build as failure

CI: https://ci.nodejs.org/job/libuv-test-commit/1328/

cc @apaprocki