### PR TITLE
unix: fix race condition in uv_async_send()

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -57,12 +57,13 @@ int uv_async_init(uv_loop_t* loop, uv_async_t* handle, uv_async_cb async_cb) {
 
 
 int uv_async_send(uv_async_t* handle) {
+  uv_loop_t* loop = handle->loop;
   /* Do a cheap read first. */
   if (ACCESS_ONCE(int, handle->pending) != 0)
     return 0;
 
   if (cmpxchgi(&handle->pending, 0, 1) == 0)
-    uv__async_send(handle->loop);
+    uv__async_send(loop);
 
   return 0;
 }


### PR DESCRIPTION
This is a simpler fix to the https://github.com/libuv/libuv/issues/2226 issue.
We simply need to read the loop before doing the cmpxchgi(). After the exchange the handle might as well be freed, we simply use the previously read loop to call uv__async_send(). The exchange op will enforce proper ordering.