### PR TITLE
unix,win: introduced uv_udp_send_ex and uv_udp_try_send_ex

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -312,6 +312,29 @@ API
 
     .. versionchanged:: 1.27.0 added support for connected sockets
 
+.. c:function:: int uv_udp_send_ex(uv_udp_send_t* req, uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr, unsigned int addrlen, uv_udp_send_cb send_cb)
+
+    Same as :c:func:`uv_udp_send`, but accepts any `struct sockaddr`.
+
+    :param req: UDP request handle. Need not be initialized.
+
+    :param handle: UDP handle. Should have been initialized with
+        :c:func:`uv_udp_init`.
+
+    :param bufs: List of buffers to send.
+
+    :param nbufs: Number of buffers in `bufs`.
+
+    :param addr: any `struct sockaddr`
+    
+    :param addrlen: Length of given `struct sockaddr`
+
+    :param send_cb: Callback to invoke when the data has been sent out.
+
+    :returns: 0 on success, or an error code < 0 on failure.
+    
+    .. versionadded:: 1.28.0
+
 .. c:function:: int uv_udp_try_send(uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr)
 
     Same as :c:func:`uv_udp_send`, but won't queue a send request if it can't
@@ -328,6 +351,17 @@ API
         can't be sent immediately).
 
     .. versionchanged:: 1.27.0 added support for connected sockets
+
+.. c:function:: int uv_udp_try_send_ex(uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr, unsigned int addrlen)
+
+    Same as :c:func:`uv_udp_send_ex`, but won't queue a send request if it can't
+    be completed immediately.
+
+    :returns: >= 0: number of bytes sent (it matches the given buffer size).
+        < 0: negative error code (``UV_EAGAIN`` is returned when the message
+        can't be sent immediately).
+        
+    .. versionadded:: 1.28.0
 
 .. c:function:: int uv_udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -655,10 +655,22 @@ UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
                           unsigned int nbufs,
                           const struct sockaddr* addr,
                           uv_udp_send_cb send_cb);
+UV_EXTERN int uv_udp_send_ex(uv_udp_send_t* req,
+                             uv_udp_t* handle,
+                             const uv_buf_t bufs[],
+                             unsigned int nbufs,
+                             const struct sockaddr* addr,
+                             unsigned int addrlen,
+                             uv_udp_send_cb send_cb);
 UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
                               const uv_buf_t bufs[],
                               unsigned int nbufs,
                               const struct sockaddr* addr);
+UV_EXTERN int uv_udp_try_send_ex(uv_udp_t* handle,
+                                 const uv_buf_t bufs[],
+                                 unsigned int nbufs,
+                                 const struct sockaddr* addr,
+                                 unsigned int addrlen);
 UV_EXTERN int uv_udp_recv_start(uv_udp_t* handle,
                                 uv_alloc_cb alloc_cb,
                                 uv_udp_recv_cb recv_cb);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -401,6 +401,16 @@ int uv_udp_send(uv_udp_send_t* req,
   return uv__udp_send(req, handle, bufs, nbufs, addr, addrlen, send_cb);
 }
 
+int uv_udp_send_ex(uv_udp_send_t* req,
+                   uv_udp_t* handle,
+                   const uv_buf_t bufs[],
+                   unsigned int nbufs,
+                   const struct sockaddr* addr,
+                   unsigned int addrlen,
+                   uv_udp_send_cb send_cb) {
+  return uv__udp_send(req, handle, bufs, nbufs, addr, addrlen, send_cb);
+}
+
 
 int uv_udp_try_send(uv_udp_t* handle,
                     const uv_buf_t bufs[],
@@ -415,6 +425,13 @@ int uv_udp_try_send(uv_udp_t* handle,
   return uv__udp_try_send(handle, bufs, nbufs, addr, addrlen);
 }
 
+int uv_udp_try_send_ex(uv_udp_t* handle,
+                       const uv_buf_t bufs[],
+                       unsigned int nbufs,
+                       const struct sockaddr* addr,
+                       unsigned int addrlen) {
+  return uv__udp_try_send(handle, bufs, nbufs, addr, addrlen);
+}
 
 int uv_udp_recv_start(uv_udp_t* handle,
                       uv_alloc_cb alloc_cb,


### PR DESCRIPTION
This is work @k13-engineering did in #1925, to which I've added tests.

> Currently only sockaddr_in or sockaddr_in6 may be passed when sending UDP packets. Up until now based on the address family (AF_INET or AF_INET6) the length parameter was determined and therefore other families result in error.
>
> The documentation of uv_udp_open suggests that also other datagram sockets may be given, giving netlink as example. In order to fullfill that those sockets may be used, we need a possibility to specify the length parameter explicitly. For this purpose this commit introduces the new uv_udp_send_ex and uv_udp_try_send_ex methods.

It would be wonderful to be able to talk to netlink from Node.