### PR TITLE
unix,win: add uv_get_usec_since_epoch 

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -583,5 +583,18 @@ API
 
     Cross-platform implementation of :man:`gettimeofday(2)`. The timezone
     argument to `gettimeofday()` is not supported, as it is considered obsolete.
+    `uv_gettimeofday()` uses a real-time clock (TZ aware, and can jump back in time),
+    whereas `uv_hrtime()` uses a monotonic clock (might slow down but not jump back).
+    It is not recommanded to use `uv_gettimeofday()` to measure time differences.
+    Refs: https://blog.habets.se/2010/09/gettimeofday-should-never-be-used-to-measure-time.html
+
+    .. versionadded:: 1.28.0
+
+.. c:function:: int64_t uv_get_usec_since_epoch(void)
+
+    Cross-platform implementation of micro-seconds since epoch. Similar to
+    :man:`gettimeofday(2)`. Negative returned values are error codes.
+    In order to support dates after Y2K38 this does not support system dates
+    before epoch (2017-01-01).
 
     .. versionadded:: 1.28.0

--- a/include/uv.h
+++ b/include/uv.h
@@ -1610,6 +1610,7 @@ UV_EXTERN void* uv_key_get(uv_key_t* key);
 UV_EXTERN void uv_key_set(uv_key_t* key, void* value);
 
 UV_EXTERN int uv_gettimeofday(uv_timeval_t* tv);
+UV_EXTERN int64_t uv_get_usec_since_epoch(void);
 
 typedef void (*uv_thread_cb)(void* arg);
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1444,3 +1444,18 @@ int uv_gettimeofday(uv_timeval_t* tv) {
   tv->tv_usec = time.tv_usec;
   return 0;
 }
+
+int64_t uv_get_usec_since_epoch() {
+  int64_t ret;
+  struct timeval time;
+
+  if (gettimeofday(&time, NULL) != 0)
+    return UV__ERR(errno);
+
+  /* cast to unsigned to prefer Y2K38 over dates < 1970 */
+  ret = (int64_t)(uint32_t)time.tv_sec * 1000000;
+  /* assert we didn't overflow when converting sec to usec */
+  assert(ret > 0);
+  ret += (int64_t)time.tv_usec;
+  return ret;
+}

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -27,13 +27,27 @@ TEST_IMPL(gettimeofday) {
   int r;
 
   tv.tv_sec = 0;
+  tv.tv_nsec = -1;
   r = uv_gettimeofday(&tv);
   ASSERT(r == 0);
   ASSERT(tv.tv_sec != 0);
+  ASSERT(tv.tv_usec != -1);
 
   /* Test invalid input. */
   r = uv_gettimeofday(NULL);
   ASSERT(r == UV_EINVAL);
+
+  return 0;
+}
+
+TEST_IMPL(get_usec_since_epoch) {
+  int64_t r;
+
+  r = uv_get_usec_since_epoch();
+  /* didn't overflow or error */
+  ASSERT(r > 0);
+  /* bigger then value at time of writing this test */
+  ASSERT(r > 1554131909151939);
 
   return 0;
 }


### PR DESCRIPTION
~Change signature to `int64_t uv_gettimeofday()`, based on https://github.com/libuv/libuv/issues/2243~

~I thought about changing the name to `uv_get_usec_since_epoch` but that might be too much...~

~CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1335/~

Went with a new `int64_t uv_get_usec_since_epoch(void)` after all.