### PR TITLE
build: use APPLE variable to detect apple platform in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
        src/unix/sysinfo-memory.c)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|Linux|OS/390")
+if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux|OS/390")
   list(APPEND uv_sources src/unix/proctitle.c)
 endif()
 
@@ -277,11 +277,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
   list(APPEND uv_libraries kvm)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin|DragonFly|FreeBSD|NetBSD|OpenBSD")
+if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
   list(APPEND uv_sources src/unix/bsd-ifaddrs.c src/unix/kqueue.c)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(APPLE)
   list(APPEND uv_defines _DARWIN_UNLIMITED_SELECT=1 _DARWIN_USE_64_BIT_INODE=1)
   list(APPEND uv_sources
        src/unix/darwin-proctitle.c
@@ -335,7 +335,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
   list(APPEND uv_sources src/unix/no-proctitle.c src/unix/sunos.c)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin|DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
+if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
   list(APPEND uv_test_libraries util)
 endif()
 


### PR DESCRIPTION
CMake 3.14 built-in support `iOS`, `tvOS`, and `watchOS` platform toolchain now. It will be nice to use `APPLE` variable to detect platforms above rather then checking by `CMAKE_SYSTEM_NAME`.

This change is not a break change because CMake supports the `APPLE` variable since 3.0.

- CMake 3.14: supports Cross Compiling for`iOS`, `tvOS`, or `watchOS` using simple toolchain files
  https://cmake.org/cmake/help/v3.14/release/3.14.html#platforms

- CMake 3.10: `APPLE` variable set to `TURE` when the target system is an Apple platform (macOS, iOS, tvOS or watchOS)
  https://cmake.org/cmake/help/v3.10/variable/APPLE.html

- CMake 3.0: `APPLE` variable support since v3.0
  https://cmake.org/cmake/help/v3.0/variable/APPLE.html

## Build Test

``` bash
mkdir build
cd build
cmake -DBUILD_TESTING=ON ..
make
```