### PR TITLE
unix,win: introduce uv_timeval64_t

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -579,7 +579,7 @@ API
 
     .. versionadded:: 1.25.0
 
-.. c:function:: int uv_gettimeofday(uv_timeval_t* tv)
+.. c:function:: int uv_gettimeofday(uv_timeval64_t* tv)
 
     Cross-platform implementation of :man:`gettimeofday(2)`. The timezone
     argument to `gettimeofday()` is not supported, as it is considered obsolete.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -65,6 +65,28 @@ Data types
 
     .. versionadded:: 1.16.0
 
+.. c:type:: uv_timeval_t
+
+    Data type for storing times.
+
+    ::
+
+        typedef struct {
+            long tv_sec;
+            long tv_usec;
+        } uv_timeval_t;
+
+.. c:type:: uv_timeval64_t
+
+    Alternative data type for storing times.
+
+    ::
+
+        typedef struct {
+            int64_t tv_sec;
+            int32_t tv_usec;
+        } uv_timeval64_t;
+
 .. c:type:: uv_rusage_t
 
     Data type for resource usage results.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1100,6 +1100,11 @@ typedef struct {
 } uv_timeval_t;
 
 typedef struct {
+  int64_t tv_sec;
+  int32_t tv_usec;
+} uv_timeval64_t;
+
+typedef struct {
    uv_timeval_t ru_utime; /* user CPU time used */
    uv_timeval_t ru_stime; /* system CPU time used */
    uint64_t ru_maxrss;    /* maximum resident set size */
@@ -1609,7 +1614,7 @@ UV_EXTERN void uv_key_delete(uv_key_t* key);
 UV_EXTERN void* uv_key_get(uv_key_t* key);
 UV_EXTERN void uv_key_set(uv_key_t* key, void* value);
 
-UV_EXTERN int uv_gettimeofday(uv_timeval_t* tv);
+UV_EXTERN int uv_gettimeofday(uv_timeval64_t* tv);
 
 typedef void (*uv_thread_cb)(void* arg);
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1431,7 +1431,7 @@ int uv__getsockpeername(const uv_handle_t* handle,
   return 0;
 }
 
-int uv_gettimeofday(uv_timeval_t* tv) {
+int uv_gettimeofday(uv_timeval64_t* tv) {
   struct timeval time;
 
   if (tv == NULL)
@@ -1440,7 +1440,7 @@ int uv_gettimeofday(uv_timeval_t* tv) {
   if (gettimeofday(&time, NULL) != 0)
     return UV__ERR(errno);
 
-  tv->tv_sec = time.tv_sec;
-  tv->tv_usec = time.tv_usec;
+  tv->tv_sec = (int64_t) time.tv_sec;
+  tv->tv_usec = (int32_t) time.tv_usec;
   return 0;
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1779,7 +1779,7 @@ error:
   return r;
 }
 
-int uv_gettimeofday(uv_timeval_t* tv) {
+int uv_gettimeofday(uv_timeval64_t* tv) {
   /* Based on https://doxygen.postgresql.org/gettimeofday_8c_source.html */
   const uint64_t epoch = (uint64_t) 116444736000000000ULL;
   FILETIME file_time;
@@ -1791,7 +1791,7 @@ int uv_gettimeofday(uv_timeval_t* tv) {
   GetSystemTimeAsFileTime(&file_time);
   ularge.LowPart = file_time.dwLowDateTime;
   ularge.HighPart = file_time.dwHighDateTime;
-  tv->tv_sec = (long) ((ularge.QuadPart - epoch) / 10000000L);
-  tv->tv_usec = (long) (((ularge.QuadPart - epoch) % 10000000L) / 10);
+  tv->tv_sec = (int64_t) ((ularge.QuadPart - epoch) / 10000000L);
+  tv->tv_usec = (int32_t) (((ularge.QuadPart - epoch) % 10000000L) / 10);
   return 0;
 }

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -23,7 +23,7 @@
 #include "task.h"
 
 TEST_IMPL(gettimeofday) {
-  uv_timeval_t tv;
+  uv_timeval64_t tv;
   int r;
 
   tv.tv_sec = 0;


### PR DESCRIPTION
These are the bits that were abandoned in https://github.com/libuv/libuv/pull/2244.

Fixes: https://github.com/libuv/libuv/issues/2243

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1340/