### PR TITLE
linux: set correct mac address for IP-aliases

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -904,7 +904,10 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     address = *addresses;
 
     for (i = 0; i < (*count); i++) {
-      if (strcmp(address->name, ent->ifa_name) == 0) {
+      size_t namelen = strlen(ent->ifa_name);
+      /* Alias interface share the same physical address */
+      if (strncmp(address->name, ent->ifa_name, namelen) == 0 &&
+          (address->name[namelen] == 0 || address->name[namelen] == ':')) {
         sll = (struct sockaddr_ll*)ent->ifa_addr;
         memcpy(address->phys_addr, sll->sll_addr, sizeof(address->phys_addr));
       }


### PR DESCRIPTION
IP-alias format is the interface name followed by a colon and a string
(usually a number). Set the physical address to the one in the 'base'
interface.