### PR TITLE
Do not use PTHREAD_STACK_MIN unconditionally for the unix target

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -219,8 +219,10 @@ int uv_thread_create_ex(uv_thread_t* tid,
     pagesize = (size_t)getpagesize();
     /* Round up to the nearest page boundary. */
     stack_size = (stack_size + pagesize - 1) &~ (pagesize - 1);
+#ifdef PTHREAD_STACK_MIN
     if (stack_size < PTHREAD_STACK_MIN)
       stack_size = PTHREAD_STACK_MIN;
+#endif
   }
 
   if (stack_size > 0) {


### PR DESCRIPTION
PTHREAD_STACK_MIN is an optional part of the POSIX spec and NetBSD
deliberately does not implement it as it's a variable value in
runtime.