### PR TITLE
doc: update the cmake testing instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,14 @@ $ make install
 To build with [CMake](https://cmake.org/):
 
 ```bash
-$ mkdir -p out/cmake ; cd out/cmake ; cmake -DBUILD_TESTING=ON ../..
-$ make all test
-# Or manually:
-$ ./uv_run_tests    # shared library build
-$ ./uv_run_tests_a  # static library build
+$ mkdir -p out/cmake ; cd out/cmake   # create build directory
+$ cmake ../.. -DBUILD_TESTING=ON      # generate project with test
+$ cmake --build .                     # build
+$ ctest -C Debug --output-on-failure  # run tests
+
+# Or manually run tests:
+$ ./out/cmake/uv_run_tests    # shared library build
+$ ./out/cmake/uv_run_tests_a  # static library build
 ```
 
 To build with GYP, first run:


### PR DESCRIPTION
Related Issue: https://github.com/libuv/libuv/issues/2251

The manually cmake testing instruction is incorrect. The test programs should always be executed at the root of libuv folder. I also update the cmake instruction for Windows.

```bash
$ mkdir -p out/cmake ; cd out/cmake ; cmake -DBUILD_TESTING=ON ../..
$ make all test                       # on Unix
$ cmake --build . ; ctest -C Debug    # on Windows

# Or manually run tests:
$ ./out/cmake/uv_run_tests    # shared library build
$ ./out/cmake/uv_run_tests_a  # static library build
```