### PR TITLE
linux: read free/total memory from /proc/meminfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,8 +297,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
        src/unix/linux-inotify.c
        src/unix/linux-syscalls.c
        src/unix/procfs-exepath.c
-       src/unix/sysinfo-loadavg.c
-       src/unix/sysinfo-memory.c)
+       src/unix/sysinfo-loadavg.c)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")

--- a/Makefile.am
+++ b/Makefile.am
@@ -425,8 +425,7 @@ libuv_la_SOURCES += src/unix/linux-core.c \
                     src/unix/linux-syscalls.h \
                     src/unix/procfs-exepath.c \
                     src/unix/proctitle.c \
-                    src/unix/sysinfo-loadavg.c \
-                    src/unix/sysinfo-memory.c
+                    src/unix/sysinfo-loadavg.c
 test_run_tests_LDFLAGS += -lutil
 endif
 

--- a/uv.gyp
+++ b/uv.gyp
@@ -241,7 +241,6 @@
             'src/unix/linux-syscalls.h',
             'src/unix/procfs-exepath.c',
             'src/unix/sysinfo-loadavg.c',
-            'src/unix/sysinfo-memory.c',
           ],
           'link_settings': {
             'libraries': [ '-ldl', '-lrt' ],


### PR DESCRIPTION
It was reported that uv_get_free_memory() and uv_get_total_memory()
report the wrong values inside an lxc container.

Libuv calls sysinfo(2) but that isn't intercepted by lxc. /proc/meminfo
however is because /proc is a FUSE fs inside the container.

This commit makes libuv try /proc/meminfo first and fall back to
sysinfo(2) in case /proc isn't mounted.

Fixes: #2249

The second commit DRYs the code in exchange for what might be considered a little more magic. Majority rule; I don't feel strongly about what approach is better.

CI: https://ci.nodejs.org/job/libuv-test-commit/1364/