### PR TITLE
linux: initialize st_flags and st_gen when using statx

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1165,6 +1165,8 @@ static int uv__fs_statx(int fd,
   buf->st_ctim.tv_nsec = statxbuf.stx_ctime.tv_nsec;
   buf->st_birthtim.tv_sec = statxbuf.stx_btime.tv_sec;
   buf->st_birthtim.tv_nsec = statxbuf.stx_btime.tv_nsec;
+  buf->st_flags = 0;
+  buf->st_gen = 0;
 
   return 0;
 #else

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1171,6 +1171,7 @@ TEST_IMPL(fs_fstat) {
   ASSERT(req.result == sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
+  memset(&req.statbuf, 0xaa, sizeof(uv_stat_t));
   r = uv_fs_fstat(NULL, &req, file, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
@@ -1257,6 +1258,8 @@ TEST_IMPL(fs_fstat) {
          s->st_birthtim.tv_sec == t.st_ctim.tv_sec);
   ASSERT(s->st_birthtim.tv_nsec == 0 ||
          s->st_birthtim.tv_nsec == t.st_ctim.tv_nsec);
+  ASSERT(s->st_flags == 0);
+  ASSERT(s->st_gen == 0);
 #endif
 
   uv_fs_req_cleanup(&req);


### PR DESCRIPTION
Explicitly initialize `uv_stat_t` fields `st_flags` and `st_gen` when using `statx` as `uv__to_stat` does when `statx` is not available. This makes valgrind happier.

Fixes: #2262 