### PR TITLE
util: fix null pointer dereferencing

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -704,8 +704,10 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
 
  error:
   /* This is safe because the cpu_infos array is zeroed on allocation. */
-  for (i = 0; i < cpu_count; i++)
-    uv__free(cpu_infos[i].model);
+  if (cpu_infos != NULL) {
+    for (i = 0; i < cpu_count; i++)
+      uv__free(cpu_infos[i].model);
+  }
 
   uv__free(cpu_infos);
   uv__free(sppi);

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -703,8 +703,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   return 0;
 
  error:
-  /* This is safe because the cpu_infos array is zeroed on allocation. */
   if (cpu_infos != NULL) {
+    /* This is safe because the cpu_infos array is zeroed on allocation. */
     for (i = 0; i < cpu_count; i++)
       uv__free(cpu_infos[i].model);
   }


### PR DESCRIPTION
If `uv__calloc` returns `NULL`, the function jumps to the `error` label and attempts to access array elements of `cpu_infos` (which is `NULL`).