### PR TITLE
Fix build with recent sphinx

### DIFF
--- a/docs/src/sphinx-plugins/manpage.py
+++ b/docs/src/sphinx-plugins/manpage.py
@@ -39,7 +39,6 @@ def man_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
 
 def setup(app):
-    app.info('Initializing manpage plugin')
     app.add_role('man', man_role)
     app.add_config_value('man_url_regex', None, 'env')
     return


### PR DESCRIPTION
`app.info()` was deprecated on Jan 4, 2017 (sphinx-doc/sphinx#3267), and removed as of Sphinx 2.0.0.

libuv 1.28.0 currently fails to build with Sphinx 2.0.1: https://github.com/Homebrew/homebrew-core/pull/38978