### PR TITLE
unix: don't assert on UV_PROCESS_WINDOWS_* flags

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -431,6 +431,8 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_SETGID |
                               UV_PROCESS_SETUID |
                               UV_PROCESS_WINDOWS_HIDE |
+                              UV_PROCESS_WINDOWS_HIDE_CONSOLE |
+                              UV_PROCESS_WINDOWS_HIDE_GUI |
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
 
   uv__handle_init(loop, (uv_handle_t*)process, UV_PROCESS);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1406,6 +1406,12 @@ TEST_IMPL(spawn_setuid_fails) {
   options.flags |= UV_PROCESS_SETUID;
   options.uid = 0;
 
+  /* These flags should be ignored on Unices. */
+  options.flags |= UV_PROCESS_WINDOWS_HIDE;
+  options.flags |= UV_PROCESS_WINDOWS_HIDE_CONSOLE;
+  options.flags |= UV_PROCESS_WINDOWS_HIDE_GUI;
+  options.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
+
   r = uv_spawn(uv_default_loop(), &process, &options);
 #if defined(__CYGWIN__)
   ASSERT(r == UV_EINVAL);


### PR DESCRIPTION
UV_PROCESS_WINDOWS_HIDE_CONSOLE and UV_PROCESS_WINDOWS_HIDE_GUI were
whitelisted on Windows but not Unices. Now they are.

Bug introduced in commit 4c2dcca27 ("win: support more fine-grained
windows hiding") which I reviewed but failed to spot it. Mea culpa.

Fixes: https://github.com/libuv/libuv/issues/2266
CI: https://ci.nodejs.org/job/libuv-test-commit/1369/