### PR TITLE
unix,win: introduce uv_autoclose()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(uv_test_sources
     test/test-callback-stack.c
     test/test-close-fd.c
     test/test-close-order.c
+    test/test-autoclose.c
     test/test-condvar.c
     test/test-connect-unspecified.c
     test/test-connection-fail.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -165,6 +165,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-callback-stack.c \
                          test/test-close-fd.c \
                          test/test-close-order.c \
+                         test/test-autoclose.c \
                          test/test-condvar.c \
                          test/test-connect-unspecified.c \
                          test/test-connection-fail.c \

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -175,6 +175,17 @@ API
     Returns the size of the given handle type. Useful for FFI binding writers
     who don't want to know the structure layout.
 
+.. c:function:: void uv_autoclose(uv_handle_t* handle, uv_close_cb close_cb)
+
+    Un-reference the given handle and automatically close it if the loop's
+    active handle count reaches zero. This is useful for handles that need
+    to be cleaned up at the end of a loop's lifecycle, but are not mandatory
+    for the loop to remain alive.
+
+    See :ref:`refcount`.
+
+    .. versionadded:: 1.29.0
+
 
 Miscellaneous API functions
 ---------------------------

--- a/include/uv.h
+++ b/include/uv.h
@@ -451,6 +451,7 @@ UV_EXTERN void uv_print_all_handles(uv_loop_t* loop, FILE* stream);
 UV_EXTERN void uv_print_active_handles(uv_loop_t* loop, FILE* stream);
 
 UV_EXTERN void uv_close(uv_handle_t* handle, uv_close_cb close_cb);
+UV_EXTERN void uv_autoclose(uv_handle_t* handle, uv_close_cb close_cb);
 
 UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value);
 UV_EXTERN int uv_recv_buffer_size(uv_handle_t* handle, int* value);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -109,6 +109,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
   assert(!uv__is_closing(handle));
 
   handle->flags |= UV_HANDLE_CLOSING;
+  handle->flags &= ~UV_HANDLE_AUTOCLOSE;
   handle->close_cb = close_cb;
 
   switch (handle->type) {
@@ -379,6 +380,22 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     }
 
     r = uv__loop_alive(loop);
+
+    if (r == 0 && !QUEUE_EMPTY(&loop->handle_queue)) {
+      QUEUE* q;
+      uv_handle_t* handle;
+
+      QUEUE_FOREACH(q, &loop->handle_queue) {
+        handle = QUEUE_DATA(q, uv_handle_t, handle_queue);
+
+        if ((handle->flags & UV_HANDLE_AUTOCLOSE) != 0 && handle->close_cb) {
+          uv_close(handle, handle->close_cb);
+        }
+      }
+
+      r = uv__loop_alive(loop);
+    }
+
     if (mode == UV_RUN_ONCE || mode == UV_RUN_NOWAIT)
       break;
   }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -515,6 +515,11 @@ int uv_has_ref(const uv_handle_t* handle) {
 }
 
 
+void uv_autoclose(uv_handle_t* handle, uv_close_cb cb) {
+  uv__handle_autoclose(handle, cb);
+}
+
+
 void uv_stop(uv_loop_t* loop) {
   loop->stop_flag = 1;
 }

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -65,6 +65,7 @@ enum {
   /* Used by all handles. */
   UV_HANDLE_CLOSING                     = 0x00000001,
   UV_HANDLE_CLOSED                      = 0x00000002,
+  UV_HANDLE_AUTOCLOSE                   = 0x00800000,
   UV_HANDLE_ACTIVE                      = 0x00000004,
   UV_HANDLE_REF                         = 0x00000008,
   UV_HANDLE_INTERNAL                    = 0x00000010,
@@ -270,6 +271,14 @@ void uv__timer_close(uv_timer_t* handle);
     if (((h)->flags & UV_HANDLE_ACTIVE) != 0) uv__active_handle_rm(h);        \
   }                                                                           \
   while (0)
+
+#define uv__handle_autoclose(h, cb)                                           \
+  do {                                                                        \
+    uv__handle_unref(h);                                                      \
+    if (((h)->flags & UV_HANDLE_CLOSING) != 0) break;                         \
+    (h)->flags |= UV_HANDLE_AUTOCLOSE;                                        \
+    (h)->close_cb = cb;                                                       \
+  } while (0);
 
 #define uv__has_ref(h)                                                        \
   (((h)->flags & UV_HANDLE_REF) != 0)

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -72,6 +72,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb cb) {
     return;
   }
 
+  handle->flags &= ~UV_HANDLE_AUTOCLOSE;
   handle->close_cb = cb;
 
   /* Handle-specific close actions */

--- a/test/test-autoclose.c
+++ b/test/test-autoclose.c
@@ -1,0 +1,116 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+static int timer1_cb_called = 0;
+static int timer2_cb_called = 0;
+static int timer1_close_cb_called = 0;
+static int timer2_close_cb_called = 0;
+
+static int also_close_timer1 = 0;
+
+static uv_timer_t timer1_handle;
+static uv_timer_t timer2_handle;
+
+
+static void timer2_close_cb(uv_handle_t *handle) {
+  ASSERT(handle == (uv_handle_t*) &timer2_handle);
+  ++timer2_close_cb_called;
+}
+
+
+static void timer1_close_cb(uv_handle_t *handle) {
+  ASSERT(handle == (uv_handle_t*) &timer1_handle);
+  ++timer1_close_cb_called;
+}
+
+
+static void timer2_cb(uv_timer_t* timer) {
+  ASSERT(timer == &timer2_handle);
+  ++timer2_cb_called;
+  uv_close((uv_handle_t*) timer, &timer2_close_cb);
+
+  if (also_close_timer1) {
+    uv_close((uv_handle_t*) &timer1_handle, &timer1_close_cb);
+  }
+}
+
+
+static void timer1_cb(uv_timer_t* timer) {
+  ASSERT(timer == &timer1_handle);
+  ++timer1_cb_called;
+
+  uv_autoclose((uv_handle_t*) timer, &timer1_close_cb);
+
+  ASSERT(uv_timer_init(timer->loop, &timer2_handle) == 0);
+  ASSERT(uv_timer_start(&timer2_handle, &timer2_cb, 0, 0) == 0);
+}
+
+
+TEST_IMPL(autoclose) {
+  uv_loop_t* loop;
+  loop = uv_default_loop();
+
+  ASSERT(uv_timer_init(loop, &timer1_handle) == 0);
+  ASSERT(uv_timer_start(&timer1_handle, timer1_cb, 0, 0) == 0);
+
+  ASSERT(timer1_cb_called == 0);
+  ASSERT(timer2_cb_called == 0);
+  ASSERT(timer1_close_cb_called == 0);
+  ASSERT(timer2_close_cb_called == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT(timer1_cb_called >= 1);
+  ASSERT(timer2_cb_called >= 1);
+  ASSERT(timer1_close_cb_called == 1);
+  ASSERT(timer2_close_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+TEST_IMPL(autoclose_manual_close) {
+  uv_loop_t* loop;
+  loop = uv_default_loop();
+
+  ASSERT(uv_timer_init(loop, &timer1_handle) == 0);
+  ASSERT(uv_timer_start(&timer1_handle, timer1_cb, 0, 0) == 0);
+
+  ASSERT(timer1_cb_called == 0);
+  ASSERT(timer2_cb_called == 0);
+  ASSERT(timer1_close_cb_called == 0);
+  ASSERT(timer2_close_cb_called == 0);
+
+  also_close_timer1 = 1;
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT(timer1_cb_called >= 1);
+  ASSERT(timer2_cb_called >= 1);
+  ASSERT(timer1_close_cb_called == 1);
+  ASSERT(timer2_close_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -24,6 +24,8 @@
 TEST_DECLARE   (platform_output)
 TEST_DECLARE   (callback_order)
 TEST_DECLARE   (close_order)
+TEST_DECLARE   (autoclose)
+TEST_DECLARE   (autoclose_manual_close)
 TEST_DECLARE   (run_once)
 TEST_DECLARE   (run_nowait)
 TEST_DECLARE   (loop_alive)
@@ -479,6 +481,8 @@ TASK_LIST_START
   TEST_ENTRY  (callback_order)
 #endif
   TEST_ENTRY  (close_order)
+  TEST_ENTRY  (autoclose)
+  TEST_ENTRY  (autoclose_manual_close)
   TEST_ENTRY  (run_once)
   TEST_ENTRY  (run_nowait)
   TEST_ENTRY  (loop_alive)

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -19,6 +19,7 @@
         'test-callback-order.c',
         'test-close-fd.c',
         'test-close-order.c',
+        'test-autoclose.c',
         'test-connect-unspecified.c',
         'test-connection-fail.c',
         'test-cwd-and-chdir.c',


### PR DESCRIPTION
> NOTE: **This is a proposal.** Perfectly fine if it's shot down.

This PR proposes a new API function `uv_autoclose()` that automatically closes all handles passed to it if the active handle count reaches zero, tying into the reference counting mechanism.

```c
uv_loop_t *loop;
uv_signal_t sigint;

loop = uv_default_loop();
uv_signal_init(loop, &sigint);
uv_signal_start(&sigint, &on_sigint, SIGINT);
uv_autoclose((uv_handle_t*) &sigint, &close_signal);

/* sigint handler no longer blocks loop (similar to uv_unref())
   but also automatically cleans itself up upon handle starvation. */
```

Things to note before this is considered 'ready':

- I want to add a few more tests for some cases I think are important (e.g. what happens when `uv_ref()` is called on a handle that has been marked as `uv_autoclose()`?)

- I want to discuss the fact there is a whole queue-scan upon a `uv_run()` iteration if there are no active handles but the queue is > 1. For applications that use `uv_unref()` in large numbers, this will potentially introduce significant overhead, especially if they're calling `uv_run()` without `UV_RUN_DEFAULT`. Would it make sense to add a second queue that holds autoclose-marked handles?

Note that the implementation and tests are written in a way that allows close handlers to create more active handles.

Thoughts? This would significantly reduce the amount of boilerplate in several applications I've already used libuv with, as well as weird and hard-to-debug `uv_run()` deadlock bugs I've run into where I haven't wanted to use `uv_unref()` due to the fact I'd still have to have an explicit cleanup step somewhere.