### PR TITLE
Add uv_get_constrained_memory

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -472,6 +472,8 @@ API
         This function currently only returns a non-zero value on Linux, based
         on cgroups if it is present.
 
+    .. versionadded:: 1.29.0
+
 .. c:function:: uint64_t uv_hrtime(void)
 
     Returns the current high-resolution real time. This is expressed in

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -461,6 +461,17 @@ API
 
     Gets memory information (in bytes).
 
+.. c:function:: uint64_t uv_get_constrained_memory(void)
+
+    Gets the amount of memory available to the process (in bytes) based on
+    limits imposed by the OS. If there is no such constraint, or the constraint
+    is unknown, `0` is returned. Note that it is not unusual for this value to
+    be less than or greater than :c:func:`uv_get_total_memory`.
+
+    .. note::
+        This function currently only returns a non-zero value on Linux, based
+        on cgroups if it is present.
+
 .. c:function:: uint64_t uv_hrtime(void)
 
     Returns the current high-resolution real time. This is expressed in

--- a/include/uv.h
+++ b/include/uv.h
@@ -1561,6 +1561,7 @@ UV_EXTERN int uv_chdir(const char* dir);
 
 UV_EXTERN uint64_t uv_get_free_memory(void);
 UV_EXTERN uint64_t uv_get_total_memory(void);
+UV_EXTERN uint64_t uv_get_usable_memory(void);
 
 UV_EXTERN uint64_t uv_hrtime(void);
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1561,7 +1561,7 @@ UV_EXTERN int uv_chdir(const char* dir);
 
 UV_EXTERN uint64_t uv_get_free_memory(void);
 UV_EXTERN uint64_t uv_get_total_memory(void);
-UV_EXTERN uint64_t uv_get_usable_memory(void);
+UV_EXTERN uint64_t uv_get_constrained_memory(void);
 
 UV_EXTERN uint64_t uv_hrtime(void);
 

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -344,8 +344,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -344,6 +344,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 void uv_loadavg(double avg[3]) {
   perfstat_cpu_total_t ps_total;
   int result = perfstat_cpu_total(NULL, &ps_total, sizeof(ps_total), 1);

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -117,8 +117,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -117,6 +117,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -137,6 +137,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -137,8 +137,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -183,8 +183,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -183,6 +183,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 void uv_loadavg(double avg[3]) {
   SSTS0200 rcvr;
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -1056,5 +1056,5 @@ uint64_t uv_get_usable_memory(void) {
     return rc;
 
   /* Maximum value that could be stored in memory.limit_in_bytes. */
-  return 0x7FFFFFFFFFFFF000;
+  return 1LL << 63;
 }

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -1020,7 +1020,7 @@ static uint64_t uv__read_cgroups_uint64(const char* cgroup, const char* param) {
   ssize_t n;
   char buf[32];  /* Large enough to hold an encoded uint64_t. */
 
-  snprintf(filename, "/sys/fs/cgroup/%s/%s", cgroup, param);
+  snprintf(filename, 256, "/sys/fs/cgroup/%s/%s", cgroup, param);
 
   rc = 0;
   fd = uv__open_cloexec(filename, O_RDONLY);

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -1043,13 +1043,10 @@ static uint64_t uv__read_cgroups_uint64(const char* cgroup, const char* param) {
 
 
 uint64_t uv_get_constrained_memory(void) {
-  uint64_t rc;
-
-  rc = uv__read_cgroups_uint64("memory", "memory.limit_in_bytes");
-
-  if (rc != 0)
-    return rc;
-
-  /* Usable memory is not constrained by cgroups. */
-  return 0;
+  /*
+   * This might return 0 if there was a problem getting the memory limit from
+   * cgroups. This is OK because a return value of 0 signifies that the memory
+   * limit is unknown.
+   */
+  return uv__read_cgroups_uint64("memory", "memory.limit_in_bytes");
 }

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -126,8 +126,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -126,6 +126,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   kvm_t *kd = NULL;
   struct kinfo_proc2 *kinfo = NULL;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -136,6 +136,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   struct kinfo_proc kinfo;
   size_t page_size = getpagesize();

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -136,8 +136,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -356,6 +356,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   char* ascb;
   char* rax;

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -356,8 +356,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -380,8 +380,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -380,6 +380,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 void uv_loadavg(double avg[3]) {
   (void) getloadavg(avg, 3);
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -320,6 +320,11 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
+uint64_t uv_get_usable_memory(void) {
+  return 1LL << 63;
+}
+
+
 uv_pid_t uv_os_getpid(void) {
   return GetCurrentProcessId();
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -320,8 +320,8 @@ uint64_t uv_get_total_memory(void) {
 }
 
 
-uint64_t uv_get_usable_memory(void) {
-  return 1LL << 63;
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
 }
 
 

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -27,7 +27,7 @@ TEST_IMPL(get_memory) {
   uint64_t total_mem = uv_get_total_memory();
   uint64_t constrained_mem = uv_get_constrained_memory();
 
-  printf("free_mem=%llu, total_mem=%llu, constrained_mem=$llu\n",
+  printf("free_mem=%llu, total_mem=%llu, constrained_mem=%llu\n",
          (unsigned long long) free_mem,
          (unsigned long long) total_mem,
          (unsigned long long) constrained_mem);

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -25,10 +25,12 @@
 TEST_IMPL(get_memory) {
   uint64_t free_mem = uv_get_free_memory();
   uint64_t total_mem = uv_get_total_memory();
+  uint64_t constrained_mem = uv_get_constrained_memory();
 
-  printf("free_mem=%llu, total_mem=%llu\n",
+  printf("free_mem=%llu, total_mem=%llu, constrained_mem=$llu\n",
          (unsigned long long) free_mem,
-         (unsigned long long) total_mem);
+         (unsigned long long) total_mem,
+         (unsigned long long) constrained_mem);
 
   ASSERT(free_mem > 0);
   ASSERT(total_mem > 0);


### PR DESCRIPTION
See #2286

This change is a start to adding a `uv_get_usable_memory` API. The only significant implementation right now is for Linux; others just have a placeholder.