### PR TITLE
darwin,linux: fix thread cancellation fd leak

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -145,7 +145,7 @@ extern char *mkdtemp(char *template); /* See issue #740 on AIX < 7 */
 static int uv__fs_close(int fd) {
   int rc;
 
-  rc = close(fd);
+  rc = uv__close_nocancel(fd);
   if (rc == -1)
     if (errno == EINTR || errno == EINPROGRESS)
       rc = 0;  /* The close is in progress, not an error. */

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -183,6 +183,7 @@ int uv__nonblock_ioctl(int fd, int set);
 int uv__nonblock_fcntl(int fd, int set);
 int uv__close(int fd); /* preserves errno */
 int uv__close_nocheckstdio(int fd);
+int uv__close_nocancel(int fd);
 int uv__socket(int domain, int type, int protocol);
 ssize_t uv__recvmsg(int fd, struct msghdr *msg, int flags);
 void uv__make_close_pending(uv_handle_t* handle);


### PR DESCRIPTION
First commit:

> The close() system call tests for thread cancellation first. That has
the unfortunate side effect of aborting the sytem call with EINTR
without actually closing the file descriptor when the thread is in
the "cancel" state. Work around that by calling close$NOCANCEL().
>
> This might well qualify as an academic bug because approximately no one
uses thread cancellation but let's aim for correctness anyway.

Second commit:

> Specifically, the glibc close() wrapper is a cancellation point;
the thread is unwound when close() is called when the thread is
in the "cancel" state.
>
> That's according to spec and therefore arguably less severe than
MacOS's "EINTR without actually closing" behavior but we can avoid
the file descriptor leak altogether by sidestepping glibc and
making the system call directly.
>
> Musl libc is unaffected, its close() wrapper doesn't check
the cancel state.

CI: https://ci.nodejs.org/job/libuv-test-commit/1383/