### PR TITLE
Removing MAX_THREADPOOL_SIZE limit.

### DIFF
--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -9,8 +9,9 @@ in the loop thread. This thread pool is internally used to run all file system
 operations, as well as getaddrinfo and getnameinfo requests.
 
 Its default size is 4, but it can be changed at startup time by setting the
-``UV_THREADPOOL_SIZE`` environment variable to any value (the absolute maximum
-is 128).
+``UV_THREADPOOL_SIZE`` environment variable to any value. There is no upper
+limit on the threadpool size and it is up to the user to ensure it is platform
+appropriate.
 
 The threadpool is global and shared across all event loops. When a particular
 function makes use of the threadpool (i.e. when using :c:func:`uv_queue_work`)

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -27,8 +27,6 @@
 
 #include <stdlib.h>
 
-#define MAX_THREADPOOL_SIZE 128
-
 static uv_once_t once = UV_ONCE_INIT;
 static uv_cond_t cond;
 static uv_mutex_t mutex;
@@ -196,8 +194,6 @@ static void init_threads(void) {
     nthreads = atoi(val);
   if (nthreads == 0)
     nthreads = 1;
-  if (nthreads > MAX_THREADPOOL_SIZE)
-    nthreads = MAX_THREADPOOL_SIZE;
 
   threads = default_threads;
   if (nthreads > ARRAY_SIZE(default_threads)) {


### PR DESCRIPTION
I've run into situations where I'd like to have more than 128 threads so I'd like to propose removing the cap. I can see the worry about creating too many threads but I don't think an arbitrary limit of 128 will always make sense.

I was looking through the issues and this has come up before in https://github.com/libuv/libuv/pull/382#issuecomment-112757613