### PR TITLE
unix: simplify uv/posix.h include logic

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -49,8 +49,6 @@
 # include "uv/linux.h"
 #elif defined (__MVS__)
 # include "uv/os390.h"
-#elif defined(__PASE__)
-# include "uv/posix.h"
 #elif defined(_AIX)
 # include "uv/aix.h"
 #elif defined(__sun)
@@ -63,9 +61,10 @@
       defined(__OpenBSD__)         || \
       defined(__NetBSD__)
 # include "uv/bsd.h"
-#elif defined(__CYGWIN__) || defined(__MSYS__)
-# include "uv/posix.h"
-#elif defined(__GNU__)
+#elif defined(__PASE__)   || \
+      defined(__CYGWIN__) || \
+      defined(__MSYS__)   || \
+      defined(__GNU__)
 # include "uv/posix.h"
 #endif
 


### PR DESCRIPTION
This commit includes `uv/posix.h` in one `#elif` instead of four. Noticed while reviewing https://github.com/libuv/libuv/pull/2301.