### PR TITLE
test: increase test timeout

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -963,7 +963,7 @@ TASK_LIST_START
   TEST_ENTRY  (strscpy)
   TEST_ENTRY  (threadpool_queue_work_simple)
   TEST_ENTRY  (threadpool_queue_work_einval)
-  TEST_ENTRY  (threadpool_multiple_event_loops)
+  TEST_ENTRY_CUSTOM (threadpool_multiple_event_loops, 0, 0, 60000)
   TEST_ENTRY  (threadpool_cancel_getaddrinfo)
   TEST_ENTRY  (threadpool_cancel_getnameinfo)
   TEST_ENTRY  (threadpool_cancel_work)


### PR DESCRIPTION
The test `threadpool_multiple_event_loops` has been timing out consistently on FreeBSD in the CI. This commit attempts to mitigate the problem by extending the test timeout.

In case anyone is curious, I tried changing the timeout to 10 seconds and still saw timeouts on FreeBSD. From there, I arbitrarily picked a 60 second timeout, and everything seems fine. I'm personally OK with leaving it as a 60 second timeout.

Two CI runs showing the timeout issue resolved:
https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1402/
https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1403/

EDIT: Upon further review, the test failed on https://ci.nodejs.org/job/libuv-test-commit-windows-cmake/136/console