### PR TITLE
win: prevent machine hang due to tty event explosion

### DIFF
--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -34,6 +34,7 @@ sNtSetInformationFile pNtSetInformationFile;
 sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 sNtQueryDirectoryFile pNtQueryDirectoryFile;
 sNtQuerySystemInformation pNtQuerySystemInformation;
+sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Kernel32 function pointers */
 sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;
@@ -103,6 +104,13 @@ void uv_winapi_init(void) {
       ntdll_module,
       "NtQuerySystemInformation");
   if (pNtQuerySystemInformation == NULL) {
+    uv_fatal_error(GetLastError(), "GetProcAddress");
+  }
+
+  pNtQueryInformationProcess = (sNtQueryInformationProcess) GetProcAddress(
+      ntdll_module,
+      "NtQueryInformationProcess");
+  if (pNtQueryInformationProcess == NULL) {
     uv_fatal_error(GetLastError(), "GetProcAddress");
   }
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4436,6 +4436,10 @@ typedef struct _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
 # define SystemProcessorPerformanceInformation 8
 #endif
 
+#ifndef ProcessConsoleHostProcess
+# define ProcessConsoleHostProcess 49
+#endif
+
 #ifndef FILE_DEVICE_FILE_SYSTEM
 # define FILE_DEVICE_FILE_SYSTEM 0x00000009
 #endif
@@ -4578,6 +4582,13 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
                   BOOLEAN RestartScan
                 );
 
+typedef NTSTATUS (NTAPI *sNtQueryInformationProcess)
+                 (HANDLE ProcessHandle,
+                  UINT ProcessInformationClass,
+                  PVOID ProcessInformation,
+                  ULONG Length,
+                  PULONG ReturnLength);
+
 /*
  * Kernel32 headers
  */
@@ -4718,6 +4729,7 @@ extern sNtSetInformationFile pNtSetInformationFile;
 extern sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 extern sNtQueryDirectoryFile pNtQueryDirectoryFile;
 extern sNtQuerySystemInformation pNtQuerySystemInformation;
+extern sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Kernel32 function pointers */
 extern sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;


### PR DESCRIPTION
**Problem**

In #1408 the detection of console window resizing on Windows was changed to use the Windows Accessibility API ([SetWinEventHook](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-setwineventhook)), apparently because the previous implementation couldn't reliably detect console window resizing under some conditions.

Unfortunately, the current implementation can easily lead to a total machine hang due to an explosion of console events being queued by the system. This can happen when multiple libuv-powered Windows console applications that write output to their console quickly are run in parallel, even if the applications don't care about SIGWINCH signals at all.

The problem is in the way SetWinEventHook is being used. The libuv code is passing `0` for the `idProcess` parameter, which means "listen for events sent by any process in the system". It was doing this presumably because on Windows the console window is actually owned by a different process (`conhost.exe`) so libuv would never receive console resizing events if it listened only on its own process ID. Unfortunately, the event hook receives notifications when many other things happen to a console, for example when it scrolls due to a new line being written, so having many chatty console applications all listening for events from all other applications quickly leads to O(N^2) events being queued which easily brings down the whole system. It seems that Microsoft warns about this [here](https://docs.microsoft.com/en-us/windows/desktop/winauto/out-of-context-hook-functions):

> The USER component of the operating system allocates memory for events that are handled by out-of-context hook functions. The memory is freed when the hook functions return. If a hook function does not process events quickly enough, USER resources are lowered, eventually resulting in a fault or extremely slow response times. These problems may occur if:
>
> - Events are fired very rapidly.
> - The system is slow.
> - The hook function processes events slowly.

To demonstrate the problem, here's a simple application that writes 25 lines/sec to the console which can easily trigger the issue:

```c
#include <uv.h>
#include <stdio.h>

void timer_cb(uv_timer_t* handle)
{
    static int i = 0;
    printf("Timer: %d\n", ++i);
}

int main()
{
    uv_timer_t timer;
    uv_timer_init(uv_default_loop(), &timer);
    uv_timer_start(&timer, timer_cb, 0, 40);
    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
}
```

You can save that to a file called `uvhang.c` and build the application as follows from an *x64 Native Tools Command Prompt for VS2017*:

```
cl /c /EHsc /Ilibuv/include uvhang.c
link uvhang.obj libuv/Release/lib/libuv.lib ws2_32.lib iphlpapi.lib advapi32.lib user32.lib userenv.lib psapi.lib
```

Now that you have `uvhang.exe` in the current directory, create a batch file called `uvhang.bat` with these contents:

```
@echo off
FOR /L %%A IN (1,1,50) DO (
	start /min uvhang.exe
)
```

**NOTE: Running this batch file will probably hang your system. Proceed with care.**

This batch file will start 50 instances of the program in parallel. On an 8-core Ryzen 2700X machine this leads to an unresponsive system within 5 seconds. We've seen 36-core production servers brought to their knees with a slightly larger number of instances (our production environment fits this profile of many console applications running in parallel).

From looking at the ETW profiling data, one can see that the `win32kfull.sys` driver spends an inordinate amount of time queueing these console events. Here's an example profile:

![hang](https://user-images.githubusercontent.com/5482684/58146363-93a39800-7c0a-11e9-86cc-6450b633201e.png)

You can see from this 23-second profile that `win32kfull.sys` queued 170,000 event messages and spent 17 seconds doing so. If you want to capture a profile like this yourself you can use a batch file like this:

```
@echo off
xperf -on Latency -f %temp%\kernel.etl -stackwalk Profile -start MyTrace -on Microsoft-Windows-Win32k -f %temp%\user.etl -BufferSize 1024 -MaxBuffers 1024 -MaxFile 1024
FOR /L %%A IN (1,1,50) DO (
	start /min uvhang.exe
)
ping -n 5 localhost
taskkill /f /im:uvhang.exe
xperf -stop MyTrace -stop
xperf -merge %temp%\kernel.etl %temp%\user.etl %temp%\merged.etl
wpa %temp%\merged.etl
```

The problem also occurs with Node applications. Save this code to `uvhang.js`:

```js
var i = 0;

function timerFunc() {
  console.log(`Timer: ${++i}`);
}

setInterval(timerFunc, 40);
```

Now you can cause the system hang with this batch file:

```
@echo off
FOR /L %%A IN (1,1,50) DO (
	start /min node uvhang.js
)
```

**Solution**

The idea behind this PR is simply to listen for console events _only_ from our corresponding `conhost.exe` process, which we find using `NtQueryInformationProcess` with `ProcessConsoleHostProcess`. With this change, we still receive console resizing events for our console and the number of events queued by `win32kfull.sys` grows only linearly with the number of processes:

![nohang](https://user-images.githubusercontent.com/5482684/58146830-b6cf4700-7c0c-11e9-87dd-417a91c3f194.png)

This works for 32-bit applications running on 32-bit Windows and 64-bit applications running on 64-bit Windows. Unfortunately it doesn't work for 32-bit applications running on 64-bit Windows because the WOW64 translation layer disallows the use of `ProcessConsoleHostProcess` for some reason. This PR currently falls back to the existing behavior of listening for events from all processes in that case, but since that means it can still cause system hangs I was wondering which of these alternatives would be preferred:

1. Leave the PR as-is and add a warning somewhere about this problem for 32-bit apps on 64-bit Windows.
2. Revert the console window resizing detection change from #1408 to its old behavior.
3. Use [this method](https://support.microsoft.com/en-ca/help/124103/how-to-obtain-a-console-window-handle-hwnd) which involves changing the window title to some unique string to find our `conhost.exe` process.