### PR TITLE
darwin: add 32bit close$NOCANCEL implementation

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -526,8 +526,13 @@ int uv__close_nocancel(int fd) {
 #if defined(__APPLE__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
+#if defined(__LP64__)
   extern int close$NOCANCEL(int);
   return close$NOCANCEL(fd);
+#else
+  extern int close$NOCANCEL$UNIX2003(int);
+  return close$NOCANCEL$UNIX2003(fd);
+#endif
 #pragma GCC diagnostic pop
 #elif defined(__linux__)
   return syscall(SYS_close, fd);


### PR DESCRIPTION
On a number of systems, when building 32bit, we see 
```
Undefined symbols for architecture i386: "_close$NOCANCEL"
```
See report <https://trac.macports.org/ticket/58507>.

The link symbol for close$NOCANCEL appears to be slightly different for 32bit builds.

I believe this is the right fix (seems to work from 10.5 to 10.12). There is another much more complicated approach here <https://codereview.chromium.org/23455051/diff/1/base/mac/close_nocancel.cc#newcode33>, and more info here <https://github.com/lionheart/openradar-mirror/issues/4506> as well.

Appreciate any feedback / thoughts / experience in this area. This is a slightly messy area with all the  darwin_extension business.