### PR TITLE
fsevents: fix file event reporting

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -626,7 +626,7 @@ static void file_remove_cb(uv_fs_event_t* handle,
   /* TODO(bnoordhuis) Harmonize the behavior across platforms. Right now
    * this test merely ensures the status quo doesn't regress.
    */
-#ifdef __linux__
+#if defined(_AIX) || defined(__linux__)
   ASSERT(UV_CHANGE == events);
 #else
   ASSERT(UV_RENAME == events);
@@ -657,6 +657,10 @@ TEST_IMPL(fs_event_watch_file_remove) {
   uv_fs_event_t watcher;
   uv_timer_t timer;
   uv_loop_t* loop;
+
+#if defined(__MVS__)
+  RETURN_SKIP("test does not work on this OS");
+#endif
 
   remove("watch_dir/file1");
   remove("watch_dir/");

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -62,6 +62,15 @@ static char fs_event_filename[1024];
 static int timer_cb_touch_called;
 static int timer_cb_exact_called;
 
+static void expect_filename(const char* path, const char* expected) {
+#if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT(0 == strcmp(path, expected));
+#else
+  if (path != NULL)
+    ASSERT(0 == strcmp(path, expected));
+#endif
+}
+
 static void fs_event_fail(uv_fs_event_t* handle,
                           const char* filename,
                           int events,
@@ -130,11 +139,7 @@ static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE);
-  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
-  ASSERT(strcmp(filename, "file1") == 0);
-  #else
-  ASSERT(filename == NULL || strcmp(filename, "file1") == 0);
-  #endif
+  expect_filename(filename, "file1");
   ASSERT(0 == uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }
@@ -312,11 +317,7 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE);
-  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
-  ASSERT(strcmp(filename, "file2") == 0);
-  #else
-  ASSERT(filename == NULL || strcmp(filename, "file2") == 0);
-  #endif
+  expect_filename(filename, "file2");
   ASSERT(0 == uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }
@@ -339,11 +340,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   ASSERT(handle == &fs_event);
   ASSERT(status == 0);
   ASSERT(events == UV_CHANGE);
-  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
-  ASSERT(strcmp(filename, "watch_file") == 0);
-  #else
-  ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
-  #endif
+  expect_filename(filename, "watch_file");
 
   /* Regression test for SunOS: touch should generate just one event. */
   {
@@ -625,7 +622,7 @@ static void file_remove_cb(uv_fs_event_t* handle,
                            int status) {
   fs_event_cb_called++;
 
-  ASSERT(0 == strcmp(path, "file1"));
+  expect_filename(path, "file1");
   /* TODO(bnoordhuis) Harmonize the behavior across platforms. Right now
    * this test merely ensures the status quo doesn't regress.
    */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -333,6 +333,7 @@ TEST_DECLARE   (fs_event_watch_dir_short_path)
 #endif
 TEST_DECLARE   (fs_event_watch_file)
 TEST_DECLARE   (fs_event_watch_file_exact_path)
+TEST_DECLARE   (fs_event_watch_file_remove)
 TEST_DECLARE   (fs_event_watch_file_twice)
 TEST_DECLARE   (fs_event_watch_file_current_dir)
 #ifdef _WIN32
@@ -920,6 +921,7 @@ TASK_LIST_START
 #endif
   TEST_ENTRY  (fs_event_watch_file)
   TEST_ENTRY  (fs_event_watch_file_exact_path)
+  TEST_ENTRY  (fs_event_watch_file_remove)
   TEST_ENTRY  (fs_event_watch_file_twice)
   TEST_ENTRY  (fs_event_watch_file_current_dir)
 #ifdef _WIN32


### PR DESCRIPTION
Commit 2d2af38 ("fsevents: really watch files with fsevents on macos
10.7+") from last November introduced a regression where events that
were previously reported as UV_RENAME were now reported as UV_CHANGE.
This commit rectifies that.

Fixes: https://github.com/nodejs/node/issues/27869
CI: https://ci.nodejs.org/job/libuv-test-commit/1411/