### PR TITLE
win,fs: don't modify global file translation mode

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -204,9 +204,6 @@ static void uv_init(void) {
   /* Initialize winsock */
   uv_winsock_init();
 
-  /* Initialize FS */
-  uv_fs_init();
-
   /* Initialize signal stuff */
   uv_signals_init();
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -137,10 +137,6 @@ const WCHAR UNC_PATH_PREFIX_LEN = 8;
 
 static int uv__file_symlink_usermode_flag = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
 
-void uv_fs_init(void) {
-  _fmode = _O_BINARY;
-}
-
 
 INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
     const char* new_path, const int copy_path) {

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -241,12 +241,6 @@ int uv_translate_sys_error(int sys_errno);
 
 
 /*
- * FS
- */
-void uv_fs_init(void);
-
-
-/*
  * FS Event
  */
 void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -55,6 +55,7 @@ int platform_init(int argc, char **argv) {
   _setmode(0, _O_BINARY);
   _setmode(1, _O_BINARY);
   _setmode(2, _O_BINARY);
+  _set_fmode(_O_BINARY);
 
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);


### PR DESCRIPTION
Back in https://github.com/libuv/libuv/commit/25175c when the filesystem API was initially implemented on Windows, `uv_fs_open` was internally implemented by calling the [_open](https://github.com/libuv/libuv/blob/25175c/src/win/fs.c#L105) function. Shortly thereafter, in https://github.com/libuv/libuv/commit/e1af07, the implementation was changed to use [CreateFile](https://github.com/libuv/libuv/blob/e1af07/src/win/fs.c#L216) instead. However, the code in [uv_fs_init](https://github.com/libuv/libuv/blob/25175c/src/win/fs.c#L76) that was modifying the global [_fmode](https://docs.microsoft.com/en-us/cpp/c-runtime-library/fmode?view=vs-2019) variable to set the default file translation mode to binary was left in place, and has been there for 8 years.

A library like libuv shouldn't be changing this global state, because the embedding application may need to use a different default file translation mode (this is how we found out libuv was doing this). Also, since the change to use CreateFile there's no longer a need for libuv to change this mode anyway, because it no longer uses either _open or _pipe, which are the functions that this global mode variable affects as per the [docs](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/set-fmode?view=vs-2019).

This change stops libuv from changing this global state. All tests still pass after this change.