### PR TITLE
OpenBSD: only get active CPU core count

### DIFF
--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -193,7 +193,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   if (sysctl(which, 2, &model, &size, NULL, 0))
     return UV__ERR(errno);
 
-  which[1] = HW_NCPU;
+  which[1] = HW_NCPUONLINE;
   size = sizeof(numcpus);
   if (sysctl(which, 2, &numcpus, &size, NULL, 0))
     return UV__ERR(errno);


### PR DESCRIPTION
Newer computers may have some cores offline because of the
Meltdown/Spectre patches from a while ago, making `uv_cpu_info`
potentially misleading and leading to people attempting to use more
threads than they actually have available. This makes it so only the
cores that are online and doing any work are counted.