### PR TITLE
unix: make uv_cwd() report UV_ENOBUFS

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -25,6 +25,7 @@
 #include "uv-common.h"
 
 #include <assert.h>
+#include <limits.h> /* _POSIX_PATH_MAX, PATH_MAX */
 #include <stdlib.h> /* abort */
 #include <string.h> /* strrchr */
 #include <fcntl.h>  /* O_CLOEXEC, may be */
@@ -58,6 +59,14 @@
 
 #if defined(__APPLE__) && !TARGET_OS_IPHONE
 # include <AvailabilityMacros.h>
+#endif
+
+#if defined(_POSIX_PATH_MAX)
+# define UV__PATH_MAX _POSIX_PATH_MAX
+#elif defined(PATH_MAX)
+# define UV__PATH_MAX PATH_MAX
+#else
+# define UV__PATH_MAX 8192
 #endif
 
 #if defined(__ANDROID__)

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -33,9 +33,16 @@ TEST_IMPL(cwd_and_chdir) {
   size_t size2;
   int err;
 
+  size1 = 1;
+  err = uv_cwd(buffer_orig, &size1);
+  ASSERT(err == UV_ENOBUFS);
+  ASSERT(size1 > 1);
+
   size1 = sizeof buffer_orig;
   err = uv_cwd(buffer_orig, &size1);
   ASSERT(err == 0);
+  ASSERT(size1 > 0);
+  ASSERT(buffer_orig[size1] != '/');
 
   err = uv_chdir(buffer_orig);
   ASSERT(err == 0);


### PR DESCRIPTION
Make uv_cwd() do what the documentation says it did when the destination
buffer is too small: report UV_ENOBUFS and set the `size` in/out param
to the size of the path including the trailing nul byte.

Fixes: https://github.com/libuv/libuv/issues/2333
CI: https://ci.nodejs.org/job/libuv-test-commit/1428/ (flakes and a build error addressed by #2334)