### PR TITLE
doc: fix wrong doc about Mutex

### DIFF
--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -77,7 +77,7 @@ The mutex functions are a **direct** map to the pthread equivalents.
 
 .. rubric:: libuv mutex functions
 .. literalinclude:: ../../../include/uv.h
-    :lines: 1355-1360
+    :lines: 1575-1580
 
 The ``uv_mutex_init()``, ``uv_mutex_init_recursive()`` and ``uv_mutex_trylock()``
 functions will return 0 on success, and an error code otherwise.


### PR DESCRIPTION
I found the doc about Mutex is wrong, it show signature of uv_fs_access
and uv_fs_chmod:

http://docs.libuv.org/en/v1.x/guide/threads.html#mutexes

so i just fix it.

Signed-off-by: leo chung <gewalalb@gmail.com>