### PR TITLE
Fix uv_os_tmpdir when env variable is 260 chars

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1171,18 +1171,18 @@ int uv_os_homedir(char* buffer, size_t* size) {
 
 
 int uv_os_tmpdir(char* buffer, size_t* size) {
-  wchar_t path[MAX_PATH + 1];
+  wchar_t path[MAX_PATH + 2];
   DWORD bufsize;
   size_t len;
 
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  len = GetTempPathW(MAX_PATH + 1, path);
+  len = GetTempPathW(ARRAY_SIZE(path), path);
 
   if (len == 0) {
     return uv_translate_sys_error(GetLastError());
-  } else if (len > MAX_PATH + 1) {
+  } else if (len > ARRAY_SIZE(path)) {
     /* This should not be possible */
     return UV_EIO;
   }

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -67,5 +67,16 @@ TEST_IMPL(tmpdir) {
   r = uv_os_tmpdir(tmpdir, &len);
   ASSERT(r == UV_EINVAL);
 
+#ifdef _WIN32
+  const char *name = "TMP";
+  char tmpdir_win[] = "C:\\xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  r = uv_os_setenv(name, tmpdir_win);
+  ASSERT(r == 0);
+  char tmpdirx[PATHMAX];
+  size_t lenx = sizeof tmpdirx;
+  r = uv_os_tmpdir(tmpdirx, &lenx);
+  ASSERT(r == 0);
+#endif
+
   return 0;
 }


### PR DESCRIPTION
When TMP environment variable is 261 chars (including the trailing slash) or 260 chars without the trailing slash, `uv_os_tmpdir` throws an `UV_EIO` error which it shouldn't, since the total input string size allowable for this function is PATH_MAX+1 (including the trailing slash).

Please see the  Julia code in https://github.com/libuv/libuv/issues/2336 which demonstrates the problem. 

In any case, there is also no harm in setting the buffer larger.