### PR TITLE
test: fix gcc 8 warnings for tests

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -44,6 +44,10 @@
 # pragma clang diagnostic ignored "-Wc99-extensions"
 #endif
 
+#ifdef __GNUC__
+# pragma GCC diagnostic ignored "-Wvariadic-macros"
+#endif
+
 #define TEST_PORT 9123
 #define TEST_PORT_2 9124
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -838,10 +838,10 @@ static unsigned int write_until_data_queued() {
                  closed_handle_large_write_cb);
     ASSERT(r == 0);
     i++;
-  } while (((uv_stream_t*)&channel)->write_queue_size == 0 &&
+  } while (channel.write_queue_size == 0 &&
            i < ARRAY_SIZE(write_reqs));
 
-  return ((uv_stream_t*)&channel)->write_queue_size;
+  return channel.write_queue_size;
 }
 
 static void send_handle_and_close() {


### PR DESCRIPTION
In test-ipc.c, remove unnecessarily casting uv_stream_s to
uv_pipe_s that makes gcc complain about stric-aliasing
(-Wstrict-aliasing)

In test-queue-foreach-delete.c, using C99 variadic macros
to fix a gcc 8 warning (-Wcast-function-type)

Fixes #2337 