### PR TITLE
doc: fix incorrect versionchanged

### DIFF
--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -12,7 +12,7 @@ Its default size is 4, but it can be changed at startup time by setting the
 ``UV_THREADPOOL_SIZE`` environment variable to any value (the absolute maximum
 is 1024).
 
-.. versionchanged:: 1.29.2 the maximum UV_THREADPOOL_SIZE allowed was increased from 128 to 1024.
+.. versionchanged:: 1.30.0 the maximum UV_THREADPOOL_SIZE allowed was increased from 128 to 1024.
 
 The threadpool is global and shared across all event loops. When a particular
 function makes use of the threadpool (i.e. when using :c:func:`uv_queue_work`)


### PR DESCRIPTION
Version 1.29.2 never happened. Update the versionchanged from 9a10058e72fb62c3e6ffd82e1f3f393c717e63f5 to be 1.30.0.