### PR TITLE
unix: add uv_get_constrained_memory() cygwin stub

### DIFF
--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -52,3 +52,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   (void)cpu_infos;
   (void)count;
 }
+
+uint64_t uv_get_constrained_memory(void) {
+  return 0;  /* Memory constraints are unknown. */
+}


### PR DESCRIPTION
I don't really have any way to test this.

Refs: https://github.com/libuv/libuv/issues/1906#issuecomment-507280243