### PR TITLE
unix: unused-function uv__fs_preadv on BSD

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -292,6 +292,7 @@ static ssize_t uv__fs_open(uv_fs_t* req) {
 }
 
 
+#if !HAVE_PREADV
 static ssize_t uv__fs_preadv(uv_file fd,
                              uv_buf_t* bufs,
                              unsigned int nbufs,
@@ -338,6 +339,7 @@ static ssize_t uv__fs_preadv(uv_file fd,
 
   return result;
 }
+#endif
 
 
 static ssize_t uv__fs_read(uv_fs_t* req) {


### PR DESCRIPTION
Jenkins build:  https://ci.nodejs.org/job/libuv-test-commit-freebsd/1412/nodes=freebsd11-x64/console