### PR TITLE
build: cmake_minimum_required(VERSION 2.8.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO: determine CMAKE_SYSTEM_NAME on OS/390.  Currently assumes "OS/390".
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.12)
 project(libuv)
 
 if(MSVC)


### PR DESCRIPTION
While I'm not a CMake expert nothing seems to require CMake 3.0 really, and it was tested (via this branch) with Neovim's build, where we have a CI job that uses CMake 2.8.12 (https://travis-ci.org/neovim/neovim/jobs/556751739).