### PR TITLE
build: CMake: set OUTPUT_NAME for uv_a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ target_compile_definitions(uv_a PRIVATE ${uv_defines})
 target_compile_options(uv_a PRIVATE ${uv_cflags})
 target_include_directories(uv_a PRIVATE include src)
 target_link_libraries(uv_a ${uv_libraries})
+set_target_properties(uv_a PROPERTIES OUTPUT_NAME uv)
 
 option(libuv_buildtests "Build the unit tests when BUILD_TESTING is enabled." ON)
 


### PR DESCRIPTION
It is not clear to me really why there cannot be just a single "uv"
library, which could be driven through `BUILD_SHARED_LIBS` to be shared
(by default), or static.

This change therefore provides to be a minimal fix, resulting in an
output of `libuv.a`, instead of `libuv_a.a`.