### PR TITLE
win, fs: mkdir return UV_EINVAL for invalid names

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -846,8 +846,13 @@ void fs__unlink(uv_fs_t* req) {
 
 void fs__mkdir(uv_fs_t* req) {
   /* TODO: use req->mode. */
-  int result = _wmkdir(req->file.pathw);
-  SET_REQ_RESULT(req, result);
+  req->result = _wmkdir(req->file.pathw);
+  if (req->result == -1) {
+    req->sys_errno_ = _doserrno;
+    req->result = req->sys_errno_ == ERROR_INVALID_NAME
+                ? UV_EINVAL
+                : uv_translate_sys_error(req->sys_errno_);
+  }
 }
 
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3873,4 +3873,16 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
 
     return 0;
 }
+
+TEST_IMPL(fs_invalid_mkdir_name) {
+  uv_loop_t* loop;
+  uv_fs_t req;
+  int r;
+
+  loop = uv_default_loop();
+  r = uv_fs_mkdir(loop, &req, "invalid>", 0, NULL);
+  ASSERT(r == UV_EINVAL);
+
+  return 0;
+}
 #endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -374,6 +374,7 @@ TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_file_flag_no_buffering)
 TEST_DECLARE   (fs_open_readonly_acl)
 TEST_DECLARE   (fs_fchmod_archive_readonly)
+TEST_DECLARE   (fs_invalid_mkdir_name)
 #endif
 TEST_DECLARE   (strscpy)
 TEST_DECLARE   (threadpool_queue_work_simple)
@@ -961,6 +962,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_file_flag_no_buffering)
   TEST_ENTRY  (fs_open_readonly_acl)
   TEST_ENTRY  (fs_fchmod_archive_readonly)
+  TEST_ENTRY  (fs_invalid_mkdir_name)
 #endif
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (open_osfhandle_valid_handle)


### PR DESCRIPTION
Makes `uv_fs_mkdir` return `UV_EINVAL` for invalid filenames instead of `UV_ENOENT`.

Ref: https://github.com/nodejs/node/issues/28599