### PR TITLE
unix,win: expose UV_PATH_MAX_BYTES

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -62,6 +62,10 @@ extern "C" {
 # include "uv/unix.h"
 #endif
 
+#ifndef UV_PATH_MAX_BYTES
+# define UV_PATH_MAX_BYTES 8192
+#endif
+
 /* Expand this list if necessary. */
 #define UV_ERRNO_MAP(XX)                                                      \
   XX(E2BIG, "argument list too long")                                         \

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -35,6 +35,7 @@
 
 #include <termios.h>
 #include <pwd.h>
+#include <limits.h>
 
 #if !defined(__MVS__)
 #include <semaphore.h>
@@ -80,6 +81,12 @@
 
 #ifndef UV_IO_PRIVATE_PLATFORM_FIELDS
 # define UV_IO_PRIVATE_PLATFORM_FIELDS /* empty */
+#endif
+
+#if defined(_POSIX_PATH_MAX)
+# define UV_PATH_MAX_BYTES _POSIX_PATH_MAX
+#elif defined(PATH_MAX)
+# define UV_PATH_MAX_BYTES PATH_MAX
 #endif
 
 struct uv__io_s;

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -62,6 +62,9 @@ typedef struct pollfd {
 #include "uv/tree.h"
 #include "uv/threadpool.h"
 
+/* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
+#define UV_PATH_MAX_BYTES (MAX_PATH * 4)
+
 #define MAX_PIPENAME_LEN 256
 
 #ifndef S_IFLNK

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -701,7 +701,7 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
 
 
 int uv_cwd(char* buffer, size_t* size) {
-  char scratch[1 + UV__PATH_MAX];
+  char scratch[1 + UV_PATH_MAX_BYTES];
 
   if (buffer == NULL || size == NULL)
     return UV_EINVAL;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -525,7 +525,7 @@ static ssize_t uv__fs_pathmax_size(const char* path) {
   pathmax = pathconf(path, _PC_PATH_MAX);
 
   if (pathmax == -1)
-    pathmax = UV__PATH_MAX;
+    pathmax = UV_PATH_MAX_BYTES;
 
   return pathmax;
 }

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -61,14 +61,6 @@
 # include <AvailabilityMacros.h>
 #endif
 
-#if defined(_POSIX_PATH_MAX)
-# define UV__PATH_MAX _POSIX_PATH_MAX
-#elif defined(PATH_MAX)
-# define UV__PATH_MAX PATH_MAX
-#else
-# define UV__PATH_MAX 8192
-#endif
-
 #if defined(__ANDROID__)
 int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset);
 # ifdef pthread_sigmask


### PR DESCRIPTION
This commit exposes a cross-platform constant, `UV_PATH_MAX_BYTES`, representing the maximum number of bytes needed to store a file path.

I've seen a need for this in multiple projects, and thought it would make sense to just expose this as a constant.