### PR TITLE
ibmi: support Makefile build for IBM i

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -322,6 +322,12 @@ test_run_tests_CFLAGS += -D_ALL_SOURCE \
                          -D_LINUX_SOURCE_COMPAT
 endif
 
+if OS400
+test_run_tests_CFLAGS += -D_ALL_SOURCE \
+                         -D_XOPEN_SOURCE=500 \
+                         -D_LINUX_SOURCE_COMPAT
+endif
+
 if HAIKU
 test_run_tests_CFLAGS += -D_BSD_SOURCE
 endif
@@ -360,6 +366,19 @@ libuv_la_CFLAGS += -D_ALL_SOURCE \
                    -DHAVE_SYS_AHAFS_EVPRODS_H
 uvinclude_HEADERS += include/uv/aix.h
 libuv_la_SOURCES += src/unix/aix.c src/unix/aix-common.c
+endif
+
+if OS400
+libuv_la_CFLAGS += -D_ALL_SOURCE \
+                   -D_XOPEN_SOURCE=500 \
+                   -D_LINUX_SOURCE_COMPAT \
+                   -D_THREAD_SAFE
+uvinclude_HEADERS += include/uv/posix.h
+libuv_la_SOURCES += src/unix/aix-common.c \
+                    src/unix/ibmi.c \
+                    src/unix/posix-poll.c \
+                    src/unix/no-fsevents.c \
+                    src/unix/no-proctitle.c
 endif
 
 if ANDROID

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ AM_CONDITIONAL([MSYS],     [AS_CASE([$host_os],[msys*],         [true], [false])
 AM_CONDITIONAL([NETBSD],   [AS_CASE([$host_os],[netbsd*],       [true], [false])])
 AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])])
 AM_CONDITIONAL([OS390],    [AS_CASE([$host_os],[openedition*],  [true], [false])])
+AM_CONDITIONAL([OS400],    [AS_CASE([$host_os],[os400],         [true], [false])])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [


### PR DESCRIPTION
Currently libuv can only be compiled on IBM i using node-gyp.
Submit this PR to allow it compiled with autoconf & automake.