### PR TITLE
win, tty: improve SIGWINCH performance

### DIFF
--- a/docs/src/signal.rst
+++ b/docs/src/signal.rst
@@ -20,6 +20,15 @@ Reception of some signals is emulated:
   program is given approximately 10 seconds to perform cleanup. After that
   Windows will unconditionally terminate it.
 
+* SIGWINCH is raised whenever libuv detects that the console has been
+  resized. When a libuv app is running under a console emulator, or when a
+  32-bit libuv app is running on 64-bit system, SIGWINCH will be emulated. In
+  such cases SIGWINCH signals may not always be delivered in a timely manner.
+  For a writable :c:type:`uv_tty_t` handle libuv will only detect size changes
+  when the cursor is moved. When a readable :c:type:`uv_tty_t` handle is used,
+  resizing of the console buffer will be detected only if the handle is in raw
+  mode and is being read.
+
 * Watchers for other signals can be successfully created, but these signals
   are never received. These signals are: `SIGILL`, `SIGABRT`, `SIGFPE`, `SIGSEGV`,
   `SIGTERM` and `SIGKILL.`
@@ -28,6 +37,8 @@ Reception of some signals is emulated:
   not detected by libuv; these will not trigger a signal watcher.
 
 .. versionchanged:: 1.15.0 SIGWINCH support on Windows was improved.
+.. versionchanged:: 1.31.0 32-bit libuv SIGWINCH support on 64-bit Windows was
+                           rolled back to old implementation.
 
 Unix notes
 ----------


### PR DESCRIPTION
Continuing improvement of SIGWINCH from PR #2308.

Running `SetWinEventHook` without filtering for the specific PIDs has a [significant impact on the performance of the entire system](https://github.com/microsoft/terminal/issues/410). This PR changes the way `SIGWINCH` is handled.

The `SetWinEventHook` callback now signals a separate thread, `uv__tty_console_resize_watcher_thread`. This thread calls `uv__tty_console_signal_resize()` which checks if the console was actually resized. The `uv__tty_console_resize_watcher_thread` makes sure to not to call the `uv__tty_console_signal_resize` function more than 30 times per second.

The `SetWinEventHook` will not be installed if the PID of the `conhost.exe` process that owns the console window cannot be determined. This can happen when a 32bit libuv app is running on a 64bit Windows.

For such cases, PR #1408 is partially reverted - when `tty` reads `WINDOW_BUFFER_SIZE_EVENT`, it will also trigger a call to `uv__tty_console_signal_resize()`. This will also help when the [app is running under console emulators](https://github.com/microsoft/terminal/issues/1811). Documentation was also updated to reflect that.
