### PR TITLE
stream,unix: remove UV_HANDLE_READING flag before callback

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1000,12 +1000,12 @@ uv_handle_type uv__handle_type(int fd) {
 
 static void uv__stream_eof(uv_stream_t* stream, const uv_buf_t* buf) {
   stream->flags |= UV_HANDLE_READ_EOF;
+  stream->flags &= ~UV_HANDLE_READING;
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   if (!uv__io_active(&stream->io_watcher, POLLOUT))
     uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
   stream->read_cb(stream, UV_EOF, buf);
-  stream->flags &= ~UV_HANDLE_READING;
 }
 
 


### PR DESCRIPTION
The UV_HANDLE_READING flag should be removed before stopping the IO watcher and calling the callback. If the callback calls uv_read_start, the IO watcher will be started then after the callback the UV_HANDLE_READING flag is removed. This will result in epoll constantly report POLLIN event while no one handles it and 100% CPU usage. 