### PR TITLE
readme: add %p to valgrind log-file arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ $ gdb --args out/Debug/run-tests TEST_NAME
 Use the `--trace-children=yes` parameter:
 
 ```bash
-$ valgrind --trace-children=yes -v --tool=memcheck --leak-check=full --track-origins=yes --leak-resolution=high --show-reachable=yes --log-file=memcheck.log out/Debug/run-tests TEST_NAME
+$ valgrind --trace-children=yes -v --tool=memcheck --leak-check=full --track-origins=yes --leak-resolution=high --show-reachable=yes --log-file=memcheck-%p.log out/Debug/run-tests TEST_NAME
 ```
 
 ### Running benchmarks


### PR DESCRIPTION
Since the tests fork processes, a single log file is largely unreadable.