### PR TITLE
test: avoid AF_LOCAL

### DIFF
--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -171,7 +171,7 @@ TEST_IMPL(pipe_getsockname_abstract) {
   socklen_t sun_len;
   char abstract_pipe[] = "\0test-pipe";
 
-  sock = socket(AF_LOCAL, SOCK_STREAM, 0);
+  sock = socket(AF_UNIX, SOCK_STREAM, 0);
   ASSERT(sock != -1);
 
   sun_len = sizeof sun;


### PR DESCRIPTION
Linux specific and practically an alias of AF_UNIX which is POSIX