### PR TITLE
test: fix assignment bug in assert

### DIFF
--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -825,7 +825,7 @@ int ipc_helper_tcp_connection(void) {
   return 0;
 }
 
-static unsigned int write_until_data_queued() {
+static unsigned int write_until_data_queued(void) {
   unsigned int i;
   int r;
 
@@ -844,7 +844,7 @@ static unsigned int write_until_data_queued() {
   return ((uv_stream_t*)&channel)->write_queue_size;
 }
 
-static void send_handle_and_close() {
+static void send_handle_and_close(void) {
   int r;
   struct sockaddr_in addr;
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -450,6 +450,9 @@ static int run_ipc_test(const char* helper, uv_read_cb read_cb) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
+  if (read_cb == on_read_closed_handle)
+    ASSERT(closed_handle_data_read == LARGE_SIZE);
+
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
@@ -599,7 +602,6 @@ static void tcp_connection_write_cb(uv_write_t* req, int status) {
 
 static void closed_handle_large_write_cb(uv_write_t* req, int status) {
   ASSERT(status == 0);
-  ASSERT(closed_handle_data_read = LARGE_SIZE);
   if (++write_reqs_completed == ARRAY_SIZE(write_reqs)) {
     write_reqs_completed = 0;
     if (write_until_data_queued() > 0)


### PR DESCRIPTION
Assignment instead of comparison made the assert effectively a no-op and
hid the fact that it was in the wrong place.

Refs: #2307

CI: https://ci.nodejs.org/job/libuv-test-commit/1468/