### PR TITLE
github: add root warning to template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,9 @@ If you want to report a bug, you are in the right place!
 If you need help or have a question, go here:
 https://github.com/libuv/help/issues/new
 
+If you are reporting a libuv test failure, please ensure that you are not
+running the test as root.
+
 Please include code that demonstrates the bug and keep it short and simple.
 -->
 * **Version**: <!-- libuv version -->


### PR DESCRIPTION
A number of bug reports about the test suite are the result of the user running the test suite as root. It might be wishful thinking, but perhaps some of the bug reports can be eliminated by adding some text to the GitHub issue template.