### PR TITLE
win: fix uv_spawn() ENOMEM on empty env

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -714,7 +714,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
 
   /* second pass: copy to UTF-16 environment block */
   dst_copy = (WCHAR*)uv__malloc(env_len * sizeof(WCHAR));
-  if (!dst_copy) {
+  if (dst_copy == NULL && env_len > 0) {
     return ERROR_OUTOFMEMORY;
   }
   env_copy = alloca(env_block_count * sizeof(WCHAR*));
@@ -739,7 +739,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
     }
   }
   *ptr_copy = NULL;
-  assert(env_len == (size_t) (ptr - dst_copy));
+  assert(env_len == 0 || env_len == (size_t) (ptr - dst_copy));
 
   /* sort our (UTF-16) copy */
   qsort(env_copy, env_block_count-1, sizeof(wchar_t*), qsort_wcscmp);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -264,6 +264,7 @@ TEST_DECLARE   (spawn_fails)
 #ifndef _WIN32
 TEST_DECLARE   (spawn_fails_check_for_waitpid_cleanup)
 #endif
+TEST_DECLARE   (spawn_empty_env)
 TEST_DECLARE   (spawn_exit_code)
 TEST_DECLARE   (spawn_stdout)
 TEST_DECLARE   (spawn_stdin)
@@ -829,6 +830,7 @@ TASK_LIST_START
 #ifndef _WIN32
   TEST_ENTRY  (spawn_fails_check_for_waitpid_cleanup)
 #endif
+  TEST_ENTRY  (spawn_empty_env)
   TEST_ENTRY  (spawn_exit_code)
   TEST_ENTRY  (spawn_stdout)
   TEST_ENTRY  (spawn_stdin)

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -233,10 +233,17 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
 
 
 TEST_IMPL(spawn_empty_env) {
-#ifdef __sun
-  RETURN_SKIP("fails on smartos");
-#else  /* !__sun */
   char* env[1];
+
+  /* The autotools dynamic library build requires the presence of
+   * DYLD_LIBARY_PATH (macOS) or LD_LIBRARY_PATH (other Unices)
+   * in the environment, but of course that doesn't work with
+   * the empty environment that we're testing here.
+   */
+  if (NULL != getenv("DYLD_LIBARY_PATH") ||
+      NULL != getenv("LD_LIBRARY_PATH")) {
+    RETURN_SKIP("doesn't work with DYLD_LIBRARY_PATH/LD_LIBRARY_PATH");
+  }
 
   init_process_options("spawn_helper1", exit_cb);
   options.env = env;
@@ -250,7 +257,6 @@ TEST_IMPL(spawn_empty_env) {
 
   MAKE_VALGRIND_HAPPY();
   return 0;
-#endif  /* !__sun */
 }
 
 

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -232,6 +232,28 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
 #endif
 
 
+TEST_IMPL(spawn_empty_env) {
+#ifdef __sun
+  RETURN_SKIP("fails on smartos");
+#else  /* !__sun */
+  char* env[1];
+
+  init_process_options("spawn_helper1", exit_cb);
+  options.env = env;
+  env[0] = NULL;
+
+  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT(exit_cb_called == 1);
+  ASSERT(close_cb_called == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+#endif  /* !__sun */
+}
+
+
 TEST_IMPL(spawn_exit_code) {
   int r;
 


### PR DESCRIPTION
Commit ba780231 ("unix,win: handle zero-sized allocations uniformly")
makes `uv__malloc()` return NULL when `size == 0`.

That's exactly the size that is passed to it when uv_spawn() tries to
spawn a process with an empty environment so handle that edge case.

Fixes: https://github.com/nodejs/node/issues/29008
CI: https://ci.nodejs.org/job/libuv-test-commit/1493/

(Caveat emptor: the test failed in a previous run on exactly _one_ linux buildbot: https://ci.nodejs.org/job/libuv-test-commit-linux/1538/nodes=debian9-64/console)