### PR TITLE
Fix building tests on MinGW (use old fmode)

### DIFF
--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -55,7 +55,12 @@ int platform_init(int argc, char **argv) {
   _setmode(0, _O_BINARY);
   _setmode(1, _O_BINARY);
   _setmode(2, _O_BINARY);
+
+#ifdef _MSC_VER
   _set_fmode(_O_BINARY);
+#else
+  _fmode = _O_BINARY;
+#endif
 
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);


### PR DESCRIPTION
MinGW [does not export](https://github.com/mirror/mingw-w64/blob/782c94fb63dfbde91c14f64a9184dda105fcdc2f/mingw-w64-crt/lib-common/msvcrt.def.in#L947) the `_set_fmode` function via its `libmsvcrt.a` import library unless on an ARM platform. This causes the test target build to fail unless manually adjusting the link parameters - which is a nuisance.

It is safe to assume `_fmode` is widely available by all stable releases and that should be preferred unless using MSVC. This is unrelated to #2407 but when both are fixed, MinGW builds should complete successfully.