### PR TITLE
Don't use try-except outside MSVC

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -218,6 +218,11 @@ API
 
     Equivalent to :man:`preadv(2)`.
 
+    .. warning::
+        On Windows, under non-MSVC environments (e.g. when GCC or Clang is used
+        to build libuv), files opened using ``UV_FS_O_FILEMAP`` may cause a fatal
+        crash if the memory mapped read operation fails.
+
 .. c:function:: int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
     Equivalent to :man:`unlink(2)`.
@@ -225,6 +230,11 @@ API
 .. c:function:: int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file, const uv_buf_t bufs[], unsigned int nbufs, int64_t offset, uv_fs_cb cb)
 
     Equivalent to :man:`pwritev(2)`.
+
+    .. warning::
+        On Windows, under non-MSVC environments (e.g. when GCC or Clang is used
+        to build libuv), files opened using ``UV_FS_O_FILEMAP`` may cause a fatal
+        crash if the memory mapped write operation fails.
 
 .. c:function:: int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode, uv_fs_cb cb)
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -786,10 +786,13 @@ void fs__read_filemap(uv_fs_t* req, struct uv__fd_info_s* fd_info) {
     int err = 0;
     size_t this_read_size = MIN(req->fs.info.bufs[index].len,
                                 read_size - done_read);
+#ifdef _MSC_VER
     __try {
+#endif
       memcpy(req->fs.info.bufs[index].base,
              (char*)view + view_offset + done_read,
              this_read_size);
+#ifdef _MSC_VER
     }
     __except (fs__filemap_ex_filter(GetExceptionCode(),
                                     GetExceptionInformation(), &err)) {
@@ -797,6 +800,7 @@ void fs__read_filemap(uv_fs_t* req, struct uv__fd_info_s* fd_info) {
       UnmapViewOfFile(view);
       return;
     }
+#endif
     done_read += this_read_size;
   }
   assert(done_read == read_size);
@@ -978,10 +982,13 @@ void fs__write_filemap(uv_fs_t* req, HANDLE file,
   done_write = 0;
   for (index = 0; index < req->fs.info.nbufs; ++index) {
     int err = 0;
+#ifdef _MSC_VER
     __try {
+#endif
       memcpy((char*)view + view_offset + done_write,
              req->fs.info.bufs[index].base,
              req->fs.info.bufs[index].len);
+#ifdef _MSC_VER
     }
     __except (fs__filemap_ex_filter(GetExceptionCode(),
                                     GetExceptionInformation(), &err)) {
@@ -989,6 +996,7 @@ void fs__write_filemap(uv_fs_t* req, HANDLE file,
       UnmapViewOfFile(view);
       return;
     }
+#endif
     done_write += req->fs.info.bufs[index].len;
   }
   assert(done_write == write_size);


### PR DESCRIPTION
The try-except statements are only widely supported by MSVC. This patch will perform the `memcpy` without any exception handling on non-MSVC builds.

See #2407 for details.