### PR TITLE
win: support retrieving empty env variables

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -132,6 +132,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENOBUFS:                        return UV_ENOBUFS;
     case ERROR_BAD_PATHNAME:                return UV_ENOENT;
     case ERROR_DIRECTORY:                   return UV_ENOENT;
+    case ERROR_ENVVAR_NOT_FOUND:            return UV_ENOENT;
     case ERROR_FILE_NOT_FOUND:              return UV_ENOENT;
     case ERROR_INVALID_NAME:                return UV_ENOENT;
     case ERROR_INVALID_DRIVE:               return UV_ENOENT;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1481,17 +1481,15 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
   if (r != 0)
     return r;
 
+  SetLastError(ERROR_SUCCESS);
   len = GetEnvironmentVariableW(name_w, var, MAX_ENV_VAR_LENGTH);
   uv__free(name_w);
   assert(len < MAX_ENV_VAR_LENGTH); /* len does not include the null */
 
   if (len == 0) {
     r = GetLastError();
-
-    if (r == ERROR_ENVVAR_NOT_FOUND)
-      return UV_ENOENT;
-
-    return uv_translate_sys_error(r);
+    if (r != ERROR_SUCCESS)
+      return uv_translate_sys_error(r);
   }
 
   /* Check how much space we need */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1325,7 +1325,7 @@ int uv__convert_utf8_to_utf16(const char* utf8, int utf8len, WCHAR** utf16) {
     return uv_translate_sys_error(GetLastError());
   }
 
-  (*utf16)[bufsize] = '\0';
+  (*utf16)[bufsize] = L'\0';
   return 0;
 }
 

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -88,6 +88,15 @@ TEST_IMPL(env_vars) {
   r = uv_os_unsetenv(name);
   ASSERT(r == 0);
 
+  /* Setting an environment variable to the empty string does not delete it. */
+  r = uv_os_setenv(name, "");
+  ASSERT(r == 0);
+  size = BUF_SIZE;
+  r = uv_os_getenv(name, buf, &size);
+  ASSERT(r == 0);
+  ASSERT(size == 0);
+  ASSERT(strlen(buf) == 0);
+
   /* Check getting all env variables. */
   r = uv_os_setenv(name, "123456789");
   ASSERT(r == 0);


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/2413