### PR TITLE
test: fix typo in DYLD_LIBRARY_PATH

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -240,7 +240,7 @@ TEST_IMPL(spawn_empty_env) {
    * in the environment, but of course that doesn't work with
    * the empty environment that we're testing here.
    */
-  if (NULL != getenv("DYLD_LIBARY_PATH") ||
+  if (NULL != getenv("DYLD_LIBRARY_PATH") ||
       NULL != getenv("LD_LIBRARY_PATH")) {
     RETURN_SKIP("doesn't work with DYLD_LIBRARY_PATH/LD_LIBRARY_PATH");
   }


### PR DESCRIPTION
It looks like I managed to introduce a typo between two incarnations
of the pull request, causing the test to fail on macOS when using the
autotools dynamic library build.

I even managed to spell it correctly in the skip message, just not in
the actual environment variable lookup... I hang my head in shame at
such a silly mistake.

Fixes: https://github.com/libuv/libuv/issues/2421
Refs: https://github.com/libuv/libuv/pull/2408
CI: https://ci.nodejs.org/job/libuv-test-commit/1527/