### PR TITLE
unix,signal: keep handle active if pending signal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(uv_test_sources
     test/test-shutdown-eof.c
     test/test-shutdown-twice.c
     test/test-signal-multiple-loops.c
+    test/test-signal-pending-on-close.c
     test/test-signal.c
     test/test-socket-buffer-size.c
     test/test-spawn.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -248,6 +248,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-shutdown-eof.c \
                          test/test-shutdown-twice.c \
                          test/test-signal-multiple-loops.c \
+                         test/test-signal-pending-on-close.c \
                          test/test-signal.c \
                          test/test-socket-buffer-size.c \
                          test/test-spawn.c \

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -445,6 +445,7 @@ TEST_DECLARE   (we_get_signals)
 TEST_DECLARE   (we_get_signal_one_shot)
 TEST_DECLARE   (we_get_signals_mixed)
 TEST_DECLARE   (signal_multiple_loops)
+TEST_DECLARE   (signal_pending_on_close)
 TEST_DECLARE   (closed_fd_events)
 #endif
 #ifdef __APPLE__
@@ -886,6 +887,7 @@ TASK_LIST_START
   TEST_ENTRY  (we_get_signal_one_shot)
   TEST_ENTRY  (we_get_signals_mixed)
   TEST_ENTRY  (signal_multiple_loops)
+  TEST_ENTRY  (signal_pending_on_close)
   TEST_ENTRY  (closed_fd_events)
 #endif
 

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -1,0 +1,94 @@
+/* Copyright libuv project contributors. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+#ifndef _WIN32
+
+#include "uv.h"
+#include "task.h"
+
+#include <string.h>
+#include <unistd.h>
+
+static uv_loop_t loop;
+static uv_signal_t signal_hdl;
+static uv_pipe_t pipe_hdl;
+static uv_write_t write_req;
+static char* buf;
+static int close_cb_called;
+
+
+static void signal_cb(uv_signal_t* signal, int signum) {
+  ASSERT(0);
+}
+
+static void close_cb(uv_handle_t *handle) {
+  close_cb_called++;
+}
+
+
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT(req != NULL);
+  ASSERT(status == UV_EPIPE);
+  free(buf);
+  uv_close((uv_handle_t *) &pipe_hdl, close_cb);
+  uv_close((uv_handle_t *) &signal_hdl, close_cb);
+}
+
+
+TEST_IMPL(signal_pending_on_close) {
+  int pipefds[2];
+  uv_buf_t buffer;
+  int r;
+
+  ASSERT(0 == uv_loop_init(&loop));
+
+  ASSERT(0 == uv_signal_init(&loop, &signal_hdl));
+
+  ASSERT(0 == uv_signal_start(&signal_hdl, signal_cb, SIGPIPE));
+
+  ASSERT(0 == pipe(pipefds));
+
+  ASSERT(0 == uv_pipe_init(&loop, &pipe_hdl, 0));
+
+  ASSERT(0 == uv_pipe_open(&pipe_hdl, pipefds[1]));
+
+  /* Write data large enough so it needs loop iteration */
+  buf = malloc(1<<24);
+  ASSERT(buf != NULL);
+  memset(buf, '.', 1<<24);
+  buffer = uv_buf_init(buf, 1<<24);
+
+  r = uv_write(&write_req, (uv_stream_t *) &pipe_hdl, &buffer, 1, write_cb);
+  ASSERT(0 == r);
+
+  /* cause a SIGPIPE on write in next iteration */
+  close(pipefds[0]);
+
+  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+
+  ASSERT(0 == uv_loop_close(&loop));
+
+  ASSERT(2 == close_cb_called);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+#endif

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -99,6 +99,7 @@
         'test-shutdown-twice.c',
         'test-signal.c',
         'test-signal-multiple-loops.c',
+        'test-signal-pending-on-close.c',
         'test-socket-buffer-size.c',
         'test-spawn.c',
         'test-strscpy.c',


### PR DESCRIPTION
Keep the signal handler active after being closed until all the caught
signals have been delivered.

I think it may fix both https://github.com/libuv/libuv/issues/2398 and
https://github.com/libuv/libuv/issues/2415.

I still have to add a test but feedback would be appreciated.