### PR TITLE
test: loosen assertion in fs_statfs test

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -354,7 +354,7 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT(stats->f_files == 0);
   ASSERT(stats->f_ffree == 0);
 #else
-  ASSERT(stats->f_files > 0);
+  /* There is no assertion for stats->f_files that makes sense, so ignore it. */
   ASSERT(stats->f_ffree <= stats->f_files);
 #endif
   uv_fs_req_cleanup(req);


### PR DESCRIPTION
It has been reported that this value can also equal 0.

Fixes: https://github.com/libuv/libuv/issues/2417