### PR TITLE
win: fix typo in preprocessor expression

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4109,7 +4109,7 @@
 #endif
 
 /* from winternl.h */
-#if !defined(__UNICODE_STRING_DEFINED) && defined(__MINGW32_)
+#if !defined(__UNICODE_STRING_DEFINED) && defined(__MINGW32__)
 #define __UNICODE_STRING_DEFINED
 #endif
 typedef struct _UNICODE_STRING {


### PR DESCRIPTION
I found a description of this typo in [this post](https://habr.com/ru/company/pvs-studio/blog/464145/). The CMake project is being blamed unfairly. But we know where the source is!
