### PR TITLE
doc: clarify uv_buf_t usage in uv_alloc_cb

### DIFF
--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -60,6 +60,9 @@ Data types
     a ``UV_ENOBUFS`` error will be triggered in the :c:type:`uv_udp_recv_cb` or the
     :c:type:`uv_read_cb` callback.
 
+    Each buffer is used only once and the user is responsible for freeing it in the
+    :c:type:`uv_udp_recv_cb` or the :c:type:`uv_read_cb` callback.
+
     A suggested size (65536 at the moment in most cases) is provided, but it's just an indication,
     not related in any way to the pending data to be read. The user is free to allocate the amount
     of memory they decide.

--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -50,8 +50,8 @@ Data types
     from the stream again is undefined.
 
     The callee is responsible for freeing the buffer, libuv does not reuse it.
-    The buffer may be a null buffer (where buf->base=NULL and buf->len=0) on
-    error.
+    The buffer may be a null buffer (where `buf->base` == NULL and `buf->len` == 0)
+    on error.
 
 .. c:type:: void (*uv_write_cb)(uv_write_t* req, int status)
 

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -56,15 +56,18 @@ Data types
 
     * `handle`: UDP handle
     * `nread`:  Number of bytes that have been received.
-      0 if there is no more data to read. You may discard or repurpose
-      the read buffer. Note that 0 may also mean that an empty datagram
-      was received (in this case `addr` is not NULL). < 0 if a transmission
-      error was detected.
+      0 if there is no more data to read. Note that 0 may also mean that an
+      empty datagram was received (in this case `addr` is not NULL). < 0 if
+      a transmission error was detected.
     * `buf`: :c:type:`uv_buf_t` with the received data.
     * `addr`: ``struct sockaddr*`` containing the address of the sender.
       Can be NULL. Valid for the duration of the callback only.
     * `flags`: One or more or'ed UV_UDP_* constants. Right now only
       ``UV_UDP_PARTIAL`` is used.
+
+    The callee is responsible for freeing the buffer, libuv does not reuse it.
+    The buffer may be a null buffer (where `buf->base` == NULL and `buf->len` == 0)
+    on error.
 
     .. note::
         The receive callback will be called with `nread` == 0 and `addr` == NULL when there is


### PR DESCRIPTION
Clarify the uv_buf_t isn't reused and the user is responsible for
freeing it in the recv/read callback.

Previously, this wasn't clear when reading only the docs for
uv_udp_recv_cb and uv_alloc_cb.