### PR TITLE
unix,tcp: set identifier for tcp sockets on FreeBSD.

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -236,6 +236,9 @@ int uv__open_cloexec(const char* path, int flags);
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 int uv__tcp_nodelay(int fd, int on);
 int uv__tcp_keepalive(int fd, int on, unsigned int delay);
+#if defined(__FreeBSD__)
+int uv__tcp_setid(int fd, uint32_t id);
+#endif
 
 /* pipe */
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -366,6 +366,14 @@ int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
   return 0;
 }
 
+#if defined(__FreeBSD__)
+int uv__tcp_setid(int fd, uint32_t id) {
+  if (setsockopt(fd, SOL_SOCKET, SO_USER_COOKIE, &id, sizeof(id)))
+    return UV__ERR(errno);
+  return 0;
+}
+#endif
+
 
 int uv__tcp_nodelay(int fd, int on) {
   if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)))


### PR DESCRIPTION
FreeBSD allows to set an ID for a given socket, mainly for
DTrace purpose or ipfw.