### PR TITLE
unix: fix UV_FS_O_DIRECT definition on Linux

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -405,11 +405,25 @@ typedef struct {
 #else
 # define UV_FS_O_CREAT        0
 #endif
-#if defined(O_DIRECT)
+
+#if defined(__linux__) && defined(__arm__)
+# define UV_FS_O_DIRECT       0x10000
+#elif defined(__linux__) && defined(__m68k__)
+# define UV_FS_O_DIRECT       0x10000
+#elif defined(__linux__) && defined(__mips__)
+# define UV_FS_O_DIRECT       0x08000
+#elif defined(__linux__) && defined(__powerpc__)
+# define UV_FS_O_DIRECT       0x20000
+#elif defined(__linux__) && defined(__s390x__)
+# define UV_FS_O_DIRECT       0x04000
+#elif defined(__linux__) && defined(__x86_64__)
+# define UV_FS_O_DIRECT       0x04000
+#elif defined(O_DIRECT)
 # define UV_FS_O_DIRECT       O_DIRECT
 #else
 # define UV_FS_O_DIRECT       0
 #endif
+
 #if defined(O_DIRECTORY)
 # define UV_FS_O_DIRECTORY    O_DIRECTORY
 #else


### PR DESCRIPTION
A few observations:

For the following architectures, [musl defines O_DIRECT](https://github.com/libuv/libuv/issues/2420#issuecomment-523464048) as:

* 0x04000 on `generic`. I skipped this assuming it's just a default fallback for unknown architectures and we fallback to O_DIRECT in any event?

* 0x04000 on `x32` and `x86_64`. We just use `__x86_64__` for both.

* 0x08000 on `mips`, `mipsn32` and `mips64`. We just use `__mips__` for all three.

* 0x10000 on `arm` and `aarch64`. We just use `__arm__` for both.

* 0x20000 on `powerpc` and `powerpc64`. We just use `__powerpc__` for both. Ben, you had 0x4000 in your example?