### PR TITLE
build: Add link for test/fixtures/lorem_ipsum.txt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,4 +80,5 @@ AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])
 AC_CONFIG_LINKS([test/fixtures/empty_file:test/fixtures/empty_file])
 AC_CONFIG_LINKS([test/fixtures/load_error.node:test/fixtures/load_error.node])
+AC_CONFIG_LINKS([test/fixtures/lorem_ipsum.txt:test/fixtures/lorem_ipsum.txt])
 AC_OUTPUT


### PR DESCRIPTION
Test `test-fs.c` fails when built in a relocated directory because
the build does link the required test fixture.