### PR TITLE
cmake build: add library VERSION, SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,10 @@ if(UNIX)
   endforeach(x)
   file(STRINGS configure.ac configure_ac REGEX ^AC_INIT)
   string(REGEX MATCH [0-9]+[.][0-9]+[.][0-9]+ PACKAGE_VERSION "${configure_ac}")
+  string(REGEX MATCH ^[0-9]+ UV_VERSION_MAJOR "${PACKAGE_VERSION}")
+  # The version in the filename is mirroring the behaviour of autotools.
+  set_target_properties(uv PROPERTIES VERSION ${UV_VERSION_MAJOR}.0.0
+				      SOVERSION ${UV_VERSION_MAJOR})
   set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
   set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
   set(prefix ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
This mimics the behavior of the automake build, using `libuv.so.${UV_VERSION_MAJOR}.0.0` as the output file (discussed in #1745), and setting the `soname` property to be `libuv.so.${UV_VERSION_MAJOR}`, currently ending up like this :
```
libuv.so.1.0.0
libuv.so.1 -> libuv.so.1.0.0
libuv.so -> libuv.so.1
```
_Edit_
_It currently generates a single, unversioned file:_
```
libuv.so
```

The version information is extracted from the `PACKAGE_VERSION` string.

I have inserted the changes under `if(UNIX)`, to not touch Windows with this, since I'm not experienced with it.  If this affects Windows as well, then I can move it out, and perhaps use `include/uv/version.h` to extract it, instead of using`PACKAGE_VERSION` (which is taken from `configure.ac`).

This was tested on Gentoo Linux, x86_64, gcc-8.3.0 and on OpenWRT master, mipsel_74kc, gcc-7.4.0.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>