### PR TITLE
stream: replace ECONNRESET with EOF if already closed on AIX

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1180,6 +1180,9 @@ static void uv__read(uv_stream_t* stream) {
       } else if (errno == ECONNRESET && stream->type == UV_NAMED_PIPE) {
         uv__stream_eof(stream, &buf);
         return;
+#elif defined(_AIX)
+      } else if (errno == ECONNRESET && (stream->flags & UV_DISCONNECT)) {
+        uv__stream_eof(stream, &buf);
 #endif
       } else {
         /* Error. User should call uv_close(). */

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1183,6 +1183,7 @@ static void uv__read(uv_stream_t* stream) {
 #elif defined(_AIX)
       } else if (errno == ECONNRESET && (stream->flags & UV_DISCONNECT)) {
         uv__stream_eof(stream, &buf);
+        return;
 #endif
       } else {
         /* Error. User should call uv_close(). */


### PR DESCRIPTION
We have been getting a lot of failures on AIX when `node-gyp` tries to download from https://nodejs.org/download/, an issue has been created with more details on the problem:
https://github.com/nodejs/node-addon-api/issues/522

There has been two attempts to fix similar issues on libuv a few years ago:
https://github.com/libuv/libuv/commit/05a003a3f78d07185b7137601fe8e93561855a8d (which is reverted) and https://github.com/libuv/libuv/commit/c7c8e916b86d2b168e97b04d7b4c8913322c8329 .

This PR uses `UV_DISCONNECT` introduced in the second commit above, and adds an error check similar to the first commit (only on AIX) to emit EOF when a read returns ECONNRESET after a UV_DISCONNECT event.