### PR TITLE
win: fail fs_open with append and file mapping

### DIFF
--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -350,9 +350,17 @@ static void fs_open_flags(int add_flags) {
   openFail(empty_file, UV_EEXIST);
   openFail(dummy_file, UV_EEXIST);
   openFail(empty_dir, UV_EEXIST);
+}
+TEST_IMPL(fs_open_flags) {
+  setup();
 
+  /* Flags excluding append */
+  fs_open_flags(0);
+  fs_open_flags(UV_FS_O_FILEMAP);
+
+  /* Append without UV_FS_O_FILEMAP */
   /* a */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY;
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY;
   writeExpect(absent_file, "bc", 2);
   readFail(absent_file, UV_EPERM);
   writeExpect(empty_file, "bc", 2);
@@ -363,7 +371,7 @@ static void fs_open_flags(int add_flags) {
   readFail(empty_dir, UV_EPERM);
 
   /* ax */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
     UV_FS_O_EXCL;
   writeExpect(absent_file, "bc", 2);
   readFail(absent_file, UV_EPERM);
@@ -372,8 +380,7 @@ static void fs_open_flags(int add_flags) {
   openFail(empty_dir, UV_EEXIST);
 
   /* as */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
-    UV_FS_O_SYNC;
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY | UV_FS_O_SYNC;
   writeExpect(absent_file, "bc", 2);
   readFail(absent_file, UV_EPERM);
   writeExpect(empty_file, "bc", 2);
@@ -384,7 +391,7 @@ static void fs_open_flags(int add_flags) {
   readFail(empty_dir, UV_EPERM);
 
   /* a+ */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR;
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR;
   writeExpect(absent_file, "bc", 2);
   readExpect(absent_file, "", 0);
   writeExpect(empty_file, "bc", 2);
@@ -395,8 +402,7 @@ static void fs_open_flags(int add_flags) {
   readFail(empty_dir, UV_EISDIR);
 
   /* ax+ */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR |
-    UV_FS_O_EXCL;
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR | UV_FS_O_EXCL;
   writeExpect(absent_file, "bc", 2);
   readExpect(absent_file, "", 0);
   openFail(empty_file, UV_EEXIST);
@@ -404,8 +410,7 @@ static void fs_open_flags(int add_flags) {
   openFail(empty_dir, UV_EEXIST);
 
   /* as+ */
-  flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR |
-    UV_FS_O_SYNC;
+  flags = UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR | UV_FS_O_SYNC;
   writeExpect(absent_file, "bc", 2);
   readExpect(absent_file, "", 0);
   writeExpect(empty_file, "bc", 2);
@@ -414,12 +419,53 @@ static void fs_open_flags(int add_flags) {
   readExpect(dummy_file, "a", 1);
   writeFail(empty_dir, UV_EISDIR);
   readFail(empty_dir, UV_EISDIR);
-}
-TEST_IMPL(fs_open_flags) {
-  setup();
 
-  fs_open_flags(0);
-  fs_open_flags(UV_FS_O_FILEMAP);
+  /* Append with UV_FS_O_FILEMAP */
+  /* a */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
+
+  /* ax */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
+    UV_FS_O_EXCL;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
+
+  /* as */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
+    UV_FS_O_SYNC;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
+
+  /* a+ */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
+
+  /* ax+ */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR |
+    UV_FS_O_EXCL;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
+
+  /* as+ */
+  flags = UV_FS_O_FILEMAP | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR |
+    UV_FS_O_SYNC;
+  openFail(absent_file, UV_EACCES);
+  openFail(empty_file, UV_EACCES);
+  openFail(dummy_file, UV_EACCES);
+  openFail(empty_dir, UV_EACCES);
 
   /* Cleanup. */
   rmdir(empty_dir);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -382,7 +382,6 @@ TEST_DECLARE   (fs_null_req)
 TEST_DECLARE   (fs_read_dir)
 #ifdef _WIN32
 TEST_DECLARE   (fs_file_pos_write)
-TEST_DECLARE   (fs_file_pos_append)
 TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_file_flag_no_buffering)
 TEST_DECLARE   (fs_open_readonly_acl)
@@ -985,7 +984,6 @@ TASK_LIST_START
   TEST_ENTRY  (fs_read_dir)
 #ifdef _WIN32
   TEST_ENTRY  (fs_file_pos_write)
-  TEST_ENTRY  (fs_file_pos_append)
   TEST_ENTRY  (fs_exclusive_sharing_mode)
   TEST_ENTRY  (fs_file_flag_no_buffering)
   TEST_ENTRY  (fs_open_readonly_acl)


### PR DESCRIPTION
@bnoordhuis suggested in https://github.com/nodejs/node/pull/29260#issuecomment-524567394 that `uv_fs_open` should fail with `EACCES` when both `O_APPEND` and `UV_FS_O_FILEMAP` are specified. This is an implementation of that suggestion.

I would rather keep the current behavior and not land this PR, but don't have strong feelings.
- With the current implementation, the behavior of `uv_fs_read` and `uv_fs_write` is exactly the same with or without `UV_FS_O_FILEMAP`. The code to support this is very small, and I suspect supporting this in Unix would also require little code - an unexpected but useful extension.
- With this PR, `uv_fs_open` behaves more like what would be expected of a Unix implementation, by failing.

I'll leave the decision for the libuv maintainers.
