### PR TITLE
Revert "fsevents: really watch files with fsevents on macos 10.7+"

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -256,54 +256,41 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
       path = paths[i];
       len = strlen(path);
 
-      if (handle->realpath_len == 0)
-        continue; /* This should be unreachable */
-
       /* Filter out paths that are outside handle's request */
-      if (len < handle->realpath_len)
+      if (strncmp(path, handle->realpath, handle->realpath_len) != 0)
         continue;
 
-      if (handle->realpath_len != len &&
-          path[handle->realpath_len] != '/')
-        /* Make sure that realpath actually named a directory,
-         * or that we matched the whole string */
-        continue;
-
-      if (memcmp(path, handle->realpath, handle->realpath_len) != 0)
-        continue;
-
-      if (!(handle->realpath_len == 1 && handle->realpath[0] == '/')) {
-        /* Remove common prefix, unless the watched folder is "/" */
+      if (handle->realpath_len > 1 || *handle->realpath != '/') {
         path += handle->realpath_len;
         len -= handle->realpath_len;
 
-        /* Ignore events with path equal to directory itself */
-        if (len <= 1 && (flags & kFSEventStreamEventFlagItemIsDir))
-          continue;
-
-        if (len == 0) {
-          /* Since we're using fsevents to watch the file itself,
-           * realpath == path, and we now need to get the basename of the file back
-           * (for commonality with other codepaths and platforms). */
-          while (len < handle->realpath_len && path[-1] != '/') {
-            path--;
-            len++;
-          }
-          /* Created and Removed seem to be always set, but don't make sense */
-          flags &= ~kFSEventsRenamed;
-        } else {
-          /* Skip forward slash */
+        /* Skip forward slash */
+        if (*path != '\0') {
           path++;
           len--;
         }
       }
 
+#ifdef MAC_OS_X_VERSION_10_7
+      /* Ignore events with path equal to directory itself */
+      if (len == 0)
+        continue;
+#else
+      if (len == 0 && (flags & kFSEventStreamEventFlagItemIsDir))
+        continue;
+#endif /* MAC_OS_X_VERSION_10_7 */
+
       /* Do not emit events from subdirectories (without option set) */
-      if ((handle->cf_flags & UV_FS_EVENT_RECURSIVE) == 0 && *path != '\0') {
+      if ((handle->cf_flags & UV_FS_EVENT_RECURSIVE) == 0 && *path != 0) {
         pos = strchr(path + 1, '/');
         if (pos != NULL)
           continue;
       }
+
+#ifndef MAC_OS_X_VERSION_10_7
+      path = "";
+      len = 0;
+#endif /* MAC_OS_X_VERSION_10_7 */
 
       event = uv__malloc(sizeof(*event) + len);
       if (event == NULL)
@@ -313,11 +300,22 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
       memcpy(event->path, path, len + 1);
       event->events = UV_RENAME;
 
-      if (0 == (flags & kFSEventsRenamed)) {
-        if (0 != (flags & kFSEventsModified) ||
-            0 == (flags & kFSEventStreamEventFlagItemIsDir))
-          event->events = UV_CHANGE;
+#ifdef MAC_OS_X_VERSION_10_7
+      if (0 != (flags & kFSEventsModified) &&
+          0 == (flags & kFSEventsRenamed)) {
+        event->events = UV_CHANGE;
       }
+#else
+      if (0 != (flags & kFSEventsModified) &&
+          0 != (flags & kFSEventStreamEventFlagItemIsDir) &&
+          0 == (flags & kFSEventStreamEventFlagItemRenamed)) {
+        event->events = UV_CHANGE;
+      }
+      if (0 == (flags & kFSEventStreamEventFlagItemIsDir) &&
+          0 == (flags & kFSEventStreamEventFlagItemRenamed)) {
+        event->events = UV_CHANGE;
+      }
+#endif /* MAC_OS_X_VERSION_10_7 */
 
       QUEUE_INSERT_TAIL(&head, &event->member);
     }

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -293,6 +293,24 @@ int uv__fsevents_init(uv_fs_event_t* handle);
 int uv__fsevents_close(uv_fs_event_t* handle);
 void uv__fsevents_loop_delete(uv_loop_t* loop);
 
+/* OSX < 10.7 has no file events, polyfill them */
+#ifndef MAC_OS_X_VERSION_10_7
+
+static const int kFSEventStreamCreateFlagFileEvents = 0x00000010;
+static const int kFSEventStreamEventFlagItemCreated = 0x00000100;
+static const int kFSEventStreamEventFlagItemRemoved = 0x00000200;
+static const int kFSEventStreamEventFlagItemInodeMetaMod = 0x00000400;
+static const int kFSEventStreamEventFlagItemRenamed = 0x00000800;
+static const int kFSEventStreamEventFlagItemModified = 0x00001000;
+static const int kFSEventStreamEventFlagItemFinderInfoMod = 0x00002000;
+static const int kFSEventStreamEventFlagItemChangeOwner = 0x00004000;
+static const int kFSEventStreamEventFlagItemXattrMod = 0x00008000;
+static const int kFSEventStreamEventFlagItemIsFile = 0x00010000;
+static const int kFSEventStreamEventFlagItemIsDir = 0x00020000;
+static const int kFSEventStreamEventFlagItemIsSymlink = 0x00040000;
+
+#endif /* __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070 */
+
 #endif /* defined(__APPLE__) */
 
 UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -466,10 +466,15 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   if (fd == -1)
     return UV__ERR(errno);
 
+  handle->path = uv__strdup(path);
+  if (handle->path == NULL) {
+    uv__close_nocheckstdio(fd);
+    return UV_ENOMEM;
+  }
+
+  handle->cb = cb;
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);
-  handle->path = uv__strdup(path);
-  handle->cb = cb;
 
 #if defined(__APPLE__)
   if (uv__has_forked_with_cfrunloop)

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -59,7 +59,7 @@ int uv__kqueue_init(uv_loop_t* loop) {
 }
 
 
-#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+#if defined(__APPLE__)
 static int uv__has_forked_with_cfrunloop;
 #endif
 
@@ -70,7 +70,7 @@ int uv__io_fork(uv_loop_t* loop) {
   if (err)
     return err;
 
-#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+#if defined(__APPLE__)
   if (loop->cf_state != NULL) {
     /* We cannot start another CFRunloop and/or thread in the child
        process; CF aborts if you try or if you try to touch the thread
@@ -86,7 +86,7 @@ int uv__io_fork(uv_loop_t* loop) {
     uv__free(loop->cf_state);
     loop->cf_state = NULL;
   }
-#endif /* #if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070 */
+#endif
   return err;
 }
 
@@ -453,51 +453,49 @@ int uv_fs_event_start(uv_fs_event_t* handle,
                       uv_fs_event_cb cb,
                       const char* path,
                       unsigned int flags) {
+#if defined(__APPLE__)
+  struct stat statbuf;
+#endif /* defined(__APPLE__) */
   int fd;
 
   if (uv__is_active(handle))
     return UV_EINVAL;
-
-#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-  /* Nullify field to perform checks later */
-  handle->cf_cb = NULL;
-  handle->realpath = NULL;
-  handle->realpath_len = 0;
-  handle->cf_flags = flags;
-
-  if (!uv__has_forked_with_cfrunloop) {
-    int r;
-    /* The fallback fd is not used */
-    handle->event_watcher.fd = -1;
-    handle->path = uv__strdup(path);
-    if (handle->path == NULL)
-      return UV_ENOMEM;
-    handle->cb = cb;
-    r = uv__fsevents_init(handle);
-    if (r == 0) {
-      uv__handle_start(handle);
-    } else {
-      uv__free(handle->path);
-      handle->path = NULL;
-    }
-    return r;
-  }
-#endif /* #if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070 */
 
   /* TODO open asynchronously - but how do we report back errors? */
   fd = open(path, O_RDONLY);
   if (fd == -1)
     return UV__ERR(errno);
 
-  handle->path = uv__strdup(path);
-  if (handle->path == NULL) {
-    uv__close_nocheckstdio(fd);
-    return UV_ENOMEM;
-  }
-
-  handle->cb = cb;
   uv__handle_start(handle);
   uv__io_init(&handle->event_watcher, uv__fs_event, fd);
+  handle->path = uv__strdup(path);
+  handle->cb = cb;
+
+#if defined(__APPLE__)
+  if (uv__has_forked_with_cfrunloop)
+    goto fallback;
+
+  /* Nullify field to perform checks later */
+  handle->cf_cb = NULL;
+  handle->realpath = NULL;
+  handle->realpath_len = 0;
+  handle->cf_flags = flags;
+
+  if (fstat(fd, &statbuf))
+    goto fallback;
+  /* FSEvents works only with directories */
+  if (!(statbuf.st_mode & S_IFDIR))
+    goto fallback;
+
+  /* The fallback fd is no longer needed */
+  uv__close(fd);
+  handle->event_watcher.fd = -1;
+
+  return uv__fsevents_init(handle);
+
+fallback:
+#endif /* defined(__APPLE__) */
+
   uv__io_start(handle->loop, &handle->event_watcher, POLLIN);
 
   return 0;
@@ -505,29 +503,29 @@ int uv_fs_event_start(uv_fs_event_t* handle,
 
 
 int uv_fs_event_stop(uv_fs_event_t* handle) {
-  int r;
-  r = 0;
-
   if (!uv__is_active(handle))
     return 0;
 
   uv__handle_stop(handle);
 
-#if defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-  if (!uv__has_forked_with_cfrunloop)
-    r = uv__fsevents_close(handle);
-#endif
-
-  if (handle->event_watcher.fd != -1) {
+#if defined(__APPLE__)
+  if (uv__has_forked_with_cfrunloop || uv__fsevents_close(handle))
+#endif /* defined(__APPLE__) */
+  {
     uv__io_close(handle->loop, &handle->event_watcher);
-    uv__close(handle->event_watcher.fd);
-    handle->event_watcher.fd = -1;
   }
 
   uv__free(handle->path);
   handle->path = NULL;
 
-  return r;
+  if (handle->event_watcher.fd != -1) {
+    /* When FSEvents is used, we don't use the event_watcher's fd under certain
+     * confitions. (see uv_fs_event_start) */
+    uv__close(handle->event_watcher.fd);
+    handle->event_watcher.fd = -1;
+  }
+
+  return 0;
 }
 
 


### PR DESCRIPTION
This commit introduces numerous regressions, see the Node.js container
bug and the issues linked therein.

I did not revert the changes to the test suite since those work okay
with and without the reverted commit.

I also had to roll back (parts of) the following commits:

* 6602fca unix: fall back to kqueue on older macOS systems
* 09ba477 bsd: plug uv_fs_event_start() error path fd leak

This reverts commit 2d2af38.

Fixes: nodejs/node#29460
Refs: #2082

CI: https://ci.nodejs.org/job/libuv-test-commit/1559/

<hr>

cc @vtjnash I'm not too invested but since people keep filing bugs and #2313 isn't progressing, I'm moving to revert.