### PR TITLE
aix: Fix broken cmpxchgi() XL C++ specialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ Check the [SUPPORTED_PLATFORMS file](SUPPORTED_PLATFORMS.md).
 
 ### AIX Notes
 
+AIX compilation using IBM XL C/C++ requires version 12.1 or greater.
+
 AIX support for filesystem events requires the non-default IBM `bos.ahafs`
 package to be installed.  This package provides the AIX Event Infrastructure
 that is detected by `autoconf`.

--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -36,10 +36,6 @@ UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval)) {
                         : "r" (newval), "0" (oldval)
                         : "memory");
   return out;
-#elif defined(_AIX) && defined(__xlC__)
-  const int out = (*(volatile int*) ptr);
-  __compare_and_swap(ptr, &oldval, newval);
-  return out;
 #elif defined(__MVS__)
   unsigned int op4;
   if (__plo_CSST(ptr, (unsigned int*) &oldval, newval,


### PR DESCRIPTION
The preprocessor was used to select a special implementation when
building on AIX using XL C++ (strangely, not XL C).  This code
implemented `cmpxchgi()` by directly reading the old value and then
calling `__compare_and_swap()`, an intrinsic that does not provide
any sort of memory barrier guarantees.  The return value was not
used, and the value read prior to the `__compare_and_swap()` call
was returned.  There is no way that this code could provide the
required semantics of the function and it causes observable data
races and strange library failures in production under load.

XL C/C++ for AIX has provided support for the GCC intrinsic used in
the GCC/Clang cases since version 12.1 of the compiler.  This
version of the compiler is old enough that it doesn't warrant a
version check.  (The compiler was released 8-Jun-2012, maintenance
ended 9-Jul-2019, and service ends 30-Apr-2020.)

This change fixes all observed atomic issues and unifies XL C/C++
with GCC/Clang.

Relevant XL C/C++ for AIX V12.1 documentation links:
  - [__compare_and_swap](https://www.ibm.com/support/knowledgecenter/en/SSGH3R_12.1.0/com.ibm.xlcpp121.aix.doc/compiler_ref/bif_compare_and_swap_compare_and_swaplp.html)
  - [__sync_val_compare_and_swap](https://www.ibm.com/support/knowledgecenter/en/SSGH3R_12.1.0/com.ibm.xlcpp121.aix.doc/compiler_ref/bif_gcc_atomic_val_comp_swap.html)