### PR TITLE
fsevents: regression in watching /

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -263,10 +263,12 @@ static void uv__fsevents_event_cb(ConstFSEventStreamRef streamRef,
       if (len < handle->realpath_len)
         continue;
 
+      /* Make sure that realpath actually named a directory,
+       * (unless watching root, which alone keeps a trailing slash on the realpath)
+       * or that we matched the whole string */
       if (handle->realpath_len != len &&
+          handle->realpath_len > 1 &&
           path[handle->realpath_len] != '/')
-        /* Make sure that realpath actually named a directory,
-         * or that we matched the whole string */
         continue;
 
       if (memcmp(path, handle->realpath, handle->realpath_len) != 0)

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -394,8 +394,10 @@ static void timer_cb_watch_twice(uv_timer_t* handle) {
   uv_close((uv_handle_t*) handle, NULL);
 }
 
-static void fs_event_cb_close(uv_fs_event_t* handle, const char* filename,
-    int events, int status) {
+static void fs_event_cb_close(uv_fs_event_t* handle,
+                              const char* filename,
+                              int events,
+                              int status) {
   ASSERT(status == 0);
 
   ASSERT(fs_event_cb_called < 3);
@@ -467,7 +469,10 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
 
   r = uv_fs_event_init(loop, &fs_event);
   ASSERT(r == 0);
-  r = uv_fs_event_start(&fs_event, fs_event_cb_dir_multi_file_in_subdir, "watch_dir", UV_FS_EVENT_RECURSIVE);
+  r = uv_fs_event_start(&fs_event,
+                        fs_event_cb_dir_multi_file_in_subdir,
+                        "watch_dir",
+                        UV_FS_EVENT_RECURSIVE);
   ASSERT(r == 0);
   r = uv_timer_init(loop, &timer);
   ASSERT(r == 0);
@@ -479,11 +484,15 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
    * This will be noisier, so we're just checking for any couple events to happen. */
   r = uv_fs_event_init(loop, &fs_event_root);
   ASSERT(r == 0);
-  r = uv_fs_event_start(&fs_event_root, fs_event_cb_close, "/", UV_FS_EVENT_RECURSIVE);
+  r = uv_fs_event_start(&fs_event_root,
+                        fs_event_cb_close,
+                        "/",
+                        UV_FS_EVENT_RECURSIVE);
   ASSERT(r == 0);
 #else
   fs_event_cb_called += 3;
   close_cb_called += 1;
+  (void)fs_event_root;
 #endif
 
   uv_run(loop, UV_RUN_DEFAULT);


### PR DESCRIPTION
This case got lost by accident while I tried to address review comment https://github.com/libuv/libuv/pull/2082#discussion_r238172936. This prevented the realpath `/` from ever matching a file.

Fixes: https://github.com/nodejs/node/issues/28917
CI: https://ci.nodejs.org/job/libuv-test-commit/1569/