### PR TITLE
Fix undefined MCAST_* under MinGW

### DIFF
--- a/src/win/winsock.h
+++ b/src/win/winsock.h
@@ -54,6 +54,14 @@
 # define SIO_BASE_HANDLE 0x48000022
 #endif
 
+#ifndef MCAST_JOIN_SOURCE_GROUP
+# define MCAST_JOIN_SOURCE_GROUP 45
+#endif
+
+#ifndef MCAST_LEAVE_SOURCE_GROUP
+# define MCAST_LEAVE_SOURCE_GROUP 46
+#endif
+
 /*
  * TDI defines that are only in the DDK.
  * We only need receive flags so far.


### PR DESCRIPTION
Yet another missing macro required by f91702a - originates from `ws2ipdef.h` ([here](https://github.com/kinke/mingw-w64-crt/blob/66694dbedd870a3ec8e47278a220d73ff526ac7f/mingw-w64-headers/include/ws2ipdef.h#L55)). I believe this is the best place for it to go alongside the similar others.