### PR TITLE
cmake: Allow exporting CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,16 +339,32 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
   list(APPEND uv_test_libraries util)
 endif()
 
+if (LIBUV_EXPORT_CMAKE)
+  message("-- Exporting for CMake")
+endif()
+
 add_library(uv SHARED ${uv_sources})
 target_compile_definitions(uv PRIVATE ${uv_defines} BUILDING_UV_SHARED=1)
 target_compile_options(uv PRIVATE ${uv_cflags})
-target_include_directories(uv PRIVATE include src)
+if(LIBUV_EXPORT_CMAKE)
+  target_include_directories(uv
+    PUBLIC $<INSTALL_INTERFACE:include>
+    PRIVATE include src)
+else()
+  target_include_directories(uv PRIVATE include src)
+endif()
 target_link_libraries(uv ${uv_libraries})
 
 add_library(uv_a STATIC ${uv_sources})
 target_compile_definitions(uv_a PRIVATE ${uv_defines})
 target_compile_options(uv_a PRIVATE ${uv_cflags})
-target_include_directories(uv_a PRIVATE include src)
+if (LIBUV_EXPORT_CMAKE)
+  target_include_directories(uv_a
+    PUBLIC $<INSTALL_INTERFACE:include>
+    PRIVATE include src)
+else()
+  target_include_directories(uv_a PRIVATE include src)
+endif()
 target_link_libraries(uv_a ${uv_libraries})
 
 if(BUILD_TESTING)
@@ -372,23 +388,79 @@ if(BUILD_TESTING)
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-if(UNIX)
-  # Now for some gibbering horrors from beyond the stars...
-  include(GNUInstallDirs)
-  foreach(x ${uv_libraries})
-    set(LIBS "${LIBS} -l${x}")
-  endforeach(x)
-  file(STRINGS configure.ac configure_ac REGEX ^AC_INIT)
-  string(REGEX MATCH [0-9]+[.][0-9]+[.][0-9]+ PACKAGE_VERSION "${configure_ac}")
-  set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
-  set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-  set(prefix ${CMAKE_INSTALL_PREFIX})
-  configure_file(libuv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libuv.pc @ONLY)
+# Now for some gibbering horrors from beyond the stars...
 
-  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libuv.pc
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+if(LIBUV_NO_GNUINSTALLDIRS)
+  set(CMAKE_INSTALL_LIBDIR lib)
+  set(CMAKE_INSTALL_BINDIR bin)
+  set(CMAKE_INSTALL_INCLUDEDIR include)
+  set(CMAKE_INSTALL_DOCDIR share/doc/libuv)
+else()
+  include(GNUInstallDirs)
+endif()
+
+foreach(x ${uv_libraries})
+  set(LIBS "${LIBS} -l${x}")
+endforeach(x)
+file(STRINGS configure.ac configure_ac REGEX ^AC_INIT)
+string(REGEX MATCH [0-9]+[.][0-9]+[.][0-9]+ PACKAGE_VERSION "${configure_ac}")
+set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(prefix ${CMAKE_INSTALL_PREFIX})
+configure_file(libuv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libuv.pc @ONLY)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libuv.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+if(LIBUV_EXPORT_CMAKE)
+  export(TARGETS uv uv_a FILE ${CMAKE_BINARY_DIR}/libuv-targets.cmake)
+  install(
+    EXPORT libuv-targets
+    NAMESPACE libuv::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
+    COMPONENT dev)
+
+  install(TARGETS uv
+          EXPORT libuv-targets
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS uv_a
+          EXPORT libuv-targets
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  # Generate the libuv-config.cmake for find_package()
+  file(WRITE ${CMAKE_BINARY_DIR}/libuv-config.cmake
+"# libuv-config.cmake
+
+# Config file for the libuv package.
+# It defines the following variables:
+#  LIBUV_INCLUDE_DIRS - include directories for libuv
+#  LIBUV_LIBRARIES    - libraries to link against
+
+# Dependencies
+#  - These could be added but are not required for now as all dependencies are
+#    platform specific and provided by the OS
+# find_package(Threads REQUIRED)
+
+if(LIBUV_CMAKE_DIR)
+  # already imported
+endif()
+
+# Compute paths
+get_filename_component(LIBUV_CMAKE_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
+
+# Set include dir
+set(LIBUV_INCLUDE_DIRS include)
+set(LIBUV_LIBRARIES uv_a uv)
+
+include(\${LIBUV_CMAKE_DIR}/libuv-targets.cmake)
+")
+
+  install(FILES ${CMAKE_BINARY_DIR}/libuv-config.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
+          COMPONENT dev)
+else()
   install(TARGETS uv LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(TARGETS uv_a ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,13 @@ if (LIBUV_EXPORT_CMAKE)
 endif()
 
 add_library(uv SHARED ${uv_sources})
-target_compile_definitions(uv PRIVATE ${uv_defines} BUILDING_UV_SHARED=1)
+target_compile_definitions(
+  uv
+  PRIVATE
+    ${uv_defines}
+    BUILDING_UV_SHARED=1
+  INTERFACE
+    USING_UV_SHARED=1)
 target_compile_options(uv PRIVATE ${uv_cflags})
 if(LIBUV_EXPORT_CMAKE)
   target_include_directories(uv


### PR DESCRIPTION
This PR provides a way for CMake users to use standard CMake idioms to find an installed `libuv`.

In particular, `libuv` currently does not generate a `libuv-config.cmake` file and cannot be found through `find_package` without providing a `Findlibuv.cmake` which is not distributed with vanilla CMake.

Also, currently, non-UNIX platforms don't get a `libuv.<shared-lib>` or `libuv_a.<static-lib>` file installed.

*Fixes*:
 - Allow `libuv` installs on all platforms
 - Enable CMake to find the `libuv` package if at CMake generation time, `LIBUV_EXPORT_CMAKE` is truthy.

*Testing*:
 - Created a new folder `foo` containing two files:
   - `foo/foo.c` : test C code
```c
// foo.c

#include <uv.h>

char const* foo()
{
    return uv_strerror(UV__EOF);
}
```
   - `foo/CMakeLists.txt`: a CMake user of `libuv`
```c
# CMakeLists.txt test
cmake_minimum_required(VERSION 3.0)
project(foo LANGUAGES C)
find_package(libuv CONFIG REQUIRED)

add_library(foo foo.c)
target_link_libraries(foo libuv::uv_a)
```

*Test output*:
```sh
# Existing CMake setup works as usual
$ cmake -H. -B_build -G'Visual Studio 15 Win64' -DCMAKE_INSTALL_PREFIX=_install
-- Selecting Windows SDK version 10.0.16299.0 to target Windows 10.0.18362.
-- The C compiler identification is MSVC 19.12.25831.0
-- The CXX compiler identification is MSVC 19.12.25831.0
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: <retracted>/code/libuv/_build

# -- run install, and see the regular install tree

$ cmake -H. -B_build -DCMAKE_INSTALL_PREFIX=_install -G'Visual Studio 15 Win64' -DBUILD_SHARED_LIBS=1 -DLIBUV_EXPORT_CMAKE=1
-- Selecting Windows SDK version 10.0.16299.0 to target Windows 10.0.18362.
-- The C compiler identification is MSVC 19.12.25831.0
-- The CXX compiler identification is MSVC 19.12.25831.0
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Exporting for CMake
-- Configuring done
-- Generating done
-- Build files have been written to: <retracted>/code/libuv/_build

# -- run install, and see the newer files in the install tree

$ tree -h _install
... skip old stuff ...
---+ lib
---|---+ cmake
---|---|---+ libuv
   |   |   |-- libuv-config.cmake [669 B]
   |   |   |-- libuv-targets-debug.cmake [1.24 KB]
   |   |   |-- libuv-targets.cmake [3.76 KB]
... skip old stuff ...

$ cmake -Hfoo -Bfoo/_build -DCMAKE_INSTALL_PREFIX=_install -G'Visual Studio 15 Win64' -DBUILD_SHARED_LIBS=1
-- Selecting Windows SDK version 10.0.16299.0 to target Windows 10.0.18362.
-- The C compiler identification is MSVC 19.12.25831.0
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: <retracted>/code/libuv/foo/_build

$ cmake --build foo/_build/ --target foo --config Debug
Microsoft (R) Build Engine version 15.5.180.51428 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  CMake does not need to re-run because <retracted>/code/libuv/foo/_build/CMakeFiles/generate.stamp is up-to-date.
  Building Custom Rule <retracted>/code/libuv/foo/CMakeLists.txt
  CMake does not need to re-run because <retracted>/code/libuv/foo/_build/CMakeFiles/generate.stamp is up-to-date.
  foo.c
  foo.vcxproj -> <retracted>\code\libuv\foo\_build\Debug\foo.dll

```