### PR TITLE
win, build: Fix the problem that cannot build with MSYS2/MinGW-w64

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -29,6 +29,13 @@
 #include "req-inl.h"
 
 
+#ifndef MCAST_JOIN_SOURCE_GROUP
+# define MCAST_JOIN_SOURCE_GROUP  45
+#endif
+#ifndef MCAST_LEAVE_SOURCE_GROUP
+# define MCAST_LEAVE_SOURCE_GROUP 46
+#endif
+
 /*
  * Threshold of active udp streams for which to preallocate udp read buffers.
  */


### PR DESCRIPTION
Build with `MSYS2/MinGW-w64` fails with the following error:

```
../src/win/udp.c:793:15: error: 'MCAST_JOIN_SOURCE_GROUP' undeclared (first use in this function)
  793 |     optname = MCAST_JOIN_SOURCE_GROUP;
      |               ^~~~~~~~~~~~~~~~~~~~~~~
../src/win/udp.c:793:15: note: each undeclared identifier is reported only once for each function it appears in
../src/win/udp.c:795:15: error: 'MCAST_LEAVE_SOURCE_GROUP' undeclared (first use in this function)
  795 |     optname = MCAST_LEAVE_SOURCE_GROUP;
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
```