### PR TITLE
win: fix reading hidden env vars

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1417,7 +1417,9 @@ int uv_os_environ(uv_env_item_t** envitems, int* count) {
     if (uv__convert_utf16_to_utf8(penv, -1, &buf) != 0)
       goto fail;
 
-    ptr = strchr(buf, '=');
+    /* Using buf + 1 here because we know that `buf` has length at least 1,
+     * and some special environment variables on Windows start with a = sign. */
+    ptr = strchr(buf + 1, '=');
     if (ptr == NULL) {
       uv__free(buf);
       goto do_continue;

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -30,7 +30,7 @@ TEST_IMPL(env_vars) {
   const char* name2 = "UV_TEST_FOO2";
   char buf[BUF_SIZE];
   size_t size;
-  int i, r, envcount, found;
+  int i, r, envcount, found, found_win_special;
   uv_env_item_t* envitems;
 
   /* Reject invalid inputs when setting an environment variable */
@@ -108,6 +108,7 @@ TEST_IMPL(env_vars) {
   ASSERT(envcount > 0);
 
   found = 0;
+  found_win_special = 0;
 
   for (i = 0; i < envcount; i++) {
     /* printf("Env: %s = %s\n", envitems[i].name, envitems[i].value); */
@@ -117,10 +118,15 @@ TEST_IMPL(env_vars) {
     } else if (strcmp(envitems[i].name, name2) == 0) {
       found++;
       ASSERT(strlen(envitems[i].value) == 0);
+    } else if (envitems[i].name[0] == '=') {
+      found_win_special++;
     }
   }
 
   ASSERT(found == 2);
+#ifdef _WIN32
+  ASSERT(found_win_special > 0);
+#endif
 
   uv_os_free_environ(envitems, envcount);
 


### PR DESCRIPTION
There are some special environment variables on Windows that
start with a '=' sign, e.g. per-drive working directories.
In those cases, an initial '=' in the name of the environment
variable needs to be skipped when looking for the '=' that separates
it from its value.