### PR TITLE
fs: use statvfs in uv__fs_statfs() for Haiku

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -78,7 +78,7 @@
     defined(__NetBSD__)
 # include <sys/param.h>
 # include <sys/mount.h>
-#elif defined(__sun) || defined(__MVS__) || defined(__NetBSD__)
+#elif defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__)
 # include <sys/statvfs.h>
 #else
 # include <sys/statfs.h>
@@ -532,7 +532,7 @@ static int uv__fs_closedir(uv_fs_t* req) {
 
 static int uv__fs_statfs(uv_fs_t* req) {
   uv_statfs_t* stat_fs;
-#if defined(__sun) || defined(__MVS__) || defined(__NetBSD__)
+#if defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__)
   struct statvfs buf;
 
   if (0 != statvfs(req->path, &buf))
@@ -549,7 +549,7 @@ static int uv__fs_statfs(uv_fs_t* req) {
     return -1;
   }
 
-#if defined(__sun) || defined(__MVS__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__sun) || defined(__MVS__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__HAIKU__)
   stat_fs->f_type = 0;  /* f_type is not supported. */
 #else
   stat_fs->f_type = buf.f_type;


### PR DESCRIPTION
This patch fixes the build for Haiku and uses sys/statvfs.h in uv__fs_statfs().