### PR TITLE
win, tty: fix problem of receiving unexpected SIGWINCH

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2373,6 +2373,7 @@ static void uv__tty_console_signal_resize(void) {
   height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
 
   uv_mutex_lock(&uv__tty_console_resize_mutex);
+  assert(uv__tty_console_width != -1 && uv__tty_console_height != -1);
   if (width != uv__tty_console_width || height != uv__tty_console_height) {
     uv__tty_console_width = width;
     uv__tty_console_height = height;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -169,10 +169,15 @@ void uv_console_init(void) {
                                        0,
                                        0);
   if (uv__tty_console_handle != INVALID_HANDLE_VALUE) {
+    CONSOLE_SCREEN_BUFFER_INFO sb_info;
     QueueUserWorkItem(uv__tty_console_resize_message_loop_thread,
                       NULL,
                       WT_EXECUTELONGFUNCTION);
     uv_mutex_init(&uv__tty_console_resize_mutex);
+    if (GetConsoleScreenBufferInfo(uv__tty_console_handle, &sb_info)) {
+      uv__tty_console_width = sb_info.dwSize.X;
+      uv__tty_console_height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
+    }
   }
 }
 
@@ -2290,16 +2295,9 @@ static void uv__determine_vterm_state(HANDLE handle) {
 }
 
 static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param) {
-  CONSOLE_SCREEN_BUFFER_INFO sb_info;
   NTSTATUS status;
   ULONG_PTR conhost_pid;
   MSG msg;
-
-  if (!GetConsoleScreenBufferInfo(uv__tty_console_handle, &sb_info))
-    return 0;
-
-  uv__tty_console_width = sb_info.dwSize.X;
-  uv__tty_console_height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
 
   if (pSetWinEventHook == NULL || pNtQueryInformationProcess == NULL)
     return 0;


### PR DESCRIPTION
Fix an issue where `WINDOWS_BUFFER_SIZE_EVENT` occurs and unexpected `SIGWINCH` is received before calling `uv__tty_console_resize_message_loop_thread()`.

We encountered this problem in neovim functional tests.

Ref. https://github.com/neovim/neovim/pull/10978#issuecomment-530742148