### PR TITLE
win: simplify mkdtemp

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -36,8 +36,6 @@
 #include "handle-inl.h"
 #include "fs-fd-hash-inl.h"
 
-#include <wincrypt.h>
-
 
 #define UV_FS_FREE_PATHS         0x0002
 #define UV_FS_FREE_PTR           0x0008
@@ -1207,9 +1205,7 @@ void fs__mkdtemp(uv_fs_t* req) {
   WCHAR *cp, *ep;
   unsigned int tries, i;
   size_t len;
-  HCRYPTPROV h_crypt_prov;
   uint64_t v;
-  BOOL released;
 
   len = wcslen(req->file.pathw);
   ep = req->file.pathw + len;
@@ -1218,16 +1214,10 @@ void fs__mkdtemp(uv_fs_t* req) {
     return;
   }
 
-  if (!CryptAcquireContext(&h_crypt_prov, NULL, NULL, PROV_RSA_FULL,
-                           CRYPT_VERIFYCONTEXT)) {
-    SET_REQ_WIN32_ERROR(req, GetLastError());
-    return;
-  }
-
   tries = TMP_MAX;
   do {
-    if (!CryptGenRandom(h_crypt_prov, sizeof(v), (BYTE*) &v)) {
-      SET_REQ_WIN32_ERROR(req, GetLastError());
+    if (uv__random_rtlgenrandom((void *)&v, sizeof(v)) < 0) {
+      SET_REQ_UV_ERROR(req, UV_EIO, ERROR_IO_DEVICE);
       break;
     }
 
@@ -1248,8 +1238,6 @@ void fs__mkdtemp(uv_fs_t* req) {
     }
   } while (--tries);
 
-  released = CryptReleaseContext(h_crypt_prov, 0);
-  assert(released);
   if (tries == 0) {
     SET_REQ_RESULT(req, -1);
   }


### PR DESCRIPTION
Use our builtin getrandom helper instead of the more verbose CryptoAPI
functions, which also happen to be deprecated.

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1585/