### PR TITLE
Refactor most of CMakeLists.txt to use modern CMake approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,380 +1,416 @@
 # TODO: determine CMAKE_SYSTEM_NAME on OS/390.  Currently assumes "OS/390".
 cmake_minimum_required(VERSION 3.0)
-project(libuv)
-enable_testing()
+project(libuv LANGUAGES C)
 
-if(MSVC)
-  list(APPEND uv_cflags /W4)
-elseif(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
-  list(APPEND uv_cflags -fvisibility=hidden --std=gnu89)
-  list(APPEND uv_cflags -Wall -Wextra -Wstrict-prototypes)
-  list(APPEND uv_cflags -Wno-unused-parameter)
-endif()
+include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
+include(GNUInstallDirs)
+include(CTest)
 
-set(uv_sources
-    src/fs-poll.c
-    src/idna.c
-    src/inet.c
-    src/loop-watcher.c
-    src/strscpy.c
-    src/threadpool.c
-    src/timer.c
-    src/uv-common.c
-    src/uv-data-getter-setters.c
-    src/version.c)
+find_package(Threads)
 
-set(uv_test_sources
-    test/blackhole-server.c
-    test/echo-server.c
-    test/run-tests.c
-    test/runner.c
-    test/test-active.c
-    test/test-async-null-cb.c
-    test/test-async.c
-    test/test-barrier.c
-    test/test-buf.c
-    test/test-callback-order.c
-    test/test-callback-stack.c
-    test/test-close-fd.c
-    test/test-close-order.c
-    test/test-condvar.c
-    test/test-connect-unspecified.c
-    test/test-connection-fail.c
-    test/test-cwd-and-chdir.c
-    test/test-default-loop-close.c
-    test/test-delayed-accept.c
-    test/test-dlerror.c
-    test/test-eintr-handling.c
-    test/test-embed.c
-    test/test-emfile.c
-    test/test-env-vars.c
-    test/test-error.c
-    test/test-fail-always.c
-    test/test-fork.c
-    test/test-fs-copyfile.c
-    test/test-fs-event.c
-    test/test-fs-poll.c
-    test/test-fs.c
-    test/test-fs-readdir.c
-    test/test-get-currentexe.c
-    test/test-get-loadavg.c
-    test/test-get-memory.c
-    test/test-get-passwd.c
-    test/test-getaddrinfo.c
-    test/test-gethostname.c
-    test/test-getnameinfo.c
-    test/test-getsockname.c
-    test/test-getters-setters.c
-    test/test-gettimeofday.c
-    test/test-handle-fileno.c
-    test/test-homedir.c
-    test/test-hrtime.c
-    test/test-idle.c
-    test/test-idna.c
-    test/test-ip4-addr.c
-    test/test-ip6-addr.c
-    test/test-ip6-addr.c
-    test/test-ipc-heavy-traffic-deadlock-bug.c
-    test/test-ipc-send-recv.c
-    test/test-ipc.c
-    test/test-loop-alive.c
-    test/test-loop-close.c
-    test/test-loop-configure.c
-    test/test-loop-handles.c
-    test/test-loop-stop.c
-    test/test-loop-time.c
-    test/test-multiple-listen.c
-    test/test-mutexes.c
-    test/test-osx-select.c
-    test/test-pass-always.c
-    test/test-ping-pong.c
-    test/test-pipe-bind-error.c
-    test/test-pipe-close-stdout-read-stdin.c
-    test/test-pipe-connect-error.c
-    test/test-pipe-connect-multiple.c
-    test/test-pipe-connect-prepare.c
-    test/test-pipe-getsockname.c
-    test/test-pipe-pending-instances.c
-    test/test-pipe-sendmsg.c
-    test/test-pipe-server-close.c
-    test/test-pipe-set-fchmod.c
-    test/test-pipe-set-non-blocking.c
-    test/test-platform-output.c
-    test/test-poll-close-doesnt-corrupt-stack.c
-    test/test-poll-close.c
-    test/test-poll-closesocket.c
-    test/test-poll-oob.c
-    test/test-poll.c
-    test/test-process-priority.c
-    test/test-process-title-threadsafe.c
-    test/test-process-title.c
-    test/test-queue-foreach-delete.c
-    test/test-ref.c
-    test/test-run-nowait.c
-    test/test-run-once.c
-    test/test-semaphore.c
-    test/test-shutdown-close.c
-    test/test-shutdown-eof.c
-    test/test-shutdown-twice.c
-    test/test-signal-multiple-loops.c
-    test/test-signal.c
-    test/test-socket-buffer-size.c
-    test/test-spawn.c
-    test/test-stdio-over-pipes.c
-    test/test-strscpy.c
-    test/test-tcp-alloc-cb-fail.c
-    test/test-tcp-bind-error.c
-    test/test-tcp-bind6-error.c
-    test/test-tcp-close-accept.c
-    test/test-tcp-close-while-connecting.c
-    test/test-tcp-close.c
-    test/test-tcp-connect-error-after-write.c
-    test/test-tcp-connect-error.c
-    test/test-tcp-connect-timeout.c
-    test/test-tcp-connect6-error.c
-    test/test-tcp-create-socket-early.c
-    test/test-tcp-flags.c
-    test/test-tcp-oob.c
-    test/test-tcp-open.c
-    test/test-tcp-read-stop.c
-    test/test-tcp-shutdown-after-write.c
-    test/test-tcp-try-write.c
-    test/test-tcp-unexpected-read.c
-    test/test-tcp-write-after-connect.c
-    test/test-tcp-write-fail.c
-    test/test-tcp-write-queue-order.c
-    test/test-tcp-write-to-half-open-connection.c
-    test/test-tcp-writealot.c
-    test/test-thread-equal.c
-    test/test-thread.c
-    test/test-thread-affinity.c
-    test/test-threadpool-cancel.c
-    test/test-threadpool.c
-    test/test-timer-again.c
-    test/test-timer-from-check.c
-    test/test-timer.c
-    test/test-tmpdir.c
-    test/test-tty-duplicate-key.c
-    test/test-tty.c
-    test/test-udp-alloc-cb-fail.c
-    test/test-udp-bind.c
-    test/test-udp-connect.c
-    test/test-udp-create-socket-early.c
-    test/test-udp-dgram-too-big.c
-    test/test-udp-ipv6.c
-    test/test-udp-multicast-interface.c
-    test/test-udp-multicast-interface6.c
-    test/test-udp-multicast-join.c
-    test/test-udp-multicast-join6.c
-    test/test-udp-multicast-ttl.c
-    test/test-udp-open.c
-    test/test-udp-options.c
-    test/test-udp-send-and-recv.c
-    test/test-udp-send-hang-loop.c
-    test/test-udp-send-immediate.c
-    test/test-udp-send-unreachable.c
-    test/test-udp-try-send.c
-    test/test-uname.c
-    test/test-walk-handles.c
-    test/test-watcher-cross-stop.c)
+cmake_dependent_option(UV_BUILD_TESTS
+  "Build libuv unit tests" ON
+  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-if(WIN32)
-  list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0600)
-  list(APPEND uv_libraries
-       advapi32
-       iphlpapi
-       psapi
-       secur32
-       shell32
-       user32
-       userenv
-       ws2_32)
-  list(APPEND uv_sources
-       src/win/async.c
-       src/win/core.c
-       src/win/detect-wakeup.c
-       src/win/dl.c
-       src/win/error.c
-       src/win/fs.c
-       src/win/fs-event.c
-       src/win/getaddrinfo.c
-       src/win/getnameinfo.c
-       src/win/handle.c
-       src/win/pipe.c
-       src/win/thread.c
-       src/win/poll.c
-       src/win/process.c
-       src/win/process-stdio.c
-       src/win/signal.c
-       src/win/stream.c
-       src/win/tcp.c
-       src/win/tty.c
-       src/win/udp.c
-       src/win/util.c
-       src/win/winapi.c
-       src/win/winsock.c)
-  list(APPEND uv_test_libraries ws2_32)
-  list(APPEND uv_test_sources test/runner-win.c)
-else()
-  list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
-    # Android has pthread as part of its c library, not as a separate
-    # libpthread.so.
-    list(APPEND uv_libraries pthread)
-  endif()
-  list(APPEND uv_sources
-       src/unix/async.c
-       src/unix/core.c
-       src/unix/dl.c
-       src/unix/fs.c
-       src/unix/getaddrinfo.c
-       src/unix/getnameinfo.c
-       src/unix/loop.c
-       src/unix/pipe.c
-       src/unix/poll.c
-       src/unix/process.c
-       src/unix/signal.c
-       src/unix/stream.c
-       src/unix/tcp.c
-       src/unix/thread.c
-       src/unix/tty.c
-       src/unix/udp.c)
-  list(APPEND uv_test_sources test/runner-unix.c)
-endif()
+# Generator expression queries to make it easier to read later on
+set(is-clang $<OR:$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:Clang>>)
+set(is-msvc $<C_COMPILER_ID:MSVC>)
+set(is-gcc $<C_COMPILER_ID:GNU>)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
-  list(APPEND uv_defines
-       _ALL_SOURCE
-       _LINUX_SOURCE_COMPAT
-       _THREAD_SAFE
-       _XOPEN_SOURCE=500)
-  list(APPEND uv_libraries perfstat)
-  list(APPEND uv_sources src/unix/aix.c)
-endif()
+set(is-clang-or-gcc $<OR:${is-clang},${is-gcc}>)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-  list(APPEND uv_libs dl)
-  list(APPEND uv_sources
-       src/unix/android-ifaddrs.c
-       src/unix/linux-core.c
-       src/unix/linux-inotify.c
-       src/unix/linux-syscalls.c
-       src/unix/procfs-exepath.c
-       src/unix/pthread-fixes.c
-       src/unix/sysinfo-loadavg.c
-       src/unix/sysinfo-memory.c)
-endif()
+set(c-standard $<AND:$<VERSION_LESS:${CMAKE_VERSION},3.1>,${is-clang-or-gcc}>)
 
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux|OS/390")
-  list(APPEND uv_sources src/unix/proctitle.c)
-endif()
+set(is-dragonfly $<PLATFORM_ID:DragonFly>)
+set(is-freebsd $<PLATFORM_ID:FreeBSD>)
+set(is-openbsd $<PLATFORM_ID:OpenBSD>)
+set(is-netbsd $<PLATFORM_ID:NetBSD>)
+set(is-darwin $<PLATFORM_ID:Darwin>)
 
-if(CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD")
-  list(APPEND uv_sources src/unix/freebsd.c)
-endif()
+set(is-android $<PLATFORM_ID:Android>)
+set(is-os/390 $<PLATFORM_ID:OS/390>)
+set(is-linux $<PLATFORM_ID:Linux>)
+set(is-sunos $<PLATFORM_ID:SunOS>)
+set(is-aix $<PLATFORM_ID:AIX>)
 
-if(CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
-  list(APPEND uv_sources src/unix/posix-hrtime.c src/unix/bsd-proctitle.c)
-  list(APPEND uv_libraries kvm)
-endif()
+set(is-windows $<PLATFORM_ID:Windows>)
+set(is-unix $<BOOL:${UNIX}>)
 
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
-  list(APPEND uv_sources src/unix/bsd-ifaddrs.c src/unix/kqueue.c)
-endif()
+set(is-not-darwin-bsd $<OR:${is-dragonfly},${is-freebsd},${is-openbsd},${is-netbsd}>)
+set(is-bsd $<OR:${is-darwin},${is-not-darwin-bsd}>)
 
-if(APPLE)
-  list(APPEND uv_defines _DARWIN_UNLIMITED_SELECT=1 _DARWIN_USE_64_BIT_INODE=1)
-  list(APPEND uv_sources
-       src/unix/darwin-proctitle.c
-       src/unix/darwin.c
-       src/unix/fsevents.c)
-endif()
+set(uv-sources
+  src/fs-poll.c
+  src/idna.c
+  src/inet.c
+  src/loop-watcher.c
+  src/strscpy.c
+  src/threadpool.c
+  src/timer.c
+  src/uv-common.c
+  src/uv-data-getter-setters.c
+  src/version.c
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  list(APPEND uv_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
-  list(APPEND uv_libraries dl rt)
-  list(APPEND uv_sources
-       src/unix/linux-core.c
-       src/unix/linux-inotify.c
-       src/unix/linux-syscalls.c
-       src/unix/procfs-exepath.c
-       src/unix/sysinfo-loadavg.c)
-endif()
+  $<$<OR:${is-darwin},${is-android},${is-linux},${is-os/390}>:src/unix/proctitle.c>
+  $<$<OR:${is-dragonfly},${is-freebsd}>:src/unix/freebsd.c>
+  $<${is-not-darwin-bsd}:src/unix/bsd-proctitle.c>
+  $<${is-not-darwin-bsd}:src/unix/posix-hrtime.c>
 
-if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
-  list(APPEND uv_sources src/unix/netbsd.c)
-endif()
+  $<${is-linux}:src/unix/sysinfo-loadavg.c>
+  $<${is-linux}:src/unix/procfs-exepath.c>
+  $<${is-linux}:src/unix/linux-syscalls.c>
+  $<${is-linux}:src/unix/linux-inotify.c>
+  $<${is-linux}:src/unix/linux-core.c>
 
-if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-  list(APPEND uv_sources src/unix/openbsd.c)
-endif()
+  $<${is-darwin}:src/unix/darwin-proctitle.c>
+  $<${is-darwin}:src/unix/darwin.c>
+  $<${is-darwin}:src/unix/fsevents.c>
+ 
+  $<${is-openbsd}:src/unix/openbsd.c>
+  $<${is-netbsd}:src/unix/netbsd.c>
 
-if(CMAKE_SYSTEM_NAME STREQUAL "OS/390")
-  list(APPEND uv_defines PATH_MAX=255)
-  list(APPEND uv_defines _AE_BIMODAL)
-  list(APPEND uv_defines _ALL_SOURCE)
-  list(APPEND uv_defines _LARGE_TIME_API)
-  list(APPEND uv_defines _OPEN_MSGQ_EXT)
-  list(APPEND uv_defines _OPEN_SYS_FILE_EXT)
-  list(APPEND uv_defines _OPEN_SYS_IF_EXT)
-  list(APPEND uv_defines _OPEN_SYS_SOCK_IPV6)
-  list(APPEND uv_defines _UNIX03_SOURCE)
-  list(APPEND uv_defines _UNIX03_THREADS)
-  list(APPEND uv_defines _UNIX03_WITHDRAWN)
-  list(APPEND uv_defines _XOPEN_SOURCE_EXTENDED)
-  list(APPEND uv_sources
-       src/unix/pthread-fixes.c
-       src/unix/pthread-barrier.c
-       src/unix/os390.c
-       src/unix/os390-syscalls.c)
-endif()
+  $<${is-bsd}:src/unix/bsd-ifaddrs.c>
+  $<${is-bsd}:src/unix/kqueue.c>
 
-if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
-  list(APPEND uv_defines __EXTENSIONS__ _XOPEN_SOURCE=500)
-  list(APPEND uv_libraries kstat nsl sendfile socket)
-  list(APPEND uv_sources src/unix/no-proctitle.c src/unix/sunos.c)
-endif()
+  $<${is-sunos}:src/unix/no-proctitle.c>
+  $<${is-sunos}:src/unix/sunos.c>
 
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
-  list(APPEND uv_test_libraries util)
-endif()
+  $<${is-aix}:src/unix/aix.c>
 
-add_library(uv SHARED ${uv_sources})
-target_compile_definitions(uv PRIVATE ${uv_defines} BUILDING_UV_SHARED=1)
-target_compile_options(uv PRIVATE ${uv_cflags})
-target_include_directories(uv PRIVATE include src)
-target_link_libraries(uv ${uv_libraries})
+  $<${is-os/390}:src/unix/pthread-barrier.c>
+  $<${is-os/390}:src/unix/pthread-fixes.c>
+  $<${is-os/390}:src/unix/os390-syscalls.c>
+  $<${is-os/390}:src/unix/os390.c>
 
-add_library(uv_a STATIC ${uv_sources})
-target_compile_definitions(uv_a PRIVATE ${uv_defines})
-target_compile_options(uv_a PRIVATE ${uv_cflags})
-target_include_directories(uv_a PRIVATE include src)
-target_link_libraries(uv_a ${uv_libraries})
+  $<${is-android}:src/unix/android-ifaddrs.c>
+  $<${is-android}:src/unix/linux-core.c>
+  $<${is-android}:src/unix/linux-inotify.c>
+  $<${is-android}:src/unix/linux-syscalls.c>
+  $<${is-android}:src/unix/procfs-exepath.c>
+  $<${is-android}:src/unix/pthread-fixes.c>
+  $<${is-android}:src/unix/sysinfo-loadavc.c>
+  $<${is-android}:src/unix/sysinfo-memory.c>
 
-if(BUILD_TESTING)
-  include(CTest)
-  add_executable(uv_run_tests ${uv_test_sources})
-  target_compile_definitions(uv_run_tests
-                             PRIVATE ${uv_defines} USING_UV_SHARED=1)
-  target_compile_options(uv_run_tests PRIVATE ${uv_cflags})
-  target_include_directories(uv_run_tests PRIVATE include)
-  target_link_libraries(uv_run_tests uv ${uv_test_libraries})
-  add_test(NAME uv_test
-           COMMAND uv_run_tests
-           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-  add_executable(uv_run_tests_a ${uv_test_sources})
-  target_compile_definitions(uv_run_tests_a PRIVATE ${uv_defines})
-  target_compile_options(uv_run_tests_a PRIVATE ${uv_cflags})
-  target_include_directories(uv_run_tests_a PRIVATE include)
-  target_link_libraries(uv_run_tests_a uv_a ${uv_test_libraries})
-  add_test(NAME uv_test_a
-           COMMAND uv_run_tests_a
-           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  $<${is-windows}:src/win/async.c>
+  $<${is-windows}:src/win/core.c>
+  $<${is-windows}:src/win/detect-wakeup.c>
+  $<${is-windows}:src/win/dl.c>
+  $<${is-windows}:src/win/error.c>
+  $<${is-windows}:src/win/fs.c>
+  $<${is-windows}:src/win/fs-event.c>
+  $<${is-windows}:src/win/getaddrinfo.c>
+  $<${is-windows}:src/win/getnameinfo.c>
+  $<${is-windows}:src/win/handle.c>
+  $<${is-windows}:src/win/pipe.c>
+  $<${is-windows}:src/win/thread.c>
+  $<${is-windows}:src/win/poll.c>
+  $<${is-windows}:src/win/process.c>
+  $<${is-windows}:src/win/process-stdio.c>
+  $<${is-windows}:src/win/signal.c>
+  $<${is-windows}:src/win/stream.c>
+  $<${is-windows}:src/win/tcp.c>
+  $<${is-windows}:src/win/tty.c>
+  $<${is-windows}:src/win/udp.c>
+  $<${is-windows}:src/win/util.c>
+  $<${is-windows}:src/win/winapi.c>
+  $<${is-windows}:src/win/winsock.c>
+  
+  $<${is-unix}:src/unix/async.c>
+  $<${is-unix}:src/unix/core.c>
+  $<${is-unix}:src/unix/dl.c>
+  $<${is-unix}:src/unix/fs.c>
+  $<${is-unix}:src/unix/getaddrinfo.c>
+  $<${is-unix}:src/unix/getnameinfo.c>
+  $<${is-unix}:src/unix/loop.c>
+  $<${is-unix}:src/unix/pipe.c>
+  $<${is-unix}:src/unix/poll.c>
+  $<${is-unix}:src/unix/process.c>
+  $<${is-unix}:src/unix/signal.c>
+  $<${is-unix}:src/unix/stream.c>
+  $<${is-unix}:src/unix/tcp.c>
+  $<${is-unix}:src/unix/thread.c>
+  $<${is-unix}:src/unix/tty.c>
+  $<${is-unix}:src/unix/udp.c>)
+
+add_library(uv-common INTERFACE)
+
+target_include_directories(uv-common
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_compile_definitions(uv-common
+  INTERFACE
+    $<${is-darwin}:_DARWIN_UNLIMITED_SELECT=1>
+    $<${is-darwin}:_DARWIN_USE_64_BIT_INODE=1>
+
+    $<${is-windows}:WIN32_LEAN_AND_MEAN>
+    $<${is-windows}:_WIN32_WINNT=0x0600>
+
+    $<${is-linux}:_POSIX_C_SOURCE=200112>
+    $<${is-linux}:_GNU_SOURCE>
+
+    $<${is-unix}:_FILE_OFFSET_BITS=64>
+    $<${is-unix}:_LARGEFILE_SOURCE>
+
+    $<${is-os/390}:_XOPEN_SOURCE_EXTENDED>
+    $<${is-os/390}:_OPEN_SYS_SOCK_IPV6>
+    $<${is-os/390}:_OPEN_SYS_FILE_EXT>
+    $<${is-os/390}:_OPEN_SYS_IF_EXT>
+    $<${is-os/390}:_OPEN_MSGQ_EXT>
+    $<${is-os/390}:_UNIX03_WITHDRAWN>
+    $<${is-os/390}:_UNIX03_THREADS>
+    $<${is-os/390}:_UNIX03_SOURCE>
+    $<${is-os/390}:_LARGE_TIME_API>
+    $<${is-os/390}:_AE_BIMODAL>
+    $<${is-os/390}:_ALL_SOURCE>
+    $<${is-os/390}:PATH_MAX=255>
+
+    $<${is-sunos}:_XOPEN_SOURCE=500>
+    $<${is-sunos}:__EXTENSIONS__>
+
+    $<${is-aix}:_LINUX_SOURCE_COMPAT>
+    $<${is-aix}:_XOPEN_SOURCE=500>
+    $<${is-aix}:_THREAD_SAFE>
+    $<${is-aix}:_ALL_SOURCE>)
+
+target_compile_options(uv-common
+  INTERFACE
+     $<${is-msvc}:/W4>
+     $<$<AND:${is-windows},${is-clang-or-gcc}>:-Wno-unknown-pragmas>
+     $<${is-clang-or-gcc}:-Wall -Wextra -Wstrict-prototypes -Wno-unused-parameter>
+     $<${is-clang-or-gcc}:--std=gnu89>)
+
+target_link_libraries(uv-common
+  INTERFACE
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+
+    $<${is-not-darwin-bsd}:kvm>
+
+    $<${is-windows}:advapi32>
+    $<${is-windows}:iphlpapi>
+    $<${is-windows}:psapi>
+    $<${is-windows}:secur32>
+    $<${is-windows}:user32>
+    $<${is-windows}:userenv>
+    $<${is-windows}:ws2_32>
+
+    $<${is-linux}:rt>
+
+    $<${is-sunos}:sendfile>
+    $<${is-sunos}:socket>
+    $<${is-sunos}:kstat>
+    $<${is-sunos}:nsl>
+
+    $<${is-aix}:perfstat>)
+
+
+add_library(uv_a STATIC ${uv-sources})
+add_library(uv SHARED ${uv-sources})
+
+add_library(uv::static ALIAS uv_a)
+add_library(uv::shared ALIAS uv)
+
+target_include_directories(uv_a
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+target_include_directories(uv
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+
+target_compile_definitions(uv
+  PRIVATE
+    BUILDING_UV_SHARED=1)
+
+target_link_libraries(uv_a PRIVATE uv-common)
+target_link_libraries(uv PRIVATE uv-common)
+
+if (UV_BUILD_TESTS)
+  set(uv-test-sources
+      $<${is-windows}:test/runner-win.c>
+      $<${is-unix}:test/runner-unix.c>
+      test/blackhole-server.c
+      test/echo-server.c
+      test/run-tests.c
+      test/runner.c
+      test/test-active.c
+      test/test-async-null-cb.c
+      test/test-async.c
+      test/test-barrier.c
+      test/test-buf.c
+      test/test-callback-order.c
+      test/test-callback-stack.c
+      test/test-close-fd.c
+      test/test-close-order.c
+      test/test-condvar.c
+      test/test-connect-unspecified.c
+      test/test-connection-fail.c
+      test/test-cwd-and-chdir.c
+      test/test-default-loop-close.c
+      test/test-delayed-accept.c
+      test/test-dlerror.c
+      test/test-eintr-handling.c
+      test/test-embed.c
+      test/test-emfile.c
+      test/test-env-vars.c
+      test/test-error.c
+      test/test-fail-always.c
+      test/test-fork.c
+      test/test-fs-copyfile.c
+      test/test-fs-event.c
+      test/test-fs-poll.c
+      test/test-fs.c
+      test/test-fs-readdir.c
+      test/test-get-currentexe.c
+      test/test-get-loadavg.c
+      test/test-get-memory.c
+      test/test-get-passwd.c
+      test/test-getaddrinfo.c
+      test/test-gethostname.c
+      test/test-getnameinfo.c
+      test/test-getsockname.c
+      test/test-getters-setters.c
+      test/test-gettimeofday.c
+      test/test-handle-fileno.c
+      test/test-homedir.c
+      test/test-hrtime.c
+      test/test-idle.c
+      test/test-idna.c
+      test/test-ip4-addr.c
+      test/test-ip6-addr.c
+      test/test-ip6-addr.c
+      test/test-ipc-heavy-traffic-deadlock-bug.c
+      test/test-ipc-send-recv.c
+      test/test-ipc.c
+      test/test-loop-alive.c
+      test/test-loop-close.c
+      test/test-loop-configure.c
+      test/test-loop-handles.c
+      test/test-loop-stop.c
+      test/test-loop-time.c
+      test/test-multiple-listen.c
+      test/test-mutexes.c
+      test/test-osx-select.c
+      test/test-pass-always.c
+      test/test-ping-pong.c
+      test/test-pipe-bind-error.c
+      test/test-pipe-close-stdout-read-stdin.c
+      test/test-pipe-connect-error.c
+      test/test-pipe-connect-multiple.c
+      test/test-pipe-connect-prepare.c
+      test/test-pipe-getsockname.c
+      test/test-pipe-pending-instances.c
+      test/test-pipe-sendmsg.c
+      test/test-pipe-server-close.c
+      test/test-pipe-set-fchmod.c
+      test/test-pipe-set-non-blocking.c
+      test/test-platform-output.c
+      test/test-poll-close-doesnt-corrupt-stack.c
+      test/test-poll-close.c
+      test/test-poll-closesocket.c
+      test/test-poll-oob.c
+      test/test-poll.c
+      test/test-process-priority.c
+      test/test-process-title-threadsafe.c
+      test/test-process-title.c
+      test/test-queue-foreach-delete.c
+      test/test-ref.c
+      test/test-run-nowait.c
+      test/test-run-once.c
+      test/test-semaphore.c
+      test/test-shutdown-close.c
+      test/test-shutdown-eof.c
+      test/test-shutdown-twice.c
+      test/test-signal-multiple-loops.c
+      test/test-signal.c
+      test/test-socket-buffer-size.c
+      test/test-spawn.c
+      test/test-stdio-over-pipes.c
+      test/test-strscpy.c
+      test/test-tcp-alloc-cb-fail.c
+      test/test-tcp-bind-error.c
+      test/test-tcp-bind6-error.c
+      test/test-tcp-close-accept.c
+      test/test-tcp-close-while-connecting.c
+      test/test-tcp-close.c
+      test/test-tcp-connect-error-after-write.c
+      test/test-tcp-connect-error.c
+      test/test-tcp-connect-timeout.c
+      test/test-tcp-connect6-error.c
+      test/test-tcp-create-socket-early.c
+      test/test-tcp-flags.c
+      test/test-tcp-oob.c
+      test/test-tcp-open.c
+      test/test-tcp-read-stop.c
+      test/test-tcp-shutdown-after-write.c
+      test/test-tcp-try-write.c
+      test/test-tcp-unexpected-read.c
+      test/test-tcp-write-after-connect.c
+      test/test-tcp-write-fail.c
+      test/test-tcp-write-queue-order.c
+      test/test-tcp-write-to-half-open-connection.c
+      test/test-tcp-writealot.c
+      test/test-thread-equal.c
+      test/test-thread.c
+      test/test-thread-affinity.c
+      test/test-threadpool-cancel.c
+      test/test-threadpool.c
+      test/test-timer-again.c
+      test/test-timer-from-check.c
+      test/test-timer.c
+      test/test-tmpdir.c
+      test/test-tty-duplicate-key.c
+      test/test-tty.c
+      test/test-udp-alloc-cb-fail.c
+      test/test-udp-bind.c
+      test/test-udp-connect.c
+      test/test-udp-create-socket-early.c
+      test/test-udp-dgram-too-big.c
+      test/test-udp-ipv6.c
+      test/test-udp-multicast-interface.c
+      test/test-udp-multicast-interface6.c
+      test/test-udp-multicast-join.c
+      test/test-udp-multicast-join6.c
+      test/test-udp-multicast-ttl.c
+      test/test-udp-open.c
+      test/test-udp-options.c
+      test/test-udp-send-and-recv.c
+      test/test-udp-send-hang-loop.c
+      test/test-udp-send-immediate.c
+      test/test-udp-send-unreachable.c
+      test/test-udp-try-send.c
+      test/test-uname.c
+      test/test-walk-handles.c
+      test/test-watcher-cross-stop.c)
+
+  add_library(uv-tests-common INTERFACE)
+  target_link_libraries(uv-tests-common
+    INTERFACE
+      $<${is-windows}:ws2_32>
+      $<${is-linux}:util>
+      $<${is-bsd}:util>
+      uv-common)
+
+  add_executable(uv-run-tests-shared ${uv-test-sources})
+  add_executable(uv-run-tests-static ${uv-test-sources})
+
+  target_compile_definitions(uv-run-tests-shared PRIVATE USING_UV_SHARED=1)
+
+  target_link_libraries(uv-run-tests-shared PRIVATE uv-tests-common uv::shared)
+  target_link_libraries(uv-run-tests-static PRIVATE uv-tests-common uv::static)
+
+  add_test(NAME uv::test::static
+    COMMAND uv-run-tests-static
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  add_test(NAME uv::test::shared
+    COMMAND uv-run-tests-shared
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
 if(UNIX)
   # Now for some gibbering horrors from beyond the stars...
-  include(GNUInstallDirs)
   foreach(x ${uv_libraries})
     set(LIBS "${LIBS} -l${x}")
   endforeach(x)


### PR DESCRIPTION
Hi!

This is meant to be more of a WIP/discussion. I quite like libuv, but its CMake style leaves a lot to be desired. In an ideal world, the minimum CMake version would be bumped to 3.4, but that's a discussion for another time.

## Fixes
1) CMake will not longer look for a C++ compiler when building the project on its own
2) Project is now safe to be used in an `add_subdirectory` way.
3) CTest is included by default, which calls enable_testing and adds the BUILD_TESTING option, but unit tests are locked behind a `UV_BUILD_TESTS` option that is enabled if BUILD_TESTING is true *and* is libuv is the root project. This can also be force enabled from the command line, but these defaults fix issues when its included into larger projects.
4) List of test files is only constructed if unit tests are enabled. This might seem like a micro-optimization, but in a large tree of projects it can affect CMake's performance and memory usage.

## New Features

1) A common 'interface' library for sharing specific settings between the shared and static libraries
2) Aliases for `uv` and `uv_a` to `::shared` and `::static`. These are available if its used as a subdirectory. Some more work is needed to make sure these are "exported" in a given build
3) Generator expressions *everywhere*. These are more efficient as it puts most of the logic that occurs at configure time (which is single threaded) to generation time (which is multithreaded, and can error with more information as needed). They can be a bit confusing, but I think the examples shown here should handle the minimum.

## Misc

Please let me know if you'd like changes or additional work done. Some suggestions I'd make:

1) Add a `uv::uv` target based on whether `BUILD_SHARED_LIBS` is true. Alternatively rely on the builtin `BUILD_SHARED_LIBS` command so that one can only build the static or shared library.
2) Upgrade minimum CMake version to something very recent, such as 3.4 or even just 3.8.
3) Add CPack support (This is something I can easily put in as well)
4) Create `uv-config.cmake` files for installation.