### PR TITLE
unix: set sin_len and sin6_len

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -211,6 +211,9 @@ int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr) {
   memset(addr, 0, sizeof(*addr));
   addr->sin_family = AF_INET;
   addr->sin_port = htons(port);
+#ifdef SIN6_LEN
+  addr->sin_len = sizeof(*addr);
+#endif
   return uv_inet_pton(AF_INET, ip, &(addr->sin_addr.s_addr));
 }
 

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -42,6 +42,10 @@ TEST_IMPL(ip4_addr) {
   ASSERT(UV_EINVAL == uv_ip4_addr("2555.0.0.0", TEST_PORT, &addr));
   ASSERT(UV_EINVAL == uv_ip4_addr("255", TEST_PORT, &addr));
 
+#ifdef SIN6_LEN
+  ASSERT(addr.sin_len == sizeof(addr));
+#endif
+
   /* for broken address family */
   ASSERT(UV_EAFNOSUPPORT == uv_inet_pton(42, "127.0.0.1",
     &addr.sin_addr.s_addr));

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -160,3 +160,12 @@ TEST_IMPL(ip6_pton) {
 
 #undef GOOD_ADDR_LIST
 #undef BAD_ADDR_LIST
+
+#ifdef SIN6_LEN
+TEST_IMPL(ip6_sin6_len) {
+  struct sockaddr_in6 s;
+  ASSERT(uv_ip6_addr("::", 0, &s) < 0);
+  ASSERT(s.sin6_len == sizeof(s));
+  return 0;
+}
+#endif


### PR DESCRIPTION
FreeBSD defines `sin_len` and `sin6_len` inside `sockaddr_in` and
`sockaddr_in6`. `sockaddr`s come from `getsockname` and `uv_ip4_addr`
will differ in the first byte if libuv doesn't set `sin_len` correctly.

Refs: 
- https://www.freebsd.org/doc/en_US.ISO8859-1/books/developers-handbook/sockets-essential-functions.html
- https://github.com/nodejs/quic/pull/135