### PR TITLE
build: remove -lrt link dependency

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -236,7 +236,7 @@
             'src/unix/linux-syscalls.h',
           ],
           'link_settings': {
-            'libraries': [ '-ldl', '-lrt' ],
+            'libraries': [ '-ldl' ],
           },
         }],
         [ 'OS=="android"', {


### PR DESCRIPTION
It does not appear to be necessary, at least not for Node.js.

See:
- https://github.com/nodejs/node/pull/29727