### PR TITLE
Modernize CMake Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 # TODO: determine CMAKE_SYSTEM_NAME on OS/390.  Currently assumes "OS/390".
-cmake_minimum_required(VERSION 2.8.12)
-project(libuv)
+cmake_minimum_required(VERSION 3.4)
+project(libuv LANGUAGES C)
+
+include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
+include(GNUInstallDirs)
+include(CTest)
+
+cmake_dependent_option(LIBUV_BUILD_TESTS
+  "Build the unit tests when BUILD_TESTING is enabled and we are the root project" ON
+  "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
 if(MSVC)
   list(APPEND uv_cflags /W4)
@@ -369,11 +378,7 @@ target_compile_options(uv_a PRIVATE ${uv_cflags})
 target_include_directories(uv_a PUBLIC include PRIVATE src)
 target_link_libraries(uv_a ${uv_libraries})
 
-option(libuv_buildtests "Build the unit tests when BUILD_TESTING is enabled." ON)
-
-include(CTest)
-if(BUILD_TESTING AND libuv_buildtests)
-  enable_testing()
+if(LIBUV_BUILD_TESTS)
   add_executable(uv_run_tests ${uv_test_sources})
   target_compile_definitions(uv_run_tests
                              PRIVATE ${uv_defines} USING_UV_SHARED=1)
@@ -393,7 +398,6 @@ endif()
 
 if(UNIX)
   # Now for some gibbering horrors from beyond the stars...
-  include(GNUInstallDirs)
   foreach(x ${uv_libraries})
     set(LIBS "${LIBS} -l${x}")
   endforeach(x)


### PR DESCRIPTION
This is a better attempt at #2490, with the intent of having smaller more piecemeal diffs in the PR that aren't hard to analyze. I'm also hoping to avoid stepping on the toes of downstream projects and am willing to coordinate and work with them to get their build situation updated and modernized as well if necessary. @blueyed's recent #2373 PR is effectively undone by this one. I left a comment on there asking what could be done, but since this is an open PR, a more public discussion could occur. I also would like to incorporate the other CMake PRs that are currently waiting to be merged in, but would need to probably tag each author individually, and I'm unsure if that would be considered good etiquette for this change so early on.

### Summary of this current PR

:bug: libuv will no longer try to detect a C++ compiler. This can speed up the configure process quite a bit in large C only project hierarchies.

:arrow_up: Bump CMake version to 3.4 so we can eventually use all the cool things like better generator expression support, and `target_sources`, and also better linking against the MSVC runtime (This would be a feature that can be implemented via generator expressions in CMake 3.4, but wasn't properly introduced at the CMake level until 3.15 just a few months ago. I've successfully backported it a few times for other projects that support MSVC now)

:art: Reorganize includes to be all in one place.

:art: Rename `libuv_buildtests` option to `LIBUV_BUILD_TESTS`. It is disabled unless `BUILD_TESTING` is `ON` *and* libuv is the "root" project. This helps projects that might use libuv as a git submodule, or as a download that is then passed to `add_subdirectory`.