### PR TITLE
test: fix order of operations in test

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -295,7 +295,8 @@ API
 
     .. note::
         On success this function allocates memory that must be freed using
-        `uv_fs_req_cleanup()`.
+        `uv_fs_req_cleanup()`. `uv_fs_req_cleanup()` must be called before
+        closing the directory with `uv_fs_closedir()`.
 
 .. c:function:: int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags, uv_fs_cb cb)
 .. c:function:: int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent)

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -62,12 +62,12 @@ static void empty_readdir_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_READDIR);
   ASSERT(req->result == 0);
   dir = req->ptr;
+  uv_fs_req_cleanup(req);
   r = uv_fs_closedir(uv_default_loop(),
                      &closedir_req,
                      dir,
                      empty_closedir_cb);
   ASSERT(r == 0);
-  uv_fs_req_cleanup(req);
 }
 
 static void empty_opendir_cb(uv_fs_t* req) {


### PR DESCRIPTION
In the fs_readdir_empty_dir test, the `uv_fs_readdir()` request is cleaned up after calling `uv_fs_closedir()`. However, the readdir request should be cleaned up before calling `uv_fs_closedir()`.

Fixes: https://github.com/libuv/libuv/issues/2496