### PR TITLE
RFC: make stalebot less manual work

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,9 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 21
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+# Set to false to disable. If disabled, issues still need to be closed
+# manually, but will remain marked as stale.
+daysUntilClose: 120
 # Issues with these labels will never be considered stale
 exemptLabels:
   - v2


### PR DESCRIPTION
With the current settings, I need to either opt out entirely from the benefits of stalebot with "no-stale", or handle an additional continual stream of email notifications to avoid them falling off my list. I propose we make the "close" operation a manual step, such that "stale" operates instead like an automation of the existing "stalled" label.

Since it seems that each application of "stale" need be reviewed anyways, it seems equally reasonable to expect the reviewer to click the Github close button instead of the no-stale button and deleting the comment. This also means folks can take more than a one-week (daysToClose: 7) vacation, and the queue (https://github.com/libuv/libuv/labels/stale) will still be sitting there waiting for whenever you return.