### PR TITLE
win,fs: fix uv_statfs_t being leaked in uv_fs_statfs

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2575,6 +2575,7 @@ static void fs__statfs(uv_fs_t* req) {
   stat_fs->f_files = 0;
   stat_fs->f_ffree = 0;
   req->ptr = stat_fs;
+  req->flags |= UV_FS_FREE_PTR;
   SET_REQ_RESULT(req, 0);
 }
 


### PR DESCRIPTION
`uv_fs_req_cleanup` wouldn't free `req->ptr` because the `req->flags` were never set to include `UV_FS_FREE_PTR`. Only affects Windows.

Minimal test case:

```c
#include <uv.h>
#include <stdlib.h>
#include <string.h>

#ifdef _MSC_VER
#define FMT "%Iu"
#else
#define FMT "%zu"
#endif

static void *malloc_(size_t size) {
    static size_t n = 0;
    size_t *p = malloc(size + sizeof(size_t) * 2);
    if (!p) return 0;
    fprintf(stderr, "+++ [#" FMT ", size: " FMT "] +++\n", ++n, size);
    *p = n;
    *(p + 1) = size;
    return p + 2;
}

static void free_(void *ptr) {
    size_t *p;
    if (!ptr) return;
    p = (size_t *)ptr - 2;
    fprintf(stderr, "--- [#" FMT ", size: " FMT "] ---\n", *p, *(p + 1));
    free(p);
}

int main() {
    uv_replace_allocator(malloc_, realloc, calloc, free_);

    uv_fs_t req;
    int r = uv_fs_statfs(NULL, &req, ".", NULL);
    uv_fs_req_cleanup(&req);

    return 0;
}
```

without this patch:

```
+++ [#1, size: 4] +++
+++ [#2, size: 88] +++
--- [#1, size: 4] ---
```

with this patch:

```
+++ [#1, size: 4] +++
+++ [#2, size: 88] +++
--- [#1, size: 4] ---
--- [#2, size: 88] ---
```