### PR TITLE
doc: fix misleading uv_{send,recv}_buffer_size docs

### DIFF
--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -190,8 +190,11 @@ just for some handle types.
     Gets or sets the size of the send buffer that the operating
     system uses for the socket.
 
-    If `*value` == 0, it will return the current send buffer size,
-    otherwise it will use `*value` to set the new send buffer size.
+    If `*value` == 0, then it will set `*value` to the current send buffer size.
+    If `*value` > 0 then it will use `*value` to set the new send buffer size.
+
+    On success, zero is returned. On error, a negative result is
+    returned.
 
     This function works for TCP, pipe and UDP handles on Unix and for TCP and
     UDP handles on Windows.
@@ -204,8 +207,11 @@ just for some handle types.
     Gets or sets the size of the receive buffer that the operating
     system uses for the socket.
 
-    If `*value` == 0, it will return the current receive buffer size,
-    otherwise it will use `*value` to set the new receive buffer size.
+    If `*value` == 0, then it will set `*value` to the current receive buffer size.
+    If `*value` > 0 then it will use `*value` to set the new receive buffer size.
+
+    On success, zero is returned. On error, a negative result is
+    returned.
 
     This function works for TCP, pipe and UDP handles on Unix and for TCP and
     UDP handles on Windows.


### PR DESCRIPTION
The docs currently say that the current send/receive buffer size is returned from `uv_send_buffer_size`/`uv_recv_buffer_size`, but that is not true. The return is either 0 or an error code, and the buffer size is returned via the `int* value` argument.

Relevant code:
https://github.com/libuv/libuv/blob/e797163e754c871eceeda4a277fe8d819c06f03c/src/uv-common.c#L543-L549

https://github.com/libuv/libuv/blob/2c279504f92a7ab1fc54c85ec36272722198a77e/src/win/core.c#L599-L625

https://github.com/libuv/libuv/blob/59146f2f4bea7b692238103a8a8e82c4bdc1fc2b/src/unix/core.c#L193-L219