### PR TITLE
unix: sysctl size argument using ARRAY_SIZE macro.

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -110,7 +110,7 @@ uint64_t uv_get_total_memory(void) {
   int which[] = {CTL_HW, HW_MEMSIZE};
   size_t size = sizeof(info);
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info;
@@ -127,7 +127,7 @@ void uv_loadavg(double avg[3]) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_LOADAVG};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) return;
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0) < 0) return;
 
   avg[0] = (double) info.ldavg[0] / info.fscale;
   avg[1] = (double) info.ldavg[1] / info.fscale;
@@ -162,7 +162,7 @@ int uv_uptime(double* uptime) {
   size_t size = sizeof(info);
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   now = time(NULL);

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -95,7 +95,7 @@ int uv_exepath(char* buffer, size_t* size) {
   mib[3] = -1;
 
   abspath_size = sizeof abspath;
-  if (sysctl(mib, 4, abspath, &abspath_size, NULL, 0))
+  if (sysctl(mib, ARRAY_SIZE(mib), abspath, &abspath_size, NULL, 0))
     return UV__ERR(errno);
 
   assert(abspath_size > 0);
@@ -130,7 +130,7 @@ uint64_t uv_get_total_memory(void) {
 
   size_t size = sizeof(info);
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info;
@@ -147,7 +147,7 @@ void uv_loadavg(double avg[3]) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_LOADAVG};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) return;
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0) < 0) return;
 
   avg[0] = (double) info.ldavg[0] / info.fscale;
   avg[1] = (double) info.ldavg[1] / info.fscale;
@@ -168,7 +168,7 @@ int uv_resident_set_memory(size_t* rss) {
 
   kinfo_size = sizeof(kinfo);
 
-  if (sysctl(mib, 4, &kinfo, &kinfo_size, NULL, 0))
+  if (sysctl(mib, ARRAY_SIZE(mib), &kinfo, &kinfo_size, NULL, 0))
     return UV__ERR(errno);
 
   page_size = getpagesize();

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -55,7 +55,7 @@ void uv_loadavg(double avg[3]) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_LOADAVG};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0) == -1) return;
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0) == -1) return;
 
   avg[0] = (double) info.ldavg[0] / info.fscale;
   avg[1] = (double) info.ldavg[1] / info.fscale;
@@ -102,7 +102,7 @@ uint64_t uv_get_free_memory(void) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_UVMEXP};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
@@ -119,7 +119,7 @@ uint64_t uv_get_total_memory(void) {
 #endif
   size_t size = sizeof(info);
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info;
@@ -167,7 +167,7 @@ int uv_uptime(double* uptime) {
   size_t size = sizeof(info);
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   now = time(NULL);

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -185,6 +185,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   char model[512];
   int numcpus = 1;
   int which[] = {CTL_HW,HW_MODEL};
+  int percpu[] = {CTL_HW,HW_CPUSPEED,0};
   size_t size;
   int i, j;
   uv_cpu_info_t* cpu_info;
@@ -205,18 +206,17 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   i = 0;
   *count = numcpus;
 
-  which[1] = HW_CPUSPEED;
   size = sizeof(cpuspeed);
-  if (sysctl(which, ARRAY_SIZE(which), &cpuspeed, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(percpu), &cpuspeed, &size, NULL, 0))
     goto error;
 
   size = sizeof(info);
-  which[0] = CTL_KERN;
-  which[1] = KERN_CPTIME2;
+  percpu[0] = CTL_KERN;
+  percpu[1] = KERN_CPTIME2;
   for (i = 0; i < numcpus; i++) {
-    which[2] = i;
+    percpu[2] = i;
     size = sizeof(info);
-    if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
+    if (sysctl(which, ARRAY_SIZE(percpu), &info, &size, NULL, 0))
       goto error;
 
     cpu_info = &(*cpu_infos)[i];

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -184,7 +184,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   uint64_t info[CPUSTATES];
   char model[512];
   int numcpus = 1;
-  int which[] = {CTL_HW,HW_MODEL,0};
+  int which[] = {CTL_HW,HW_MODEL};
   size_t size;
   int i, j;
   uv_cpu_info_t* cpu_info;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -50,7 +50,7 @@ void uv_loadavg(double avg[3]) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_LOADAVG};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0) < 0) return;
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0) < 0) return;
 
   avg[0] = (double) info.ldavg[0] / info.fscale;
   avg[1] = (double) info.ldavg[1] / info.fscale;
@@ -81,7 +81,7 @@ int uv_exepath(char* buffer, size_t* size) {
     mib[1] = KERN_PROC_ARGS;
     mib[2] = mypid;
     mib[3] = KERN_PROC_ARGV;
-    if (sysctl(mib, 4, argsbuf, &argsbuf_size, NULL, 0) == 0) {
+    if (sysctl(mib, ARRAY_SIZE(mib), argsbuf, &argsbuf_size, NULL, 0) == 0) {
       break;
     }
     if (errno != ENOMEM) {
@@ -117,7 +117,7 @@ uint64_t uv_get_free_memory(void) {
   size_t size = sizeof(info);
   int which[] = {CTL_VM, VM_UVMEXP};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info.free * sysconf(_SC_PAGESIZE);
@@ -129,7 +129,7 @@ uint64_t uv_get_total_memory(void) {
   int which[] = {CTL_HW, HW_PHYSMEM64};
   size_t size = sizeof(info);
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   return (uint64_t) info;
@@ -154,7 +154,7 @@ int uv_resident_set_memory(size_t* rss) {
   mib[4] = sizeof(struct kinfo_proc);
   mib[5] = 1;
 
-  if (sysctl(mib, 6, &kinfo, &size, NULL, 0) < 0)
+  if (sysctl(mib, ARRAY_SIZE(mib), &kinfo, &size, NULL, 0) < 0)
     return UV__ERR(errno);
 
   *rss = kinfo.p_vm_rssize * page_size;
@@ -168,7 +168,7 @@ int uv_uptime(double* uptime) {
   size_t size = sizeof(info);
   static int which[] = {CTL_KERN, KERN_BOOTTIME};
 
-  if (sysctl(which, 2, &info, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);
 
   now = time(NULL);
@@ -190,12 +190,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   uv_cpu_info_t* cpu_info;
 
   size = sizeof(model);
-  if (sysctl(which, 2, &model, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &model, &size, NULL, 0))
     return UV__ERR(errno);
 
   which[1] = HW_NCPUONLINE;
   size = sizeof(numcpus);
-  if (sysctl(which, 2, &numcpus, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &numcpus, &size, NULL, 0))
     return UV__ERR(errno);
 
   *cpu_infos = uv__malloc(numcpus * sizeof(**cpu_infos));
@@ -207,7 +207,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   which[1] = HW_CPUSPEED;
   size = sizeof(cpuspeed);
-  if (sysctl(which, 2, &cpuspeed, &size, NULL, 0))
+  if (sysctl(which, ARRAY_SIZE(which), &cpuspeed, &size, NULL, 0))
     goto error;
 
   size = sizeof(info);
@@ -216,7 +216,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   for (i = 0; i < numcpus; i++) {
     which[2] = i;
     size = sizeof(info);
-    if (sysctl(which, 3, &info, &size, NULL, 0))
+    if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
       goto error;
 
     cpu_info = &(*cpu_infos)[i];


### PR DESCRIPTION
Following up previous PR on NetBSD thus left one on purpose.