### PR TITLE
build: move -Wno-long-long check to configure time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,11 +140,7 @@ EXTRA_DIST = test/fixtures/empty_file \
 
 TESTS = test/run-tests
 check_PROGRAMS = test/run-tests
-if OS390
 test_run_tests_CFLAGS =
-else
-test_run_tests_CFLAGS = -Wno-long-long
-endif
 
 if SUNOS
 # Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ CC_CHECK_CFLAGS_APPEND([-g])
 CC_CHECK_CFLAGS_APPEND([-std=gnu89])
 CC_CHECK_CFLAGS_APPEND([-Wall])
 CC_CHECK_CFLAGS_APPEND([-Wextra])
+CC_CHECK_CFLAGS_APPEND([-Wno-long-long])
 CC_CHECK_CFLAGS_APPEND([-Wno-unused-parameter])
 CC_CHECK_CFLAGS_APPEND([-Wstrict-prototypes])
 # AM_PROG_AR is not available in automake v0.11 but it's essential in v0.12.


### PR DESCRIPTION
xlc reportedly doesn't support the `-Wno-long-long` flag. Detect that
at configure time instead of trying to fix it up at build time.

This enables the flag for both the library and the test suite instead
of just the test suite but that seems fine to me.

CI: https://ci.nodejs.org/job/libuv-test-commit/1608/