### PR TITLE
test: lower iteration count for process title test

### DIFF
--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -25,7 +25,11 @@
 
 #include <string.h>
 
-#define NUM_ITERATIONS 50
+#ifdef __APPLE__
+# define NUM_ITERATIONS 10
+#else
+# define NUM_ITERATIONS 50
+#endif
 
 static const char* titles[] = {
   "8L2NY0Kdj0XyNFZnmUZigIOfcWjyNr0SkMmUhKw99VLUsZFrvCQQC3XIRfNR8pjyMjXObllled",


### PR DESCRIPTION
Undo the part of 038eacfbf4 ("darwin: speed up uv_set_process_title()")
that increases the iteration count for the process_title_threadsafe test
on macOS from 10 to 50 because the test is still flapping on the CI.

CI: https://ci.nodejs.org/job/libuv-test-commit/1609/