### PR TITLE
unix/fs: Fix copyfile() when using FICLONE fails

### DIFF
--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -188,7 +188,7 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE_FORCE,
                      NULL);
-  ASSERT(r == 0 || r == UV_ENOSYS || r == UV_ENOTSUP);
+  ASSERT(r == 0 || r == UV_ENOSYS || r < 0);
 
   if (r == 0)
     handle_result(&req);


### PR DESCRIPTION
Fixes `uv_fs_copyfile()` in cases where an unknown error occurs when copy-on-write is requested by setting `UV_FS_COPYFILE_FICLONE`. The original approach tried to catch some of the errors raised by the `ioctl()` call, assuming that `sendfile()` would also fail in those cases. This is not necessarily true, some variants of `ioctl()` also raise `EINVAL` (some maybe `EBADF`), but `sendfile()` works just fine (#2483).

The new version reverses the logic and falls back to `sendfile()` in any case when `ioctl()` returns an error, i.e. it tries much harder to make `uv_fs_copyfile()` work.

Related to that, the original approach returned `UV_ENOTSUP` unconditionally in cases where `ioctl()` failed and `UV_FS_COPYFILE_FICLONE_FORCE` was set. However, `ioctl()` may have failed for other reasons than `FICLONE` being not supported. The function now returns the actual error raised by `ioctl()`, leaving it to the caller to deal with it.

Adapts the tests to accept any error value when testing `uv_fs_copyfile()` with `UV_FS_COPYFILE_FICLONE_FORCE`.

Fixes #2483 and related downstream bugs, most notably jupyterlab/jupyterlab#6969 and probably yarnpkg/yarn#7440, yarnpkg/yarn#7152