### PR TITLE
unix/fs: Fix copyfile() when using FICLONE fails -- bugfix only

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1055,18 +1055,14 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
 #ifdef FICLONE
   if (req->flags & UV_FS_COPYFILE_FICLONE ||
       req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
-    if (ioctl(dstfd, FICLONE, srcfd) == -1) {
-      /* If an error occurred that the sendfile fallback also won't handle, or
-         this is a force clone then exit. Otherwise, fall through to try using
-         sendfile(). */
-      if (errno != ENOTTY && errno != EOPNOTSUPP && errno != EXDEV) {
-        err = UV__ERR(errno);
-        goto out;
-      } else if (req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
-        err = UV_ENOTSUP;
-        goto out;
-      }
-    } else {
+    if (ioctl(dstfd, FICLONE, srcfd) == 0) {
+      /* ioctl() with FICLONE succeeded. */
+      goto out;
+    }
+    /* If an error occurred and force was set, assume it is not supported and
+     * return UV_ENOTSUP. Fall back to sendfile() when force was not set. */
+    if (req->flags & UV_FS_COPYFILE_FICLONE_FORCE) {
+      err = UV_ENOTSUP;
       goto out;
     }
   }


### PR DESCRIPTION
Fixes `uv_fs_copyfile()` in cases where a yet unknown error occurs when copy-on-write is requested by setting `UV_FS_COPYFILE_FICLONE`. The original approach tried to catch some of the errors raised by the `ioctl()` call, assuming that `sendfile()` would then also fail. This is not necessarily true, some (older) variants of `ioctl()` also raise `EINVAL` (some maybe `EBADF`), but `sendfile()` works just fine ([#2483](https://github.com/libuv/libuv/issues/2483)).

This change reverses the logic, falling back to `sendfile()` in any case when `ioctl()` returns an error, i.e. trying harder to successfully copy the file.

Fixes #2483 and related downstream bugs, most notably jupyterlab/jupyterlab#6969 and probably yarnpkg/yarn#7440, yarnpkg/yarn#7152 as well.

Supersedes #2514