### PR TITLE
fix -Wunused-but-set-variable

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -565,6 +565,7 @@ static void uv__signal_stop(uv_signal_t* handle) {
     if (first_oneshot && !rem_oneshot) {
       ret = uv__signal_register_handler(handle->signum, 1);
       assert(ret == 0);
+      (void)ret;
     }
   }
 


### PR DESCRIPTION
fix warning about
```
/root/work/portable/libuv/src/unix/signal.c: In function 'uv__signal_stop':
/root/work/portable/libuv/src/unix/signal.c:544:7: warning: variable 'ret' set but not used [-Wunused-but-set-variable]
   int ret;
       ^~~
```