### PR TITLE
fs: fallback to stat if statx is not available in a container

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1254,7 +1254,6 @@ static int uv__fs_statx(int fd,
     return UV_ENOSYS; 
   }
   
-
   buf->st_dev = 256 * statxbuf.stx_dev_major + statxbuf.stx_dev_minor;
   buf->st_mode = statxbuf.stx_mode;
   buf->st_nlink = statxbuf.stx_nlink;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1233,18 +1233,18 @@ static int uv__fs_statx(int fd,
     flags |= AT_SYMLINK_NOFOLLOW;
 
   rc = uv__statx(dirfd, path, flags, mode, &statxbuf); 
-  /* Normally on success, zero is returned and On error, -1 is returned.
-   * Observed on S390 RHEL running in a docker container with statx not
-   * implemented, rc might return 1 with 0 set as the error code in which 
-   * case we return ENOSYS.
-   */   
-  if (rc != 0) {
+  
+  switch (rc) {
+  case 0:
+    break;
+  case -1:
     /* EPERM happens when a seccomp filter rejects the system call.
      * Has been observed with libseccomp < 2.3.3 and docker < 18.04.
      */
-    if (errno != 0 && errno != EINVAL && errno != EPERM && errno != ENOSYS)
+    if (errno != EINVAL && errno != EPERM && errno != ENOSYS)
       return -1;
-
+    /* Fall through. */
+  default:
     no_statx = 1;
     return UV_ENOSYS;
   }

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1243,7 +1243,17 @@ static int uv__fs_statx(int fd,
 
     no_statx = 1;
     return UV_ENOSYS;
+  } else if (rc == 1) { 
+    /* statx is not implemented on RHEL 7 and trying to call it from
+     * within a docker container might result in a ret value of 1 
+     * (which is not an expected value according to statx man page, 
+     * expected values are 0 or -1), in which case assume statx is not 
+     * implemented.
+     */  
+    no_statx = 1;
+    return UV_ENOSYS; 
   }
+  
 
   buf->st_dev = 256 * statxbuf.stx_dev_major + statxbuf.stx_dev_minor;
   buf->st_mode = statxbuf.stx_mode;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1245,6 +1245,11 @@ static int uv__fs_statx(int fd,
       return -1;
     /* Fall through. */
   default:
+    /* Normally on success, zero is returned and On error, -1 is returned.
+     * Observed on S390 RHEL running in a docker container with statx not
+     * implemented, rc might return 1 with 0 set as the error code in which 
+     * case we return ENOSYS.
+     */    
     no_statx = 1;
     return UV_ENOSYS;
   }

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1253,7 +1253,7 @@ static int uv__fs_statx(int fd,
     no_statx = 1;
     return UV_ENOSYS; 
   }
-  
+ 
   buf->st_dev = 256 * statxbuf.stx_dev_major + statxbuf.stx_dev_minor;
   buf->st_mode = statxbuf.stx_mode;
   buf->st_nlink = statxbuf.stx_nlink;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1233,7 +1233,12 @@ static int uv__fs_statx(int fd,
     flags |= AT_SYMLINK_NOFOLLOW;
 
   rc = uv__statx(dirfd, path, flags, mode, &statxbuf);
-
+ 
+  /* Normally on success, zero is returned and On error, -1 is returned.
+   * Observed on S390 RHEL running in a docker container with statx not
+   * implemented, rc might return 1 with 0 set as the error code in which 
+   * case we return ENOSYS.
+   */   
   if (rc != 0) {
     /* EPERM happens when a seccomp filter rejects the system call.
      * Has been observed with libseccomp < 2.3.3 and docker < 18.04.

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1234,7 +1234,17 @@ static int uv__fs_statx(int fd,
 
   rc = uv__statx(dirfd, path, flags, mode, &statxbuf);
 
-  if (rc == -1) {
+  if (rc != 0) {
+    if (errno == 0) {
+    /* statx is not implemented on RHEL 7 and trying to call it from
+     * within a docker container might result in a ret value of 1 
+     * (which is not an expected value according to statx man page, 
+     * expected values are 0 or -1) and errno is set to 0, in which 
+     * case assume statx is not implemented.
+     */  
+      no_statx = 1;
+      return UV_ENOSYS;
+    }
     /* EPERM happens when a seccomp filter rejects the system call.
      * Has been observed with libseccomp < 2.3.3 and docker < 18.04.
      */
@@ -1253,7 +1263,7 @@ static int uv__fs_statx(int fd,
     no_statx = 1;
     return UV_ENOSYS; 
   }
- 
+
   buf->st_dev = 256 * statxbuf.stx_dev_major + statxbuf.stx_dev_minor;
   buf->st_mode = statxbuf.stx_mode;
   buf->st_nlink = statxbuf.stx_nlink;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1232,8 +1232,7 @@ static int uv__fs_statx(int fd,
   if (is_lstat)
     flags |= AT_SYMLINK_NOFOLLOW;
 
-  rc = uv__statx(dirfd, path, flags, mode, &statxbuf);
- 
+  rc = uv__statx(dirfd, path, flags, mode, &statxbuf); 
   /* Normally on success, zero is returned and On error, -1 is returned.
    * Observed on S390 RHEL running in a docker container with statx not
    * implemented, rc might return 1 with 0 set as the error code in which 


### PR DESCRIPTION
statx is not implemented on RHEL 7 and trying to call it from within a docker container might result in a ret value of 1 (which is not an expected value according to statx man page,  expected values are 0 or -1) and errno is set to 0, in which case assume statx is not implemented.

Above behaviour has been seen on RHEL 7 running on a s390:
https://bugzilla.redhat.com/show_bug.cgi?id=1759152