### PR TITLE
misc: make more tags "not-stale"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,11 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - v2
+  - enhancement
+  - good first issue
+  - feature-request
+  - doc
+  - bug
   - not-stale
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
As discussed in #2498, add some more tags to not-stale. This list is primarily about preserving past discussions about a known bug/improvement/doc-fix, for the eventual time someone makes a PR to implement a feature. There's two primary goals here:
 - making a "doc-fest" or "first-issue hackathon" more productive
 - preserve existing discussion context so it doesn't need to be repeated when/if someone resubmits a duplicate and/or a pull request