### PR TITLE
Fix Build on Android API < 28

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -42,7 +42,7 @@ static int uv__random(void* buf, size_t buflen) {
     rc = uv__random_devurandom(buf, buflen);
 #elif defined(__NetBSD__)
   rc = uv__random_sysctl(buf, buflen);
-#elif defined(__FreeBSD__) || defined(__linux__)
+#elif (defined(__FreeBSD__) || defined(__linux__)) && !defined(__ANDROID_API__)
   rc = uv__random_getrandom(buf, buflen);
   if (rc == UV_ENOSYS)
     rc = uv__random_devurandom(buf, buflen);


### PR DESCRIPTION
When trying to build (with CMake) for Android (API < 28), you get:
```
../deps/libuv/src/random.c:43: error: undefined reference to 'uv__random_getrandom'
../deps/libuv/src/random.c:55: error: undefined reference to 'uv__random_sysctl'
```
This fixes the issue, by forcing ```libuv``` to not use ```uv__random_getrandom``` and ```uv__random_sysctl``` because they are not included in the Android build.