### PR TITLE
note uv_close call needed in timers

### DIFF
--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -50,6 +50,9 @@ API
 .. c:function:: int uv_timer_stop(uv_timer_t* handle)
 
     Stop the timer, the callback will not be called anymore.
+    
+    .. note::
+        Does not close the handle and a call to :c:func:`uv_close` is still required.
 
 .. c:function:: int uv_timer_again(uv_timer_t* handle)
 


### PR DESCRIPTION
Just lost a couple of days debugging an issue that was caused by a free before uv_close with timers so I thought I'd note it in the documentation it for others in case they make the same mistake.