### PR TITLE
aix: fix setting of physical addresses (alternate take)

### DIFF
--- a/src/unix/aix-common.c
+++ b/src/unix/aix-common.c
@@ -165,7 +165,6 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   int sockfd, inet6, size = 1, i;
   struct ifconf ifc;
   struct ifreq *ifr, *p, flg;
-  struct sockaddr_dl* sa_addr;
   struct kinfo_ndd *nddps, *nddp;
   void* end;
   *count = 0;
@@ -279,7 +278,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     nddps = (struct kinfo_ndd *)uv__malloc(size);
     if (nddps) {
       if (getkerninfo(KINFO_NDD, (char*)nddps, &size, 0) >= 0) {
-        end = (void*) nddps + size;
+        end = (void*)(nddps + size);
         nddp = nddps;
         while ((void *)nddp < end) {
           address = *addresses;


### PR DESCRIPTION
This is an alternative fix to https://github.com/libuv/libuv/pull/2546. Instead of being
based on existing bsd code in this repository it is based on an example program from
the AIX docs: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/commprogramming/skt_sndother_ex.html

It yields the same result as https://github.com/libuv/libuv/pull/2546 on the CI:
https://ci.nodejs.org/job/libuv-test-commit-aix/1671/nodes=aix72-xlc-ppc64/console
```console
# uv_interface_addresses:
#   name: en0
#   internal: 0
#   physical address: 5a:c6:c5:74:19:02
#   address: 140.211.9.30
#   netmask: none
#   name: lo0
#   internal: 1
#   physical address: 00:00:00:00:00:00
#   address: 127.0.0.1
#   netmask: none
#   name: lo0
#   internal: 1
#   physical address: 00:00:00:00:00:00
#   address: ::1
#   netmask: none
```

I do have a preference for the other PR given they're producing the same output as 
for this one I can't find any documentation on the `getkerninfo()` call in the example 
program (I even had to forward declare it to silence the compiler). But I'm submitting
this too so the implementations can be compared.