### PR TITLE
doc: fix flipped documentation in process.rst

### DIFF
--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -75,13 +75,13 @@ Data types
             */
             UV_PROCESS_WINDOWS_HIDE = (1 << 4),
             /*
-            * Hide the subprocess console window that would normally be created. This 
+            * Hide the subprocess GUI window that would normally be created. This 
             * option is only meaningful on Windows systems. On Unix it is silently
             * ignored.
             */
             UV_PROCESS_WINDOWS_HIDE_CONSOLE = (1 << 5),
             /*
-            * Hide the subprocess GUI window that would normally be created. This 
+            * Hide the subprocess console window that would normally be created. This 
             * option is only meaningful on Windows systems. On Unix it is silently
             * ignored.
             */


### PR DESCRIPTION
The descriptions of UV_PROCESS_WINDOWS_HIDE and UV_PROCESS_WINDOWS_HIDE_CONSOLE were flipped.