### PR TITLE
unix: switch uv_sleep() to nanosleep()

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1557,13 +1557,9 @@ int uv_gettimeofday(uv_timeval64_t* tv) {
 }
 
 void uv_sleep(unsigned int msec) {
-  unsigned int sec;
-  unsigned int usec;
+  struct timespec timeout;
 
-  sec = msec / 1000;
-  usec = (msec % 1000) * 1000;
-  if (sec > 0)
-    sleep(sec);
-  if (usec > 0)
-    usleep(usec);
+  timeout.tv_sec = msec / 1000;
+  timeout.tv_nsec = (msec % 1000) * 1000 * 1000;
+  nanosleep(&timeout, NULL);
 }

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1558,8 +1558,14 @@ int uv_gettimeofday(uv_timeval64_t* tv) {
 
 void uv_sleep(unsigned int msec) {
   struct timespec timeout;
+  int rc;
 
   timeout.tv_sec = msec / 1000;
   timeout.tv_nsec = (msec % 1000) * 1000 * 1000;
-  nanosleep(&timeout, NULL);
+
+  do
+    rc = nanosleep(&timeout, &timeout);
+  while (rc == -1 && errno == EINTR);
+
+  assert(rc == 0);
 }

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -27,6 +27,7 @@
 #include <termios.h>
 #include <sys/msg.h>
 
+#define CW_INTRPT 1
 #define CW_CONDVAR 32
 
 #pragma linkage(BPX4CTW, OS)

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -23,7 +23,6 @@
 #include "os390-syscalls.h"
 #include <errno.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <search.h>
 #include <termios.h>
 #include <sys/msg.h>
@@ -350,27 +349,34 @@ int nanosleep(const struct timespec* req, struct timespec* rem) {
   unsigned secrem;
   unsigned nanorem;
   int rv;
-  int rc;
+  int err;
   int rsn;
 
   nano = (int)req->tv_nsec;
   seconds = req->tv_sec;
   events = CW_CONDVAR;
+  secrem = 0;
+  nanorem = 0;
 
 #if defined(_LP64)
-  BPX4CTW(&seconds, &nano, &events, &secrem, &nanorem, &rv, &rc, &rsn);
+  BPX4CTW(&seconds, &nano, &events, &secrem, &nanorem, &rv, &err, &rsn);
 #else
-  BPX1CTW(&seconds, &nano, &events, &secrem, &nanorem, &rv, &rc, &rsn);
+  BPX1CTW(&seconds, &nano, &events, &secrem, &nanorem, &rv, &err, &rsn);
 #endif
 
-  assert(rv == -1 && errno == EAGAIN);
+  /* Don't clobber errno unless BPX1CTW/BPX4CTW errored.
+   * Don't leak EAGAIN, that just means the timeout expired.
+   */
+  if (rv == -1)
+    if (err != EAGAIN)
+      errno = err;
 
-  if(rem != NULL) {
+  if (rem != NULL && (rv == 0 || err == EINTR || err == EAGAIN)) {
     rem->tv_nsec = nanorem;
     rem->tv_sec = secrem;
   }
 
-  return 0;
+  return rv;
 }
 
 

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -354,7 +354,7 @@ int nanosleep(const struct timespec* req, struct timespec* rem) {
 
   nano = (int)req->tv_nsec;
   seconds = req->tv_sec;
-  events = CW_CONDVAR;
+  events = CW_CONDVAR | CW_INTRPT;
   secrem = 0;
   nanorem = 0;
 


### PR DESCRIPTION
Before this commit, uv_sleep() made two library calls: sleep() to sleep
for the requested number of seconds, and then an usleep() call to sleep
for the remaining milliseconds. Make a single nanosleep() call instead.

Receiving a signal will wake up prematurely from sleep() but then
re-enter sleep mode again in usleep(), which seems undesirable.

~~CI: https://ci.nodejs.org/job/libuv-test-commit/1634/~~
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1636/~~
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1650/~~
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1652/~~
CI: https://ci.nodejs.org/job/libuv-test-commit/1653/