### PR TITLE
unix,win: introduced uv_udp_send_ex and uv_udp_try_send_ex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-udp-open.c
        test/test-udp-options.c
        test/test-udp-send-and-recv.c
+       test/test-udp-send-ex.c
        test/test-udp-send-hang-loop.c
        test/test-udp-send-immediate.c
        test/test-udp-sendmmsg-error.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -298,6 +298,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-udp-open.c \
                          test/test-udp-options.c \
                          test/test-udp-send-and-recv.c \
+                         test/test-udp-send-ex.c \
                          test/test-udp-send-hang-loop.c \
                          test/test-udp-send-immediate.c \
                          test/test-udp-sendmmsg-error.c \

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -364,6 +364,10 @@ API
 .. c:function:: int uv_udp_send_ex(uv_udp_send_t* req, uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr, unsigned int addrlen, uv_udp_send_cb send_cb)
 
     Same as :c:func:`uv_udp_send`, but accepts any `struct sockaddr`.
+    :c:func:`uv_udp_send` does not take an addrlen parameter, as it performs an
+    internal addrlen lookup based on the address family (AF_INET, AF_INET6 and
+    AF_UNIX are supported). This function supports arbitrary address families
+    (e.g. AF_NETLINK).
 
     :param req: UDP request handle. Need not be initialized.
 
@@ -375,14 +379,14 @@ API
     :param nbufs: Number of buffers in `bufs`.
 
     :param addr: any `struct sockaddr`
-    
+
     :param addrlen: Length of given `struct sockaddr`
 
     :param send_cb: Callback to invoke when the data has been sent out.
 
     :returns: 0 on success, or an error code < 0 on failure.
-    
-    .. versionadded:: 1.28.0
+
+    .. versionadded:: 1.40.0
 
 .. c:function:: int uv_udp_try_send(uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr)
 
@@ -409,8 +413,8 @@ API
     :returns: >= 0: number of bytes sent (it matches the given buffer size).
         < 0: negative error code (``UV_EAGAIN`` is returned when the message
         can't be sent immediately).
-        
-    .. versionadded:: 1.28.0
+
+    .. versionadded:: 1.40.0
 
 .. c:function:: int uv_udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb)
 

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -361,6 +361,29 @@ API
 
     .. versionchanged:: 1.27.0 added support for connected sockets
 
+.. c:function:: int uv_udp_send_ex(uv_udp_send_t* req, uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr, unsigned int addrlen, uv_udp_send_cb send_cb)
+
+    Same as :c:func:`uv_udp_send`, but accepts any `struct sockaddr`.
+
+    :param req: UDP request handle. Need not be initialized.
+
+    :param handle: UDP handle. Should have been initialized with
+        :c:func:`uv_udp_init`.
+
+    :param bufs: List of buffers to send.
+
+    :param nbufs: Number of buffers in `bufs`.
+
+    :param addr: any `struct sockaddr`
+    
+    :param addrlen: Length of given `struct sockaddr`
+
+    :param send_cb: Callback to invoke when the data has been sent out.
+
+    :returns: 0 on success, or an error code < 0 on failure.
+    
+    .. versionadded:: 1.28.0
+
 .. c:function:: int uv_udp_try_send(uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr)
 
     Same as :c:func:`uv_udp_send`, but won't queue a send request if it can't
@@ -377,6 +400,17 @@ API
         can't be sent immediately).
 
     .. versionchanged:: 1.27.0 added support for connected sockets
+
+.. c:function:: int uv_udp_try_send_ex(uv_udp_t* handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr, unsigned int addrlen)
+
+    Same as :c:func:`uv_udp_send_ex`, but won't queue a send request if it can't
+    be completed immediately.
+
+    :returns: >= 0: number of bytes sent (it matches the given buffer size).
+        < 0: negative error code (``UV_EAGAIN`` is returned when the message
+        can't be sent immediately).
+        
+    .. versionadded:: 1.28.0
 
 .. c:function:: int uv_udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -693,10 +693,22 @@ UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
                           unsigned int nbufs,
                           const struct sockaddr* addr,
                           uv_udp_send_cb send_cb);
+UV_EXTERN int uv_udp_send_ex(uv_udp_send_t* req,
+                             uv_udp_t* handle,
+                             const uv_buf_t bufs[],
+                             unsigned int nbufs,
+                             const struct sockaddr* addr,
+                             unsigned int addrlen,
+                             uv_udp_send_cb send_cb);
 UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
                               const uv_buf_t bufs[],
                               unsigned int nbufs,
                               const struct sockaddr* addr);
+UV_EXTERN int uv_udp_try_send_ex(uv_udp_t* handle,
+                                 const uv_buf_t bufs[],
+                                 unsigned int nbufs,
+                                 const struct sockaddr* addr,
+                                 unsigned int addrlen);
 UV_EXTERN int uv_udp_recv_start(uv_udp_t* handle,
                                 uv_alloc_cb alloc_cb,
                                 uv_udp_recv_cb recv_cb);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -450,6 +450,16 @@ int uv_udp_send(uv_udp_send_t* req,
   return uv__udp_send(req, handle, bufs, nbufs, addr, addrlen, send_cb);
 }
 
+int uv_udp_send_ex(uv_udp_send_t* req,
+                   uv_udp_t* handle,
+                   const uv_buf_t bufs[],
+                   unsigned int nbufs,
+                   const struct sockaddr* addr,
+                   unsigned int addrlen,
+                   uv_udp_send_cb send_cb) {
+  return uv__udp_send(req, handle, bufs, nbufs, addr, addrlen, send_cb);
+}
+
 
 int uv_udp_try_send(uv_udp_t* handle,
                     const uv_buf_t bufs[],
@@ -464,6 +474,13 @@ int uv_udp_try_send(uv_udp_t* handle,
   return uv__udp_try_send(handle, bufs, nbufs, addr, addrlen);
 }
 
+int uv_udp_try_send_ex(uv_udp_t* handle,
+                       const uv_buf_t bufs[],
+                       unsigned int nbufs,
+                       const struct sockaddr* addr,
+                       unsigned int addrlen) {
+  return uv__udp_try_send(handle, bufs, nbufs, addr, addrlen);
+}
 
 int uv_udp_recv_start(uv_udp_t* handle,
                       uv_alloc_cb alloc_cb,

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -162,6 +162,9 @@ TEST_DECLARE   (udp_create_early)
 TEST_DECLARE   (udp_create_early_bad_bind)
 TEST_DECLARE   (udp_create_early_bad_domain)
 TEST_DECLARE   (udp_send_and_recv)
+#ifndef _WIN32
+TEST_DECLARE   (udp_send_ex)
+#endif
 TEST_DECLARE   (udp_send_hang_loop)
 TEST_DECLARE   (udp_send_immediate)
 TEST_DECLARE   (udp_send_unreachable)
@@ -721,6 +724,7 @@ TASK_LIST_START
   TEST_ENTRY  (udp_create_early_bad_bind)
   TEST_ENTRY  (udp_create_early_bad_domain)
   TEST_ENTRY  (udp_send_and_recv)
+  TEST_ENTRY  (udp_send_ex)
   TEST_ENTRY  (udp_send_hang_loop)
   TEST_ENTRY  (udp_send_immediate)
   TEST_ENTRY  (udp_send_unreachable)


### PR DESCRIPTION
Currently only sockaddr_in or sockaddr_in6 may be passed when sending UDP packets. Up until now based on the address family (AF_INET or AF_INET6) the length parameter was determined and therefore other families result in error.

The documentation of uv_udp_open suggests that also other datagram sockets may be given, giving netlink as example. In order to fullfill that those sockets may be used, we need a possibility to specify
the length parameter explicitly. For this purpose this commit introduces the new uv_udp_send_ex and uv_udp_try_send_ex methods.

----

Original PR was closed due to lack of tests (#1925).
Tests were added in PR #2241 but feedback was not implemented.

This PR contains everything plus feedback of #2241 

I used versionadded:: 1.34.0 for this feature in documentation.