### PR TITLE
unix,win,doc,test: never listen on an IPC pipe

### DIFF
--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -24,6 +24,8 @@ Public members
 .. c:member:: int uv_pipe_t.ipc
 
     Whether this pipe is suitable for handle passing between processes.
+    Only a connected pipe that will be passing the handles should have this flag
+    set, not the listening pipe that uv_accept is called on.
 
 .. seealso:: The :c:type:`uv_stream_t` members also apply.
 
@@ -35,7 +37,9 @@ API
 
     Initialize a pipe handle. The `ipc` argument is a boolean to indicate if
     this pipe will be used for handle passing between processes (which may
-    change the bytes on the wire).
+    change the bytes on the wire). Only a connected pipe that will be
+    passing the handles should have this flag set, not the listening pipe
+    that uv_accept is called on.
 
 .. c:function:: int uv_pipe_open(uv_pipe_t* handle, uv_file file)
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -95,6 +95,9 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
   if (uv__stream_fd(handle) == -1)
     return UV_EINVAL;
 
+  if (handle->ipc)
+    return UV_EINVAL;
+
 #if defined(__MVS__) || defined(__PASE__)
   /* On zOS, backlog=0 has undefined behaviour */
   /* On IBMi PASE, backlog=0 leads to "Connection refused" error */

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -955,6 +955,10 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
     return ERROR_NOT_SUPPORTED;
   }
 
+  if (handle->ipc) {
+    return WSAEINVAL;
+  }
+
   handle->flags |= UV_HANDLE_LISTENING;
   INCREASE_ACTIVE_COUNT(loop, handle);
   handle->stream.serv.connection_cb = cb;

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -218,8 +218,12 @@ static void send_listen_handles(uv_handle_type type,
   }
   else
     ASSERT(0);
-
-  ASSERT(0 == uv_pipe_init(loop, &ctx.ipc_pipe, 1));
+  /* We need to initialize this pipe with ipc=0 - this is not a uv_pipe we'll
+   * be sending handles over, it's just for listening for new connections.
+   * If we accept a connection then the connected pipe must be initialized
+   * with ipc=1.
+   */
+  ASSERT(0 == uv_pipe_init(loop, &ctx.ipc_pipe, 0));
   ASSERT(0 == uv_pipe_bind(&ctx.ipc_pipe, IPC_PIPE_NAME));
   ASSERT(0 == uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb));
 


### PR DESCRIPTION
Clarify the documentation about `ipc` parameter in uv_pipe_init -
it should be set to true only for pipes that are used to pass handles,
not the ones that are used to listen for incoming connections. This
works on Unices, but breaks horribly on Windows.

Fix benchmark-multi-accept - initialize pipe with ipc=0 for listening.

Add a check in uv_pipe_listen in both unix and windows to disallow
listening on a pipe with `ipc` set - in Windows it's required (uv_accept
on such a handle won't work), in unix it's just to help with making
the code platform-independent.

This fixes https://github.com/libuv/libuv/issues/2158

As a sidenote - there seems to be a problem with .sln files generation with gyp, test\test.sln 
 always gives me "MSB5011: Parent project GUID not found in..." error, it only builds after removing dependendies manually.