### PR TITLE
Fix GCC -Wpedantic warning

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -267,7 +267,9 @@ static void uv__mkostemp_initonce(void) {
    * because it doesn't have mkostemp(O_CLOEXEC) either.
    */
 #ifdef RTLD_DEFAULT
-  uv__mkostemp = (int (*)(char*, int)) dlsym(RTLD_DEFAULT, "mkostemp");
+  union { void *vp; int(*mkostemp)(char*, int); } fp;
+  fp.vp = dlsym(RTLD_DEFAULT, "mkostemp");
+  uv__mkostemp = fp.mkostemp;
 
   /* We don't care about errors, but we do want to clean them up.
    * If there has been no error, then dlerror() will just return


### PR DESCRIPTION
In commit 0d3b487f ("unix: fix -Wstrict-aliasing compiler warning") a GCC warning was fixed, only to be replaced with a new warning:
```
src/unix/fs.c: In function ‘uv__mkostemp_initonce’:
src/unix/fs.c:270:18: warning: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
   uv__mkostemp = (int (*)(char*, int)) dlsym(RTLD_DEFAULT, "mkostemp");
                  ^
```
Tested with gcc 8.3.0 and clang 8.0.1

Fixes: 0d3b487f5d501cf54ebbffe0dbdc79c1b029dd05