### PR TITLE
build: remove -pedantic from compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,9 +24,6 @@ AC_ENABLE_SHARED
 AC_ENABLE_STATIC
 AC_PROG_CC
 AM_PROG_CC_C_O
-AS_IF([AS_CASE([$host_os],[openedition*],  [false], [true])], [
-  CC_CHECK_CFLAGS_APPEND([-pedantic])
-])
 CC_FLAG_VISIBILITY #[-fvisibility=hidden]
 CC_CHECK_CFLAGS_APPEND([-g])
 CC_CHECK_CFLAGS_APPEND([-std=gnu89])

--- a/uv.gyp
+++ b/uv.gyp
@@ -93,7 +93,7 @@
           '-Wno-unused-parameter',
           '-Wstrict-prototypes',
         ],
-        'OTHER_CFLAGS': [ '-g', '--std=gnu89', '-pedantic' ],
+        'OTHER_CFLAGS': [ '-g', '--std=gnu89' ],
       },
       'conditions': [
         [ 'OS=="win"', {
@@ -217,7 +217,6 @@
             '-fvisibility=hidden',
             '-g',
             '--std=gnu89',
-            '-pedantic',
             '-Wall',
             '-Wextra',
             '-Wno-unused-parameter',


### PR DESCRIPTION
This flag emits warnings with some versions of gcc that we don't care
about (libuv targets POSIX conformance, not strict ISO C conformance)
and it's arguably not that useful as libuv is compiled in -std=gnu89
mode.

Fixes: https://github.com/libuv/libuv/pull/2567
CI: https://ci.nodejs.org/job/libuv-test-commit/1660/