### PR TITLE
Those tests fail under NetBSD and OpenBSD.

### DIFF
--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -42,13 +42,17 @@ TEST_IMPL(dlerror) {
 
   msg = uv_dlerror(&lib);
   ASSERT(msg != NULL);
+#ifndef __OpenBSD__
   ASSERT(strstr(msg, path) != NULL);
+#endif
   ASSERT(strstr(msg, dlerror_no_error) == NULL);
 
   /* Should return the same error twice in a row. */
   msg = uv_dlerror(&lib);
   ASSERT(msg != NULL);
+#ifndef __OpenBSD__
   ASSERT(strstr(msg, path) != NULL);
+#endif
   ASSERT(strstr(msg, dlerror_no_error) == NULL);
 
   uv_dlclose(&lib);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -343,7 +343,8 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT(req->ptr != NULL);
   stats = req->ptr;
 
-#if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__)
+#if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
+  defined(__OpenBSD__) || defined(__NetBSD__)
   ASSERT(stats->f_type == 0);
 #else
   ASSERT(stats->f_type > 0);

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -126,8 +126,10 @@ static void cl_recv_cb(uv_udp_t* handle,
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_LEAVE_GROUP);
     ASSERT(r == 0);
 
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, NULL, source_addr, UV_JOIN_GROUP);
     ASSERT(r == 0);
+#endif
 
     r = do_send(&req_ss);
     ASSERT(r == 0);


### PR DESCRIPTION
For the dl api, OpenBSD reporting only wrong binary format.
Others are unsupported.