### PR TITLE
test: skip some test cases on IBMi

### DIFF
--- a/test/task.h
+++ b/test/task.h
@@ -215,7 +215,7 @@ UNUSED static int can_ipv6(void) {
   return supported;
 }
 
-#if defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__CYGWIN__) || defined(__MSYS__) || defined(__PASE__)
 # define NO_FS_EVENTS "Filesystem watching not supported on this platform."
 #endif
 

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -58,9 +58,13 @@ TEST_IMPL(platform_output) {
 #endif
 
   err = uv_uptime(&uptime);
+#if defined(__PASE__)
+  ASSERT(err == UV_ENOSYS);
+#else
   ASSERT(err == 0);
   ASSERT(uptime > 0);
   printf("uv_uptime: %f\n", uptime);
+#endif
 
   err = uv_getrusage(&rusage);
   ASSERT(err == 0);


### PR DESCRIPTION
On IBMi, uv_uptime() and uv_fs_event_init() return UV_ENOSYS.
Set NO_FS_EVENTS on IBMi.