### PR TITLE
test: skip uv_(get|set)_process_title on IBMi

### DIFF
--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -68,7 +68,7 @@ TEST_IMPL(process_title_threadsafe) {
   int i;
 
 #if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__) || \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__PASE__)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #endif
 

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -60,7 +60,8 @@ static void uv_get_process_title_edge_cases(void) {
 
 
 TEST_IMPL(process_title) {
-#if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__) || \
+    defined(__PASE__)
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #endif
 


### PR DESCRIPTION
uv_(get|set)_process_title is not implemented on IBMi.