### PR TITLE
win: implement reflink (UV_FS_COPYFILE_FICLONE_FORCE) on ReFS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.dimInactiveRegions": false
+}

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -151,6 +151,9 @@ void uv_fs_init(void) {
   uv__fd_hash_init();
 }
 
+INLINE static uint64_t roundup(uint64_t n, uint64_t multiple) {
+  return (n + multiple - 1) / multiple * multiple;
+}
 
 INLINE static int fs__capture_path(uv_fs_t* req, const char* path,
     const char* new_path, const int copy_path) {
@@ -2010,7 +2013,7 @@ static void fs__ftruncate(uv_fs_t* req) {
   }
 }
 
-static BOOL fs__clonefile_dup_extents(HANDLE src, 
+INLINE static BOOL fs__clonefile_dup_extents(HANDLE src,
                                       HANDLE dst, 
                                       int64_t offset,
                                       int64_t clone_size) {
@@ -2104,7 +2107,7 @@ static DWORD fs__clonefile(const WCHAR* src, const WCHAR* dst, int flags, int* n
    * but at the same time we can't have extra clusters hanging. So we can't
    * just use some big number here. */
   for (int i = 0; i < 2; i++) {
-    int64_t size = (src_size - offset + (CLUSTERSIZES[i] - 1)) / CLUSTERSIZES[i];
+    int64_t size = roundup(src_size - offset, CLUSTERSIZES);
     if (!fs__clonefile_dup_extents(src_handle, dst_handle, offset, size)) {
       error = GetLastError();
       continue;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2015,12 +2015,11 @@ static BOOL fs__clonefile_dup_extents(HANDLE src,
                                       int64_t offset,
                                       int64_t clone_size) {
   DWORD lpBytesReturned;
-  DUPLICATE_EXTENTS_DATA dup = {
-    .FileHandle = src,
-    .SourceFileOffset = { .QuadPart = offset },
-    .TargetFileOffset = { .QuadPart = offset },
-    .ByteCount = clone_size
-  };
+  DUPLICATE_EXTENTS_DATA dup;
+  dup.FileHandle = src;
+  dup.SourceFileOffset.QuadPart = offset;
+  dup.TargetFileOffset.QuadPart = offset;
+  dup.ByteCount = clone_size;
   return DeviceIoControl(
     dst,
     FSCTL_DUPLICATE_EXTENTS_TO_FILE,
@@ -2035,7 +2034,8 @@ static BOOL fs__clonefile_dup_extents(HANDLE src,
 
 static DWORD fs__clonefile(const WCHAR* src, const WCHAR* dst, int flags) {
   DWORD error = 0;
-  HANDLE src_handle, dst_handle;
+  HANDLE src_handle;
+  HANDLE dst_handle;
 
   uv_stat_t statbuf;
   FILE_END_OF_FILE_INFORMATION eof_info;
@@ -2044,8 +2044,8 @@ static DWORD fs__clonefile(const WCHAR* src, const WCHAR* dst, int flags) {
 
   int64_t src_size;
   int64_t offset = 0;
-  const int64_t GIG = 1 << 30;
-  const int64_t CLUSTERSIZES[] = { 1 << 16, 1 << 12 };
+  const int64_t GIG = 0x40000000; /* 1 << 30 */
+  const int64_t CLUSTERSIZES[] = { 0x10000, 0x1000 }; /* 1 << 16, 1 << 12 */
 
   src_handle = CreateFileW(src,
                            GENERIC_READ,

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2010,7 +2010,10 @@ static void fs__ftruncate(uv_fs_t* req) {
   }
 }
 
-static BOOL fs__clonefile_dup_extents(HANDLE src, HANDLE dst, int64_t offset, int64_t clone_size) {
+static BOOL fs__clonefile_dup_extents(HANDLE src, 
+                                      HANDLE dst, 
+                                      int64_t offset,
+                                      int64_t clone_size) {
   DWORD lpBytesReturned;
   DUPLICATE_EXTENTS_DATA dup = {
     .FileHandle = src,
@@ -2090,7 +2093,7 @@ static DWORD fs__clonefile(const WCHAR* src, const WCHAR* dst, int flags) {
   /* Do the cloning. Clones must fall by cluster boundary and may not be
    * larger than 4GiB. */
   for (; offset < src_size - GIG; offset += GIG) {
-    if (! fs__clonefile_dup_extents(src_handle, dst_handle, offset, GIG)) {
+    if (!fs__clonefile_dup_extents(src_handle, dst_handle, offset, GIG)) {
       error = GetLastError();
       goto exit2;
     }
@@ -2099,7 +2102,7 @@ static DWORD fs__clonefile(const WCHAR* src, const WCHAR* dst, int flags) {
   /* Try to clone the rest with cluster size. Size overflow is fine here. */
   for (int i = 0; i < 2, i++) {
     int64_t size = (src_size - offset + (CLUSTERSIZES[i] - 1)) / CLUSTERSIZES[i];
-    if (! fs__clonefile_dup_extents(src_handle, dst_handle, offset, size)) {
+    if (!fs__clonefile_dup_extents(src_handle, dst_handle, offset, size)) {
       error = GetLastError();
       goto exit2;
     }
@@ -2139,6 +2142,7 @@ static void fs__copyfile(uv_fs_t* req) {
         overwrite = 1;
       }
     } else {
+      SET_REQ_RESULT(req, 0);
       return;
     }
   }

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -185,13 +185,11 @@ TEST_IMPL(fs_copyfile) {
   handle_result(&req);
 
   /* Don't test on Windows until we got ReFS set up. */
-#if !defined(_WIN32) || defined(UV_WIN32_WE_CAN_HAZ_REFS)
   /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE_FORCE,
                      NULL);
   ASSERT(r <= 0);
-#endif
 
   if (r == 0)
     handle_result(&req);

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -184,11 +184,14 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(r == 0);
   handle_result(&req);
 
+  /* Don't test on Windows until we got ReFS set up. */
+#if !defined(_WIN32) || defined(UV_WIN32_WE_CAN_HAZ_REFS)
   /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE_FORCE,
                      NULL);
   ASSERT(r <= 0);
+#endif
 
   if (r == 0)
     handle_result(&req);


### PR DESCRIPTION
I do not have energy for setting up a Windows Server instance and testing it. While this might, theoretically, work, keeping this PR open by a burger-flipper like me is no longer productive. I am closing this issue, but anyone may use the proposed code (and even resurrect the PR when CoW becomes a thing on desktop Windows) per whatever license libuv uses.

* * *
Windows Server has a reflink feature built onto the dedup-capable ReFS.
This is completely irrelevant for client users, but it would still be a
good thing to add given how Microsoft loves Nodejs now.

The FICLONE_FORCE mode is likely to fail since you have to pay for the
server thing to get it to work. Remove the check if the CI is capable.
(We still really need someone to test it.)

This PR is based on the git-lfs implementation.

Ref: https://github.com/git-lfs/git-lfs/pull/3790