### PR TITLE
unix: Clear -Waddress-of-packed-member warnings

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -211,6 +211,8 @@ typedef struct {
   void* pending_queue[2];                                                     \
   void* watcher_queue[2];                                                     \
   uv__io_t** watchers;                                                        \
+  void* poll_events;                                                          \
+  int poll_nfds;                                                              \
   unsigned int nwatchers;                                                     \
   unsigned int nfds;                                                          \
   void* wq[2];                                                                \

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -250,8 +250,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     nevents = 0;
 
     assert(loop->watchers != NULL);
-    loop->watchers[loop->nwatchers] = (void*) events;
-    loop->watchers[loop->nwatchers + 1] = (void*) (uintptr_t) nfds;
+    loop->poll_events = (void*) events;
+    loop->poll_nfds = nfds;
 
     for (i = 0; i < nfds; i++) {
       pe = events + i;
@@ -291,8 +291,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (have_signals != 0)
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
 
-    loop->watchers[loop->nwatchers] = NULL;
-    loop->watchers[loop->nwatchers + 1] = NULL;
+    loop->poll_events = NULL;
 
     if (have_signals != 0)
       return;  /* Event loop should cycle now so don't poll again. */

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1040,15 +1040,14 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct pollfd* events;
-  uintptr_t i;
-  uintptr_t nfds;
+  int i;
+  int nfds;
   struct poll_ctl pc;
 
-  assert(loop->watchers != NULL);
   assert(fd >= 0);
 
-  events = (struct pollfd*) loop->watchers[loop->nwatchers];
-  nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
+  events = (struct pollfd*) loop->poll_events;
+  nfds = loop->poll_nfds;
 
   if (events != NULL)
     /* Invalidate events with same file descriptor */

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -788,33 +788,19 @@ static unsigned int next_power_of_two(unsigned int val) {
 
 static void maybe_resize(uv_loop_t* loop, unsigned int len) {
   uv__io_t** watchers;
-  void* fake_watcher_list;
-  void* fake_watcher_count;
   unsigned int nwatchers;
   unsigned int i;
 
   if (len <= loop->nwatchers)
     return;
 
-  /* Preserve fake watcher list and count at the end of the watchers */
-  if (loop->watchers != NULL) {
-    fake_watcher_list = loop->watchers[loop->nwatchers];
-    fake_watcher_count = loop->watchers[loop->nwatchers + 1];
-  } else {
-    fake_watcher_list = NULL;
-    fake_watcher_count = NULL;
-  }
-
-  nwatchers = next_power_of_two(len + 2) - 2;
-  watchers = uv__realloc(loop->watchers,
-                         (nwatchers + 2) * sizeof(loop->watchers[0]));
+  nwatchers = next_power_of_two(len);
+  watchers = uv__realloc(loop->watchers, nwatchers * sizeof(loop->watchers[0]));
 
   if (watchers == NULL)
     abort();
   for (i = loop->nwatchers; i < nwatchers; i++)
     watchers[i] = NULL;
-  watchers[nwatchers] = fake_watcher_list;
-  watchers[nwatchers + 1] = fake_watcher_count;
 
   loop->watchers = watchers;
   loop->nwatchers = nwatchers;

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -382,14 +382,13 @@ update_timeout:
 
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct kevent* events;
-  uintptr_t i;
-  uintptr_t nfds;
+  int i;
+  int nfds;
 
-  assert(loop->watchers != NULL);
   assert(fd >= 0);
 
-  events = (struct kevent*) loop->watchers[loop->nwatchers];
-  nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
+  events = (struct kevent*) loop->poll_events;
+  nfds = loop->poll_nfds;
   if (events == NULL)
     return;
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -250,8 +250,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     nevents = 0;
 
     assert(loop->watchers != NULL);
-    loop->watchers[loop->nwatchers] = (void*) events;
-    loop->watchers[loop->nwatchers + 1] = (void*) (uintptr_t) nfds;
+    loop->poll_events = (void*) events;
+    loop->poll_nfds = nfds;
     for (i = 0; i < nfds; i++) {
       ev = events + i;
       fd = ev->ident;
@@ -348,8 +348,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (have_signals != 0)
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
 
-    loop->watchers[loop->nwatchers] = NULL;
-    loop->watchers[loop->nwatchers + 1] = NULL;
+    loop->poll_events = NULL;
 
     if (have_signals != 0)
       return;  /* Event loop should cycle now so don't poll again. */

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -142,14 +142,13 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct epoll_event* events;
   struct epoll_event dummy;
-  uintptr_t i;
-  uintptr_t nfds;
+  int i;
+  int nfds;
 
-  assert(loop->watchers != NULL);
   assert(fd >= 0);
 
-  events = (struct epoll_event*) loop->watchers[loop->nwatchers];
-  nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
+  events = (struct epoll_event*) loop->poll_events;
+  nfds = loop->poll_nfds;
   if (events != NULL)
     /* Invalidate events with same file descriptor */
     for (i = 0; i < nfds; i++)

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -323,8 +323,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     nevents = 0;
 
     assert(loop->watchers != NULL);
-    loop->watchers[loop->nwatchers] = (void*) events;
-    loop->watchers[loop->nwatchers + 1] = (void*) (uintptr_t) nfds;
+    loop->poll_events = (void*) events;
+    loop->poll_nfds = nfds;
     for (i = 0; i < nfds; i++) {
       pe = events + i;
       fd = pe->data.fd;
@@ -390,8 +390,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (have_signals != 0)
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
 
-    loop->watchers[loop->nwatchers] = NULL;
-    loop->watchers[loop->nwatchers + 1] = NULL;
+    loop->poll_events = NULL;
 
     if (have_signals != 0)
       return;  /* Event loop should cycle now so don't poll again. */

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -919,8 +919,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
 
     assert(loop->watchers != NULL);
-    loop->watchers[loop->nwatchers] = (void*) events;
-    loop->watchers[loop->nwatchers + 1] = (void*) (uintptr_t) nfds;
+    loop->poll_events = (void*) events;
+    loop->poll_nfds = nfds;
     for (i = 0; i < nfds; i++) {
       pe = events + i;
       fd = pe->fd;
@@ -965,8 +965,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         nevents++;
       }
     }
-    loop->watchers[loop->nwatchers] = NULL;
-    loop->watchers[loop->nwatchers + 1] = NULL;
+    loop->poll_events = NULL;
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -658,14 +658,13 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct epoll_event* events;
   struct epoll_event dummy;
-  uintptr_t i;
-  uintptr_t nfds;
+  int i;
+  int nfds;
 
-  assert(loop->watchers != NULL);
   assert(fd >= 0);
 
-  events = (struct epoll_event*) loop->watchers[loop->nwatchers];
-  nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
+  events = (struct epoll_event*) loop->poll_events;
+  nfds = loop->poll_nfds;
   if (events != NULL)
     /* Invalidate events with same file descriptor */
     for (i = 0; i < nfds; i++)

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -113,14 +113,13 @@ int uv__io_fork(uv_loop_t* loop) {
 
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct port_event* events;
-  uintptr_t i;
-  uintptr_t nfds;
+  int i;
+  int nfds;
 
-  assert(loop->watchers != NULL);
   assert(fd >= 0);
 
-  events = (struct port_event*) loop->watchers[loop->nwatchers];
-  nfds = (uintptr_t) loop->watchers[loop->nwatchers + 1];
+  events = (struct port_event*) loop->poll_events;
+  nfds = loop->poll_nfds;
   if (events == NULL)
     return;
 

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -260,8 +260,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     nevents = 0;
 
     assert(loop->watchers != NULL);
-    loop->watchers[loop->nwatchers] = (void*) events;
-    loop->watchers[loop->nwatchers + 1] = (void*) (uintptr_t) nfds;
+    loop->poll_events = (void*) events;
+    loop->poll_nfds = nfds;
     for (i = 0; i < nfds; i++) {
       pe = events + i;
       fd = pe->portev_object;
@@ -300,8 +300,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (have_signals != 0)
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
 
-    loop->watchers[loop->nwatchers] = NULL;
-    loop->watchers[loop->nwatchers + 1] = NULL;
+    loop->poll_events = NULL;
 
     if (have_signals != 0)
       return;  /* Event loop should cycle now so don't poll again. */


### PR DESCRIPTION
Getting the new GCC 9.x `-Waddress-of-packed-member` warnings for some lines in the current master branch, e.g. in `unix/linux-core.c`:

```
loop->watchers[loop->n_watchers] = (void*) events;
```

The `epoll_event` struct on my system is packed and 1-byte aligned, so IIRC the behavior should be undefined when assigning `(void*) events` to a `uv__io_t*`, at least in C11:

> A pointer to an object type may be converted to a pointer to a different object type. If the
resulting pointer is not correctly aligned for the referenced type, the behavior is
undeﬁned.

This PR clears the warnings by introducing two new private members in `struct uv_loop_s` to hold the values that are otherwise being appended to the `watchers`.