### PR TITLE
test: fix pthread memory leak

### DIFF
--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -232,6 +232,7 @@ static void thread_check_stack(void* arg) {
   if (expected == 0)
     expected = (size_t)lim.rlim_cur;
   ASSERT(stack_size >= expected);
+  ASSERT(0 == pthread_attr_destroy(&attr));
 #endif
 }
 


### PR DESCRIPTION
When the thread attributes object returned by pthread_getattr_np() is no
longer required, it should be destroyed using pthread_attr_destroy().