### PR TITLE
test: disallow running the test suite as root

### DIFF
--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -51,6 +51,13 @@ static int maybe_run_test(int argc, char **argv);
 
 
 int main(int argc, char **argv) {
+#ifndef _WIN32
+  if (0 == geteuid() && NULL == getenv("UV_RUN_AS_ROOT")) {
+    fprintf(stderr, "The libuv test suite cannot be run as root.\n");
+    return EXIT_FAILURE;
+  }
+#endif
+
   if (platform_init(argc, argv))
     return EXIT_FAILURE;
 


### PR DESCRIPTION
The test suite is known to have issues when run as root. This commit prevents the test suite from running when the euid is 0.

I'm not sure how the other maintainers will feel about this change, but people clearly don't read the GitHub issue template, so I thought this was worth a shot to prevent issues like https://github.com/libuv/libuv/issues/2549 (and many more).

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1666/ (looks like a normal libuv CI run)