### PR TITLE
test: skip the pwd_shell test on IBMi

### DIFF
--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -38,7 +38,9 @@ TEST_IMPL(get_passwd) {
   ASSERT(pwd.shell == NULL);
 #else
   len = strlen(pwd.shell);
+# ifndef __PASE__
   ASSERT(len > 0);
+# endif
 #endif
 
   len = strlen(pwd.homedir);


### PR DESCRIPTION
On IBMi PASE, the value of pw_shell is always an empty string.
Seems the API getpwuid_r() is not fully implemented on PASE.