### PR TITLE
Revert "aix: replace ECONNRESET with EOF if already closed"

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1185,10 +1185,6 @@ static void uv__read(uv_stream_t* stream) {
       } else if (errno == ECONNRESET && stream->type == UV_NAMED_PIPE) {
         uv__stream_eof(stream, &buf);
         return;
-#elif defined(_AIX)
-      } else if (errno == ECONNRESET && (stream->flags & UV_DISCONNECT)) {
-        uv__stream_eof(stream, &buf);
-        return;
 #endif
       } else {
         /* Error. User should call uv_close(). */


### PR DESCRIPTION
As mentioned in the text of https://github.com/libuv/libuv/pull/2447, this seems to have been attempted before and quickly reverted because it was causing errors to be forgotten (breaking tests). The ability to test this codepath in libuv directly was added only very recently (https://github.com/libuv/libuv/issues/1991), and so now adding tests of this code reveal that this PR would re-introduce that failure mode for AIX (https://github.com/libuv/libuv/pull/2409#issuecomment-571277235). So this proposes reverting commit ca08b48252230db27592248aef10c2d1779bccce for the same reason that this code was reverted before in https://github.com/libuv/libuv/pull/475.