### PR TITLE
fix documentation links

### DIFF
--- a/docs/src/design.rst
+++ b/docs/src/design.rst
@@ -126,7 +126,7 @@ Unlike network I/O, there are no platform-specific file I/O primitives libuv cou
 so the current approach is to run blocking file I/O operations in a thread pool.
 
 For a thorough explanation of the cross-platform file I/O landscape, checkout
-`this post <http://blog.libtorrent.org/2012/10/asynchronous-disk-io/>`_.
+`this post <https://blog.libtorrent.org/2012/10/asynchronous-disk-io/>`_.
 
 libuv currently uses a global thread pool on which all loops can queue work. 3 types of
 operations are currently run on this pool:

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -403,7 +403,7 @@ API
 .. c:function:: int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, const char* path, double atime, double mtime, uv_fs_cb cb)
 .. c:function:: int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_file file, double atime, double mtime, uv_fs_cb cb)
 
-    Equivalent to :man:`utime(2)` and :man:`futime(2)` respectively.
+    Equivalent to :man:`utime(2)` and :man:`futimes(3)` respectively.
 
     .. note::
       AIX: This function only works for AIX 7.1 and newer. It can still be called on older
@@ -435,7 +435,7 @@ API
 
 .. c:function:: int uv_fs_realpath(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
-    Equivalent to :man:`realpath(3)` on Unix. Windows uses `GetFinalPathNameByHandle <https://msdn.microsoft.com/en-us/library/windows/desktop/aa364962(v=vs.85).aspx>`_.
+    Equivalent to :man:`realpath(3)` on Unix. Windows uses `GetFinalPathNameByHandle <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlea>`_.
     The resulting string is stored in `req->ptr`.
 
     .. warning::
@@ -512,7 +512,7 @@ Helper functions
 .. c:function:: uv_os_fd_t uv_get_osfhandle(int fd)
 
    For a file descriptor in the C runtime, get the OS-dependent handle.
-   On UNIX, returns the ``fd`` intact. On Windows, this calls `_get_osfhandle <https://msdn.microsoft.com/en-us/library/ks2530z6.aspx>`_.
+   On UNIX, returns the ``fd`` intact. On Windows, this calls `_get_osfhandle <https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=vs-2019>`_.
    Note that the return value is still owned by the C runtime,
    any attempts to close it or to use it after closing the fd may lead to malfunction.
 
@@ -521,7 +521,7 @@ Helper functions
 .. c:function:: int uv_open_osfhandle(uv_os_fd_t os_fd)
 
    For a OS-dependent handle, get the file descriptor in the C runtime.
-   On UNIX, returns the ``os_fd`` intact. On Windows, this calls `_open_osfhandle <https://msdn.microsoft.com/en-us/library/bdts1c9x.aspx>`_.
+   On UNIX, returns the ``os_fd`` intact. On Windows, this calls `_open_osfhandle <https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=vs-2019>`_.
    Note that the return value is still owned by the CRT,
    any attempts to close it or to use it after closing the handle may lead to malfunction.
 
@@ -547,7 +547,7 @@ File open constants
 
     .. note::
         `UV_FS_O_DIRECT` is supported on Linux, and on Windows via
-        `FILE_FLAG_NO_BUFFERING <https://msdn.microsoft.com/en-us/library/windows/desktop/cc644950.aspx>`_.
+        `FILE_FLAG_NO_BUFFERING <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
         `UV_FS_O_DIRECT` is not supported on macOS.
 
 .. c:macro:: UV_FS_O_DIRECTORY
@@ -564,7 +564,7 @@ File open constants
 
     .. note::
         `UV_FS_O_DSYNC` is supported on Windows via
-        `FILE_FLAG_WRITE_THROUGH <https://msdn.microsoft.com/en-us/library/windows/desktop/cc644950.aspx>`_.
+        `FILE_FLAG_WRITE_THROUGH <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
 
 .. c:macro:: UV_FS_O_EXCL
 
@@ -631,7 +631,7 @@ File open constants
 
     .. note::
         `UV_FS_O_RANDOM` is only supported on Windows via
-        `FILE_FLAG_RANDOM_ACCESS <https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx>`_.
+        `FILE_FLAG_RANDOM_ACCESS <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea>`_.
 
 .. c:macro:: UV_FS_O_RDONLY
 
@@ -648,7 +648,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SEQUENTIAL` is only supported on Windows via
-        `FILE_FLAG_SEQUENTIAL_SCAN <https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx>`_.
+        `FILE_FLAG_SEQUENTIAL_SCAN <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea>`_.
 
 .. c:macro:: UV_FS_O_SHORT_LIVED
 
@@ -656,7 +656,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SHORT_LIVED` is only supported on Windows via
-        `FILE_ATTRIBUTE_TEMPORARY <https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx>`_.
+        `FILE_ATTRIBUTE_TEMPORARY <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea>`_.
 
 .. c:macro:: UV_FS_O_SYMLINK
 
@@ -669,7 +669,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SYNC` is supported on Windows via
-        `FILE_FLAG_WRITE_THROUGH <https://msdn.microsoft.com/en-us/library/windows/desktop/cc644950.aspx>`_.
+        `FILE_FLAG_WRITE_THROUGH <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
 
 .. c:macro:: UV_FS_O_TEMPORARY
 
@@ -677,7 +677,7 @@ File open constants
 
     .. note::
         `UV_FS_O_TEMPORARY` is only supported on Windows via
-        `FILE_ATTRIBUTE_TEMPORARY <https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858.aspx>`_.
+        `FILE_ATTRIBUTE_TEMPORARY <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea>`_.
 
 .. c:macro:: UV_FS_O_TRUNC
 

--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -23,7 +23,7 @@ the best backend for the job on each platform.
     creation/deletion within a directory that is being monitored.
     See the `IBM Knowledge centre`_ for more details.
 
-    .. _documentation: http://www.ibm.com/developerworks/aix/library/au-aix_event_infrastructure/
+    .. _documentation: https://developer.ibm.com/articles/au-aix_event_infrastructure/
     .. _`IBM Knowledge centre`: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.2.0/com.ibm.zos.v2r1.bpxb100/ioc.htm
 
 

--- a/docs/src/guide/about.rst
+++ b/docs/src/guide/about.rst
@@ -1,7 +1,7 @@
 About
 =====
 
-`Nikhil Marathe <http://nikhilism.com>`_ started writing this book one
+`Nikhil Marathe <https://nikhilism.com>`_ started writing this book one
 afternoon (June 16, 2012) when he didn't feel like programming. He had recently
 been stung by the lack of good documentation on libuv while working on
 `node-taglib <https://github.com/nikhilm/node-taglib>`_. Although reference
@@ -13,8 +13,8 @@ Nikhil is indebted to Marc Lehmann's comprehensive `man page
 <http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod>`_ about libev which
 describes much of the semantics of the two libraries.
 
-This book was made using `Sphinx <http://sphinx.pocoo.org/>`_ and `vim
-<http://www.vim.org>`_.
+This book was made using `Sphinx <https://www.sphinx-doc.org>`_ and `vim
+<https://www.vim.org>`_.
 
 .. note::
     In 2017 the libuv project incorporated the Nikhil's work into the official

--- a/docs/src/guide/introduction.rst
+++ b/docs/src/guide/introduction.rst
@@ -66,10 +66,10 @@ There is no need to ``make install``. To build the examples run ``make`` in the
 .. _Clone: https://github.com/nikhilm/uvbook
 .. _Download: https://github.com/nikhilm/uvbook/downloads
 .. _v1.3.0: https://github.com/libuv/libuv/tags
-.. _V8: http://code.google.com/p/v8/
+.. _V8: https://v8.dev
 .. _libev: http://software.schmorp.de/pkg/libev.html
 .. _libuv: https://github.com/libuv/libuv
-.. _node.js: http://www.nodejs.org
+.. _node.js: https://www.nodejs.org
 .. _libev was removed: https://github.com/joyent/libuv/issues/485
-.. _Rust: http://rust-lang.org
+.. _Rust: https://www.rust-lang.org
 .. _variety: https://github.com/libuv/libuv/wiki/Projects-that-use-libuv

--- a/docs/src/guide/networking.rst
+++ b/docs/src/guide/networking.rst
@@ -175,7 +175,7 @@ where ``membership`` is ``UV_JOIN_GROUP`` or ``UV_LEAVE_GROUP``.
 
 The concepts of multicasting are nicely explained in `this guide`_.
 
-.. _this guide: http://www.tldp.org/HOWTO/Multicast-HOWTO-2.html
+.. _this guide: https://www.tldp.org/HOWTO/Multicast-HOWTO-2.html
 
 Local loopback of multicast packets is enabled by default [#]_, use
 ``uv_udp_set_multicast_loop`` to switch it off.
@@ -234,17 +234,17 @@ useful to allow your service to bind to IP addresses when it starts.
 interface has multiple IPv4/IPv6 addresses, the name will be reported multiple
 times, with each address being reported once.
 
-.. _c-ares: http://c-ares.haxx.se
-.. _getaddrinfo: http://www.kernel.org/doc/man-pages/online/pages/man3/getaddrinfo.3.html
+.. _c-ares: https://c-ares.haxx.se
+.. _getaddrinfo: https://www.kernel.org/doc/man-pages/online/pages/man3/getaddrinfo.3.html
 
-.. _User Datagram Protocol: http://en.wikipedia.org/wiki/User_Datagram_Protocol
-.. _DHCP: http://tools.ietf.org/html/rfc2131
+.. _User Datagram Protocol: https://en.wikipedia.org/wiki/User_Datagram_Protocol
+.. _DHCP: https://tools.ietf.org/html/rfc2131
 
 ----
 
-.. [#] http://beej.us/guide/bgnet/output/html/multipage/advanced.html#broadcast
+.. [#] https://beej.us/guide/bgnet/html/#broadcast-packetshello-world
 .. [#] on Windows only supported on Windows Vista and later.
-.. [#] http://www.tldp.org/HOWTO/Multicast-HOWTO-6.html#ss6.1
+.. [#] https://www.tldp.org/HOWTO/Multicast-HOWTO-6.html#ss6.1
 .. [#] libuv use the system ``getaddrinfo`` in the libuv threadpool. libuv
     v0.8.0 and earlier also included c-ares_ as an alternative, but this has been
     removed in v0.9.0.

--- a/docs/src/guide/processes.rst
+++ b/docs/src/guide/processes.rst
@@ -42,11 +42,9 @@ exits. This is achieved using ``uv_spawn``.
 The ``uv_process_t`` struct only acts as the handle, all options are set via
 ``uv_process_options_t``. To simply launch a process, you need to set only the
 ``file`` and ``args`` fields. ``file`` is the program to execute. Since
-``uv_spawn`` uses execvp_ internally, there is no need to supply the full
+``uv_spawn`` uses :man:`execvp(3)` internally, there is no need to supply the full
 path. Finally as per underlying conventions, **the arguments array has to be
 one larger than the number of arguments, with the last element being NULL**.
-
-.. _execvp: http://man7.org/linux/man-pages/man3/exec.3.html
 
 After the call to ``uv_spawn``, ``uv_process_t.pid`` will contain the process
 ID of the child process.

--- a/docs/src/guide/processes.rst
+++ b/docs/src/guide/processes.rst
@@ -46,7 +46,7 @@ The ``uv_process_t`` struct only acts as the handle, all options are set via
 path. Finally as per underlying conventions, **the arguments array has to be
 one larger than the number of arguments, with the last element being NULL**.
 
-.. _execvp: http://www.kernel.org/doc/man-pages/online/pages/man3/exec.3.html
+.. _execvp: http://man7.org/linux/man-pages/man3/exec.3.html
 
 After the call to ``uv_spawn``, ``uv_process_t.pid`` will contain the process
 ID of the child process.
@@ -213,7 +213,7 @@ to ``UV_INHERIT_STREAM`` and setting ``data.stream`` to the stream in the
 parent process, the child process can treat that stream as standard I/O. This
 can be used to implement something like CGI_.
 
-.. _CGI: http://en.wikipedia.org/wiki/Common_Gateway_Interface
+.. _CGI: https://en.wikipedia.org/wiki/Common_Gateway_Interface
 
 A sample CGI script/executable is:
 
@@ -254,9 +254,9 @@ not related to anonymous pipes, rather it is an IPC mechanism. ``uv_pipe_t``
 can be backed by a `Unix Domain Socket`_ or `Windows Named Pipe`_ to allow
 multiple processes to communicate. This is discussed below.
 
-.. _pipe(7): http://www.kernel.org/doc/man-pages/online/pages/man7/pipe.7.html
-.. _Unix Domain Socket: http://www.kernel.org/doc/man-pages/online/pages/man7/unix.7.html
-.. _Windows Named Pipe: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365590(v=vs.85).aspx
+.. _pipe(7): http://man7.org/linux/man-pages/man7/pipe.7.html
+.. _Unix Domain Socket: http://man7.org/linux/man-pages/man7/unix.7.html
+.. _Windows Named Pipe: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
 
 Parent-child IPC
 ++++++++++++++++
@@ -276,7 +276,7 @@ notification. Various applications can then react when a contact comes online
 or new hardware is detected. The MySQL server also runs a domain socket on
 which clients can interact with it.
 
-.. _D-BUS: http://www.freedesktop.org/wiki/Software/dbus
+.. _D-BUS: https://www.freedesktop.org/wiki/Software/dbus
 
 When using domain sockets, a client-server pattern is usually followed with the
 creator/owner of the socket acting as the server. After the initial setup,

--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -12,7 +12,7 @@ asynchronously that is actually blocking, by spawning a thread and collecting
 the result when it is done.
 
 Today there are two predominant thread libraries: the Windows threads
-implementation and POSIX's `pthreads`_. libuv's thread API is analogous to
+implementation and POSIX's :man:`pthreads(7)`. libuv's thread API is analogous to
 the pthreads API and often has similar semantics.
 
 A notable aspect of libuv's thread facilities is that it is a self contained
@@ -68,7 +68,7 @@ Synchronization Primitives
 
 This section is purposely spartan. This book is not about threads, so I only
 catalogue any surprises in the libuv APIs here. For the rest you can look at
-the pthreads `man pages <pthreads>`_.
+the :man:`pthreads(7)` man pages.
 
 Mutexes
 ~~~~~~~
@@ -378,8 +378,6 @@ which binds a third party library. It may go something like this:
 
 4. The async callback, invoked in the main loop thread, which is the v8 thread,
    then interacts with v8 to invoke the JavaScript callback.
-
-.. _pthreads: http://man7.org/linux/man-pages/man7/pthreads.7.html
 
 ----
 

--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -141,9 +141,9 @@ Others
 libuv also supports semaphores_, `condition variables`_ and barriers_ with APIs
 very similar to their pthread counterparts.
 
-.. _semaphores: http://en.wikipedia.org/wiki/Semaphore_(programming)
-.. _condition variables: http://en.wikipedia.org/wiki/Condition_variable#Waiting_and_signaling
-.. _barriers: http://en.wikipedia.org/wiki/Barrier_(computer_science)
+.. _semaphores: https://en.wikipedia.org/wiki/Semaphore_(programming)
+.. _condition variables: https://en.wikipedia.org/wiki/Monitor_(synchronization)#Condition_variables_2
+.. _barriers: https://en.wikipedia.org/wiki/Barrier_(computer_science)
 
 In addition, libuv provides a convenience function ``uv_once()``. Multiple
 threads can attempt to call ``uv_once()`` with a given guard and a function
@@ -383,5 +383,5 @@ which binds a third party library. It may go something like this:
 
 ----
 
-.. _node.js is cancer: http://teddziuba.github.io/2011/10/node-js-is-cancer.html
+.. _node.js is cancer: http://widgetsandshit.com/teddziuba/2011/10/node-js-is-cancer.html
 .. _bnoordhuis: https://github.com/bnoordhuis

--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -196,7 +196,7 @@ to access the underlying file descriptors and provide functions that process
 tasks in small increments as decided by your application. Some libraries though
 will not allow such access, providing only a standard blocking function which
 will perform the entire I/O transaction and only then return. It is unwise to
-use these in the event loop thread, use the :ref:`libuv-work-queue` instead. Of
+use these in the event loop thread, use the :ref:`threadpool` instead. Of
 course, this will also mean losing granular control on the library.
 
 The ``uv_poll`` section of libuv simply watches file descriptors using the
@@ -210,8 +210,8 @@ download files. Rather than give all control to libcurl, we'll instead be
 using the libuv event loop, and use the non-blocking, async multi_ interface to
 progress with the download whenever libuv notifies of I/O readiness.
 
-.. _libcurl: http://curl.haxx.se/libcurl/
-.. _multi: http://curl.haxx.se/libcurl/c/libcurl-multi.html
+.. _libcurl: https://curl.haxx.se/libcurl/
+.. _multi: https://curl.haxx.se/libcurl/c/libcurl-multi.html
 
 .. rubric:: uvwget/main.c - The setup
 .. literalinclude:: ../../code/uvwget/main.c
@@ -352,7 +352,7 @@ to get the error message.
 argument. ``init_plugin_function`` is a function pointer to the sort of
 function we are looking for in the application's plugins.
 
-.. _shared libraries: http://en.wikipedia.org/wiki/Shared_library#Shared_libraries
+.. _shared libraries: https://en.wikipedia.org/wiki/Shared_library#Shared_libraries
 
 TTY
 ---
@@ -365,7 +365,7 @@ implement the ANSI escape codes across all platforms. By this I mean that libuv
 converts ANSI codes to the Windows equivalent, and provides functions to get
 terminal information.
 
-.. _pretty standardised: http://en.wikipedia.org/wiki/ANSI_escape_sequences
+.. _pretty standardised: https://en.wikipedia.org/wiki/ANSI_escape_sequences
 
 The first thing to do is to initialize a ``uv_tty_t`` with the file descriptor
 it reads/writes from. This is achieved with::
@@ -422,7 +422,7 @@ As you can see this is very useful to produce nicely formatted output, or even
 console based arcade games if that tickles your fancy. For fancier control you
 can try `ncurses`_.
 
-.. _ncurses: http://www.gnu.org/software/ncurses/ncurses.html
+.. _ncurses: https://www.gnu.org/software/ncurses/ncurses.html
 
 .. versionchanged:: 1.23.1: the `readable` parameter is now unused and ignored.
                     The appropriate value will now be auto-detected from the kernel.
@@ -431,7 +431,7 @@ can try `ncurses`_.
 
 .. [#] I was first introduced to the term baton in this context, in Konstantin
        Käfer's excellent slides on writing node.js bindings --
-       http://kkaefer.github.com/node-cpp-modules/#baton
+       https://kkaefer.com/node-cpp-modules/#baton
 .. [#] mfp is My Fancy Plugin
 
 .. _libev man page: http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#COMMON_OR_USEFUL_IDIOMS_OR_BOTH

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -13,9 +13,9 @@ was primarily developed for use by `Node.js`_, but it's also used by `Luvit`_,
     In case you find errors in this documentation you can help by sending
     `pull requests <https://github.com/libuv/libuv>`_!
 
-.. _Node.js: http://nodejs.org
-.. _Luvit: http://luvit.io
-.. _Julia: http://julialang.org
+.. _Node.js: https://nodejs.org
+.. _Luvit: https://luvit.io
+.. _Julia: https://julialang.org
 .. _pyuv: https://github.com/saghul/pyuv
 .. _others: https://github.com/libuv/libuv/wiki/Projects-that-use-libuv
 
@@ -52,7 +52,7 @@ Documentation
 Downloads
 ---------
 
-libuv can be downloaded from `here <http://dist.libuv.org/dist/>`_.
+libuv can be downloaded from `here <https://dist.libuv.org/dist/>`_.
 
 
 Installation

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -646,7 +646,7 @@ API
 
     Retrieves system information in `buffer`. The populated data includes the
     operating system name, release, version, and machine. On non-Windows
-    systems, `uv_os_uname()` is a thin wrapper around :man:`uname(3)`. Returns
+    systems, `uv_os_uname()` is a thin wrapper around :man:`uname(2)`. Returns
     zero on success, and a non-zero error value otherwise.
 
     .. versionadded:: 1.25.0

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -314,7 +314,7 @@ API
 
 .. c:function:: void uv_loadavg(double avg[3])
 
-    Gets the load average. See: `<http://en.wikipedia.org/wiki/Load_(computing)>`_
+    Gets the load average. See: `<https://en.wikipedia.org/wiki/Load_(computing)>`_
 
     .. note::
         Returns [0,0,0] on Windows (i.e., it's not implemented).

--- a/docs/src/sphinx-plugins/manpage.py
+++ b/docs/src/sphinx-plugins/manpage.py
@@ -18,7 +18,7 @@ from string import Template
 def make_link_node(rawtext, app, name, manpage_num, options):
     ref = app.config.man_url_regex
     if not ref:
-        ref = "https://linux.die.net/man/%s/%s" % (manpage_num, name)
+        ref = "http://man7.org/linux/man-pages/man%s/%s.%s.html" %(manpage_num, name, manpage_num)
     else:
         s = Template(ref)
         ref = s.substitute(num=manpage_num, topic=name)

--- a/docs/src/sphinx-plugins/manpage.py
+++ b/docs/src/sphinx-plugins/manpage.py
@@ -18,7 +18,7 @@ from string import Template
 def make_link_node(rawtext, app, name, manpage_num, options):
     ref = app.config.man_url_regex
     if not ref:
-        ref = "http://linux.die.net/man/%s/%s" % (manpage_num, name)
+        ref = "https://linux.die.net/man/%s/%s" % (manpage_num, name)
     else:
         s = Template(ref)
         ref = s.substitute(num=manpage_num, topic=name)

--- a/docs/src/version.rst
+++ b/docs/src/version.rst
@@ -10,7 +10,7 @@ a major release. In this section you'll find all macros and functions that
 will allow you to write or compile code conditionally, in order to work with
 multiple libuv versions.
 
-.. _semantic versioning: http://semver.org
+.. _semantic versioning: https://semver.org
 
 
 Macros


### PR DESCRIPTION
Running `make -C docs linkcheck` revealed a couple dead (or incorrect) links, plus many of moved resources. This changes everything to prefer https, plus fixes those links that were redirecting or dead.