### PR TITLE
docs: fix formatting

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -192,10 +192,10 @@ Data types
 
     ::
 
-    typedef struct uv_env_item_s {
-        char* name;
-        char* value;
-    } uv_env_item_t;
+        typedef struct uv_env_item_s {
+            char* name;
+            char* value;
+        } uv_env_item_t;
 
 .. c:type:: uv_random_t
 
@@ -687,7 +687,7 @@ API
     - Other UNIX: `/dev/urandom` after reading from `/dev/random` once.
 
     :returns: 0 on success, or an error code < 0 on failure. The contents of
-    `buf` is undefined after an error.
+        `buf` is undefined after an error.
 
     .. note::
         When using the synchronous version, both `loop` and `req` parameters


### PR DESCRIPTION
Typos introduced in https://github.com/libuv/libuv/pull/2404 and https://github.com/libuv/libuv/pull/2347. Fixes these warnings:
```
misc.rst:195: WARNING: Literal block expected; none found.
misc.rst:198: WARNING: Definition list ends without a blank line; unexpected unindent.
misc.rst:690: WARNING: Field list ends without a blank line; unexpected unindent.
```