### PR TITLE
test: fix fs birth time test failure

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3714,7 +3714,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
 }
 
 #ifdef _WIN32
-static void fs_file_pos_common() {
+static void fs_file_pos_common(void) {
   int r;
 
   iov = uv_buf_init("abc", 3);


### PR DESCRIPTION
The claim here was false. Relax the test to claim something that is hopefully true.

Fixes: https://github.com/libuv/libuv/issues/2235
CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1694/