### PR TITLE
tty,unix: avoid affecting controlling TTY

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -139,7 +139,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int unused) {
      * slave device.
      */
     if (uv__tty_is_slave(fd) && ttyname_r(fd, path, sizeof(path)) == 0)
-      r = uv__open_cloexec(path, mode);
+      r = uv__open_cloexec(path, mode | O_NOCTTY);
     else
       r = -1;
 


### PR DESCRIPTION
Since this re-open logic is supposed to be transparent to the parent
program, this flag helps ensure that there are no unintended
side-effects. This flag is already the default (and only possible
option) on FreeBSD. Normally, Linux will also act as if you passed
NOCTTY. However, it appears that mac OS sometimes strips the parent
process of its controlling terminal if you don't pass this flag.

See discussion in https://github.com/libuv/libuv/issues/973

Fixes: https://github.com/JuliaLang/julia/issues/16398