### PR TITLE
osx,fsevent: fix race during uv_loop_close

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -747,6 +747,8 @@ static void* uv__cf_loop_runner(void* arg) {
                          state->signal_source,
                          *pkCFRunLoopDefaultMode);
 
+  state->loop = NULL;
+
   return NULL;
 }
 

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -799,12 +799,13 @@ int uv__cf_loop_signal(uv_loop_t* loop,
 
   uv_mutex_lock(&loop->cf_mutex);
   QUEUE_INSERT_TAIL(&loop->cf_signals, &item->member);
-  uv_mutex_unlock(&loop->cf_mutex);
 
   state = loop->cf_state;
   assert(state != NULL);
   pCFRunLoopSourceSignal(state->signal_source);
   pCFRunLoopWakeUp(state->loop);
+
+  uv_mutex_unlock(&loop->cf_mutex);
 
   return 0;
 }


### PR DESCRIPTION
The mutex also needs to protect the access to the state->loop variable,
since that's owned by the child thread and will be destroyed as soon as
it processes our message.

This previously caused shutdown of libuv loops (especially the stress test fs_event_error_reporting) to segfault occasionally.

Fixes: https://github.com/libuv/libuv/issues/2625