### PR TITLE
ibmi: skip unsupported fs test cases

### DIFF
--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -199,8 +199,11 @@ TEST_IMPL(fs_copyfile) {
   touch_file(dst, 0);
   chmod(dst, S_IRUSR|S_IRGRP|S_IROTH); /* Sets file mode to 444 (read-only). */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
+  /* On IBMi PASE, qsecofr users can overwrite read-only files */
+# ifndef __PASE__
   ASSERT(req.result == UV_EACCES);
   ASSERT(r == UV_EACCES);
+# endif
   uv_fs_req_cleanup(&req);
 #endif
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -309,6 +309,12 @@ static void chown_root_cb(uv_fs_t* req) {
 #   if defined(__CYGWIN__)
     /* On Cygwin, uid 0 is invalid (no root). */
     ASSERT(req->result == UV_EINVAL);
+#   elif defined(__PASE__)
+    /* On IBMi PASE, there is no root user. uid 0 is user qsecofr.
+     * User may grant qsecofr's privileges, including changing 
+     * the file's ownership to uid 0.
+     */
+    ASSERT(req->result == 0);
 #   else
     ASSERT(req->result == UV_EPERM);
 #   endif
@@ -2214,7 +2220,12 @@ int test_symlink_dir_impl(int type) {
 #ifdef _WIN32
   ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen(test_dir + 4));
 #else
+# ifdef __PASE__
+  /* On IBMi PASE, st_size returns the length of the symlink itself. */
+  ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen("test_dir_symlink"));
+# else
   ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen(test_dir));
+# endif
 #endif
   uv_fs_req_cleanup(&req);
 


### PR DESCRIPTION
On IBMi PASE, we need to skip some file permission tests for `root`.
And the file stat of symbolic links are different as well.