### PR TITLE
ibmi: ensure that pipe backlog is not zero

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -95,8 +95,9 @@ int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
   if (uv__stream_fd(handle) == -1)
     return UV_EINVAL;
 
-#if defined(__MVS__)
+#if defined(__MVS__) || defined(__PASE__)
   /* On zOS, backlog=0 has undefined behaviour */
+  /* On IBMi PASE, backlog=0 leads to "Connection refused" error */
   if (backlog == 0)
     backlog = 1;
   else if (backlog < 0)


### PR DESCRIPTION
On IBMi PASE, listen(pipe_fd, backlog=0) leads to "Connection refused" error.

This patch fixes below 2 failed test cases on IBMi PASE --
```
not ok 170 - pipe_getsockname
# exit code 393350
# Output from process `pipe_getsockname`:
# Assertion failed in ../test/test-pipe-getsockname.c on line 149: r == 0

not ok 182 - pipe_server_close
# exit code 393350
# Output from process `pipe_server_close`:
# Assertion failed in ../test/test-pipe-server-close.c on line 46: status == 0
```