### PR TITLE
unix: handle uv__open_cloexec return value correctly

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -990,7 +990,7 @@ static uint64_t uv__read_proc_meminfo(const char* what) {
   rc = 0;
   fd = uv__open_cloexec("/proc/meminfo", O_RDONLY);
 
-  if (fd == -1)
+  if (fd < 0)
     return 0;
 
   n = read(fd, buf, sizeof(buf) - 1);

--- a/src/unix/random-devurandom.c
+++ b/src/unix/random-devurandom.c
@@ -37,8 +37,8 @@ int uv__random_readpath(const char* path, void* buf, size_t buflen) {
 
   fd = uv__open_cloexec(path, O_RDONLY);
 
-  if (fd == -1)
-    return UV__ERR(errno);
+  if (fd < 0)
+    return fd;
 
   if (fstat(fd, &s)) {
     uv__close(fd);


### PR DESCRIPTION
`uv__open_cloexec()` already returns a libuv error code in case
of failure, and not `-1` like syscalls do.

Fixes: https://github.com/nodejs/help/issues/2099