### PR TITLE
Reintroduce uv_export and uv_import functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ set(uv_test_sources
     test/test-tcp-connect-timeout.c
     test/test-tcp-connect6-error.c
     test/test-tcp-create-socket-early.c
+    test/test-tcp-exportimport.c
     test/test-tcp-flags.c
     test/test-tcp-oob.c
     test/test-tcp-open.c

--- a/include/uv.h
+++ b/include/uv.h
@@ -224,6 +224,7 @@ typedef struct uv_process_s uv_process_t;
 typedef struct uv_fs_event_s uv_fs_event_t;
 typedef struct uv_fs_poll_s uv_fs_poll_t;
 typedef struct uv_signal_s uv_signal_t;
+typedef struct uv_stream_info_s uv_stream_info_t;
 
 /* Request types. */
 typedef struct uv_req_s uv_req_t;
@@ -575,6 +576,28 @@ UV_EXTERN int uv_tcp_connect(uv_connect_t* req,
                              uv_tcp_t* handle,
                              const struct sockaddr* addr,
                              uv_connect_cb cb);
+
+/*
+ * uv_stream_info_t is used to store exported stream (using uv_export),
+ * which can be imported into a different event-loop within the same process
+ * (using uv_import).
+ */
+struct uv_stream_info_s {
+  uv_handle_type type;
+  UV_STREAM_INFO_PRIVATE_FIELDS
+};
+
+/*
+ * Exports uv_stream_t as uv_stream_info_t value, which could
+ * be used to initialize shared streams within the same process.
+ */
+UV_EXTERN int uv_export(uv_stream_t* stream, uv_stream_info_t* info);
+
+/*
+ * Imports uv_stream_info_t value into uv_stream_t to initialize
+ * shared stream.
+ */
+UV_EXTERN int uv_import(uv_stream_t* stream, uv_stream_info_t* info);
 
 /* uv_connect_t is a subclass of uv_req_t. */
 struct uv_connect_s {

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -394,6 +394,9 @@ typedef struct {
   uv_fs_event_cb cb;                                                          \
   UV_PLATFORM_FS_EVENT_FIELDS                                                 \
 
+#define UV_STREAM_INFO_PRIVATE_FIELDS                                         \
+  int fd;
+
 /* fs open() flags supported on this platform: */
 #if defined(O_APPEND)
 # define UV_FS_O_APPEND       O_APPEND

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -651,6 +651,11 @@ typedef struct {
   struct uv_req_s signal_req;                                                 \
   unsigned long pending_signum;
 
+#define UV_STREAM_INFO_PRIVATE_FIELDS                                         \
+  union {                                                                     \
+    WSAPROTOCOL_INFOW socket_info;                                            \
+  };
+
 #ifndef F_OK
 #define F_OK 0
 #endif

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -669,6 +669,27 @@ int uv__cloexec_fcntl(int fd, int set) {
 }
 
 
+/* This function is not execve-safe, there is a race window
+ * between the call to dup() and fcntl(FD_CLOEXEC).
+ */
+int uv__dup(int fd) {
+  int err;
+
+  fd = dup(fd);
+
+  if (fd == -1)
+    return UV__ERR(errno);
+
+  err = uv__cloexec(fd, 1);
+  if (err) {
+    uv__close(fd);
+    return err;
+  }
+
+  return fd;
+}
+
+
 ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
   struct cmsghdr* cmsg;
   ssize_t rc;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -194,6 +194,7 @@ int uv__close(int fd); /* preserves errno */
 int uv__close_nocheckstdio(int fd);
 int uv__close_nocancel(int fd);
 int uv__socket(int domain, int type, int protocol);
+int uv__dup(int fd);
 ssize_t uv__recvmsg(int fd, struct msghdr *msg, int flags);
 void uv__make_close_pending(uv_handle_t* handle);
 int uv__getiovmax(void);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1602,6 +1602,36 @@ int uv_read_stop(uv_stream_t* stream) {
   return 0;
 }
 
+int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
+  int fd;
+
+  if (stream->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+
+  fd = uv__dup(stream->io_watcher.fd);
+
+  if (fd < 0) {
+    return fd;
+  }
+
+  info->type = stream->type;
+  info->fd = fd;
+
+  return 0;
+}
+
+int uv_import(uv_stream_t* stream, uv_stream_info_t* info) {
+  if (info->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+
+  if (stream->io_watcher.fd != -1) {
+    return UV_EALREADY;
+  }
+
+  return uv_tcp_open((uv_tcp_t *)stream, info->fd);
+}
 
 int uv_is_readable(const uv_stream_t* stream) {
   return !!(stream->flags & UV_HANDLE_READABLE);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1605,15 +1605,13 @@ int uv_read_stop(uv_stream_t* stream) {
 int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
   int fd;
 
-  if (stream->type != UV_TCP) {
+  if (stream->type != UV_TCP)
     return UV_EINVAL;
-  }
 
   fd = uv__dup(stream->io_watcher.fd);
 
-  if (fd < 0) {
+  if (fd < 0)
     return fd;
-  }
 
   info->type = stream->type;
   info->fd = fd;
@@ -1622,15 +1620,13 @@ int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
 }
 
 int uv_import(uv_stream_t* stream, uv_stream_info_t* info) {
-  if (info->type != UV_TCP) {
+  if (info->type != UV_TCP)
     return UV_EINVAL;
-  }
 
-  if (stream->io_watcher.fd != -1) {
-    return UV_EALREADY;
-  }
+  if (stream->io_watcher.fd != -1)
+    return UV_EBUSY;
 
-  return uv_tcp_open((uv_tcp_t *)stream, info->fd);
+  return uv_tcp_open((uv_tcp_t*)stream, info->fd);
 }
 
 int uv_is_readable(const uv_stream_t* stream) {

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -246,18 +246,18 @@ int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
   uv__ipc_socket_xfer_info_t xfer_info;
   uv__ipc_socket_xfer_type_t xfer_type = UV__IPC_SOCKET_XFER_NONE;
 
-  if (stream->type != UV_TCP) {
+  if (stream->type != UV_TCP)
     return UV_EINVAL;
-  }
-  int r = uv__tcp_xfer_export((uv_tcp_t *) stream,
+
+  int r = uv__tcp_xfer_export((uv_tcp_t*) stream,
                               GetCurrentProcessId(),
                               &xfer_type, &xfer_info);
-  if (r != 0) {
-    return (r);
-  }
-  if (xfer_info.delayed_error != 0) {
+  if (r != 0)
+    return r;
+
+  if (xfer_info.delayed_error != 0)
     return xfer_info.delayed_error;
-  }
+
   info->type = UV_TCP;
   info->socket_info = xfer_info.socket_info;
   return 0;
@@ -266,13 +266,12 @@ int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
 int uv_import(uv_stream_t* stream, uv_stream_info_t* info) {
   uv__ipc_socket_xfer_info_t xfer_info;
 
-  if (stream->type != UV_TCP || info->type != UV_TCP) {
+  if (stream->type != UV_TCP || info->type != UV_TCP)
     return UV_EINVAL;
-  }
 
   xfer_info.socket_info = info->socket_info;
   xfer_info.delayed_error = 0;
-  return uv__tcp_xfer_import((uv_tcp_t *) stream,
+  return uv__tcp_xfer_import((uv_tcp_t*) stream,
                              UV__IPC_SOCKET_XFER_TCP_SERVER,
                              &xfer_info);
 }

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -241,3 +241,38 @@ int uv_stream_set_blocking(uv_stream_t* handle, int blocking) {
 
   return 0;
 }
+
+int uv_export(uv_stream_t* stream, uv_stream_info_t* info) {
+  uv__ipc_socket_xfer_info_t xfer_info;
+  uv__ipc_socket_xfer_type_t xfer_type = UV__IPC_SOCKET_XFER_NONE;
+
+  if (stream->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+  int r = uv__tcp_xfer_export((uv_tcp_t *) stream,
+                              GetCurrentProcessId(),
+                              &xfer_type, &xfer_info);
+  if (r != 0) {
+    return (r);
+  }
+  if (xfer_info.delayed_error != 0) {
+    return xfer_info.delayed_error;
+  }
+  info->type = UV_TCP;
+  info->socket_info = xfer_info.socket_info;
+  return 0;
+}
+
+int uv_import(uv_stream_t* stream, uv_stream_info_t* info) {
+  uv__ipc_socket_xfer_info_t xfer_info;
+
+  if (stream->type != UV_TCP || info->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+
+  xfer_info.socket_info = info->socket_info;
+  xfer_info.delayed_error = 0;
+  return uv__tcp_xfer_import((uv_tcp_t *) stream,
+                             UV__IPC_SOCKET_XFER_TCP_SERVER,
+                             &xfer_info);
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -124,6 +124,8 @@ TEST_DECLARE   (tcp_create_early_accept)
 TEST_DECLARE   (tcp_close_accept)
 TEST_DECLARE   (tcp_oob)
 #endif
+TEST_DECLARE   (tcp_exportimport_listen_after_write)
+TEST_DECLARE   (tcp_exportimport_listen_before_write)
 TEST_DECLARE   (tcp_flags)
 TEST_DECLARE   (tcp_write_to_half_open_connection)
 TEST_DECLARE   (tcp_unexpected_read)
@@ -646,6 +648,8 @@ TASK_LIST_START
   TEST_ENTRY  (tcp_close_accept)
   TEST_ENTRY  (tcp_oob)
 #endif
+  TEST_ENTRY  (tcp_exportimport_listen_after_write)
+  TEST_ENTRY  (tcp_exportimport_listen_before_write)
   TEST_ENTRY  (tcp_flags)
   TEST_ENTRY  (tcp_write_to_half_open_connection)
   TEST_ENTRY  (tcp_unexpected_read)

--- a/test/test-tcp-exportimport.c
+++ b/test/test-tcp-exportimport.c
@@ -131,7 +131,7 @@ void on_parent_msg(uv_async_t* handle) {
   parent.server.data = &parent;
 
   r = uv_import((uv_stream_t*)&parent.server,
-    (uv_stream_info_t*)&dup_stream);
+               (uv_stream_info_t*)&dup_stream);
   ASSERT(r == 0);
 
   r = uv_listen((uv_stream_t*)&parent.server, 12, on_connection);

--- a/test/test-tcp-exportimport.c
+++ b/test/test-tcp-exportimport.c
@@ -1,0 +1,240 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "runner.h"
+#include "task.h"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+  uv_loop_t* loop;
+  uv_thread_t thread;
+  uv_async_t* recv_channel;
+  uv_async_t* send_channel;
+  uv_tcp_t server;
+  uv_tcp_t conn;
+  int connection_accepted;
+  int close_cb_called;
+} worker_t;
+
+static uv_async_t send_channel;
+static uv_async_t recv_channel;
+static worker_t parent;
+static worker_t child;
+
+static volatile uv_stream_info_t dup_stream;
+
+typedef struct {
+  uv_connect_t conn_req;
+  uv_tcp_t conn;
+} tcp_conn;
+
+#define CONN_COUNT 100
+
+static void close_cb(uv_handle_t* handle) {
+  worker_t* worker = (worker_t*)handle->data;
+  ASSERT(worker);
+  worker->close_cb_called++;
+}
+
+
+static void on_connection(uv_stream_t* server, int status) {
+  int r;
+  worker_t* worker = container_of(server, worker_t, server);
+
+  if (!worker->connection_accepted) {
+    /*
+     * Accept the connection and close it.
+     */
+    ASSERT(status == 0);
+
+    r = uv_tcp_init(server->loop, &worker->conn);
+    ASSERT(r == 0);
+
+    worker->conn.data = worker;
+
+    r = uv_accept(server, (uv_stream_t*)&worker->conn);
+    ASSERT(r == 0);
+
+    worker->connection_accepted = 1;
+
+    uv_close((uv_handle_t*)worker->recv_channel, close_cb);
+    uv_close((uv_handle_t*)&worker->conn, close_cb);
+    uv_close((uv_handle_t*)server, close_cb);
+  }
+}
+
+
+static void close_client_conn_cb(uv_handle_t* handle) {
+  tcp_conn* p = (tcp_conn*)handle->data;
+  free(p);
+}
+
+
+static void connect_cb(uv_connect_t* req, int status) {
+  uv_close((uv_handle_t*)req->handle, close_client_conn_cb);
+}
+
+
+static void make_many_connections(void) {
+  tcp_conn* conn;
+  struct sockaddr_in addr;
+  int r, i;
+
+  for (i = 0; i < CONN_COUNT; i++) {
+    conn = malloc(sizeof(*conn));
+    ASSERT(conn);
+
+    r = uv_tcp_init(uv_default_loop(), &conn->conn);
+    ASSERT(r == 0);
+
+    r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+    ASSERT(r == 0);
+
+    r = uv_tcp_connect(&conn->conn_req, (uv_tcp_t*)&conn->conn, (struct sockaddr *) &addr, connect_cb);
+    ASSERT(r == 0);
+
+    conn->conn.data = conn;
+  }
+}
+
+
+void on_parent_msg(uv_async_t* handle) {
+  int r;
+
+  ASSERT(dup_stream.type == UV_TCP);
+
+  /* Import the shared TCP server, and start listening on it. */
+  r = uv_tcp_init(parent.loop, &parent.server);
+  ASSERT(r == 0);
+
+  parent.server.data = &parent;
+
+  r = uv_import((uv_stream_t*)&parent.server,
+    (uv_stream_info_t*)&dup_stream);
+  ASSERT(r == 0);
+
+  r = uv_listen((uv_stream_t*)&parent.server, 12, on_connection);
+  ASSERT(r == 0);
+
+  /* Create a bunch of connections to get both servers to accept. */
+  make_many_connections();
+}
+
+
+void on_child_msg(uv_async_t* handle) {
+  ASSERT(!"no");
+}
+
+
+static void child_thread_entry(void* arg) {
+  int r;
+  int listen_after_write = *(int*) arg;
+  struct sockaddr_in addr;
+
+  r = uv_tcp_init(child.loop, &child.server);
+  ASSERT(r == 0);
+
+  child.server.data = &child;
+  
+  r = uv_ip4_addr("0.0.0.0", TEST_PORT, &addr);
+  ASSERT(r == 0);
+
+  r = uv_tcp_bind(&child.server, (struct sockaddr*) &addr, 0);
+  ASSERT(r == 0);
+
+  if (!listen_after_write) {
+    r = uv_listen((uv_stream_t*)&child.server, 12, on_connection);
+    ASSERT(r == 0);
+  }
+
+  r = uv_export((uv_stream_t*)&child.server,
+    (uv_stream_info_t*)&dup_stream);
+  ASSERT(r == 0);
+
+  r = uv_async_send(child.send_channel);
+  ASSERT(r == 0);
+
+  if (listen_after_write) {
+    r = uv_listen((uv_stream_t*)&child.server, 12, on_connection);
+    ASSERT(r == 0);
+  }
+
+  r = uv_run(child.loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(child.connection_accepted == 1);
+  ASSERT(child.close_cb_called == 3);
+}
+
+
+static void run_tcp_exportimport_test(int listen_after_write) {
+  int r;
+
+  parent.send_channel = &send_channel;
+  parent.recv_channel = &recv_channel;
+  child.send_channel = &recv_channel;
+  child.recv_channel = &send_channel;
+
+  parent.loop = uv_default_loop();
+  child.loop = uv_loop_new();
+  ASSERT(child.loop);
+
+  r = uv_async_init(parent.loop, parent.recv_channel, on_parent_msg);
+  ASSERT(r == 0);
+  parent.recv_channel->data = &parent;
+
+  r = uv_async_init(child.loop, child.recv_channel, on_child_msg);
+  ASSERT(r == 0);
+  child.recv_channel->data = &child;
+
+  r = uv_thread_create(&child.thread, child_thread_entry, &listen_after_write);
+  ASSERT(r == 0);
+
+  r = uv_run(parent.loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(parent.connection_accepted == 1);
+  ASSERT(parent.close_cb_called == 3);
+
+  r = uv_thread_join(&child.thread);
+  ASSERT(r == 0);
+
+  /* Satisfy valgrind. Maybe we should delete the default loop from the
+   * test runner.
+   */
+  uv_loop_delete(child.loop);
+  uv_loop_delete(uv_default_loop());
+}
+
+
+TEST_IMPL(tcp_exportimport_listen_after_write) {
+  run_tcp_exportimport_test(1);
+  return 0;
+}
+
+
+TEST_IMPL(tcp_exportimport_listen_before_write) {
+  run_tcp_exportimport_test(0);
+  return 0;
+}


### PR DESCRIPTION
Creating a multithreaded TCP listener is currently a big PITA - it requires creating a pipe and passing the socket through it to child listener threads (as test/benchmark-multi-accept.c does), it's complicated and error-prone.

This PR reintroduced once removed uv_export and uv_import functions - with those a bound TCP socket can be passed e.g. using an async channel, simplifying the code significantly.

Both code and the test are based on the original removed code but ported to v1.x APIs.
