### PR TITLE
unix: remove spin wait in uv__async_io to fix performance downgrade on single-core system

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -326,6 +326,7 @@ typedef struct {
   uv_async_cb async_cb;                                                       \
   void* queue[2];                                                             \
   int pending;                                                                \
+  int busy;                                                                   \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
   uv_timer_cb timer_cb;                                                       \

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -326,7 +326,6 @@ typedef struct {
   uv_async_cb async_cb;                                                       \
   void* queue[2];                                                             \
   int pending;                                                                \
-  int busy;                                                                   \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
   uv_timer_cb timer_cb;                                                       \

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -62,12 +62,12 @@ int uv_async_send(uv_async_t* handle) {
   if (ACCESS_ONCE(int, handle->pending) != 0)
     return 0;
 
-  /* Set async pending  */
-  if (cmpxchgi(&handle->pending, 0, 1) != 0)
-    return 0;
-
   /* Tell the other thread we're busy with the handle. */
   if (cmpxchgi(&handle->busy, 0, 1) != 0)
+    return 0;
+
+  /* Set async pending  */
+  if (cmpxchgi(&handle->pending, 0, 1) != 0)
     return 0;
 
   /* Wake up the other thread's event loop. */

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -72,7 +72,7 @@ int uv_async_send(uv_async_t* handle) {
   if (cmpxchgi(&handle->u.fd, 0, 1) != 0)
     return 0;
 
-  /* Set async pending  */
+  /* Set async pending. */
   if (cmpxchgi(&handle->pending, 0, 1) != 0)
     return 0;
 
@@ -87,21 +87,15 @@ int uv_async_send(uv_async_t* handle) {
 }
 
 
-/* Only call this from the event loop thread. */
-static void uv__async_spin(uv_async_t* handle) {
+void uv__async_close(uv_async_t* handle) {
   for (;;) {
-    /* mark the handle to be closed if not busy */
+    /* Mark the handle to be closed if not busy. */
     if (cmpxchgi(&handle->u.fd, 0, 2) == 0)
-        break;
+      break;
 
     /* Other thread is busy with this handle, spin until it's done. */
     cpu_relax();
   }
-}
-
-
-void uv__async_close(uv_async_t* handle) {
-  uv__async_spin(handle);
   QUEUE_REMOVE(&handle->queue);
   uv__handle_stop(handle);
 }


### PR DESCRIPTION
This PR fixed uv_async performance issue on single-core system after version 1.28.0, detail issue is described in #2651 and can be reproduced by [test case](https://gist.github.com/frankfoxy/55df6297535b3712b97aa7cf5990a7b6) on ARM single-core and x64 single-core (Virtual machine) environment.

The spin-wait in uv__async_io (introduced in #2231) may downgrade the performance when other threads invoke uv_async_send too often, especially on the single-core system.

This PR eliminates the use of spin wait in uv__async_io, while keeping spin wait in uv__async_close