### PR TITLE
revert spin wait in uv__async_io?

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -61,43 +61,14 @@ int uv_async_send(uv_async_t* handle) {
   if (ACCESS_ONCE(int, handle->pending) != 0)
     return 0;
 
-  /* Tell the other thread we're busy with the handle. */
-  if (cmpxchgi(&handle->pending, 0, 1) != 0)
-    return 0;
-
-  /* Wake up the other thread's event loop. */
-  uv__async_send(handle->loop);
-
-  /* Tell the other thread we're done. */
-  if (cmpxchgi(&handle->pending, 1, 2) != 1)
-    abort();
+  if (cmpxchgi(&handle->pending, 0, 1) == 0)
+    uv__async_send(handle->loop);
 
   return 0;
 }
 
 
-/* Only call this from the event loop thread. */
-static int uv__async_spin(uv_async_t* handle) {
-  int rc;
-
-  for (;;) {
-    /* rc=0 -- handle is not pending.
-     * rc=1 -- handle is pending, other thread is still working with it.
-     * rc=2 -- handle is pending, other thread is done.
-     */
-    rc = cmpxchgi(&handle->pending, 2, 0);
-
-    if (rc != 1)
-      return rc;
-
-    /* Other thread is busy with this handle, spin until it's done. */
-    cpu_relax();
-  }
-}
-
-
 void uv__async_close(uv_async_t* handle) {
-  uv__async_spin(handle);
   QUEUE_REMOVE(&handle->queue);
   uv__handle_stop(handle);
 }
@@ -138,8 +109,8 @@ static void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     QUEUE_REMOVE(q);
     QUEUE_INSERT_TAIL(&loop->async_handles, q);
 
-    if (0 == uv__async_spin(h))
-      continue;  /* Not pending. */
+    if (cmpxchgi(&h->pending, 1, 0) == 0)
+      continue;
 
     if (h->async_cb == NULL)
       continue;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -78,7 +78,7 @@ int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset);
 #endif
 
 #define ACCESS_ONCE(type, var)                                                \
-  (*(volatile type*) &(var))
+  (*(type volatile*) &(var))
 
 #define ROUND_UP(a, b)                                                        \
   ((a) % (b) ? ((a) + (b)) - ((a) % (b)) : (a))

--- a/src/win/async.c
+++ b/src/win/async.c
@@ -64,7 +64,7 @@ void uv_async_close(uv_loop_t* loop, uv_async_t* handle) {
 
 
 int uv_async_send(uv_async_t* handle) {
-  uv_loop_t* loop = handle->loop;
+  uv_loop_t* loop = *(uv_loop_t* volatile*) &handle->loop;
 
   if (handle->type != UV_ASYNC) {
     /* Can't set errno because that's not thread-safe. */


### PR DESCRIPTION
I think this may be an alternate fix for #2226 that avoids impacting the code in any other way (avoiding #2651 / #2654). I think this can also address the underlying problem simply by ensuring we don't use the pointer again after setting the notification. (@frankfoxy)