### PR TITLE
unix: make uv_tcp_keepalive predictable

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -379,8 +379,16 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
     return UV__ERR(errno);
 
 #ifdef TCP_KEEPIDLE
-  if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &delay, sizeof(delay)))
-    return UV__ERR(errno);
+  if (on) {
+    int intvl = 1;  /*  1 second; same as default on Win32 */
+    int cnt = 10;  /* 10 retries; same as hardcoded on Win32 */
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &delay, sizeof(delay)))
+      return UV__ERR(errno);
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl)))
+      return UV__ERR(errno);
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt)))
+      return UV__ERR(errno);
+  }
 #endif
 
   /* Solaris/SmartOS, if you don't support keep-alive,


### PR DESCRIPTION
Current UNIX systems define various defaults for
TCP_KEEPINTVL and TCP_KEEPCNT, which makes the time
between TCP_KEEPIDLE delay is reached and timeout
effectively occurs unpredictable (Linux: /proc/sys
/net/ipv4/tcp_keepalive_intvl;tcp_keepalive_probes).

Do the following: set TCP_KEEPINTVL to 1 second (same
as Win32 default) and TCP_KEEPCNT to 10 times (same
as Win32 hardcoded value).