### PR TITLE
test: skip some UDP tests on IBMi

### DIFF
--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -98,6 +98,9 @@ static void sv_recv_cb(uv_udp_t* handle,
 
 
 TEST_IMPL(udp_connect) {
+#if defined(__PASE__)
+  RETURN_SKIP("IBMi PASE's UDP connection can not be disconnected with AF_UNSPEC.");
+#endif
   uv_udp_send_t req;
   struct sockaddr_in ext_addr;
   struct sockaddr_in tmp_addr;

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -26,8 +26,9 @@
 #include <errno.h>
 
 /* NOTE: Number should be big enough to trigger this problem */
-#if defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__CYGWIN__) || defined(__MSYS__) || defined(__PASE__)
 /* Cygwin crashes or hangs in socket() with too many AF_INET sockets.  */
+/* IBMi PASE timeout with too many AF_INET sockets.  */
 static uv_udp_t sockets[1250];
 #else
 static uv_udp_t sockets[2500];


### PR DESCRIPTION
- The watcher_cross_stop test timeout with too many AF_INET sockets on IBMi PASE. 
- In the udp_connect test, UDP connections can not be disconnected with `AF_UNSPEC` on IBMi PASE. So [this line](https://github.com/libuv/libuv/blob/v1.x/test/test-udp-connect.c#L150) fails.

Below test code shows the different behaviors --
```
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <arpa/inet.h>
#include <sys/select.h>
#include <errno.h>

int main()
{
    int sockClient, peerLen;
    struct sockaddr_in addrServer, addrLocal, addrPeer;
    socklen_t addrLen;
    char ipAddr[INET_ADDRSTRLEN];

    sockClient = socket(AF_INET, SOCK_DGRAM, 0);
    addrLen = sizeof(struct sockaddr_in);
    memset(&addrServer, 0, sizeof(addrServer));
    addrServer.sin_family = AF_INET;
    addrServer.sin_addr.s_addr = inet_addr("127.0.0.1");
    addrServer.sin_port = htons(9123);

    addrLocal.sin_family = AF_INET;
    addrLocal.sin_addr.s_addr = htonl(INADDR_ANY);
    addrLocal.sin_port = htons(9000);
    if (bind(sockClient, (struct sockaddr *)&addrLocal, sizeof(addrLocal)) == -1)
    {
        perror("error in binding");
        exit(1);
    }
    if (connect(sockClient, (struct sockaddr *)&addrServer, sizeof(addrServer)) == -1)
    {
        perror("error in connecting");
        exit(1);
    }
    if (getpeername(sockClient, (struct sockaddr *)&addrPeer, &peerLen) == -1)
    {
        perror("error in getpeername1");
        exit(1);
    }
    printf("connected peer address = %s:%d\n", inet_ntop(AF_INET, &addrPeer.sin_addr, ipAddr, sizeof(ipAddr)), ntohs(addrPeer.sin_port));

    int r = 0;
    memset(&addrServer, 0, sizeof(addrServer));
    addrServer.sin_family = AF_UNSPEC;
    do
    {
        errno = 0;
        r = connect(sockClient, (struct sockaddr *)&addrServer, sizeof(addrServer));
    } while (r == -1 && errno == EINTR);
    if (r == -1 && errno != EAFNOSUPPORT)
    {
        perror("error in disconnect");
        exit(1);
    }

    if (getpeername(sockClient, (struct sockaddr *)&addrPeer, &peerLen) == -1)
    {
        perror("error in getpeername2");
        exit(1);
    }
    printf("connected peer address = %s:%d\n", inet_ntop(AF_INET, &addrPeer.sin_addr, ipAddr, sizeof(ipAddr)), ntohs(addrPeer.sin_port));
}
```

On IBMi PASE
```
connected peer address = 124.221.140.13:4094
connected peer address = 0.0.0.0:0
```
On MacOS:
```
connected peer address = 0.0.0.0:0
error in getpeername2: Socket is not connected
```
On Ubuntu:
```
connected peer address = 0.0.0.0:0
error in getpeername2: Transport endpoint is not connected
```