### PR TITLE
test: skip some spawn test cases on IBMi

### DIFF
--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -210,7 +210,11 @@ static int maybe_run_test(int argc, char **argv) {
     notify_parent_process();
     ASSERT(sizeof(fd) == read(0, &fd, sizeof(fd)));
     ASSERT(fd > 2);
+# if defined(__PASE__)  /* On IBMi PASE, write() returns 1 */
+    ASSERT(1 == write(fd, "x", 1));
+# else
     ASSERT(-1 == write(fd, "x", 1));
+# endif  /* !__PASE__ */
 
     return 1;
   }


### PR DESCRIPTION
On IBMi PASE, there is no root user or nobody user.
User may grant root-like privileges, including setting uid/gid to 0.