### PR TITLE
aix: protect uv_exepath() from uv_set_process_title()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
     src/unix/aix-common.c
     src/unix/ibmi.c
     src/unix/no-fsevents.c
-    src/unix/no-proctitle.c
     src/unix/posix-poll.c)
 endif()
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -380,8 +380,7 @@ uvinclude_HEADERS += include/uv/posix.h
 libuv_la_SOURCES += src/unix/aix-common.c \
                     src/unix/ibmi.c \
                     src/unix/posix-poll.c \
-                    src/unix/no-fsevents.c \
-                    src/unix/no-proctitle.c
+                    src/unix/no-fsevents.c
 endif
 
 if ANDROID

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -261,9 +261,9 @@ API
 
 .. c:function:: char** uv_setup_args(int argc, char** argv)
 
-    Store the program arguments. Required for getting / setting the process title.
-    Libuv may take ownership of the memory that `argv` points to. This function
-    should be called exactly once, at program start-up.
+    Store the program arguments. Required for getting / setting the process title
+    or the executable path. Libuv may take ownership of the memory that `argv` 
+    points to. This function should be called exactly once, at program start-up.
 
     Example:
 
@@ -440,7 +440,8 @@ API
 
 .. c:function:: int uv_exepath(char* buffer, size_t* size)
 
-    Gets the executable path.
+    Gets the executable path. You *must* call `uv_setup_args` before calling
+    this function.
 
 .. c:function:: int uv_cwd(char* buffer, size_t* size)
 

--- a/src/unix/aix-common.c
+++ b/src/unix/aix-common.c
@@ -22,42 +22,23 @@
 #include "uv.h"
 #include "internal.h"
 
-#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
 
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <net/if.h>
-#include <netinet/in.h>
-#include <netinet/in6_var.h>
-#include <arpa/inet.h>
 
 #include <sys/time.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <utmp.h>
-#include <libgen.h>
 
-#include <sys/protosw.h>
 #include <procinfo.h>
-#include <sys/proc.h>
-#include <sys/procfs.h>
 
-#include <sys/poll.h>
-
-#include <sys/pollset.h>
 #include <ctype.h>
 
-#include <sys/mntctl.h>
-#include <sys/vmount.h>
-#include <limits.h>
-#include <strings.h>
-#include <sys/vnode.h>
+extern char* original_exepath;
+extern uv_mutex_t process_title_mutex;
+extern uv_once_t process_title_mutex_once;
+extern void init_process_title_mutex_once(void);
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
   uint64_t G = 1000000000;
@@ -78,80 +59,31 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
  */
 int uv_exepath(char* buffer, size_t* size) {
   int res;
-  char args[PATH_MAX];
-  char abspath[PATH_MAX];
-  size_t abspath_size;
+  char args[UV__PATH_MAX];
+  size_t cached_len;
   struct procsinfo pi;
 
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
+  uv_once(&process_title_mutex_once, init_process_title_mutex_once);
+  uv_mutex_lock(&process_title_mutex);
+  if (original_exepath != NULL) {
+    cached_len = strlen(original_exepath);
+    *size -= 1;
+    if (*size > cached_len)
+      *size = cached_len;
+    memcpy(buffer, original_exepath, *size);
+    buffer[*size] = '\0';
+    uv_mutex_unlock(&process_title_mutex);
+    return 0;
+  }
+  uv_mutex_unlock(&process_title_mutex);
   pi.pi_pid = getpid();
   res = getargs(&pi, sizeof(pi), args, sizeof(args));
+
   if (res < 0)
     return UV_EINVAL;
 
-  /*
-   * Possibilities for args:
-   * i) an absolute path such as: /home/user/myprojects/nodejs/node
-   * ii) a relative path such as: ./node or ../myprojects/nodejs/node
-   * iii) a bare filename such as "node", after exporting PATH variable
-   *     to its location.
-   */
-
-  /* Case i) and ii) absolute or relative paths */
-  if (strchr(args, '/') != NULL) {
-    if (realpath(args, abspath) != abspath)
-      return UV__ERR(errno);
-
-    abspath_size = strlen(abspath);
-
-    *size -= 1;
-    if (*size > abspath_size)
-      *size = abspath_size;
-
-    memcpy(buffer, abspath, *size);
-    buffer[*size] = '\0';
-
-    return 0;
-  } else {
-    /* Case iii). Search PATH environment variable */
-    char trypath[PATH_MAX];
-    char *clonedpath = NULL;
-    char *token = NULL;
-    char *path = getenv("PATH");
-
-    if (path == NULL)
-      return UV_EINVAL;
-
-    clonedpath = uv__strdup(path);
-    if (clonedpath == NULL)
-      return UV_ENOMEM;
-
-    token = strtok(clonedpath, ":");
-    while (token != NULL) {
-      snprintf(trypath, sizeof(trypath) - 1, "%s/%s", token, args);
-      if (realpath(trypath, abspath) == abspath) {
-        /* Check the match is executable */
-        if (access(abspath, X_OK) == 0) {
-          abspath_size = strlen(abspath);
-
-          *size -= 1;
-          if (*size > abspath_size)
-            *size = abspath_size;
-
-          memcpy(buffer, abspath, *size);
-          buffer[*size] = '\0';
-
-          uv__free(clonedpath);
-          return 0;
-        }
-      }
-      token = strtok(NULL, ":");
-    }
-    uv__free(clonedpath);
-
-    /* Out of tokens (path entries), and no match found */
-    return UV_EINVAL;
-  }
+  return uv__search_path(args, buffer, size);
 }

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -268,6 +268,7 @@ void uv__udp_finish_close(uv_udp_t* handle);
 uv_handle_type uv__handle_type(int fd);
 FILE* uv__open_file(const char* path);
 int uv__getpwuid_r(uv_passwd_t* pwd);
+int uv__search_path(const char* prog, char* buf, size_t* buflen);
 
 /* random */
 int uv__random_devurandom(void* buf, size_t buflen);

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -254,8 +254,6 @@ static int getexe(const int pid, char* buf, size_t len) {
 int uv_exepath(char* buffer, size_t* size) {
   int res;
   char args[PATH_MAX];
-  char abspath[PATH_MAX];
-  size_t abspath_size;
   int pid;
 
   if (buffer == NULL || size == NULL || *size == 0)
@@ -266,69 +264,7 @@ int uv_exepath(char* buffer, size_t* size) {
   if (res < 0)
     return UV_EINVAL;
 
-  /*
-   * Possibilities for args:
-   * i) an absolute path such as: /home/user/myprojects/nodejs/node
-   * ii) a relative path such as: ./node or ../myprojects/nodejs/node
-   * iii) a bare filename such as "node", after exporting PATH variable
-   *     to its location.
-   */
-
-  /* Case i) and ii) absolute or relative paths */
-  if (strchr(args, '/') != NULL) {
-    if (realpath(args, abspath) != abspath)
-      return UV__ERR(errno);
-
-    abspath_size = strlen(abspath);
-
-    *size -= 1;
-    if (*size > abspath_size)
-      *size = abspath_size;
-
-    memcpy(buffer, abspath, *size);
-    buffer[*size] = '\0';
-
-    return 0;
-  } else {
-    /* Case iii). Search PATH environment variable */
-    char trypath[PATH_MAX];
-    char* clonedpath = NULL;
-    char* token = NULL;
-    char* path = getenv("PATH");
-
-    if (path == NULL)
-      return UV_EINVAL;
-
-    clonedpath = uv__strdup(path);
-    if (clonedpath == NULL)
-      return UV_ENOMEM;
-
-    token = strtok(clonedpath, ":");
-    while (token != NULL) {
-      snprintf(trypath, sizeof(trypath) - 1, "%s/%s", token, args);
-      if (realpath(trypath, abspath) == abspath) {
-        /* Check the match is executable */
-        if (access(abspath, X_OK) == 0) {
-          abspath_size = strlen(abspath);
-
-          *size -= 1;
-          if (*size > abspath_size)
-            *size = abspath_size;
-
-          memcpy(buffer, abspath, *size);
-          buffer[*size] = '\0';
-
-          uv__free(clonedpath);
-          return 0;
-        }
-      }
-      token = strtok(NULL, ":");
-    }
-    uv__free(clonedpath);
-
-    /* Out of tokens (path entries), and no match found */
-    return UV_EINVAL;
-  }
+  return uv__search_path(args, buffer, size);
 }
 
 

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -88,5 +88,19 @@ TEST_IMPL(get_currentexe) {
   ASSERT(buffer[0] != '\0');
   ASSERT(buffer[1] == '\0');
 
+  /* Verify uv_exepath is not affected by uv_set_process_title(). */
+  r = uv_set_process_title("foobar");
+  ASSERT_EQ(r, 0);
+  size = sizeof(buffer);
+  r = uv_exepath(buffer, &size);
+  ASSERT_EQ(r, 0);
+
+  match = strstr(buffer, path);
+  /* Verify that the path returned from uv_exepath is a subdirectory of
+   * executable_path.
+   */
+  ASSERT_NOT_NULL(match);
+  ASSERT_STR_EQ(match, path);
+  ASSERT_EQ(size, strlen(buffer));
   return 0;
 }


### PR DESCRIPTION
Store a copy of the original argv[0] to protect `uv_exepath()`
against `uv_set_process_title()` changing the value of argv[0].

Since `uv_exepath()` is in `src/unix/aix-common.c`.
cc @dmabupt re. IBMi

Changes assume it is possible for `uv_setup_args()` not to 
be called prior to `uv_exepath()` being called (current 
[documentation for `uv_setup_args()`](http://docs.libuv.org/en/v1.x/misc.html#c.uv_setup_args) says that it is
"Required for getting / setting the process title.") in 
which case the existing code is used. Our test runner always
calls `uv_setup_args()` prior to running any tests.

Fixes: https://github.com/libuv/libuv/issues/2674
CI: https://ci.nodejs.org/job/libuv-test-commit/1985/