### PR TITLE
test: add UV_TIMEOUT_MULTIPLIER environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Some tests are timing sensitive. Relaxing test timeouts may be necessary
 on slow or overloaded machines:
 
 ```bash
-$ env UV_TIMEOUT_MULTIPLIER=2 ./out/Debug/run-tests  # 10s instead of 5s
+$ env UV_TEST_TIMEOUT_MULTIPLIER=2 ./out/Debug/run-tests  # 10s instead of 5s
 ```
 
 #### Run one test

--- a/README.md
+++ b/README.md
@@ -347,6 +347,13 @@ $ make -C out
 $ ./out/Debug/run-tests
 ```
 
+Some tests are timing sensitive. Relaxing test timeouts may be necessary
+on slow or overloaded machines:
+
+```bash
+$ env UV_TIMEOUT_MULTIPLIER=2 ./out/Debug/run-tests  # 10s instead of 5s
+```
+
 #### Run one test
 
 The list of all tests is in `test/test-list.h`.

--- a/test/runner.c
+++ b/test/runner.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "runner.h"
@@ -167,6 +168,7 @@ int run_test(const char* test,
   process_info_t processes[1024];
   process_info_t *main_proc;
   task_entry_t* task;
+  int timeout_multiplier;
   int process_count;
   int result;
   int status;
@@ -249,7 +251,22 @@ int run_test(const char* test,
     goto out;
   }
 
-  result = process_wait(main_proc, 1, task->timeout);
+  timeout_multiplier = 1;
+#ifndef _WIN32
+  do {
+    const char* var;
+
+    var = getenv("UV_TIMEOUT_MULTIPLIER");
+    if (var == NULL)
+      break;
+
+    timeout_multiplier = atoi(var);
+    if (timeout_multiplier <= 0)
+      timeout_multiplier = 1;
+  } while (0);
+#endif
+
+  result = process_wait(main_proc, 1, task->timeout * timeout_multiplier);
   if (result == -1) {
     FATAL("process_wait failed");
   } else if (result == -2) {

--- a/test/runner.c
+++ b/test/runner.c
@@ -256,7 +256,7 @@ int run_test(const char* test,
   do {
     const char* var;
 
-    var = getenv("UV_TIMEOUT_MULTIPLIER");
+    var = getenv("UV_TEST_TIMEOUT_MULTIPLIER");
     if (var == NULL)
       break;
 


### PR DESCRIPTION
Add an environment variable that lets people running the test suite
specify a timeout multiplier. Useful when running the tests on slow
machines.

Fixes: https://github.com/libuv/libuv/issues/2678
CI: https://ci.nodejs.org/job/libuv-test-commit/1754/