### PR TITLE
doc: update gyp link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $ ./out/cmake/uv_run_tests_a  # static library build
 To build with GYP, first run:
 
 ```bash
-$ git clone https://chromium.googlesource.com/external/gyp build/gyp
+$ git clone https://github.com/libuv/gyp build/gyp
 ```
 
 ### Windows

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -128,8 +128,8 @@ if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
 if exist build\gyp goto have_gyp
-echo git clone https://chromium.googlesource.com/external/gyp build/gyp
-git clone https://chromium.googlesource.com/external/gyp build/gyp
+echo git clone https://github.com/libuv/gyp build/gyp
+git clone https://github.com/libuv/gyp build/gyp
 if errorlevel 1 goto gyp_install_failed
 goto have_gyp
 


### PR DESCRIPTION
The original upstream hasn't been maintained for some time now.

I've copied https://github.com/nodejs/node/tree/master/tools/gyp to
https://github.com/libuv/gyp after stripping it down a bit. Let's
point users to that. I'll work on getting it tested on the CI, too.

Refs: https://github.com/libuv/help/issues/126
Refs: https://github.com/nodejs/build/issues/2172
CI: https://ci.nodejs.org/job/libuv-test-commit/1755/