### PR TITLE
fix: non-portable path issues

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -44,9 +44,9 @@ typedef struct pollfd {
 # define LOCALE_INVARIANT 0x007f
 #endif
 
-#include <mswsock.h>
-#include <ws2tcpip.h>
-#include <windows.h>
+#include <MSWSock.h>
+#include <WS2tcpip.h>
+#include <Windows.h>
 
 #include <process.h>
 #include <signal.h>

--- a/src/win/winsock.h
+++ b/src/win/winsock.h
@@ -22,11 +22,11 @@
 #ifndef UV_WIN_WINSOCK_H_
 #define UV_WIN_WINSOCK_H_
 
-#include <winsock2.h>
+#include <WinSock2.h>
 #include <iptypes.h>
-#include <mswsock.h>
-#include <ws2tcpip.h>
-#include <windows.h>
+#include <MSWSock.h>
+#include <WS2tcpip.h>
+#include <Windows.h>
 
 #include "winapi.h"
 


### PR DESCRIPTION
This PR fixes an issue surfaced in Electron whereby we experienced compilation errors owing to non-portable path names for Windows-specific files:

```
../../third_party/electron_node/deps/uv/include/uv/win.h(49,10): error: non-portable path to file '<Windows.h>'; specified path differs in case from file name on disk [-Werror,-Wnonportable-system-include-path]
#include <windows.h>
         ^~~~~~~~~~~
         <Windows.h>
```

Our other option is, of course, to just disable `-Wnonportable-system-include-path`, but I don't believe that upstreaming this would have negative effects for any other downstream consumers so i thought i'd start here.

cc @bnoordhuis 