### PR TITLE
fix: Do not stop the poll watcher twice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c
        test/test-poll-closesocket.c
+       test/test-poll-multiple-handles.c
        test/test-poll-oob.c
        test/test-poll.c
        test/test-process-priority.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -225,6 +225,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-poll-close.c \
                          test/test-poll-close-doesnt-corrupt-stack.c \
                          test/test-poll-closesocket.c \
+                         test/test-poll-multiple-handles.c \
                          test/test-poll-oob.c \
                          test/test-process-priority.c \
                          test/test-process-title.c \

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -925,13 +925,12 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   if (w->pevents == 0) {
     QUEUE_REMOVE(&w->watcher_queue);
     QUEUE_INIT(&w->watcher_queue);
+    w->events = 0;
 
-    if (loop->watchers[w->fd] != NULL) {
-      assert(loop->watchers[w->fd] == w);
+    if (w == loop->watchers[w->fd]) {
       assert(loop->nfds > 0);
       loop->watchers[w->fd] = NULL;
       loop->nfds--;
-      w->events = 0;
     }
   }
   else if (QUEUE_EMPTY(&w->watcher_queue))

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -116,11 +116,20 @@ int uv_poll_stop(uv_poll_t* handle) {
 
 
 int uv_poll_start(uv_poll_t* handle, int pevents, uv_poll_cb poll_cb) {
+  uv__io_t** watchers;
+  uv__io_t* w;
   int events;
 
   assert((pevents & ~(UV_READABLE | UV_WRITABLE | UV_DISCONNECT |
                       UV_PRIORITIZED)) == 0);
   assert(!uv__is_closing(handle));
+
+  watchers = handle->loop->watchers;
+  w = &handle->io_watcher;
+
+  if (uv__fd_exists(handle->loop, w->fd))
+    if (watchers[w->fd] != w)
+      return UV_EEXIST;
 
   uv__poll_stop(handle);
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -453,6 +453,7 @@ TEST_DECLARE   (poll_nested_epoll)
 #ifdef UV_HAVE_KQUEUE
 TEST_DECLARE   (poll_nested_kqueue)
 #endif
+TEST_DECLARE   (poll_multiple_handles)
 
 TEST_DECLARE   (ip4_addr)
 TEST_DECLARE   (ip6_addr_link_local)
@@ -903,6 +904,7 @@ TASK_LIST_START
 #ifdef UV_HAVE_KQUEUE
   TEST_ENTRY  (poll_nested_kqueue)
 #endif
+  TEST_ENTRY  (poll_multiple_handles)
 
   TEST_ENTRY  (socket_buffer_size)
 

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -1,0 +1,99 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <errno.h>
+
+#ifndef _WIN32
+# include <fcntl.h>
+# include <sys/socket.h>
+# include <unistd.h>
+#endif
+
+#include "uv.h"
+#include "task.h"
+
+
+static int close_cb_called = 0;
+
+
+static void close_cb(uv_handle_t* handle) {
+  close_cb_called++;
+}
+
+static void poll_cb(uv_poll_t* handle, int status, int events) {
+  /* Not a bound socket, linux immediately reports UV_READABLE, other OS do not */
+  ASSERT(events == UV_READABLE);
+}
+
+TEST_IMPL(poll_multiple_handles) {
+  uv_os_sock_t sock;
+  uv_poll_t first_poll_handle, second_poll_handle;
+
+#ifdef _WIN32
+  {
+    struct WSAData wsa_data;
+    int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    ASSERT(r == 0);
+  }
+#endif
+
+  sock = socket(AF_INET, SOCK_STREAM, 0);
+#ifdef _WIN32
+  ASSERT(sock != INVALID_SOCKET);
+#else
+  ASSERT(sock != -1);
+#endif
+  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &first_poll_handle, sock));
+  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &second_poll_handle, sock));
+
+  ASSERT(0 == uv_poll_start(&first_poll_handle, UV_READABLE, poll_cb));
+
+  /* We may not start polling while another polling handle is active
+   * on that fd.
+   */
+#ifndef _WIN32
+  /* We do not track handles in an O(1) lookupable way on Windows,
+   * so not checking that here.
+   */
+  ASSERT(uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb) == UV_EEXIST);
+#endif
+
+  /* After stopping the other polling handle, we now should be able to poll */
+  ASSERT(0 == uv_poll_stop(&first_poll_handle));
+  ASSERT(0 == uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb));
+
+  /* Closing an already stopped polling handle is safe in any case */
+  uv_close((uv_handle_t*) &first_poll_handle, close_cb);
+
+  uv_unref(&second_poll_handle);
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT(close_cb_called == 1);
+  uv_ref(&second_poll_handle);
+
+  ASSERT(uv_is_active((uv_handle_t*) &second_poll_handle));
+  uv_close((uv_handle_t*) &second_poll_handle, close_cb);
+
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT(close_cb_called == 2);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}


### PR DESCRIPTION
Consider the following scenario:

```
uv_poll_init(loop, poll, fd);
uv_poll_start(poll, UV_READABLE, cb);
// the cb gets invoked etc.
uv_poll_stop(poll);

// some time later:
uv_poll_init(loop, otherpoll, fd);
uv_poll_start(otherpoll, UV_READABLE, cb);

uv_close(poll); // uv__io_stop: Assertion `loop->watchers[w->fd] == w' failed.
```

Reasons to change this:
- This was hard to track down. (In particular for users using the bindings for other languages, they don't know to debug the C state properly.)
- This turned out to be a very dangerous issue due to the poll handle being closed as part of a delayed garbage collection. The point in time was very much non-deterministic and it would or would maybe not happen for a long time, depending on whether there was another poll handle alive at the time or not at this fd number.
- Closing an already stopped handle should not be a failure case in general.

Fixes downstream issue discovered with the PHP bindings for libuv: https://github.com/bwoebi/php-uv/issues/81