### PR TITLE
Add API for measuring event loop idle time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-loop-handles.c
        test/test-loop-stop.c
        test/test-loop-time.c
+       test/test-metrics.c
        test/test-multiple-listen.c
        test/test-mutexes.c
        test/test-not-readable-nor-writable-on-read-error.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -203,6 +203,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-loop-stop.c \
                          test/test-loop-time.c \
                          test/test-loop-configure.c \
+                         test/test-metrics.c \
                          test/test-multiple-listen.c \
                          test/test-mutexes.c \
                          test/test-not-readable-nor-writable-on-read-error.c \

--- a/docs/src/api.rst
+++ b/docs/src/api.rst
@@ -32,4 +32,5 @@ API documentation
    dll
    threading
    misc
+   metrics
 

--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -68,6 +68,11 @@ API
       to suppress unnecessary wakeups when using a sampling profiler.
       Requesting other signals will fail with UV_EINVAL.
 
+    - UV_METRICS_IDLE_TIME: Accumulate the amount of idle time the event loop
+      spends in the event provider.
+
+      This option is necessary to use :c:func:`uv_metrics_idle_time`.
+
 .. c:function:: int uv_loop_close(uv_loop_t* loop)
 
     Releases all internal loop resources. Call this function only when the loop

--- a/docs/src/metrics.rst
+++ b/docs/src/metrics.rst
@@ -1,0 +1,25 @@
+
+.. _metrics:
+
+Metrics operations
+======================
+
+libuv provides a metrics API to track the amount of time the event loop has
+spent idle in the kernel's event provider.
+
+API
+---
+
+.. c:function:: uint64_t uv_metrics_idle_time(uv_loop_t* loop)
+
+    Retrieve the amount of time the event loop has been idle in the kernel's
+    event provider (e.g. ``epoll_wait``). The call is thread safe.
+
+    The return value is the accumulated time spent idle in the kernel's event
+    provider starting from when the :c:type:`uv_loop_t` was configured to
+    collect the idle time.
+
+    .. note::
+        The event loop will not begin accumulating the event provider's idle
+        time until calling :c:type:`uv_loop_configure` with
+        :c:type:`UV_METRICS_IDLE_TIME`.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1775,9 +1775,11 @@ struct uv_loop_s {
   unsigned int active_handles;
   void* handle_queue[2];
   union {
-    void* unused[2];
+    void* unused;
     unsigned int count;
   } active_reqs;
+  /* Internal storage for future extensions. */
+  void* internal_fields;
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
   UV_LOOP_PRIVATE_FIELDS

--- a/include/uv.h
+++ b/include/uv.h
@@ -247,7 +247,8 @@ typedef struct uv_utsname_s uv_utsname_t;
 typedef struct uv_statfs_s uv_statfs_t;
 
 typedef enum {
-  UV_LOOP_BLOCK_SIGNAL
+  UV_LOOP_BLOCK_SIGNAL = 0,
+  UV_METRICS_IDLE_TIME
 } uv_loop_option;
 
 typedef enum {
@@ -1244,6 +1245,7 @@ UV_EXTERN int uv_os_gethostname(char* buffer, size_t* size);
 
 UV_EXTERN int uv_os_uname(uv_utsname_t* buffer);
 
+UV_EXTERN uint64_t uv_metrics_idle_time(uv_loop_t* loop);
 
 typedef enum {
   UV_FS_UNKNOWN = -1,

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -145,6 +145,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int i;
   int rc;
   int add_failed;
+  int user_timeout;
+  int reset_timeout;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -214,7 +216,21 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   base = loop->time;
   count = 48; /* Benchmarks suggest this gives the best throughput. */
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   for (;;) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     nfds = pollset_poll(loop->backend_fd,
                         events,
                         ARRAY_SIZE(events),
@@ -227,6 +243,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     SAVE_ERRNO(uv__update_time(loop));
 
     if (nfds == 0) {
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+        if (timeout == -1)
+          continue;
+        if (timeout > 0)
+          goto update_timeout;
+      }
+
       assert(timeout != -1);
       return;
     }
@@ -234,6 +259,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (nfds == -1) {
       if (errno != EINTR) {
         abort();
+      }
+
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
       }
 
       if (timeout == -1)
@@ -280,16 +310,25 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       /* Run signal watchers last.  This also affects child process watchers
        * because those are implemented in terms of signal watchers.
        */
-      if (w == &loop->signal_io_watcher)
+      if (w == &loop->signal_io_watcher) {
         have_signals = 1;
-      else
+      } else {
+        uv__metrics_update_idle_time(loop);
         w->cb(loop, w, pe->revents);
+      }
 
       nevents++;
     }
 
-    if (have_signals != 0)
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
+
+    if (have_signals != 0) {
+      uv__metrics_update_idle_time(loop);
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+    }
 
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -383,6 +383,14 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
       timeout = uv_backend_timeout(loop);
 
     uv__io_poll(loop, timeout);
+
+    /* Run one final update on the provider_idle_time in case uv__io_poll
+     * returned because the timeout expired, but no events were received. This
+     * call will be ignored if the provider_entry_time was either never set (if
+     * the timeout == 0) or was already updated b/c an event was received.
+     */
+    uv__metrics_update_idle_time(loop);
+
     uv__run_check(loop);
     uv__run_closing_handles(loop);
 

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -218,6 +218,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int fd;
   int op;
   int i;
+  int user_timeout;
+  int reset_timeout;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -273,6 +275,14 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   count = 48; /* Benchmarks suggest this gives the best throughput. */
   real_timeout = timeout;
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   /* You could argue there is a dependency between these two but
    * ultimately we don't care about their ordering with respect
    * to one another. Worst case, we make a few system calls that
@@ -283,6 +293,12 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   no_epoll_wait = uv__load_relaxed(&no_epoll_wait_cached);
 
   for (;;) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     /* See the comment for max_safe_timeout for an explanation of why
      * this is necessary.  Executive summary: kernel bug workaround.
      */
@@ -327,6 +343,14 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (nfds == 0) {
       assert(timeout != -1);
 
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+      }
+
+      if (timeout == -1)
+        continue;
+
       if (timeout == 0)
         return;
 
@@ -345,6 +369,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
       if (errno != EINTR)
         abort();
+
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+      }
 
       if (timeout == -1)
         continue;
@@ -425,17 +454,26 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         /* Run signal watchers last.  This also affects child process watchers
          * because those are implemented in terms of signal watchers.
          */
-        if (w == &loop->signal_io_watcher)
+        if (w == &loop->signal_io_watcher) {
           have_signals = 1;
-        else
+        } else {
+          uv__metrics_update_idle_time(loop);
           w->cb(loop, w, pe->events);
+        }
 
         nevents++;
       }
     }
 
-    if (have_signals != 0)
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
+
+    if (have_signals != 0) {
+      uv__metrics_update_idle_time(loop);
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+    }
 
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -42,6 +42,10 @@ int uv_loop_init(uv_loop_t* loop) {
     return UV_ENOMEM;
   loop->internal_fields = lfields;
 
+  err = uv_mutex_init(&lfields->loop_metrics.lock);
+  if (err)
+    goto fail_metrics_mutex_init;
+
   heap_init((struct heap*) &loop->timer_heap);
   QUEUE_INIT(&loop->wq);
   QUEUE_INIT(&loop->idle_handles);
@@ -72,7 +76,7 @@ int uv_loop_init(uv_loop_t* loop) {
 
   err = uv__platform_loop_init(loop);
   if (err)
-    return err;
+    goto fail_platform_init;
 
   uv__signal_global_once_init();
   err = uv_signal_init(loop, &loop->child_watcher);
@@ -111,6 +115,11 @@ fail_rwlock_init:
 
 fail_signal_init:
   uv__platform_loop_delete(loop);
+
+fail_platform_init:
+  uv_mutex_destroy(&lfields->loop_metrics.lock);
+
+fail_metrics_mutex_init:
   uv__free(lfields);
   loop->internal_fields = NULL;
 
@@ -193,12 +202,21 @@ void uv__loop_close(uv_loop_t* loop) {
   loop->nwatchers = 0;
 
   lfields = uv__get_internal_fields(loop);
+  uv_mutex_destroy(&lfields->loop_metrics.lock);
   uv__free(lfields);
   loop->internal_fields = NULL;
 }
 
 
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
+  uv__loop_internal_fields_t* lfields;
+
+  lfields = uv__get_internal_fields(loop);
+  if (option == UV_METRICS_IDLE_TIME) {
+    lfields->flags |= UV_METRICS_IDLE_TIME;
+    return 0;
+  }
+
   if (option != UV_LOOP_BLOCK_SIGNAL)
     return UV_ENOSYS;
 

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -887,12 +887,13 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (nfds == 0) {
       assert(timeout != -1);
 
-      if (timeout > 0) {
-        timeout = real_timeout - timeout;
-        continue;
-      }
+      if (timeout == 0)
+        return;
 
-      return;
+      /* We may have been inside the system call for longer than |timeout|
+       * milliseconds so we need to update the timestamp to avoid drift.
+       */
+      goto update_timeout;
     }
 
     if (nfds == -1) {

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -818,6 +818,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int fd;
   int op;
   int i;
+  int user_timeout;
+  int reset_timeout;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -870,8 +872,22 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   real_timeout = timeout;
   int nevents = 0;
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   nfds = 0;
   for (;;) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     if (sizeof(int32_t) == sizeof(long) && timeout >= max_safe_timeout)
       timeout = max_safe_timeout;
 
@@ -887,6 +903,14 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     if (nfds == 0) {
       assert(timeout != -1);
 
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+      }
+
+      if (timeout == -1)
+        continue;
+
       if (timeout == 0)
         return;
 
@@ -900,6 +924,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
       if (errno != EINTR)
         abort();
+
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+      }
 
       if (timeout == -1)
         continue;
@@ -955,12 +984,18 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         pe->events |= w->pevents & (POLLIN | POLLOUT);
 
       if (pe->events != 0) {
+        uv__metrics_update_idle_time(loop);
         w->cb(loop, w, pe->events);
         nevents++;
       }
     }
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;
+
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
 
     if (nevents != 0) {
       if (nfds == ARRAY_SIZE(events) && --count != 0) {

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -154,6 +154,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t set;
   uint64_t base;
   uint64_t diff;
+  uint64_t idle_poll;
   unsigned int nfds;
   unsigned int i;
   int saved_errno;
@@ -162,6 +163,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int count;
   int err;
   int fd;
+  int user_timeout;
+  int reset_timeout;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -199,7 +202,21 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   base = loop->time;
   count = 48; /* Benchmarks suggest this gives the best throughput. */
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   for (;;) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     if (timeout != -1) {
       spec.tv_sec = timeout / 1000;
       spec.tv_nsec = (timeout % 1000) * 1000000;
@@ -242,6 +259,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     SAVE_ERRNO(uv__update_time(loop));
 
     if (events[0].portev_source == 0) {
+      if (reset_timeout != 0) {
+        timeout = user_timeout;
+        reset_timeout = 0;
+      }
+
       if (timeout == 0)
         return;
 
@@ -282,10 +304,12 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       /* Run signal watchers last.  This also affects child process watchers
        * because those are implemented in terms of signal watchers.
        */
-      if (w == &loop->signal_io_watcher)
+      if (w == &loop->signal_io_watcher) {
         have_signals = 1;
-      else
+      } else {
+        uv__metrics_update_idle_time(loop);
         w->cb(loop, w, pe->portev_events);
+      }
 
       nevents++;
 
@@ -297,8 +321,15 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
     }
 
-    if (have_signals != 0)
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
+
+    if (have_signals != 0) {
+      uv__metrics_update_idle_time(loop);
       loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
+    }
 
     loop->watchers[loop->nwatchers] = NULL;
     loop->watchers[loop->nwatchers + 1] = NULL;

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -336,6 +336,9 @@ void uv__threadpool_cleanup(void);
 #define uv__get_internal_fields(loop)                                         \
   ((uv__loop_internal_fields_t*) loop->internal_fields)
 
+#define uv__get_loop_metrics(loop)                                            \
+  (&uv__get_internal_fields(loop)->loop_metrics)
+
 /* Allocator prototypes */
 void *uv__calloc(size_t count, size_t size);
 char *uv__strdup(const char* s);
@@ -345,10 +348,21 @@ void uv__free(void* ptr);
 void* uv__realloc(void* ptr, size_t size);
 void* uv__reallocf(void* ptr, size_t size);
 
+typedef struct uv__loop_metrics_s uv__loop_metrics_t;
 typedef struct uv__loop_internal_fields_s uv__loop_internal_fields_t;
+
+struct uv__loop_metrics_s {
+  uint64_t provider_entry_time;
+  uint64_t provider_idle_time;
+  uv_mutex_t lock;
+};
+
+void uv__metrics_update_idle_time(uv_loop_t* loop);
+void uv__metrics_set_provider_entry_time(uv_loop_t* loop);
 
 struct uv__loop_internal_fields_s {
   unsigned int flags;
+  uv__loop_metrics_t loop_metrics;
 };
 
 #endif /* UV_COMMON_H_ */

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -333,6 +333,9 @@ void uv__threadpool_cleanup(void);
   }                                                                           \
   while (0)
 
+#define uv__get_internal_fields(loop)                                         \
+  ((uv__loop_internal_fields_t*) loop->internal_fields)
+
 /* Allocator prototypes */
 void *uv__calloc(size_t count, size_t size);
 char *uv__strdup(const char* s);
@@ -341,5 +344,11 @@ void* uv__malloc(size_t size);
 void uv__free(void* ptr);
 void* uv__realloc(void* ptr, size_t size);
 void* uv__reallocf(void* ptr, size_t size);
+
+typedef struct uv__loop_internal_fields_s uv__loop_internal_fields_t;
+
+struct uv__loop_internal_fields_s {
+  unsigned int flags;
+};
 
 #endif /* UV_COMMON_H_ */

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -222,6 +222,7 @@ static void uv_init(void) {
 
 
 int uv_loop_init(uv_loop_t* loop) {
+  uv__loop_internal_fields_t* lfields;
   struct heap* timer_heap;
   int err;
 
@@ -237,6 +238,10 @@ int uv_loop_init(uv_loop_t* loop) {
   if (lfields == NULL)
     return UV_ENOMEM;
   loop->internal_fields = lfields;
+
+  err = uv_mutex_init(&lfields->loop_metrics.lock);
+  if (err)
+    goto fail_metrics_mutex_init;
 
   /* To prevent uninitialized memory access, loop->time must be initialized
    * to zero before calling uv_update_time for the first time.
@@ -302,6 +307,9 @@ fail_mutex_init:
   loop->timer_heap = NULL;
 
 fail_timers_alloc:
+  uv_mutex_destroy(&lfields->loop_metrics.lock);
+
+fail_metrics_mutex_init:
   uv__free(lfields);
   loop->internal_fields = NULL;
   CloseHandle(loop->iocp);
@@ -324,6 +332,7 @@ void uv__once_init(void) {
 
 
 void uv__loop_close(uv_loop_t* loop) {
+  uv__loop_internal_fields_t* lfields;
   size_t i;
 
   uv__loops_remove(loop);
@@ -355,6 +364,7 @@ void uv__loop_close(uv_loop_t* loop) {
   loop->timer_heap = NULL;
 
   lfields = uv__get_internal_fields(loop);
+  uv_mutex_destroy(&lfields->loop_metrics.lock);
   uv__free(lfields);
   loop->internal_fields = NULL;
 
@@ -363,6 +373,14 @@ void uv__loop_close(uv_loop_t* loop) {
 
 
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
+  uv__loop_internal_fields_t* lfields;
+
+  lfields = uv__get_internal_fields(loop);
+  if (option == UV_METRICS_IDLE_TIME) {
+    lfields->flags |= UV_METRICS_IDLE_TIME;
+    return 0;
+  }
+
   return UV_ENOSYS;
 }
 
@@ -404,15 +422,43 @@ static void uv__poll_wine(uv_loop_t* loop, DWORD timeout) {
   uv_req_t* req;
   int repeat;
   uint64_t timeout_time;
+  uint64_t user_timeout;
+  int reset_timeout;
 
   timeout_time = loop->time + timeout;
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   for (repeat = 0; ; repeat++) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     GetQueuedCompletionStatus(loop->iocp,
                               &bytes,
                               &key,
                               &overlapped,
                               timeout);
+
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
+
+    /* Placed here because on success the loop will break whether there is an
+     * empty package or not, or if GetQueuedCompletionStatus returned early then
+     * the timeout will be updated and the loop will run again. In either case
+     * the idle time will need to be updated.
+     */
+    uv__metrics_update_idle_time(loop);
 
     if (overlapped) {
       /* Package was dequeued */
@@ -456,16 +502,44 @@ static void uv__poll(uv_loop_t* loop, DWORD timeout) {
   ULONG i;
   int repeat;
   uint64_t timeout_time;
+  uint64_t user_timeout;
+  int reset_timeout;
 
   timeout_time = loop->time + timeout;
 
+  if (uv__get_internal_fields(loop)->flags & UV_METRICS_IDLE_TIME) {
+    reset_timeout = 1;
+    user_timeout = timeout;
+    timeout = 0;
+  } else {
+    reset_timeout = 0;
+  }
+
   for (repeat = 0; ; repeat++) {
+    /* Only need to set the provider_entry_time if timeout != 0. The function
+     * will return early if the loop isn't configured with UV_METRICS_IDLE_TIME.
+     */
+    if (timeout != 0)
+      uv__metrics_set_provider_entry_time(loop);
+
     success = pGetQueuedCompletionStatusEx(loop->iocp,
                                            overlappeds,
                                            ARRAY_SIZE(overlappeds),
                                            &count,
                                            timeout,
                                            FALSE);
+
+    if (reset_timeout != 0) {
+      timeout = user_timeout;
+      reset_timeout = 0;
+    }
+
+    /* Placed here because on success the loop will break whether there is an
+     * empty package or not, or if GetQueuedCompletionStatus returned early then
+     * the timeout will be updated and the loop will run again. In either case
+     * the idle time will need to be updated.
+     */
+    uv__metrics_update_idle_time(loop);
 
     if (success) {
       for (i = 0; i < count; i++) {
@@ -545,6 +619,12 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
     else
       uv__poll_wine(loop, timeout);
 
+    /* Run one final update on the provider_idle_time in case uv__poll*
+     * returned because the timeout expired, but no events were received. This
+     * call will be ignored if the provider_entry_time was either never set (if
+     * the timeout == 0) or was already updated b/c an event was received.
+     */
+    uv__metrics_update_idle_time(loop);
 
     uv_check_invoke(loop);
     uv_process_endgames(loop);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -524,6 +524,10 @@ TEST_DECLARE  (idna_toascii)
 TEST_DECLARE  (utf8_decode1)
 TEST_DECLARE  (uname)
 
+TEST_DECLARE  (metrics_idle_time)
+TEST_DECLARE  (metrics_idle_time_thread)
+TEST_DECLARE  (metrics_idle_time_zero)
+
 TASK_LIST_START
   TEST_ENTRY_CUSTOM (platform_output, 0, 1, 5000)
 
@@ -1115,6 +1119,10 @@ TASK_LIST_START
   TEST_HELPER   (not_readable_nor_writable_on_read_error, tcp4_echo_server)
   TEST_ENTRY    (not_readable_on_eof)
   TEST_HELPER   (not_readable_on_eof, tcp4_echo_server)
+
+  TEST_ENTRY  (metrics_idle_time)
+  TEST_ENTRY  (metrics_idle_time_thread)
+  TEST_ENTRY  (metrics_idle_time_zero)
 
 #if 0
   /* These are for testing the test runner. */

--- a/test/test-metrics.c
+++ b/test/test-metrics.c
@@ -1,0 +1,114 @@
+#include "uv.h"
+#include "task.h"
+#include <string.h> /* memset */
+
+#define NS_MS 1000000
+
+
+static void timer_spin_cb(uv_timer_t* handle) {
+  uint64_t t;
+
+  (*(int*) handle->data)++;
+  t = uv_hrtime();
+  /* Spin for 500 ms to spin loop time out of the delta check. */
+  while (uv_hrtime() - t < 600 * NS_MS) { }
+}
+
+
+TEST_IMPL(metrics_idle_time) {
+  const uint64_t timeout = 1000;
+  uv_timer_t timer;
+  uint64_t idle_time;
+  int cntr;
+
+  cntr = 0;
+  timer.data = &cntr;
+
+  ASSERT_EQ(0, uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_EQ(0, uv_timer_start(&timer, timer_spin_cb, timeout, 0));
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_GT(cntr, 0);
+
+  idle_time = uv_metrics_idle_time(uv_default_loop());
+
+  /* Permissive check that the idle time matches within the timeout ±500 ms. */
+  ASSERT((idle_time <= (timeout + 500) * NS_MS) &&
+         (idle_time >= (timeout - 500) * NS_MS));
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
+static void metrics_routine_cb(void* arg) {
+  const uint64_t timeout = 1000;
+  uv_loop_t loop;
+  uv_timer_t timer;
+  uint64_t idle_time;
+  int cntr;
+
+  cntr = 0;
+  timer.data = &cntr;
+
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_configure(&loop, UV_METRICS_IDLE_TIME));
+  ASSERT_EQ(0, uv_timer_init(&loop, &timer));
+  ASSERT_EQ(0, uv_timer_start(&timer, timer_spin_cb, timeout, 0));
+
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_GT(cntr, 0);
+
+  idle_time = uv_metrics_idle_time(&loop);
+
+  /* Only checking that idle time is greater than the lower bound since there
+   * may have been thread contention, causing the event loop to be delayed in
+   * the idle phase longer than expected.
+   */
+  ASSERT_GE(idle_time, (timeout - 500) * NS_MS);
+
+  close_loop(&loop);
+  ASSERT_EQ(0, uv_loop_close(&loop));
+}
+
+
+TEST_IMPL(metrics_idle_time_thread) {
+  uv_thread_t threads[5];
+  int i;
+
+  for (i = 0; i < 5; i++) {
+    ASSERT_EQ(0, uv_thread_create(&threads[i], metrics_routine_cb, NULL));
+  }
+
+  for (i = 0; i < 5; i++) {
+    uv_thread_join(&threads[i]);
+  }
+
+  return 0;
+}
+
+
+static void timer_noop_cb(uv_timer_t* handle) {
+  (*(int*) handle->data)++;
+}
+
+
+TEST_IMPL(metrics_idle_time_zero) {
+  uv_timer_t timer;
+  int cntr;
+
+  cntr = 0;
+  timer.data = &cntr;
+  ASSERT_EQ(0, uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_EQ(0, uv_timer_start(&timer, timer_noop_cb, 0, 0));
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT_GT(cntr, 0);
+  ASSERT_EQ(0, uv_metrics_idle_time(uv_default_loop()));
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}


### PR DESCRIPTION
This PR contains code that I've been working on for a while as part of some research I've been doing at work, and decided it would be good to submit this for review after seeing @indutny's Node.js PR https://github.com/nodejs/node/pull/32018.

The main reasons for writing this patch are:
- Have very accurate measurements of idle time spent in the kernel's event provider.
- Allow retrieval of the idle time from another thread to allow more accurate time-series data collection (instead of only collecting the data when the event loop can process a callback).

A lot is explain in the commit message below, and I'll be happy to explain in detail why the implementation was done this way. For example, this approach was a conclusion I came to last year after researching whether it was possible to infer the state of the application based solely on event loop metrics. In order to achieve that goal it's necessary to have the level of accuracy this patch provides.

There are a few things I'm unsure about and would like feedback on, like how I've implemented atomics, and I'll need some assistance with the Windows implementation.

/cc @bnoordhuis @indutny @saghul 

Commit message:

Add API for measuring event loop idle time

The API addition `uv_metrics_idle_time()` is a thread safe call that
allows the user to retrieve the amount of time the event loop has spent
in the kernel's event provider (i.e. poll). It was done this way to
allow retrieving this value without needing to interrupt the execution
of the event loop. This option can be enabled by passing
`UV_METRICS_IDLE_TIME` to `uv_loop_configure()`.

One important aspect of this change is, when enabled, to always first
call the event provider with a `timeout == 0`. This allows libuv to know
whether any events were waiting in the event queue when the event
provider was called. The importance of this is because libuv is tracking
the amount of "idle time", not "poll time". Thus the provider entry time
is not recorded when `timeout == 0` (the event provider never idles in
this case).

While this does add a small amount of overhead, when enabled, but the
overhead decreases when the event loop has a heavier load. This is
because poll events will be waiting when the event provider is called.
Thus never actually recording the provider entry time.

Checking if `uv_loop_t` is configured with `UV_METRICS_IDLE_TIME` always
happens in `uv__metrics_set_provider_entry_time()` and
`uv__metrics_update_idle_time()`. Making the conditional logic wrapping
each call simpler and allows for instrumentation to always hook into
those two function calls.

Add struct `uv__metrics_loop_t` as a location for future metrics API
additions.

Add struct `uv__loop_internal_fields_t` as a location for future
additions to `uv_loop_t` while also maintaining v1.x compatibility. A
pointer to this struct has been placed in the `uv_loop_t::unused[1]`
space to allow for fast retrieval and maintaining ABI compatibility with
v1.x.

Currently `uv__loop_internal_fields_t` only contains both the
`uv__metrics_loop_t` and `flags` field. The reason for adding the
`flags` field is because the same field was never added to
`UV_LOOP_PRIVATE_FIELDS` in Windows as it was in Unix, and adding that
field would break ABI.

The idea for creating a struct and attaching it to `uv_loop_t` for
future API enhancements was taken from a comment by bnoordhuis in:
https://github.com/libuv/libuv/issues/2506#issuecomment-540050665

Tests and additional documentation has been included.