### PR TITLE
build: fix(?) cmake for AIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
        _THREAD_SAFE
        _XOPEN_SOURCE=500)
   list(APPEND uv_libraries perfstat)
-  list(APPEND uv_sources src/unix/aix.c)
+  list(APPEND uv_sources
+    src/unix/aix.c
+    src/unix/aix-common.c
+    )
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
        _ALL_SOURCE
        _LINUX_SOURCE_COMPAT
        _THREAD_SAFE
-       _XOPEN_SOURCE=500)
+       _XOPEN_SOURCE=500
+       HAVE_SYS_AHAFS_EVPRODS_H)
   list(APPEND uv_libraries perfstat)
   list(APPEND uv_sources
        src/unix/aix.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
        _XOPEN_SOURCE=500)
   list(APPEND uv_libraries perfstat)
   list(APPEND uv_sources
-    src/unix/aix.c
-    src/unix/aix-common.c
-    )
+       src/unix/aix.c
+       src/unix/aix-common.c)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")


### PR DESCRIPTION
While eyeballing the CMakeLists file to fix IBM i (#2729), it seems the AIX clause is missing the aix-common.c source file. Should probably get fixed at some point, so submitting this PR as one potential avenue. Currently in Draft because I don't have an AIX system with cmake for test.
cc @libuv/aix for input