### PR TITLE
ibmi: set the amount of memory in use to zero

### DIFF
--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -225,22 +225,7 @@ uint64_t uv_get_free_memory(void) {
   if (get_ibmi_system_status(&rcvr))
     return 0;
 
-  /* The amount of main storage, in kilobytes, in the system. */
-  uint64_t main_storage_size = rcvr.main_storage_size;
-
-  /* The current amount of storage in use for temporary objects.
-   * in millions (M) of bytes.
-   */
-  uint64_t current_unprotected_storage_used =
-    rcvr.current_unprotected_storage_used * 1024ULL;
-
-  /* Current unprotected storage includes the storage used for memory
-   * and disks so it is possible to exceed the amount of main storage.
-   */
-  if (main_storage_size <= current_unprotected_storage_used)
-    return 0ULL;
-
-  return (main_storage_size - current_unprotected_storage_used) * 1024ULL;
+  return (uint64_t)rcvr.main_storage_size * 1024ULL;
 }
 
 

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -32,14 +32,13 @@ TEST_IMPL(get_memory) {
          (unsigned long long) total_mem,
          (unsigned long long) constrained_mem);
 
-  /* On IBMi PASE, the amount of memory in use includes storage used for
-   * memory and disks so it is possible to exceed the amount of main storage.
-   */
-#ifndef __PASE__
   ASSERT(free_mem > 0);
-#endif
   ASSERT(total_mem > 0);
+  /* On IBMi PASE, the amount of memory in use is always zero. */
+#ifdef __PASE__
+  ASSERT(total_mem == free_mem);
+#else
   ASSERT(total_mem > free_mem);
-
+#endif
   return 0;
 }


### PR DESCRIPTION
On IBMi PASE, the amount of memory in use includes storage
used for memory and disks. So we hard coded the amount of memory
in use to zero on IBMi based on below discussion -
https://github.com/nodejs/node/pull/32043