### PR TITLE
src: add uv__reallocf()

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -834,8 +834,8 @@ static void maybe_resize(uv_loop_t* loop, unsigned int len) {
   }
 
   nwatchers = next_power_of_two(len + 2) - 2;
-  watchers = uv__realloc(loop->watchers,
-                         (nwatchers + 2) * sizeof(loop->watchers[0]));
+  watchers = uv__reallocf(loop->watchers,
+                          (nwatchers + 2) * sizeof(loop->watchers[0]));
 
   if (watchers == NULL)
     abort();

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -666,7 +666,6 @@ static ssize_t uv__fs_readlink(uv_fs_t* req) {
   ssize_t maxlen;
   ssize_t len;
   char* buf;
-  char* newbuf;
 
 #if defined(_POSIX_PATH_MAX) || defined(PATH_MAX)
   maxlen = uv__fs_pathmax_size(req->path);
@@ -710,14 +709,10 @@ static ssize_t uv__fs_readlink(uv_fs_t* req) {
 
   /* Uncommon case: resize to make room for the trailing nul byte. */
   if (len == maxlen) {
-    newbuf = uv__realloc(buf, len + 1);
+    buf = uv__reallocf(buf, len + 1);
 
-    if (newbuf == NULL) {
-      uv__free(buf);
+    if (buf == NULL)
       return -1;
-    }
-
-    buf = newbuf;
   }
 
   buf[len] = '\0';

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -61,7 +61,6 @@ void uv_loadavg(double avg[3]) {
 int uv_exepath(char* buffer, size_t* size) {
   int mib[4];
   char **argsbuf = NULL;
-  char **argsbuf_tmp;
   size_t argsbuf_size = 100U;
   size_t exepath_size;
   pid_t mypid;
@@ -73,10 +72,9 @@ int uv_exepath(char* buffer, size_t* size) {
   mypid = getpid();
   for (;;) {
     err = UV_ENOMEM;
-    argsbuf_tmp = uv__realloc(argsbuf, argsbuf_size);
-    if (argsbuf_tmp == NULL)
+    argsbuf = uv__reallocf(argsbuf, argsbuf_size);
+    if (argsbuf == NULL)
       goto out;
-    argsbuf = argsbuf_tmp;
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC_ARGS;
     mib[2] = mypid;

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -125,7 +125,7 @@ static void maybe_resize(uv__os390_epoll* lst, unsigned int len) {
   }
 
   newsize = next_power_of_two(len);
-  newlst = uv__realloc(lst->items, newsize * sizeof(lst->items[0]));
+  newlst = uv__reallocf(lst->items, newsize * sizeof(lst->items[0]));
 
   if (newlst == NULL)
     abort();

--- a/src/unix/posix-poll.c
+++ b/src/unix/posix-poll.c
@@ -61,7 +61,7 @@ static void uv__pollfds_maybe_resize(uv_loop_t* loop) {
     return;
 
   n = loop->poll_fds_size ? loop->poll_fds_size * 2 : 64;
-  p = uv__realloc(loop->poll_fds, n * sizeof(*loop->poll_fds));
+  p = uv__reallocf(loop->poll_fds, n * sizeof(*loop->poll_fds));
   if (p == NULL)
     abort();
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -100,6 +100,17 @@ void* uv__realloc(void* ptr, size_t size) {
   return NULL;
 }
 
+void* uv__reallocf(void* ptr, size_t size) {
+  void* newptr;
+
+  newptr = uv__realloc(ptr, size);
+  if (newptr == NULL)
+    if (size > 0)
+      uv__free(ptr);
+
+  return newptr;
+}
+
 int uv_replace_allocator(uv_malloc_func malloc_func,
                          uv_realloc_func realloc_func,
                          uv_calloc_func calloc_func,

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -322,5 +322,6 @@ char *uv__strndup(const char* s, size_t n);
 void* uv__malloc(size_t size);
 void uv__free(void* ptr);
 void* uv__realloc(void* ptr, size_t size);
+void* uv__reallocf(void* ptr, size_t size);
 
 #endif /* UV_COMMON_H_ */


### PR DESCRIPTION
Modeled after FreeBSD's `reallocf(3)`: a version of `realloc(3)` that
frees the memory when reallocation fails, simplifying error handling in
many cases.

CI: https://ci.nodejs.org/job/libuv-test-commit/1784/