### PR TITLE
udp: return recvmmsg-ed datagrams in order

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -607,8 +607,7 @@ enum uv_udp_flags {
    */
   UV_UDP_REUSEADDR = 4,
   /*
-   * Indicates that the message was received by recvmmsg and that it's not at
-   * the beginning of the buffer allocated by alloc_cb - so the buffer provided
+   * Indicates that the message was received by recvmmsg, so the buffer provided
    * must not be freed by the recv_cb callback.
    */
   UV_UDP_MMSG_CHUNK = 8


### PR DESCRIPTION
Introduce a new flag to signal the returned buffer. This retains the
previous behavior of returning datagrams in order to the application.

TODO:

- [x] discuss
- [x] docs
- [x] ~adapt test / benchmark code~