### PR TITLE
build: fix z/OS cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-# TODO: determine CMAKE_SYSTEM_NAME on OS/390.  Currently assumes "OS/390".
 cmake_minimum_required(VERSION 3.4)
 project(libuv LANGUAGES C)
 
@@ -114,7 +113,7 @@ if(WIN32)
   list(APPEND uv_test_sources src/win/snprintf.c test/runner-win.c)
 else()
   list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+  if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390")
     # TODO: This should be replaced with find_package(Threads) if possible
     # Android has pthread as part of its c library, not as a separate
     # libpthread.so.
@@ -170,7 +169,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
        src/unix/sysinfo-loadavg.c)
 endif()
 
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux|OS/390")
+if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux|OS390")
   list(APPEND uv_sources src/unix/proctitle.c)
 endif()
 
@@ -224,7 +223,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   list(APPEND uv_sources src/unix/openbsd.c)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "OS/390")
+if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
   list(APPEND uv_defines PATH_MAX=255)
   list(APPEND uv_defines _AE_BIMODAL)
   list(APPEND uv_defines _ALL_SOURCE)
@@ -240,9 +239,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS/390")
   list(APPEND uv_defines _XOPEN_SOURCE_EXTENDED)
   list(APPEND uv_sources
        src/unix/pthread-fixes.c
-       src/unix/pthread-barrier.c
        src/unix/os390.c
        src/unix/os390-syscalls.c)
+  list(APPEND uv_cflags -Wc,DLL -Wc,exportall -Wc,xplink)
+  list(APPEND uv_libraries -Wl,xplink)
+  list(APPEND uv_test_libraries -Wl,xplink)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
@@ -464,6 +465,10 @@ if(LIBUV_BUILD_TESTS)
   add_test(NAME uv_test
            COMMAND uv_run_tests
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
+    set_tests_properties(uv_test PROPERTIES ENVIRONMENT
+                         "LIBPATH=${CMAKE_BINARY_DIR}:$ENV{LIBPATH}")
+  endif()
   add_executable(uv_run_tests_a ${uv_test_sources})
   target_compile_definitions(uv_run_tests_a PRIVATE ${uv_defines})
   target_compile_options(uv_run_tests_a PRIVATE ${uv_cflags})

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -408,10 +408,12 @@ int nanosleep(const struct timespec* req, struct timespec* rem) {
    * Don't leak EAGAIN, that just means the timeout expired.
    */
   if (rv == -1)
-    if (err != EAGAIN)
+    if (err == EAGAIN)
+      rv = 0;
+    else
       errno = err;
 
-  if (rem != NULL && (rv == 0 || err == EINTR || err == EAGAIN)) {
+  if (rem != NULL && (rv == 0 || err == EINTR)) {
     rem->tv_nsec = nanorem;
     rem->tv_sec = secrem;
   }

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -556,3 +556,28 @@ size_t strnlen(const char* str, size_t maxlen) {
   else
     return p - str;
 }
+
+
+int sem_init(UV_PLATFORM_SEM_T* semid, int pshared, unsigned int value) {
+  UNREACHABLE();
+}
+
+
+int sem_destroy(UV_PLATFORM_SEM_T* semid) {
+  UNREACHABLE();
+}
+
+
+int sem_post(UV_PLATFORM_SEM_T* semid) {
+  UNREACHABLE();
+}
+
+
+int sem_trywait(UV_PLATFORM_SEM_T* semid) {
+  UNREACHABLE();
+}
+
+
+int sem_wait(UV_PLATFORM_SEM_T* semid) {
+  UNREACHABLE();
+}

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -65,5 +65,10 @@ int scandir(const char* maindir, struct dirent*** namelist,
 char *mkdtemp(char* path);
 ssize_t os390_readlink(const char* path, char* buf, size_t len);
 size_t strnlen(const char* str, size_t maxlen);
+int sem_init(UV_PLATFORM_SEM_T* semid, int pshared, unsigned int value);
+int sem_destroy(UV_PLATFORM_SEM_T* semid);
+int sem_post(UV_PLATFORM_SEM_T* semid);
+int sem_trywait(UV_PLATFORM_SEM_T* semid);
+int sem_wait(UV_PLATFORM_SEM_T* semid);
 
 #endif /* UV_OS390_SYSCALL_H_ */

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -236,13 +236,14 @@ TEST_IMPL(spawn_empty_env) {
   char* env[1];
 
   /* The autotools dynamic library build requires the presence of
-   * DYLD_LIBARY_PATH (macOS) or LD_LIBRARY_PATH (other Unices)
+   * DYLD_LIBARY_PATH (macOS) or LD_LIBRARY_PATH/LIBPATH (other Unices)
    * in the environment, but of course that doesn't work with
    * the empty environment that we're testing here.
    */
   if (NULL != getenv("DYLD_LIBRARY_PATH") ||
-      NULL != getenv("LD_LIBRARY_PATH")) {
-    RETURN_SKIP("doesn't work with DYLD_LIBRARY_PATH/LD_LIBRARY_PATH");
+      NULL != getenv("LD_LIBRARY_PATH") ||
+      NULL != getenv("LIBPATH")) {
+    RETURN_SKIP("doesn't work with DYLD_LIBRARY_PATH/LD_LIBRARY_PATH/LIBPATH");
   }
 
   init_process_options("spawn_helper1", exit_cb);


### PR DESCRIPTION
This is WIP attempt to fix the z/OS cmake build. CI changes are discussed in https://github.com/nodejs/build/issues/2175.

- Correct CMAKE_SYSTEM_NAME.
- Exclude pthread lib on z/OS.
- Remove deleted src/unix/pthread-barrier.c.
- Set LIBPATH for shared library test.