### PR TITLE
Using relative paths for #include

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -31,9 +31,9 @@
 
 #include "uv.h"
 #include "internal.h"
-#include "queue.h"
+#include "../queue.h"
 #include "handle-inl.h"
-#include "heap-inl.h"
+#include "../heap-inl.h"
 #include "req-inl.h"
 
 /* uv_once initialization guards */

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -24,7 +24,7 @@
 #include "uv.h"
 #include "internal.h"
 #include "req-inl.h"
-#include "idna.h"
+#include "../idna.h"
 
 /* EAI_* constants. */
 #include <winsock2.h>

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -29,7 +29,7 @@
 #include "internal.h"
 #include "req-inl.h"
 #include "stream-inl.h"
-#include "uv-common.h"
+#include "../uv-common.h"
 #include "uv.h"
 
 #include <aclapi.h>


### PR DESCRIPTION
#include "queue.h"
The intent of double quotes is to search the directory where the current file resides and, only if the file is not found, search the standard include directories .
Using relative path in double quotes can 
- Improve compilation performance slightly and make the code more standardized .
- Make it easier to embed into other projects without the cmake system .
- No need to add “\libuv\src”  to the standard include directories .

References
- C11 standard (ISO/IEC 9899:2011):6.10.2 Source file inclusion (p: 164-166)
- C99 standard (ISO/IEC 9899:1999):6.10.2 Source file inclusion (p: 149-151)
- C89/C90 standard (ISO/IEC 9899:1990):3.8.2 Source file inclusion