### PR TITLE
build: fix gyp build for Android API >= 28

### DIFF
--- a/uv.gyp
+++ b/uv.gyp
@@ -261,6 +261,7 @@
             'src/unix/random-getrandom.c',
             'src/unix/random-sysctl-linux.c',
             'src/unix/sysinfo-loadavg.c',
+            'src/unix/random-getentropy.c',
           ],
           'link_settings': {
             'libraries': [ '-ldl' ],


### PR DESCRIPTION
The commit https://github.com/libuv/libuv/commit/f261d04d0a36df7c8ab041a45399c1fcba0a3c04 ("android: enable getentropy on Android >= 28") didn't
add `random-getentropy.c` to the set of files to build on Android, a previous PR https://github.com/libuv/libuv/pull/2704 only fixed the cmake build, this PR is to fix the gyp build.