### PR TITLE
src: implements cpu_relax for arm

### DIFF
--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -53,6 +53,8 @@ UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval)) {
 UV_UNUSED(static void cpu_relax(void)) {
 #if defined(__i386__) || defined(__x86_64__)
   __asm__ __volatile__ ("rep; nop");  /* a.k.a. PAUSE */
+#elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
+  __asm__ volatile("yield");
 #endif
 }
 


### PR DESCRIPTION
Emits yield instruction in ARM mode (mainly needs to pass
 -march=...).