### PR TITLE
test: fix spawn_reads_child_path arguments

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1729,7 +1729,6 @@ TEST_IMPL(spawn_reads_child_path) {
   }
 
   options.file = file;
-  options.args[0] = file;
   options.env = env;
 
   r = uv_spawn(uv_default_loop(), &process, &options);


### PR DESCRIPTION
`args[0]` should be kept as `exepath` when spawning run-tests via lookup into PATH. This allows run-tests to correctly resolve `argv[0]` using `realpath()` in `platform_init()`. If `argv[0]` was not the absolute
path, `realpath()` will fail with ENOENT and terminate the child process instead of executing the helper code.

This resolves the spawn_reads_child_path test failure seen on z/OS in #2737.