### PR TITLE
test: canonicalize argv[0] in exepath test

### DIFF
--- a/test/run-benchmarks.c
+++ b/test/run-benchmarks.c
@@ -33,8 +33,7 @@ static int maybe_run_test(int argc, char **argv);
 
 
 int main(int argc, char **argv) {
-  if (platform_init(argc, argv))
-    return EXIT_FAILURE;
+  platform_init(argc, argv);
 
   switch (argc) {
   case 1: return run_tests(1);

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -59,9 +59,7 @@ int main(int argc, char **argv) {
   }
 #endif
 
-  if (platform_init(argc, argv))
-    return EXIT_FAILURE;
-
+  platform_init(argc, argv);
   argv = uv_setup_args(argc, argv);
 
   switch (argc) {

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -67,13 +67,12 @@ void notify_parent_process(void) {
 
 
 /* Do platform-specific initialization. */
-int platform_init(int argc, char **argv) {
+void platform_init(int argc, char **argv) {
   /* Disable stdio output buffering. */
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);
   signal(SIGPIPE, SIG_IGN);
   snprintf(executable_path, sizeof(executable_path), "%s", argv[0]);
-  return 0;
 }
 
 

--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -26,7 +26,7 @@
 #include <stdint.h> /* uintptr_t */
 
 #include <errno.h>
-#include <unistd.h> /* readlink, usleep */
+#include <unistd.h> /* usleep */
 #include <string.h> /* strdup */
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,12 +72,7 @@ int platform_init(int argc, char **argv) {
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);
   signal(SIGPIPE, SIG_IGN);
-
-  if (realpath(argv[0], executable_path) == NULL) {
-    perror("realpath");
-    return -1;
-  }
-
+  snprintf(executable_path, sizeof(executable_path), "%s", argv[0]);
   return 0;
 }
 

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -43,7 +43,7 @@
 
 
 /* Do platform-specific initialization. */
-int platform_init(int argc, char **argv) {
+void platform_init(int argc, char **argv) {
   /* Disable the "application crashed" popup. */
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
       SEM_NOOPENFILEERRORBOX);
@@ -67,8 +67,6 @@ int platform_init(int argc, char **argv) {
   setvbuf(stderr, NULL, _IONBF, 0);
 
   strcpy(executable_path, argv[0]);
-
-  return 0;
 }
 
 

--- a/test/runner.h
+++ b/test/runner.h
@@ -132,7 +132,7 @@ void print_lines(const char* buffer, size_t size, FILE* stream);
  */
 
 /* Do platform-specific initialization. */
-int platform_init(int argc, char** argv);
+void platform_init(int argc, char** argv);
 
 /* Invoke "argv[0] test-name [test-part]". Store process info in *p. Make sure
  * that all stdio output of the processes is buffered up. */

--- a/test/runner.h
+++ b/test/runner.h
@@ -84,11 +84,7 @@ typedef struct {
 #define TEST_HELPER       HELPER_ENTRY
 #define BENCHMARK_HELPER  HELPER_ENTRY
 
-#ifdef PATH_MAX
-extern char executable_path[PATH_MAX];
-#else
 extern char executable_path[4096];
-#endif
 
 /*
  * Include platform-dependent definitions

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -23,7 +23,7 @@
 #include "task.h"
 #include <string.h>
 
-#define PATHMAX 1024
+#define PATHMAX 4096
 
 TEST_IMPL(cwd_and_chdir) {
   char buffer_orig[PATHMAX];

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -24,7 +24,6 @@
 #include <string.h>
 
 #define PATHMAX 1024
-extern char executable_path[];
 
 TEST_IMPL(cwd_and_chdir) {
   char buffer_orig[PATHMAX];

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -55,7 +55,7 @@
 #endif
 
 #define TOO_LONG_NAME_LENGTH 65536
-#define PATHMAX 1024
+#define PATHMAX 4096
 
 typedef struct {
   const char* path;

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -23,28 +23,29 @@
 #include "task.h"
 #include <string.h>
 
-#define PATHMAX 1024
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#define PATHMAX 4096
 extern char executable_path[];
 
 TEST_IMPL(get_currentexe) {
   char buffer[PATHMAX];
+  char path[PATHMAX];
   size_t size;
   char* match;
-  char* path;
   int r;
 
   size = sizeof(buffer) / sizeof(buffer[0]);
   r = uv_exepath(buffer, &size);
   ASSERT(!r);
 
-  /* uv_exepath can return an absolute path on darwin, so if the test runner
-   * was run with a relative prefix of "./", we need to strip that prefix off
-   * executable_path or we'll fail. */
-  if (executable_path[0] == '.' && executable_path[1] == '/') {
-    path = executable_path + 2;
-  } else {
-    path = executable_path;
-  }
+#ifdef _WIN32
+  snprintf(path, sizeof(path), "%s", executable_path);
+#else
+  ASSERT(NULL != realpath(executable_path, path));
+#endif
 
   match = strstr(buffer, path);
   /* Verify that the path returned from uv_exepath is a subdirectory of

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -23,7 +23,7 @@
 #include "task.h"
 #include <string.h>
 
-#define PATHMAX 1024
+#define PATHMAX 4096
 #define SMALLPATH 1
 
 TEST_IMPL(homedir) {

--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -40,14 +40,23 @@ static const char* titles[] = {
 
 static void getter_thread_body(void* arg) {
   char buffer[512];
+  size_t len;
 
   for (;;) {
     ASSERT(0 == uv_get_process_title(buffer, sizeof(buffer)));
+
+    /* The maximum size of the process title on some platforms depends on
+     * the total size of the argv vector. It's therefore possible to read
+     * back a title that's shorter than what we submitted.
+     */
+    len = strlen(buffer);
+    ASSERT_GT(len, 0);
+
     ASSERT(
-      0 == strcmp(buffer, titles[0]) ||
-      0 == strcmp(buffer, titles[1]) ||
-      0 == strcmp(buffer, titles[2]) ||
-      0 == strcmp(buffer, titles[3]));
+      0 == strncmp(buffer, titles[0], len) ||
+      0 == strncmp(buffer, titles[1], len) ||
+      0 == strncmp(buffer, titles[2], len) ||
+      0 == strncmp(buffer, titles[3], len));
 
     uv_sleep(0);
   }

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -23,7 +23,7 @@
 #include "task.h"
 #include <string.h>
 
-#define PATHMAX 1024
+#define PATHMAX 4096
 #define SMALLPATH 1
 
 TEST_IMPL(tmpdir) {


### PR DESCRIPTION
Commit ff29322 ("test: canonicalize test runner path") from 2014
changed the test runner to call `realpath(3)` on `argv[0]` in order
to fix the `get_currentexe` test failing with the autotools build when
the executable path contained symbolic links but that is now causing
the `spawn_reads_child_path` test to fail on z/os with the cmake build.

Fix that by only doing path canonicalization in the `get_currentexe`
test, not always.

An auxiliary fix is applied to the `process_title_threadsafe` test
because it assumed that setting the process title to a long string,
then reading it back produces in the original string.

On some platforms however the maximum size of the process title is
limited to the size of the `argv` vector.

Because the test runner used absolute paths until now, the argv vector
was bigger than it is with relative paths, big enough to let this bad
assumption go unnoticed until now.

Refs: https://github.com/libuv/libuv/pull/2737#issuecomment-602800431
Refs: https://github.com/libuv/libuv/pull/2754#issuecomment-604015785
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1819/~~ (lots of infra errors)
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1820/~~
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1821/~~
CI: https://ci.nodejs.org/job/libuv-test-commit/1824/