### PR TITLE
Fix invalid free

### DIFF
--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -146,6 +146,8 @@ int uv_get_process_title(char* buffer, size_t size) {
 
 
 UV_DESTRUCTOR(static void free_args_mem(void)) {
-  uv__free(args_mem);  /* Keep valgrind happy. */
-  args_mem = NULL;
+  if (args_mem != NULL) {
+    uv__free(args_mem);  /* Keep valgrind happy. */
+    args_mem = NULL;
+  }
 }


### PR DESCRIPTION
memory error while `dlclose`