### PR TITLE
win: use LoadLibrary to load advapi32.dll

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -63,6 +63,9 @@
 /* Maximum environment variable size, including the terminating null */
 #define MAX_ENV_VAR_LENGTH 32767
 
+/* A RtlGenRandom() by any other name... */
+extern BOOLEAN NTAPI SystemFunction036(PVOID Buffer, ULONG BufferLength);
+
 /* Cached copy of the process title, plus a mutex guarding it. */
 static char *process_title;
 static CRITICAL_SECTION process_title_lock;
@@ -1862,13 +1865,10 @@ int uv_gettimeofday(uv_timeval64_t* tv) {
 }
 
 int uv__random_rtlgenrandom(void* buf, size_t buflen) {
-  if (pRtlGenRandom == NULL)
-    return UV_ENOSYS;
-
   if (buflen == 0)
     return 0;
 
-  if (pRtlGenRandom(buf, buflen) == FALSE)
+  if (SystemFunction036(buf, buflen) == FALSE)
     return UV_EIO;
 
   return 0;

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -36,9 +36,6 @@ sNtQueryDirectoryFile pNtQueryDirectoryFile;
 sNtQuerySystemInformation pNtQuerySystemInformation;
 sNtQueryInformationProcess pNtQueryInformationProcess;
 
-/* Advapi32 function pointers */
-sRtlGenRandom pRtlGenRandom;
-
 /* Kernel32 function pointers */
 sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;
 
@@ -54,7 +51,6 @@ void uv_winapi_init(void) {
   HMODULE powrprof_module;
   HMODULE user32_module;
   HMODULE kernel32_module;
-  HMODULE advapi32_module;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
@@ -138,12 +134,4 @@ void uv_winapi_init(void) {
     pSetWinEventHook = (sSetWinEventHook)
       GetProcAddress(user32_module, "SetWinEventHook");
   }
-
-  advapi32_module = GetModuleHandleA("advapi32.dll");
-  if (advapi32_module == NULL) {
-    uv_fatal_error(GetLastError(), "GetModuleHandleA");
-  }
-
-  pRtlGenRandom =
-      (sRtlGenRandom) GetProcAddress(advapi32_module, "SystemFunction036");
 }

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4590,11 +4590,6 @@ typedef NTSTATUS (NTAPI *sNtQueryInformationProcess)
                   PULONG ReturnLength);
 
 /*
- * Advapi32 headers
- */
-typedef BOOLEAN (WINAPI *sRtlGenRandom)(PVOID Buffer, ULONG BufferLength);
-
-/*
  * Kernel32 headers
  */
 #ifndef FILE_SKIP_COMPLETION_PORT_ON_SUCCESS
@@ -4735,9 +4730,6 @@ extern sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 extern sNtQueryDirectoryFile pNtQueryDirectoryFile;
 extern sNtQuerySystemInformation pNtQuerySystemInformation;
 extern sNtQueryInformationProcess pNtQueryInformationProcess;
-
-/* Advapi32 function pointers */
-extern sRtlGenRandom pRtlGenRandom;
 
 /* Kernel32 function pointers */
 extern sGetQueuedCompletionStatusEx pGetQueuedCompletionStatusEx;


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/2759
~~CI: https://ci.nodejs.org/job/libuv-test-commit/1826/~~ (doesn't work)
~~CI: https://ci.nodejs.org/job/libuv-test-commit-windows/2023/~~ ✅
CI: https://ci.nodejs.org/job/libuv-test-commit/1828/ ✅

<details>

~~@libuv/windows this needs your input because I'm not sure what adverse effects this could have or if it introduces new failure modes.~~

~~It changes the current "libuv won't load" failure mode to "uv_random() won't work." That seems like an improvement.~~

~~Is dynamically loading advapi32.dll a security risk on multi-user systems? If the answer is 'yes', then why do we load powrpof.dll and user32.dll that way?~~

(resolved by way of using `SystemFunction036()` directly.)

</details>