### PR TITLE
android: fix memory overwriting in uv_interface_addresses()

### DIFF
--- a/src/unix/android-ifaddrs.c
+++ b/src/unix/android-ifaddrs.c
@@ -476,7 +476,6 @@ static int interpretAddr(struct nlmsghdr *p_hdr, struct ifaddrs **p_resultList, 
                     l_addrSize += NLMSG_ALIGN(calcAddrLen(l_info->ifa_family, l_rtaDataSize));
                     l_addedNetmask = 1;
                 }
-		break;
             case IFA_BROADCAST:
                 l_addrSize += NLMSG_ALIGN(calcAddrLen(l_info->ifa_family, l_rtaDataSize));
                 break;

--- a/src/unix/android-ifaddrs.c
+++ b/src/unix/android-ifaddrs.c
@@ -470,12 +470,14 @@ static int interpretAddr(struct nlmsghdr *p_hdr, struct ifaddrs **p_resultList, 
         {
             case IFA_ADDRESS:
             case IFA_LOCAL:
+                l_addrSize += NLMSG_ALIGN(calcAddrLen(l_info->ifa_family, l_rtaDataSize));
                 if((l_info->ifa_family == AF_INET || l_info->ifa_family == AF_INET6) && !l_addedNetmask)
                 {
                     /* Make room for netmask */
                     l_addrSize += NLMSG_ALIGN(calcAddrLen(l_info->ifa_family, l_rtaDataSize));
                     l_addedNetmask = 1;
                 }
+                break;
             case IFA_BROADCAST:
                 l_addrSize += NLMSG_ALIGN(calcAddrLen(l_info->ifa_family, l_rtaDataSize));
                 break;


### PR DESCRIPTION
Fix a regression of https://github.com/libuv/libuv/pull/2486.

For `IFA_ADDRESS` and `IFA_LOCAL` network interface, we'll write two IP addresses to `ifaddrs`:
 - IP address: https://github.com/libuv/libuv/blob/v1.x/src/unix/android-ifaddrs.c#L520
 - Network mask: https://github.com/libuv/libuv/blob/v1.x/src/unix/android-ifaddrs.c#L583

In that PR, it added a `break`, then we only [malloc](https://github.com/libuv/libuv/blob/v1.x/src/unix/android-ifaddrs.c#L491) one IP address memory space for `l_entry`, which leads to memory overwriting issue.
