### PR TITLE
build: fix compilation on macOS 32-bit architectures

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -518,7 +518,7 @@ int uv__close_nocancel(int fd) {
 #if defined(__APPLE__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
-#if defined(__LP64__) || defined(TARGET_OS_IPHONE)
+#if defined(__LP64__) || TARGET_OS_IPHONE
   extern int close$NOCANCEL(int);
   return close$NOCANCEL(fd);
 #else


### PR DESCRIPTION
In #2639 we added a `defined(TARGET_OS_IPHONE)` preprocessor condition, but `TARGET_OS_IPHONE` is always defined on Apple to either `0` or `1`.  On 32-bit macOS architectures this leads to an undefined symbol reference to `_close$NOCANCEL`.  Fix the preprocessor condition to use just `TARGET_OS_IPHONE`.
