### PR TITLE
unix: Fix null pointer check

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1257,7 +1257,7 @@ int uv_os_environ(uv_env_item_t** envitems, int* count) {
 
   *envitems = uv__calloc(i, sizeof(**envitems));
 
-  if (envitems == NULL)
+  if (*envitems == NULL)
     return UV_ENOMEM;
 
   for (j = 0, cnt = 0; j < i; j++) {

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1405,7 +1405,7 @@ int uv_os_environ(uv_env_item_t** envitems, int* count) {
   for (penv = env, i = 0; *penv != L'\0'; penv += wcslen(penv) + 1, i++);
 
   *envitems = uv__calloc(i, sizeof(**envitems));
-  if (envitems == NULL) {
+  if (*envitems == NULL) {
     FreeEnvironmentStringsW(env);
     return UV_ENOMEM;
   }


### PR DESCRIPTION
Check the pointer to the allocated memory, not the pointer to the
pointer of the allocated memory. Previously, a failed allocation of
*envitems would lead to a NULL pointer dereference.