### PR TITLE
win: Fix alloca sizeof

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -692,7 +692,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   WCHAR* dst_copy;
   WCHAR** ptr_copy;
   WCHAR** env_copy;
-  DWORD* required_vars_value_len = alloca(n_required_vars * sizeof(DWORD*));
+  DWORD* required_vars_value_len = alloca(n_required_vars * sizeof(DWORD));
 
   /* first pass: determine size in UTF-16 */
   for (env = env_block; *env; env++) {


### PR DESCRIPTION
Pass the size of the elements to alloca, instead of the size of the
pointer to the elements.

DWORD is 4 bytes, so on 32-bit systems, there is no difference, but on
64-bit systems, now only the necessary memory is allocated (previously,
alloca would allocate twice as much memory as needed on 64-bit systems).