### PR TITLE
test: skip poll_duplex and poll_unidirectional on PASE

### DIFF
--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -592,10 +592,19 @@ static void start_poll_test(void) {
   MAKE_VALGRIND_HAPPY();
 }
 
-
+ 
+/* Issuing a shutdown() on IBM i PASE with parameter SHUT_WR
+ * also sends a normal close sequence to the partner program.
+ * This leads to timing issues and ECONNRESET failures in the
+ * test 'poll_duplex' and 'poll_unidirectional'.
+ * 
+ * https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_74/apis/shutdn.htm
+ */
 TEST_IMPL(poll_duplex) {
 #if defined(NO_SELF_CONNECT)
   RETURN_SKIP(NO_SELF_CONNECT);
+#elif defined(__PASE__)
+  RETURN_SKIP("API shutdown() may lead to timing issue on IBM i PASE");
 #endif
   test_mode = DUPLEX;
   start_poll_test();
@@ -606,6 +615,8 @@ TEST_IMPL(poll_duplex) {
 TEST_IMPL(poll_unidirectional) {
 #if defined(NO_SELF_CONNECT)
   RETURN_SKIP(NO_SELF_CONNECT);
+#elif defined(__PASE__)
+  RETURN_SKIP("API shutdown() may lead to timing issue on IBM i PASE");
 #endif
   test_mode = UNIDIRECTIONAL;
   start_poll_test();


### PR DESCRIPTION
Issuing a shutdown() on IBM i PASE with parameter SHUT_WR
also sends a normal **close** sequence to the partner program.
This leads to timing issues and ECONNRESET failures in the
test poll_duplex and poll_unidirectional.

https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_74/apis/shutdn.htm

We may skip these two tests until we found alternative solutions.

Related issue -> [ibmi: failed test case poll_duplex & poll_unidirectional](https://github.com/libuv/libuv/issues/2698)