### PR TITLE
win: replace alloca() with stack-based array

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -58,7 +58,6 @@ static const env_var_t required_vars[] = { /* keep me sorted */
   E_V("USERPROFILE"),
   E_V("WINDIR"),
 };
-static size_t n_required_vars = ARRAY_SIZE(required_vars);
 
 
 static HANDLE uv_global_job_handle_;
@@ -692,7 +691,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   WCHAR* dst_copy;
   WCHAR** ptr_copy;
   WCHAR** env_copy;
-  DWORD* required_vars_value_len = alloca(n_required_vars * sizeof(DWORD*));
+  DWORD required_vars_value_len[ARRAY_SIZE(required_vars)];
 
   /* first pass: determine size in UTF-16 */
   for (env = env_block; *env; env++) {
@@ -745,7 +744,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   qsort(env_copy, env_block_count-1, sizeof(wchar_t*), qsort_wcscmp);
 
   /* third pass: check for required variables */
-  for (ptr_copy = env_copy, i = 0; i < n_required_vars; ) {
+  for (ptr_copy = env_copy, i = 0; i < ARRAY_SIZE(required_vars); ) {
     int cmp;
     if (!*ptr_copy) {
       cmp = -1;
@@ -778,10 +777,10 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   }
 
   for (ptr = dst, ptr_copy = env_copy, i = 0;
-       *ptr_copy || i < n_required_vars;
+       *ptr_copy || i < ARRAY_SIZE(required_vars);
        ptr += len) {
     int cmp;
-    if (i >= n_required_vars) {
+    if (i >= ARRAY_SIZE(required_vars)) {
       cmp = 1;
     } else if (!*ptr_copy) {
       cmp = -1;


### PR DESCRIPTION
`required_vars_value_len` has a fixed number of elements. There is no
need to use alloca() to allocate it.

Refs: https://github.com/libuv/libuv/pull/2781
CI: https://ci.nodejs.org/job/libuv-test-commit/1844/