### PR TITLE
 removing redundant check in heap sort compare

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -42,12 +42,7 @@ static int timer_less_than(const struct heap_node* ha,
   /* Compare start_id when both have the same timeout. start_id is
    * allocated with loop->timer_counter in uv_timer_start().
    */
-  if (a->start_id < b->start_id)
-    return 1;
-  if (b->start_id < a->start_id)
-    return 0;
-
-  return 0;
+  return a->start_id < b->start_id;
 }
 
 


### PR DESCRIPTION
Don't know if this is significant or not 😅, but found this while traversing timers.
`timer_less_than` function is basically a comparator function
that returns true or false. At the end of the function we were
checking for the comparison of id, but the later `if` is redundant
as we are anyways, in the end, returning `0`. That extra check
can thus be safely removed. I know that the later if is stating some meaning but currently L47-L50 will be basically returning. 0 in any case.