### PR TITLE
build, win: add long path aware manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,7 +476,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-walk-handles.c
        test/test-watcher-cross-stop.c)
 
-  add_executable(uv_run_tests ${uv_test_sources})
+  add_executable(uv_run_tests ${uv_test_sources} uv_win_longpath.manifest)
   target_compile_definitions(uv_run_tests
                              PRIVATE ${uv_defines} USING_UV_SHARED=1)
   target_compile_options(uv_run_tests PRIVATE ${uv_cflags})
@@ -488,7 +488,7 @@ if(LIBUV_BUILD_TESTS)
     set_tests_properties(uv_test PROPERTIES ENVIRONMENT
                          "LIBPATH=${CMAKE_BINARY_DIR}:$ENV{LIBPATH}")
   endif()
-  add_executable(uv_run_tests_a ${uv_test_sources})
+  add_executable(uv_run_tests_a ${uv_test_sources} uv_win_longpath.manifest)
   target_compile_definitions(uv_run_tests_a PRIVATE ${uv_defines})
   target_compile_options(uv_run_tests_a PRIVATE ${uv_cflags})
   target_link_libraries(uv_run_tests_a uv_a ${uv_test_libraries})

--- a/uv_win_longpath.manifest
+++ b/uv_win_longpath.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </windowsSettings>
+    </application>
+</assembly>


### PR DESCRIPTION
Adds manifest file that makes the test runner work with long filenames when those are enabled in the system.

With https://github.com/libuv/libuv/pull/2788 and with the [longpath policy enabled](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later) this makes the test runner being able to use the new long path functionality of Win10 1607.
