### PR TITLE
unix,win: harmonize uv_read_start() error handling

### DIFF
--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -139,6 +139,11 @@ API
     be made several times until there is no more data to read or
     :c:func:`uv_read_stop` is called.
 
+    .. versionchanged:: 1.38.0 :c:func:`uv_read_start()` now consistently
+      returns `UV_EALREADY` when called twice, and `UV_EINVAL` when the
+      stream is closing. With older libuv versions, it returns `UV_EALREADY`
+      on Windows but not UNIX, and `UV_EINVAL` on UNIX but not Windows.
+
 .. c:function:: int uv_read_stop(uv_stream_t*)
 
     Stop reading data from the stream. The :c:type:`uv_read_cb` callback will

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1552,17 +1552,11 @@ int uv_try_write(uv_stream_t* stream,
 }
 
 
-int uv_read_start(uv_stream_t* stream,
-                  uv_alloc_cb alloc_cb,
-                  uv_read_cb read_cb) {
+int uv__read_start(uv_stream_t* stream,
+                   uv_alloc_cb alloc_cb,
+                   uv_read_cb read_cb) {
   assert(stream->type == UV_TCP || stream->type == UV_NAMED_PIPE ||
       stream->type == UV_TTY);
-
-  if (stream->flags & UV_HANDLE_CLOSING)
-    return UV_EINVAL;
-
-  if (!(stream->flags & UV_HANDLE_READABLE))
-    return UV_ENOTCONN;
 
   /* The UV_HANDLE_READING flag is irrelevant of the state of the tcp - it just
    * expresses the desired state of the user.

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -835,6 +835,9 @@ void uv_loop_delete(uv_loop_t* loop) {
 int uv_read_start(uv_stream_t* stream,
                   uv_alloc_cb alloc_cb,
                   uv_read_cb read_cb) {
+  if (stream == NULL || alloc_cb == NULL || read_cb == NULL)
+    return UV_EINVAL;
+
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -832,6 +832,22 @@ void uv_loop_delete(uv_loop_t* loop) {
 }
 
 
+int uv_read_start(uv_stream_t* stream,
+                  uv_alloc_cb alloc_cb,
+                  uv_read_cb read_cb) {
+  if (stream->flags & UV_HANDLE_CLOSING)
+    return UV_EINVAL;
+
+  if (stream->flags & UV_HANDLE_READING)
+    return UV_EALREADY;
+
+  if (!(stream->flags & UV_HANDLE_READABLE))
+    return UV_ENOTCONN;
+
+  return uv__read_start(stream, alloc_cb, read_cb);
+}
+
+
 void uv_os_free_environ(uv_env_item_t* envitems, int count) {
   int i;
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -136,6 +136,10 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
 
 void uv__loop_close(uv_loop_t* loop);
 
+int uv__read_start(uv_stream_t* stream,
+                   uv_alloc_cb alloc_cb,
+                   uv_read_cb read_cb);
+
 int uv__tcp_bind(uv_tcp_t* tcp,
                  const struct sockaddr* addr,
                  unsigned int addrlen,

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -65,17 +65,10 @@ int uv_accept(uv_stream_t* server, uv_stream_t* client) {
 }
 
 
-int uv_read_start(uv_stream_t* handle, uv_alloc_cb alloc_cb,
-    uv_read_cb read_cb) {
+int uv__read_start(uv_stream_t* handle,
+                   uv_alloc_cb alloc_cb,
+                   uv_read_cb read_cb) {
   int err;
-
-  if (handle->flags & UV_HANDLE_READING) {
-    return UV_EALREADY;
-  }
-
-  if (!(handle->flags & UV_HANDLE_READABLE)) {
-    return UV_ENOTCONN;
-  }
 
   err = ERROR_INVALID_PARAMETER;
   switch (handle->type) {

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -225,7 +225,9 @@ TEST_IMPL(pipe_getsockname_blocking) {
   ASSERT(r != -1);
   r = uv_pipe_open(&pipe_client, readfd);
   ASSERT(r == 0);
-  r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
+  r = uv_read_start((uv_stream_t*) &pipe_client,
+                    (uv_alloc_cb) abort,
+                    (uv_read_cb) abort);
   ASSERT(r == 0);
   Sleep(100);
   r = uv_read_stop((uv_stream_t*)&pipe_client);
@@ -236,7 +238,9 @@ TEST_IMPL(pipe_getsockname_blocking) {
   ASSERT(r == 0);
   ASSERT(len1 == 0);  /* It's an annonymous pipe. */
 
-  r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
+  r = uv_read_start((uv_stream_t*)&pipe_client,
+                    (uv_alloc_cb) abort,
+                    (uv_read_cb) abort);
   ASSERT(r == 0);
   Sleep(100);
 

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -93,6 +93,9 @@ static void connect_cb(uv_connect_t *req, int status) {
 
   /* Check error handling. */
   ASSERT_EQ(UV_EALREADY, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
+  ASSERT_EQ(UV_EINVAL, uv_read_start(NULL, alloc_cb, read_cb));
+  ASSERT_EQ(UV_EINVAL, uv_read_start((uv_stream_t*)&tcp, NULL, read_cb));
+  ASSERT_EQ(UV_EINVAL, uv_read_start((uv_stream_t*)&tcp, alloc_cb, NULL));
 
   /*
    * Write the letter 'Q' to gracefully kill the echo-server. This will not

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -89,7 +89,10 @@ static void connect_cb(uv_connect_t *req, int status) {
   ASSERT(req == &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
-  uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb);
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
+
+  /* Check error handling. */
+  ASSERT_EQ(UV_EALREADY, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
 
   /*
    * Write the letter 'Q' to gracefully kill the echo-server. This will not

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -283,7 +283,9 @@ TEST_IMPL(tcp_bind_writable_flags) {
   ASSERT(r == UV_EPIPE);
   r = uv_shutdown(&shutdown_req, (uv_stream_t*) &server, NULL);
   ASSERT(r == UV_ENOTCONN);
-  r = uv_read_start((uv_stream_t*) &server, NULL, NULL);
+  r = uv_read_start((uv_stream_t*) &server,
+                    (uv_alloc_cb) abort,
+                    (uv_read_cb) abort);
   ASSERT(r == UV_ENOTCONN);
 
   uv_close((uv_handle_t*)&server, close_cb);


### PR DESCRIPTION
The behavior of `uv_read_start()` when the handle is closing or already
busy reading wasn't consistent across platforms. Now it is.

Fixes: libuv/help#137
CI: https://ci.nodejs.org/job/libuv-test-commit/1869/

The second commit also checks the arguments.