### PR TITLE
Linux CPU times should be measured in milliseconds

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -131,11 +131,11 @@ Data types
             char* model;
             int speed;
             struct uv_cpu_times_s {
-                uint64_t user;
-                uint64_t nice;
-                uint64_t sys;
-                uint64_t idle;
-                uint64_t irq;
+                uint64_t user; /* milliseconds */
+                uint64_t nice; /* milliseconds */
+                uint64_t sys; /* milliseconds */
+                uint64_t idle; /* milliseconds */
+                uint64_t irq; /* milliseconds */
             } cpu_times;
         } uv_cpu_info_t;
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1069,11 +1069,11 @@ UV_EXTERN int uv_cancel(uv_req_t* req);
 
 
 struct uv_cpu_times_s {
-  uint64_t user;
-  uint64_t nice;
-  uint64_t sys;
-  uint64_t idle;
-  uint64_t irq;
+  uint64_t user; /* milliseconds */
+  uint64_t nice; /* milliseconds */
+  uint64_t sys; /* milliseconds */
+  uint64_t idle; /* milliseconds */
+  uint64_t irq; /* milliseconds */
 };
 
 struct uv_cpu_info_s {

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -768,7 +768,8 @@ static int read_times(FILE* statfile_fp,
                       unsigned int numcpus,
                       uv_cpu_info_t* ci) {
   struct uv_cpu_times_s ts;
-  uint64_t clock_ticks;
+  unsigned int ticks;
+  unsigned int multiplier;
   uint64_t user;
   uint64_t nice;
   uint64_t sys;
@@ -779,9 +780,10 @@ static int read_times(FILE* statfile_fp,
   uint64_t len;
   char buf[1024];
 
-  clock_ticks = sysconf(_SC_CLK_TCK);
-  assert(clock_ticks != (uint64_t) -1);
-  assert(clock_ticks != 0);
+  ticks = (unsigned int)sysconf(_SC_CLK_TCK);
+  multiplier = ((uint64_t)1000L / ticks);
+  assert(ticks != (unsigned int) -1);
+  assert(ticks != 0);
 
   rewind(statfile_fp);
 
@@ -823,11 +825,11 @@ static int read_times(FILE* statfile_fp,
                     &irq))
       abort();
 
-    ts.user = clock_ticks * user;
-    ts.nice = clock_ticks * nice;
-    ts.sys  = clock_ticks * sys;
-    ts.idle = clock_ticks * idle;
-    ts.irq  = clock_ticks * irq;
+    ts.user = user * multiplier;
+    ts.nice = nice * multiplier;
+    ts.sys  = sys * multiplier;
+    ts.idle = idle * multiplier;
+    ts.irq  = irq * multiplier;
     ci[num++].cpu_times = ts;
   }
   assert(num == numcpus);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -33,6 +33,9 @@ TEST_IMPL(platform_output) {
   uv_pid_t ppid;
   uv_rusage_t rusage;
   uv_cpu_info_t* cpus;
+  uv_cpu_info_t* cpus2;
+  uint64_t cpu1_total;
+  uint64_t cpu2_total;
   uv_interface_address_t* interfaces;
   uv_passwd_t pwd;
   uv_utsname_t uname;
@@ -102,6 +105,27 @@ TEST_IMPL(platform_output) {
     printf("  times.nice: %llu\n",
            (unsigned long long) cpus[i].cpu_times.nice);
   }
+
+  uv_sleep(100);
+  err = uv_cpu_info(&cpus2, &count);
+  ASSERT(err == 0);
+
+  cpu1_total = cpus[0].cpu_times.user +
+               cpus[0].cpu_times.nice +
+               cpus[0].cpu_times.sys +
+               cpus[0].cpu_times.idle +
+               cpus[0].cpu_times.irq;
+  cpu2_total = cpus2[0].cpu_times.user +
+               cpus2[0].cpu_times.nice +
+               cpus2[0].cpu_times.sys +
+               cpus2[0].cpu_times.idle +
+               cpus2[0].cpu_times.irq;
+
+  /* Check that total CPU times has increased by 100ms +/- 25ms. */
+  printf("uv_cpu_info cpu_times delta: %lu\n", cpu2_total - cpu1_total);
+  ASSERT(abs(cpu2_total - 100 - cpu1_total) < 25);
+
+  uv_free_cpu_info(cpus2, count);
 #endif
   uv_free_cpu_info(cpus, count);
 


### PR DESCRIPTION
This is a fix for #2773.

I have added a test, updated the documentation, and fixed the code itself.

As I'm new to this project, I have probably messed up something here - so please let me know if you'd like the three commits squashing, or extended commit messages, or indeed any other changes.

I am most uncertain about the test, as it introduces a sleep (albeit only 100ms) to be able to validate the units of the measurement.

I have tested the compilation and run the tests on Linux (gcc) and Windows (MSVC).