### PR TITLE
Two documentation improvements

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -657,7 +657,7 @@ API
 
     .. note::
         On IBM i PASE, you are not allowed to change your priority unless you
-        have the *JOBCTL special authority (even to lower it).
+        have the \*JOBCTL special authority (even to lower it).
 
     .. versionadded:: 1.23.0
 

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -69,8 +69,8 @@ API
     Returns 0 on success, or an error code < 0 on failure.
 
     Only cancellation of :c:type:`uv_fs_t`, :c:type:`uv_getaddrinfo_t`,
-    :c:type:`uv_getnameinfo_t` and :c:type:`uv_work_t` requests is
-    currently supported.
+    :c:type:`uv_getnameinfo_t`, :c:type:`uv_random_t` and :c:type:`uv_work_t`
+    requests is currently supported.
 
     Cancelled requests have their callbacks invoked some time in the future.
     It's **not** safe to free the memory associated with the request until the
@@ -80,8 +80,9 @@ API
 
     * A :c:type:`uv_fs_t` request has its req->result field set to `UV_ECANCELED`.
 
-    * A :c:type:`uv_work_t`, :c:type:`uv_getaddrinfo_t` or c:type:`uv_getnameinfo_t`
-      request has its callback invoked with status == `UV_ECANCELED`.
+    * A :c:type:`uv_work_t`, :c:type:`uv_getaddrinfo_t`,
+      :c:type:`uv_getnameinfo_t` or :c:type:`uv_random_t` request has its
+      callback invoked with status == `UV_ECANCELED`.
 
 .. c:function:: size_t uv_req_size(uv_req_type type)
 


### PR DESCRIPTION
I noticed while studying the source of uv_cancel() that it handles uv_random_t requests as well, but the documentation doesn't mention that. The second commit is an unrelated fix for a warning during the docs build.