### PR TITLE
Remove hard dependency on GetQueuedCompletionStatusEx

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -313,12 +313,12 @@ static void uv__poll(uv_loop_t* loop, int timeout) {
   timeout_time = loop->time + timeout;
 
   for (repeat = 0; ; repeat++) {
-    success = GetQueuedCompletionStatusEx(loop->iocp,
-                                          overlappeds,
-                                          ARRAY_SIZE(overlappeds),
-                                          &count,
-                                          timeout,
-                                          FALSE);
+    success = pGetQueuedCompletionStatusEx(loop->iocp,
+                                           overlappeds,
+                                           ARRAY_SIZE(overlappeds),
+                                           &count,
+                                           timeout,
+                                           FALSE);
 
     if (success) {
       for (i = 0; i < count; i++) {


### PR DESCRIPTION
libuv already works without that API since 153ea114fff672b9c621a5d2bb13cea667b4499e, but still had it as a hard requirement in the import table.
This code uses the the `pGetQueuedCompletionStatusEx` function pointer instead, hence it also works on systems that don't export `GetQueuedCompletionStatusEx`.

This simple fix improves compatibility of libuv with ReactOS and Windows XP (latter using Vista+ compatibility libraries like https://github.com/MyTDT-Mysoft/DllCompat)