### PR TITLE
doc: correct source lines

### DIFF
--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -293,7 +293,7 @@ informing the user of the status of running downloads.
 .. rubric:: progress/main.c
 .. literalinclude:: ../../code/progress/main.c
     :linenos:
-    :lines: 7-8,34-
+    :lines: 7-8,35-
     :emphasize-lines: 2,11
 
 The async thread communication works *on loops* so although any thread can be
@@ -318,7 +318,7 @@ with the async watcher whenever it receives a message.
 .. rubric:: progress/main.c
 .. literalinclude:: ../../code/progress/main.c
     :linenos:
-    :lines: 10-23
+    :lines: 10-24
     :emphasize-lines: 7-8
 
 In the download function, we modify the progress indicator and queue the message
@@ -328,7 +328,7 @@ non-blocking and will return immediately.
 .. rubric:: progress/main.c
 .. literalinclude:: ../../code/progress/main.c
     :linenos:
-    :lines: 30-33
+    :lines: 31-34
 
 The callback is a standard libuv pattern, extracting the data from the watcher.
 
@@ -337,7 +337,7 @@ Finally it is important to remember to clean up the watcher.
 .. rubric:: progress/main.c
 .. literalinclude:: ../../code/progress/main.c
     :linenos:
-    :lines: 25-28
+    :lines: 26-29
     :emphasize-lines: 3
 
 After this example, which showed the abuse of the ``data`` field, bnoordhuis_


### PR DESCRIPTION
Sample codes in documentation `guide/threads` a bit strange. This PR corrects those line referenced. Following screenshots are between original version and this PR version.

| before        | with this PR           | 
| ------------- |-------------|
|![before01](https://user-images.githubusercontent.com/554281/79873289-e3de3800-8421-11ea-9f65-835bcb9e81ce.png)|![after01](https://user-images.githubusercontent.com/554281/79873304-e8a2ec00-8421-11ea-9a49-9016117eebe8.png)|
|![before02](https://user-images.githubusercontent.com/554281/79873323-ee003680-8421-11ea-8c49-d95b40c3fa5e.png)|![after02](https://user-images.githubusercontent.com/554281/79873341-f2c4ea80-8421-11ea-953e-4a66c033954e.png)|
|![before03](https://user-images.githubusercontent.com/554281/79873357-f7899e80-8421-11ea-987a-a850fa9470bf.png)|![after03](https://user-images.githubusercontent.com/554281/79873372-fc4e5280-8421-11ea-98a0-9939564d0ba5.png)|
|![before04](https://user-images.githubusercontent.com/554281/79873384-01ab9d00-8422-11ea-8e1f-8d76b29cc859.png)|![after04](https://user-images.githubusercontent.com/554281/79873402-06705100-8422-11ea-81c2-da6139e5e09b.png)|
