### PR TITLE
doc: check/idle/prepare functions always succeed

### DIFF
--- a/docs/src/check.rst
+++ b/docs/src/check.rst
@@ -33,14 +33,22 @@ API
 
 .. c:function:: int uv_check_init(uv_loop_t* loop, uv_check_t* check)
 
-    Initialize the handle.
+    Initialize the handle. This function always succeeds.
+
+    :returns: 0
 
 .. c:function:: int uv_check_start(uv_check_t* check, uv_check_cb cb)
 
-    Start the handle with the given callback.
+    Start the handle with the given callback. This function always succeeds,
+    except when `cb` is `NULL`.
+
+    :returns: 0 on success, or `UV_EINVAL` when `cb == NULL`.
 
 .. c:function:: int uv_check_stop(uv_check_t* check)
 
     Stop the handle, the callback will no longer be called.
+    This function always succeeds.
+
+    :returns: 0
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/idle.rst
+++ b/docs/src/idle.rst
@@ -41,14 +41,22 @@ API
 
 .. c:function:: int uv_idle_init(uv_loop_t* loop, uv_idle_t* idle)
 
-    Initialize the handle.
+    Initialize the handle. This function always succeeds.
+
+    :returns: 0
 
 .. c:function:: int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb)
 
-    Start the handle with the given callback.
+    Start the handle with the given callback. This function always succeeds,
+    except when `cb` is `NULL`.
+
+    :returns: 0 on success, or `UV_EINVAL` when `cb == NULL`.
 
 .. c:function:: int uv_idle_stop(uv_idle_t* idle)
 
     Stop the handle, the callback will no longer be called.
+    This function always succeeds.
+
+    :returns: 0
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/docs/src/prepare.rst
+++ b/docs/src/prepare.rst
@@ -33,14 +33,22 @@ API
 
 .. c:function:: int uv_prepare_init(uv_loop_t* loop, uv_prepare_t* prepare)
 
-    Initialize the handle.
+    Initialize the handle. This function always succeeds.
+
+    :returns: 0
 
 .. c:function:: int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb)
 
-    Start the handle with the given callback.
+    Start the handle with the given callback. This function always succeeds,
+    except when `cb` is `NULL`.
+
+    :returns: 0 on success, or `UV_EINVAL` when `cb == NULL`.
 
 .. c:function:: int uv_prepare_stop(uv_prepare_t* prepare)
 
     Stop the handle, the callback will no longer be called.
+    This function always succeeds.
+
+    :returns: 0
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.


### PR DESCRIPTION
Make the documentation reflect that the init/start/stop functions
for check/idle/prepare handles always succeed.