### PR TITLE
fs: report original error

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -492,6 +492,13 @@ API
 
     .. versionadded:: 1.19.0
 
+.. c:function:: int uv_fs_get_system_error(const uv_fs_t* req)
+
+    Returns the platform specific error code - `GetLastError()` value on Windows
+    and `-(req->result)` on other platforms.
+
+    .. versionadded:: 1.38.0
+
 .. c:function:: void* uv_fs_get_ptr(const uv_fs_t* req)
 
     Returns `req->ptr`.

--- a/include/uv.h
+++ b/include/uv.h
@@ -1307,6 +1307,7 @@ struct uv_fs_s {
 
 UV_EXTERN uv_fs_type uv_fs_get_type(const uv_fs_t*);
 UV_EXTERN ssize_t uv_fs_get_result(const uv_fs_t*);
+UV_EXTERN int uv_fs_get_system_error(const uv_fs_t*);
 UV_EXTERN void* uv_fs_get_ptr(const uv_fs_t*);
 UV_EXTERN const char* uv_fs_get_path(const uv_fs_t*);
 UV_EXTERN uv_stat_t* uv_fs_get_statbuf(uv_fs_t*);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -2086,3 +2086,7 @@ int uv_fs_statfs(uv_loop_t* loop,
   PATH;
   POST;
 }
+
+int uv_fs_get_system_error(const uv_fs_t* req) {
+  return -req->result;
+}

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -4347,3 +4347,21 @@ TEST_IMPL(fs_statfs) {
 
   return 0;
 }
+
+TEST_IMPL(fs_get_system_error) {
+  uv_fs_t req;
+  int r;
+  int system_error;
+
+  r = uv_fs_statfs(NULL, &req, "non_existing_file", NULL);
+  ASSERT(r != 0);
+
+  system_error = uv_fs_get_system_error(&req);
+#ifdef _WIN32
+  ASSERT(system_error == ERROR_FILE_NOT_FOUND);
+#else
+  ASSERT(system_error == ENOENT);
+#endif
+
+  return 0;
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -409,6 +409,7 @@ TEST_DECLARE   (fs_open_readonly_acl)
 TEST_DECLARE   (fs_fchmod_archive_readonly)
 TEST_DECLARE   (fs_invalid_mkdir_name)
 #endif
+TEST_DECLARE   (fs_get_system_error)
 TEST_DECLARE   (strscpy)
 TEST_DECLARE   (threadpool_queue_work_simple)
 TEST_DECLARE   (threadpool_queue_work_einval)
@@ -1036,6 +1037,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_fchmod_archive_readonly)
   TEST_ENTRY  (fs_invalid_mkdir_name)
 #endif
+  TEST_ENTRY  (fs_get_system_error)
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (open_osfhandle_valid_handle)
   TEST_ENTRY  (strscpy)


### PR DESCRIPTION
Exposes the original system error of the filesystem syscalls. Adds a new `uv_fs_get_system_result` function which returns the original `errno` on Linux or `GetLastError()` on Windows.

Ref: https://github.com/libuv/libuv/issues/2348

CI: https://ci.nodejs.org/view/libuv/job/libuv-test-commit/1874/