### PR TITLE
win, fs: add IO_REPARSE_TAG_APPEXECLINK support

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -72,6 +72,7 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_NOACCESS:                    return UV_EACCES;
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
+    case ERROR_CANT_ACCESS_FILE:            return UV_EACCES;
     case ERROR_ADDRESS_ALREADY_ASSOCIATED:  return UV_EADDRINUSE;
     case WSAEADDRINUSE:                     return UV_EADDRINUSE;
     case WSAEADDRNOTAVAIL:                  return UV_EADDRNOTAVAIL;

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4152,6 +4152,10 @@ typedef const UNICODE_STRING *PCUNICODE_STRING;
       struct {
         UCHAR  DataBuffer[1];
       } GenericReparseBuffer;
+      struct {
+        ULONG StringCount;
+        WCHAR StringList[1];
+      } AppExecLinkReparseBuffer;
     };
   } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 #endif
@@ -4516,6 +4520,9 @@ typedef struct _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
 
 #ifndef IO_REPARSE_TAG_SYMLINK
 # define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
+#endif
+#ifndef IO_REPARSE_TAG_APPEXECLINK
+# define IO_REPARSE_TAG_APPEXECLINK (0x8000001BL)
 #endif
 
 typedef VOID (NTAPI *PIO_APC_ROUTINE)

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2453,6 +2453,57 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+TEST_IMPL(fs_lstat_windows_store_apps) {
+  uv_loop_t* loop;
+  char localappdata[MAX_PATH];
+  char windowsapps_path[MAX_PATH];
+  char file_path[MAX_PATH];
+  size_t len;
+  int r;
+  uv_fs_t req;
+  uv_fs_t stat_req;
+  uv_dirent_t dirent;
+
+  loop = uv_default_loop();
+  ASSERT_NOT_NULL(loop);
+  len = sizeof(localappdata);
+  r = uv_os_getenv("LOCALAPPDATA", localappdata, &len);
+  if (r == UV_ENOENT) {
+    MAKE_VALGRIND_HAPPY();
+    return TEST_SKIP;
+  }
+  ASSERT_EQ(r, 0);
+  r = snprintf(windowsapps_path,
+              sizeof(localappdata),
+              "%s\\Microsoft\\WindowsApps",
+              localappdata);
+  ASSERT_GT(r, 0);
+  if (uv_fs_opendir(loop, &req, windowsapps_path, NULL) != 0) {
+    /* If we cannot read the directory, skip the test. */
+    MAKE_VALGRIND_HAPPY();
+    return TEST_SKIP;
+  }
+  if (uv_fs_scandir(loop, &req, windowsapps_path, 0, NULL) <= 0) {
+    MAKE_VALGRIND_HAPPY();
+    return TEST_SKIP;
+  }
+  while (uv_fs_scandir_next(&req, &dirent) != UV_EOF) {
+    if (dirent.type != UV_DIRENT_LINK) {
+      continue;
+    }
+    if (snprintf(file_path,
+                 sizeof(file_path),
+                 "%s\\%s",
+                 windowsapps_path,
+                 dirent.name) < 0) {
+      continue;
+    }
+    ASSERT_EQ(uv_fs_lstat(loop, &stat_req, file_path, NULL), 0);
+  }
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
 #endif
 
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -346,6 +346,7 @@ TEST_DECLARE   (fs_symlink_dir)
 #ifdef _WIN32
 TEST_DECLARE   (fs_symlink_junction)
 TEST_DECLARE   (fs_non_symlink_reparse_point)
+TEST_DECLARE   (fs_lstat_windows_store_apps)
 TEST_DECLARE   (fs_open_flags)
 #endif
 #if defined(_WIN32) && !defined(USING_UV_SHARED)
@@ -979,6 +980,7 @@ TASK_LIST_START
 #ifdef _WIN32
   TEST_ENTRY  (fs_symlink_junction)
   TEST_ENTRY  (fs_non_symlink_reparse_point)
+  TEST_ENTRY  (fs_lstat_windows_store_apps)
   TEST_ENTRY  (fs_open_flags)
 #endif
 #if defined(_WIN32) && !defined(USING_UV_SHARED)


### PR DESCRIPTION
Adds support for `IO_REPARSE_TAG_APPEXECLINK` reparse points, used by Windows Store.

Ref: https://github.com/nodejs/node/issues/33024