### PR TITLE
win: work around QueryPerformanceCounter() turning backwards

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -306,12 +306,12 @@ fail_timers_alloc:
 
 void uv_update_time(uv_loop_t* loop) {
   uint64_t new_time = uv__hrtime(1000);
-  // new_time should always be at least loop->time, as per the API contract for
-  // QueryPerformanceCounter() and hence also uv__hrtime().
-  // However, there appears to be a bug that keeps Windows from guaranteeing
-  // that behavior on some CPUs, so we act as if no time had passed in that
-  // case.
-  // See https://github.com/libuv/libuv/issues/1633 for more details.
+  /* new_time should always be at least loop->time, as per the API contract for
+   * QueryPerformanceCounter() and hence also uv__hrtime().
+   * However, there appears to be a bug that keeps Windows from guaranteeing
+   * that behavior on some CPUs, so we act as if no time had passed in that
+   * case.
+   * See https://github.com/libuv/libuv/issues/1633 for more details. */
   if (new_time > loop->time)
     loop->time = new_time;
 }

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -306,8 +306,14 @@ fail_timers_alloc:
 
 void uv_update_time(uv_loop_t* loop) {
   uint64_t new_time = uv__hrtime(1000);
-  assert(new_time >= loop->time);
-  loop->time = new_time;
+  // new_time should always be at least loop->time, as per the API contract for
+  // QueryPerformanceCounter() and hence also uv__hrtim().
+  // However, there appears to be  a bug that keeps Windows from guaranteeing
+  // that behavior on some CPUs, so we act as if no time had passed in that
+  // case.
+  // See https://github.com/libuv/libuv/issues/1633 for more details.
+  if (new_time > loop->time)
+    loop->time = new_time;
 }
 
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -307,8 +307,8 @@ fail_timers_alloc:
 void uv_update_time(uv_loop_t* loop) {
   uint64_t new_time = uv__hrtime(1000);
   // new_time should always be at least loop->time, as per the API contract for
-  // QueryPerformanceCounter() and hence also uv__hrtim().
-  // However, there appears to be  a bug that keeps Windows from guaranteeing
+  // QueryPerformanceCounter() and hence also uv__hrtime().
+  // However, there appears to be a bug that keeps Windows from guaranteeing
   // that behavior on some CPUs, so we act as if no time had passed in that
   // case.
   // See https://github.com/libuv/libuv/issues/1633 for more details.


### PR DESCRIPTION
This is not a great solution to the referenced bug, but it seems fair
as libuv is intended to be a platform abstraction library that (also)
deals with OS bugs.

Adding a regression test does not seem feasible.

Fixes: https://github.com/libuv/libuv/issues/1633