### PR TITLE
doc: add thread safety warning for uv_replace_allocator

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -233,6 +233,8 @@ API
                  sure the allocator is changed while no memory was allocated with
                  the previous allocator, or that they are compatible.
 
+    .. warning:: Allocator must be thread-safe.
+
 .. c:function:: void uv_library_shutdown(void);
 
     .. versionadded:: 1.38.0


### PR DESCRIPTION
I noticed that libuv may allocate memory in sub-threads (e.g., `uv_fs_read`, `uv_fs_realpath`...)
but some allocators are not thread-safe, or some are thread-local, I think we need to point out it in the doc.