### PR TITLE
test: fix benchmark-ping-udp

### DIFF
--- a/test/benchmark-list.h
+++ b/test/benchmark-list.h
@@ -23,7 +23,9 @@ BENCHMARK_DECLARE (sizes)
 BENCHMARK_DECLARE (loop_count)
 BENCHMARK_DECLARE (loop_count_timed)
 BENCHMARK_DECLARE (ping_pongs)
-BENCHMARK_DECLARE (ping_udp)
+BENCHMARK_DECLARE (ping_udp1)
+BENCHMARK_DECLARE (ping_udp10)
+BENCHMARK_DECLARE (ping_udp100)
 BENCHMARK_DECLARE (tcp_write_batch)
 BENCHMARK_DECLARE (tcp4_pound_100)
 BENCHMARK_DECLARE (tcp4_pound_1000)
@@ -90,6 +92,10 @@ TASK_LIST_START
 
   BENCHMARK_ENTRY  (ping_pongs)
   BENCHMARK_HELPER (ping_pongs, tcp4_echo_server)
+
+  BENCHMARK_ENTRY  (ping_udp1)
+  BENCHMARK_ENTRY  (ping_udp10)
+  BENCHMARK_ENTRY  (ping_udp100)
 
   BENCHMARK_ENTRY  (tcp_write_batch)
   BENCHMARK_HELPER (tcp_write_batch, tcp4_blackhole_server)


### PR DESCRIPTION
- Fixes the declaration of the benchmark in `benchmark-list.h` (it was not previously runnable at all)
- Fixes the benchmark itself hanging infinitely because the data was being dropped via ICMP Destination Unreachable errors (meaning `nread` was always zero in `pinger_read_cb`)
  + The data getting lost was fixed by binding the udp socket
- Properly checks for `UV_UDP_MMSG_CHUNK`, just as an example of what should generally be done (buf_free is actually a no-op as the buf is allocated on the stack)

---

Notes:

- Tangentially related to https://github.com/libuv/libuv/issues/2807 since this benchmark was introduced in https://github.com/libuv/libuv/pull/2532
- It's unclear to me exactly what this is meant to be benchmarking or how it differs from `benchmark-udp-pummel.c`.
- Feel free to treat this PR as a bug report and implement a better fix by someone more familiar with what the intention of this benchmark was.