### PR TITLE
unix: fully initialize struct msghdr

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -202,6 +202,9 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
     msgs[k].msg_hdr.msg_iovlen = 1;
     msgs[k].msg_hdr.msg_name = peers + k;
     msgs[k].msg_hdr.msg_namelen = sizeof(peers[0]);
+    msgs[k].msg_hdr.msg_control = NULL;
+    msgs[k].msg_hdr.msg_controllen = 0;
+    msgs[k].msg_hdr.msg_flags = 0;
   }
 
   do


### PR DESCRIPTION
Commit 3d713663 ("freebsd,linux: add recvmmsg() + sendmmsg() udp
implementation") forgot to zero some of the members of the msghdr
struct. It seems to work by accident, not by design.

Refs: https://github.com/libuv/libuv/pull/2818
CI: https://ci.nodejs.org/job/libuv-test-commit/1888/