### PR TITLE
win: bump minimum supported version to windows 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ set(uv_sources
     src/version.c)
 
 if(WIN32)
-  list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0600)
+  list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0602)
   list(APPEND uv_libraries
        psapi
        iphlpapi

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ if WINNT
 uvinclude_HEADERS += include/uv/win.h include/uv/tree.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/win \
                -DWIN32_LEAN_AND_MEAN \
-               -D_WIN32_WINNT=0x0600
+               -D_WIN32_WINNT=0x0602
 libuv_la_SOURCES += src/win/async.c \
                     src/win/atomicops-inl.h \
                     src/win/core.c \

--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -4,7 +4,7 @@
 |---|---|---|---|
 | GNU/Linux | Tier 1 | Linux >= 2.6.32 with glibc >= 2.12 | |
 | macOS | Tier 1 | macOS >= 10.7 | |
-| Windows | Tier 1 | >= Windows 7 | MSVC 2008 and later are supported |
+| Windows | Tier 1 | >= Windows 8 | VS 2015 and later are supported |
 | FreeBSD | Tier 1 | >= 10 | |
 | AIX | Tier 2 | >= 6 | Maintainers: @libuv/aix |
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1328,9 +1328,8 @@ TEST_IMPL(environment_creation) {
         found = 1;
       }
     }
-    if (prev) { /* verify sort order -- requires Vista */
-#if _WIN32_WINNT >= 0x0600 && \
-    (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
+    if (prev) { /* verify sort order */
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
 #endif
     }


### PR DESCRIPTION
* Windows 7 went out of support earlier this year.

* As did Python 2.7. We no longer have to worry about MSVC 2008.
  Python 3.5 and up use VS 2015.

<hr>

#2820 for additional context - `GetSystemTimePreciseAsFileTime()` is Windows 8 and up only.

cc @libuv/windows