### PR TITLE
udp: add uv_udp_using_recvmmsg

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -391,6 +391,16 @@ API
     .. versionchanged:: 1.37.0 :man:`recvmmsg(2)` support is no longer enabled implicitly,
                         it must be explicitly requested by passing the `UV_UDP_RECVMMSG` flag to
                         :c:func:`uv_udp_init_ex`.
+    .. versionchanged:: 1.39.0 :c:func:`uv_udp_using_recvmmsg` can be used in `alloc_cb` to
+                        determine if a buffer sized for use with :man:`recvmmsg(2)` should be 
+                        allocated for the current handle/platform.
+
+.. c:function:: int uv_udp_using_recvmmsg(uv_udp_t* handle)
+
+    Returns 1 if the UDP handle was created with the `UV_UDP_RECVMMSG` flag
+    and the platform supports :man:`recvmmsg(2)`, 0 otherwise.
+
+    .. versionadded:: 1.39.0
 
 .. c:function:: int uv_udp_recv_stop(uv_udp_t* handle)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -693,6 +693,7 @@ UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
 UV_EXTERN int uv_udp_recv_start(uv_udp_t* handle,
                                 uv_alloc_cb alloc_cb,
                                 uv_udp_recv_cb recv_cb);
+UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
 UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
 UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
 UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -189,6 +189,11 @@ void uv_udp_endgame(uv_loop_t* loop, uv_udp_t* handle) {
 }
 
 
+int uv_udp_using_recvmmsg(const uv_udp_t* handle) {
+  return 0;
+}
+
+
 static int uv_udp_maybe_bind(uv_udp_t* handle,
                              const struct sockaddr* addr,
                              unsigned int addrlen,


### PR DESCRIPTION
Allows for determining if a buffer large enough for multiple dgrams should be allocated in `alloc_cb` of `uv_udp_recvstart`. See #2822 for more details.

For an example of how this would be used, see https://github.com/squeek502/libuv/commit/48e2e7d3baa9a4839e744445b4488381a105e8cd which alters the test added in #2818 to use `uv_udp_is_using_recvmmsg`

~~EDIT: Note that this PR changes the `UV_HANDLE_UDP_RECVMMSG` flag to only be set on the `uv_udp_t` handle if the platform actually supports `recvmmsg`.~~ (no longer the case)

---

I think it's also worth addressing this:

> One other thing is that, due to how the number of dgrams read via `recvmmsg` is reliant on multiples of [`UV__UDP_DGRAM_MAXSIZE`](https://github.com/libuv/libuv/blob/2bbf7d5c8cd070cc8541698fe72136328bc18eae/src/unix/udp.c#L35), it might be helpful to make that constant public in some way, or guarantee that `alloc_cb`'s `suggested_size` will always equal `UV__UDP_DGRAM_MAXSIZE` for `recv` buffer allocations.

but I wasn't sure how to do it. Note that, currently, it *is* the case that `suggested_size` in `alloc_cb` will be `UV__UDP_DGRAM_MAXSIZE` [on Unix](https://github.com/libuv/libuv/blob/e7ebae26247d2fee0a04547eb7f9aa8f78d4a642/src/unix/udp.c#L260) and [on Windows, but not as explicitly](https://github.com/libuv/libuv/blob/e7ebae26247d2fee0a04547eb7f9aa8f78d4a642/src/win/udp.c#L499) (also called [here](https://github.com/libuv/libuv/blob/e7ebae26247d2fee0a04547eb7f9aa8f78d4a642/src/win/udp.c#L282)). If it's decided that this `suggested_size` should be formalized, then suggestions on how to document it are welcome.