### PR TITLE
udp: add UV_UDP_MMSG_FREE recv_cb flag

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -48,6 +48,12 @@ Data types
              */
             UV_UDP_MMSG_CHUNK = 8,
             /*
+             * Indicates that the buffer provided has been fully utilized by recvmmsg and
+             * that it should now be freed by the recv_cb callback. When this flag is set
+             * in uv_udp_recv_cb, nread will always be 0 and addr will always be NULL.
+             */
+            UV_UDP_MMSG_FREE = 16,
+            /*
             * Indicates that recvmmsg should be used, if available.
             */
             UV_UDP_RECVMMSG = 256
@@ -80,8 +86,10 @@ Data types
     When using :man:`recvmmsg(2)`, chunks will have the `UV_UDP_MMSG_CHUNK` flag set,
     those must not be freed. There will be a final callback with `nread` set to 0,
     `addr` set to NULL and the buffer pointing at the initially allocated data with
-    the `UV_UDP_MMSG_CHUNK` flag cleared. This is a good chance for the callee to
-    free the provided buffer.
+    the `UV_UDP_MMSG_CHUNK` flag cleared and the `UV_UDP_MMSG_FREE` flag set.
+    The callee can now safely free the provided buffer.
+
+    .. versionchanged:: 1.39.0 added the `UV_UDP_MMSG_FREE` flag.
 
     .. note::
         The receive callback will be called with `nread` == 0 and `addr` == NULL when there is

--- a/include/uv.h
+++ b/include/uv.h
@@ -613,6 +613,12 @@ enum uv_udp_flags {
    * must not be freed by the recv_cb callback.
    */
   UV_UDP_MMSG_CHUNK = 8,
+  /*
+   * Indicates that the buffer provided has been fully utilized by recvmmsg and
+   * that it should now be freed by the recv_cb callback. When this flag is set
+   * in uv_udp_recv_cb, nread will always be 0 and addr will always be NULL.
+   */
+  UV_UDP_MMSG_FREE = 16,
 
   /*
    * Indicates that recvmmsg should be used, if available.

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -238,7 +238,7 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
 
     /* one last callback so the original buffer is freed */
     if (handle->recv_cb != NULL)
-      handle->recv_cb(handle, 0, buf, NULL, 0);
+      handle->recv_cb(handle, 0, buf, NULL, UV_UDP_MMSG_FREE);
   }
   return nread;
 }

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -67,16 +67,22 @@ static void recv_cb(uv_udp_t* handle,
                        unsigned flags) {
   ASSERT_GE(nread, 0);
 
-  if (nread > 0) {
-    ASSERT_EQ(nread, 4);
-    ASSERT(addr != NULL);
-    ASSERT_MEM_EQ("PING", rcvbuf->base, nread);
+  /* free and return if this is a mmsg free-only callback invocation */
+  if (flags & UV_UDP_MMSG_FREE) {
+    ASSERT_EQ(nread, 0);
+    ASSERT(addr == NULL);
+    free(rcvbuf->base);
+    return;
+  }
 
-    recv_cb_called++;
-    if (recv_cb_called == NUM_SENDS) {
-      uv_close((uv_handle_t*)handle, close_cb);
-      uv_close((uv_handle_t*)&sender, close_cb);
-    }
+  ASSERT_EQ(nread, 4);
+  ASSERT(addr != NULL);
+  ASSERT_MEM_EQ("PING", rcvbuf->base, nread);
+
+  recv_cb_called++;
+  if (recv_cb_called == NUM_SENDS) {
+    uv_close((uv_handle_t*)handle, close_cb);
+    uv_close((uv_handle_t*)&sender, close_cb);
   }
 
   /* Don't free if the buffer could be reused via mmsg */


### PR DESCRIPTION
Contributes towards #2822. From https://github.com/libuv/libuv/issues/2822#issuecomment-624512182:

> When using `UV_UDP_RECVMMSG`, `recv_cb` gets called once for each message with the `UV_UDP_MMSG_CHUNK` flag set, and then [once with `nread=0`, `addr=NULL`, and without the `UV_UDP_MMSG_CHUNK` flag set to free the buffer](https://github.com/libuv/libuv/blob/e7ebae26247d2fee0a04547eb7f9aa8f78d4a642/src/unix/udp.c#L234-L236).
> 
> For binding this in a garbage collected language, passing that last callback on seems somewhat strange, as the garbage collected language shouldn't care about it, and it would cause a discrepancy in the number of callbacks called when using `mmsg` and when not using it. That is, using the test added in #2818 as an example, where using `mmsg` leads to 2 allocs for 8 messages:
> 
> * When not using `UV_UDP_RECVMMSG`, `recv_cb` would be called 8 times (once for each message)
> * When using `UV_UDP_RECVMMSG`, `recv_cb` would be called 10 times (once for each message, and then 2 for freeing the mmsg buffers)
> 
> Not passing these 'free-only' callbacks on would be no problem except that there doesn't seem to be a way to distinguish these 'free-only' callbacks from things like [callbacks from `EAGAIN` or `EWOULDBLOCK`](https://github.com/libuv/libuv/blob/e7ebae26247d2fee0a04547eb7f9aa8f78d4a642/src/unix/udp.c#L292-L293), which doesn't seem ideal. But, again, I might be thinking about this wrong, so any feedback is appreciated.

For an example of how this would be used, see https://github.com/squeek502/libuv/commit/94de1d6af2a716fd832fe3fec4c9d5f46d781547 which alters the test added in #2818 to use `UV_UDP_MMSG_FREE`.