### PR TITLE
unix: fix memory leak when uv_loop_init() fails

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -106,6 +106,7 @@ fail_rwlock_init:
 fail_signal_init:
   uv__platform_loop_delete(loop);
 
+  free(loop->watchers);
   return err;
 }
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -106,7 +106,8 @@ fail_rwlock_init:
 fail_signal_init:
   uv__platform_loop_delete(loop);
 
-  free(loop->watchers);
+  uv__free(loop->watchers);
+  loop->nwatchers = 0;
   return err;
 }
 


### PR DESCRIPTION
`uv_signal_init()` leads to the allocation of an IO watcher,
so if the loop initialization fails at a later point,
the `loop->watchers` list needs to be released.