### PR TITLE
unix: don't abort when getrlimit() fails

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -172,10 +172,11 @@ static size_t thread_stack_size(void) {
 #if defined(__APPLE__) || defined(__linux__)
   struct rlimit lim;
 
-  if (getrlimit(RLIMIT_STACK, &lim))
-    abort();
-
-  if (lim.rlim_cur != RLIM_INFINITY) {
+  /* getrlimit() can fail on some aarch64 systems due to a glibc bug where
+   * the system call wrapper invokes the wrong system call. Don't treat
+   * that as fatal, just use the default stack size instead.
+   */
+  if (0 == getrlimit(RLIMIT_STACK, &lim) && lim.rlim_cur != RLIM_INFINITY) {
     /* pthread_attr_setstacksize() expects page-aligned values. */
     lim.rlim_cur -= lim.rlim_cur % (rlim_t) getpagesize();
 


### PR DESCRIPTION
It was reported that `getrlimit(RLIMIT_STACK)` fails on some aarch64
systems due to a glibc bug, where the getrlimit() system call wrapper
invokes the wrong system call.

Libuv could work around that by issuing a `prlimit(2)` system call
instead but since it can't assume that said system call is available
(it was added in Linux 2.6.36, libuv's baseline is 2.6.32) it seems
easier to just use the default 2M stack size when the call fails.

Fixes: https://github.com/nodejs/node/issues/33244
Refs: https://bugzilla.redhat.com/show_bug.cgi?id=1813089
CI: https://ci.nodejs.org/job/libuv-test-commit/1902/