### PR TITLE
test: support common user profile on IBMi

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -315,7 +315,7 @@ static void chown_root_cb(uv_fs_t* req) {
      * User may grant qsecofr's privileges, including changing 
      * the file's ownership to uid 0.
      */
-    ASSERT(req->result == 0);
+    ASSERT(req->result == 0 || req->result == UV_EPERM);
 #   else
     ASSERT(req->result == UV_EPERM);
 #   endif

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1452,7 +1452,7 @@ TEST_IMPL(spawn_setuid_fails) {
   options.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-#if defined(__CYGWIN__) || defined(__PASE__)
+#if defined(__CYGWIN__)
   ASSERT(r == UV_EINVAL);
 #else
   ASSERT(r == UV_EPERM);
@@ -1497,7 +1497,7 @@ TEST_IMPL(spawn_setgid_fails) {
 #endif
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-#if defined(__CYGWIN__) || defined(__MVS__) || defined(__PASE__)
+#if defined(__CYGWIN__) || defined(__MVS__)
   ASSERT(r == UV_EINVAL);
 #else
   ASSERT(r == UV_EPERM);
@@ -1689,7 +1689,7 @@ TEST_IMPL(spawn_reads_child_path) {
    */
 #if defined(__APPLE__)
   static const char dyld_path_var[] = "DYLD_LIBRARY_PATH";
-#elif defined __MVS__
+#elif defined(__MVS__) || defined(__PASE__)
   static const char dyld_path_var[] = "LIBPATH";
 #else
   static const char dyld_path_var[] = "LD_LIBRARY_PATH";


### PR DESCRIPTION
Previously libuv was tested under the user class QSECOFR on IBM i.
But most IBM i users does not have that authority.
Refine some assertions to support common user profiles on IBM i.

It resolves the issue #2851