### PR TITLE
misc: return error in uv_{get,set}_process_title when uv_setup_args is needed but not called

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -275,21 +275,36 @@ API
 .. c:function:: int uv_get_process_title(char* buffer, size_t size)
 
     Gets the title of the current process. You *must* call `uv_setup_args`
-    before calling this function. If `buffer` is `NULL` or `size` is zero,
-    `UV_EINVAL` is returned. If `size` cannot accommodate the process title and
-    terminating `NULL` character, the function returns `UV_ENOBUFS`.
+    before calling this function on Unix and AIX systems. If `uv_setup_args`
+    has not been called on systems that require it, then `UV_ENOBUFS` is
+    returned. If `buffer` is `NULL` or `size` is zero, `UV_EINVAL` is returned.
+    If `size` cannot accommodate the process title and terminating `nul`
+    character, the function returns `UV_ENOBUFS`.
+
+    .. note::
+        On BSD systems, `uv_setup_args` is needed for getting the initial process
+        title. The process title returned will be an empty string until either
+        `uv_setup_args` or `uv_set_process_title` is called.
 
     .. versionchanged:: 1.18.1 now thread-safe on all supported platforms.
+
+    .. versionchanged:: 1.39.0 now returns an error if `uv_setup_args` is needed
+                        but hasn't been called.
 
 .. c:function:: int uv_set_process_title(const char* title)
 
     Sets the current process title. You *must* call `uv_setup_args` before
-    calling this function. On platforms with a fixed size buffer for the process
-    title the contents of `title` will be copied to the buffer and truncated if
-    larger than the available space. Other platforms will return `UV_ENOMEM` if
-    they cannot allocate enough space to duplicate the contents of `title`.
+    calling this function on Unix and AIX systems. If `uv_setup_args` has not
+    been called on systems that require it, then `UV_ENOBUFS` is returned. On
+    platforms with a fixed size buffer for the process title the contents of
+    `title` will be copied to the buffer and truncated if larger than the
+    available space. Other platforms will return `UV_ENOMEM` if they cannot
+    allocate enough space to duplicate the contents of `title`.
 
     .. versionchanged:: 1.18.1 now thread-safe on all supported platforms.
+
+    .. versionchanged:: 1.39.0 now returns an error if `uv_setup_args` is needed
+                        but hasn't been called.
 
 .. c:function:: int uv_resident_set_memory(size_t* rss)
 

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -914,6 +914,10 @@ char** uv_setup_args(int argc, char** argv) {
 int uv_set_process_title(const char* title) {
   char* new_title;
 
+  /* If uv_setup_args wasn't called or failed, we can't continue. */
+  if (process_argv == NULL || args_mem == NULL)
+    return UV_ENOBUFS;
+
   /* We cannot free this pointer when libuv shuts down,
    * the process may still be using it.
    */
@@ -946,6 +950,10 @@ int uv_get_process_title(char* buffer, size_t size) {
   size_t len;
   if (buffer == NULL || size == 0)
     return UV_EINVAL;
+
+  /* If uv_setup_args wasn't called, we can't continue. */
+  if (process_argv == NULL)
+    return UV_ENOBUFS;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);

--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -100,6 +100,10 @@ int uv_set_process_title(const char* title) {
   struct uv__process_title* pt;
   size_t len;
 
+  /* If uv_setup_args wasn't called or failed, we can't continue. */
+  if (args_mem == NULL)
+    return UV_ENOBUFS;
+
   pt = &process_title;
   len = strlen(title);
 
@@ -125,6 +129,10 @@ int uv_set_process_title(const char* title) {
 int uv_get_process_title(char* buffer, size_t size) {
   if (buffer == NULL || size == 0)
     return UV_EINVAL;
+
+  /* If uv_setup_args wasn't called or failed, we can't continue. */
+  if (args_mem == NULL)
+    return UV_ENOBUFS;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);


### PR DESCRIPTION
Per-platform behavior after this commit:

- Windows: uv_setup_args does nothing, get/set process title will work as before
- Unix: get/set process title will return ENOBUFS if uv_setup_args wasn't called, if it failed, or if the process title memory has been freed by uv__process_title_cleanup (via uv_library_shutdown)
- AIX: set process title will return ENOBUFS if uv_setup_args wasn't called, if it failed to allocate memory for the argv copy, or if the proctitle memory has been freed by uv__process_title_cleanup (via uv_library_shutdown). get will do the same except it can still succeed if uv_setup_args was called but failed to allocate memory for the argv copy.
- BSD: uv_setup_args is only needed for getting the initial process title; if uv_setup_args is not called then any get_process_title calls before a set_process_title call will return an empty string.
- Platforms that use no-proctitle.c: get will return an empty string, set is a no-op (these are the same as before this commit)

Closes #2845

---

Note that before the changes in this PR, when I tested it on Linux (by commenting out [this line](https://github.com/libuv/libuv/blob/36549815eed297c74448ff580b5c84713245ec5d/test/run-tests.c#L63) and then running the `process_title` test), it would not actually crash but it would invoke undefined behavior (although Valgrind didn't seem to catch it). Since the [`process_title` struct's memory is zeroed when initialized (since it's static)](https://github.com/libuv/libuv/blob/36549815eed297c74448ff580b5c84713245ec5d/src/unix/proctitle.c#L37), `uv_set_process_title` ends up [calling `memcpy(NULL, title, 0)`](https://github.com/libuv/libuv/blob/36549815eed297c74448ff580b5c84713245ec5d/src/unix/proctitle.c#L115) and [`memset(NULL, '\0', 0)`](https://github.com/libuv/libuv/blob/36549815eed297c74448ff580b5c84713245ec5d/src/unix/proctitle.c#L116) which happen not to crash, but are [technically undefined behavior as far as I'm aware](https://www.imperialviolet.org/2016/06/26/nonnull.html).