### PR TITLE
Fix build on Android armv7a

### DIFF
--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -71,7 +71,7 @@ static int init_inotify(uv_loop_t* loop) {
   if (loop->inotify_fd != -1)
     return 0;
 
-  fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+  fd = uv__inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
   if (fd < 0)
     return UV__ERR(errno);
 

--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -89,10 +89,12 @@
 #  define __NR_dup3 292
 # elif defined(__i386__)
 #  define __NR_dup3 330
+# elif defined(__aarch64__)
+#  define __NR_dup3 24
 # elif defined(__arm__)
 #  define __NR_dup3 (UV_SYSCALL_BASE + 358)
 # endif
-#endif /* __NR_pwritev */
+#endif /* __NR_dup3 */
 
 #ifndef __NR_statx
 # if defined(__x86_64__)
@@ -125,6 +127,38 @@
 #  define __NR_getrandom 349
 # endif
 #endif /* __NR_getrandom */
+
+#ifndef __NR_inotify_init1
+# if defined(__x86_64__)
+#  define __NR_inotify_init1 294
+# elif defined(__i386__)
+#  define __NR_inotify_init1 332
+# elif defined (__aarch64__)
+#  define __NR_inotify_init1 26
+# elif defined (__arm__)
+#  define __NR_inotify_init1 (UV_SYSCALL_BASE + 360)
+# elif defined(__ppc__)
+#  define __NR_inotify_init1 318
+# elif defined(__s390__)
+#  define __NR_inotify_init1 324
+# endif
+#endif /* __NR_inotify_init1 */
+
+#ifndef __NR_close
+# if defined(__x86_64__)
+#  define __NR_close 3
+# elif defined(__i386__)
+#  define __NR_close 6
+# elif defined (__aarch64__)
+#  define __NR_close 57
+# elif defined (__arm__)
+#  define __NR_close (UV_SYSCALL_BASE + 6)
+# elif defined(__ppc__)
+#  define __NR_close 6
+# elif defined(__s390__)
+#  define __NR_close 6
+# endif
+#endif /* __NR_close */
 
 struct uv__mmsghdr;
 
@@ -199,6 +233,24 @@ int uv__statx(int dirfd,
 ssize_t uv__getrandom(void* buf, size_t buflen, unsigned flags) {
 #if defined(__NR_getrandom)
   return syscall(__NR_getrandom, buf, buflen, flags);
+#else
+  return errno = ENOSYS, -1;
+#endif
+}
+
+
+int uv__inotify_init1(int flags) {
+#if defined(__NR_inotify_init1)
+  return syscall(__NR_inotify_init1, flags);
+#else
+  return errno = ENOSYS, -1;
+#endif
+}
+
+
+int uv__sys_close(int fd) {
+#if defined(__NR_close)
+  return syscall(__NR_close, fd);
 #else
   return errno = ENOSYS, -1;
 #endif

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -70,5 +70,7 @@ int uv__statx(int dirfd,
               unsigned int mask,
               struct uv__statx* statxbuf);
 ssize_t uv__getrandom(void* buf, size_t buflen, unsigned flags);
+int uv__inotify_init1(int flags);
+int uv__sys_close(int fd);
 
 #endif /* UV_LINUX_SYSCALL_H_ */


### PR DESCRIPTION
Hi, this patch fixes the build for Android on 32-bit ARM.

I'm using Android NDK 20.1.5948944.

Here is how I'm running the build:

```
mkdir build
cd build
```

```
cmake .. \
  -DLIBUV_BUILD_TESTS=OFF \
  -DCMAKE_SYSTEM_NAME=Android \
  -DCMAKE_TOOLCHAIN_FILE=/opt/android/ndk/20.1.5948944/build/cmake/android.toolchain.cmake \
  -DANDROID_ABI=armeabi-v7a \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_FLAGS_RELEASE:STRING='-fPIC -fvisibility=hidden' \
  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
```

```
make -j4
```

I tried to keep behavior on other platforms unchanged.

Changes:

- accept4() is not available in libc and may be unavailable in
  kernel too, so don't use it on this platform

- dup3() is not available in libc; not sure about the kernel,
  but don't use it too

- inotify_init1() is not available in libc, use __NR_inotify_init1
  syscall via uv__inotify_init1(); not sure if it may be unavailable in kernel, but if I understand correctly, missing inotify support (ENOSYS) wont break other things in libuv

- SYS_close is not defined in libc, use __NR_close syscall
  via via uv__sys_close()

Reference:

* https://fedora.juszkiewicz.com.pl/syscalls.html
* https://chromium.googlesource.com/android_tools/+/20ee6d20/ndk/platforms/android-21/arch-arm64/usr/include/asm-generic/unistd.h
* https://elixir.bootlin.com/linux/v4.5.7/ident/__NR_dup3
* https://elixir.bootlin.com/linux/v4.5.7/ident/__NR_inotify_init1
* https://elixir.bootlin.com/linux/v4.5.7/ident/__NR_close