### PR TITLE
test: extend fs_event_error_reporting timeout

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -1010,7 +1010,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_event_close_with_pending_event)
   TEST_ENTRY  (fs_event_close_in_callback)
   TEST_ENTRY  (fs_event_start_and_close)
-  TEST_ENTRY  (fs_event_error_reporting)
+  TEST_ENTRY_CUSTOM (fs_event_error_reporting, 0, 0, 60000)
   TEST_ENTRY  (fs_event_getpath)
   TEST_ENTRY  (fs_scandir_empty_dir)
   TEST_ENTRY  (fs_scandir_non_existent_dir)


### PR DESCRIPTION
This test was consistently timing out on macOS. Some printf()
debugging on the CI showed that the test was still making forward
progress, but legitimately timed out. This commit bumps the test
timeout to a value that should provide much more than enough time.