### PR TITLE
Fix build for c89 with Visual C++ 9

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -775,7 +775,6 @@ int uv__udp_set_source_membership6(uv_udp_t* handle,
     mreq.gsr_interface = 0;
   }
 
-  
   memcpy(&mreq.gsr_group, multicast_addr, sizeof(*multicast_addr));
   memcpy(&mreq.gsr_source, source_addr, sizeof(*source_addr));
 

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -751,7 +751,8 @@ int uv__udp_set_source_membership6(uv_udp_t* handle,
   struct sockaddr_in6 addr6;
   int optname;
   int err;
-
+  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
+  STATIC_ASSERT(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
   if ((handle->flags & UV_HANDLE_BOUND) && !(handle->flags & UV_HANDLE_IPV6))
     return UV_EINVAL;
 
@@ -774,8 +775,7 @@ int uv__udp_set_source_membership6(uv_udp_t* handle,
     mreq.gsr_interface = 0;
   }
 
-  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
-  STATIC_ASSERT(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
+  
   memcpy(&mreq.gsr_group, multicast_addr, sizeof(*multicast_addr));
   memcpy(&mreq.gsr_source, source_addr, sizeof(*source_addr));
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -492,7 +492,8 @@ uint64_t uv_hrtime(void) {
 
 uint64_t uv__hrtime(unsigned int scale) {
   LARGE_INTEGER counter;
-
+  double scaled_freq;
+  double result;
   assert(hrtime_frequency_ != 0);
   assert(scale != 0);
   if (!QueryPerformanceCounter(&counter)) {
@@ -504,8 +505,8 @@ uint64_t uv__hrtime(unsigned int scale) {
    * performance counter interval, integer math could cause this computation
    * to overflow. Therefore we resort to floating point math.
    */
-  double scaled_freq = (double)hrtime_frequency_ / scale;
-  double result = (double) counter.QuadPart / scaled_freq;
+  scaled_freq = (double)hrtime_frequency_ / scale;
+  result = (double) counter.QuadPart / scaled_freq;
   return (uint64_t) result;
 }
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -505,7 +505,7 @@ uint64_t uv__hrtime(unsigned int scale) {
    * performance counter interval, integer math could cause this computation
    * to overflow. Therefore we resort to floating point math.
    */
-  scaled_freq = (double)hrtime_frequency_ / scale;
+  scaled_freq = (double) hrtime_frequency_ / scale;
   result = (double) counter.QuadPart / scaled_freq;
   return (uint64_t) result;
 }


### PR DESCRIPTION
Fix:
#2861 src/win/udp.c: Incompatible with Visual C++ 9/C89 build windows

src/win/udp.c:
STATIC_ASSERT (...) for C89 must be used in top of functions