### PR TITLE
add support QNX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ include(CMakeDependentOption)
 include(CheckCCompilerFlag)
 include(GNUInstallDirs)
 include(CTest)
+include(CheckFunctionExists)
+include(CheckSymbolExists)
+include(CheckIncludeFile)
+include(CheckIncludeFiles)
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -91,6 +95,24 @@ list(APPEND uv_cflags ${lint-no-hides-global-msvc})
 list(APPEND uv_cflags ${lint-no-conditional-assignment-msvc})
 list(APPEND uv_cflags ${lint-no-unsafe-msvc})
 
+check_include_file(sys/eventfd.h UV_HAVE_EVENTFD_H)
+check_include_file(sys/statvfs.h UV_HAVE_STATVFS_H)
+check_include_file(sys/statfs.h UV_HAVE_STATFS_H)
+
+check_function_exists(accept4 UV_HAVE_ACCEPT4)
+check_function_exists(dup3 UV_HAVE_DUP3)
+check_function_exists(pipe2 UV_HAVE_PIPE2)
+check_function_exists(epoll_create1 UV_HAVE_EPOLL_CREATE1)
+check_function_exists(inotify_init1 UV_HAVE_INOTIFY_INIT1)
+check_c_source_compiles(
+  "
+  #include <sys/eventfd.h>
+  int main(int argc, char **argv) 
+  { eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK); return 0; }
+  " UV_HAVE_ASYNC_EVENTFD)
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
 set(uv_sources
     src/fs-poll.c
     src/idna.c
@@ -140,7 +162,7 @@ if(WIN32)
   list(APPEND uv_test_sources src/win/snprintf.c test/runner-win.c)
 else()
   list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
-  if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390")
+  if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390|QNX")
     # TODO: This should be replaced with find_package(Threads) if possible
     # Android has pthread as part of its c library, not as a separate
     # libpthread.so.
@@ -294,6 +316,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
   list(APPEND uv_sources src/unix/no-proctitle.c src/unix/sunos.c)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  list(APPEND uv_sources src/unix/posix-hrtime.c src/unix/posix-poll.c)
+  list(APPEND uv_cflags -fno-strict-aliasing)
+endif()
+ 
 if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
   list(APPEND uv_test_libraries util)
 endif()
@@ -311,7 +338,8 @@ target_include_directories(uv
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>)
 target_link_libraries(uv ${uv_libraries})
 
 add_library(uv_a STATIC ${uv_sources})
@@ -322,7 +350,8 @@ target_include_directories(uv_a
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>)
 target_link_libraries(uv_a ${uv_libraries})
 
 if(LIBUV_BUILD_TESTS)

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,26 @@
+/* Define to 1 if `eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);` compiled */
+#cmakedefine UV_HAVE_ASYNC_EVENTFD
+
+/* Define to 1 if accept4() exists */
+#cmakedefine UV_HAVE_ACCEPT4
+
+/* Define to 1 if dup3() exists */
+#cmakedefine UV_HAVE_DUP3
+
+/* Define to 1 if pipe2() exists */
+#cmakedefine UV_HAVE_PIPE2
+
+/* Define to 1 if epoll_create1() exists */
+#cmakedefine UV_HAVE_EPOLL_CREATE1
+
+/* Define to 1 if inotify_init1() exists */
+#cmakedefine UV_HAVE_INOTIFY_INIT1
+
+/* Defined if you have the <sys/eventfd.h> header file. */
+#cmakedefine UV_HAVE_EVENTFD_H
+
+/* Defined if you have the <sys/statvfs.h> header file. */
+#cmakedefine UV_HAVE_STATVFS_H
+
+/* Defined if you have the <sys/statfs.h> header file. */
+#cmakedefine UV_HAVE_STATFS_H

--- a/include/uv/errno.h
+++ b/include/uv/errno.h
@@ -86,7 +86,7 @@
 # define UV__EAGAIN (-4088)
 #endif
 
-#if defined(EALREADY) && !defined(_WIN32)
+#if defined(EALREADY) && !defined(_WIN32) && !defined(__QNX__)
 # define UV__EALREADY UV__ERR(EALREADY)
 #else
 # define UV__EALREADY (-4084)
@@ -164,7 +164,7 @@
 # define UV__EINTR (-4072)
 #endif
 
-#if defined(EINVAL) && !defined(_WIN32)
+#if defined(EINVAL) && !defined(_WIN32) && !defined(__QNX__)
 # define UV__EINVAL UV__ERR(EINVAL)
 #else
 # define UV__EINVAL (-4071)

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -67,7 +67,7 @@
       defined(__MSYS__)   || \
       defined(__GNU__)
 # include "uv/posix.h"
-#elif defined(__HAIKU__)
+#elif defined(__HAIKU__) || defined(__QNX__)
 # include "uv/posix.h"
 #endif
 

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -34,7 +34,7 @@
 #include <unistd.h>
 #include <sched.h>  /* sched_yield() */
 
-#ifdef __linux__
+#if defined(__linux__) && defined(UV_HAVE_EVENTFD_H)
 #include <sys/eventfd.h>
 #endif
 
@@ -206,7 +206,7 @@ static int uv__async_start(uv_loop_t* loop) {
   if (loop->async_io_watcher.fd != -1)
     return 0;
 
-#ifdef __linux__
+#if defined(__linux__) && defined(UV_HAVE_ASYNC_EVENTFD)
   err = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   if (err < 0)
     return UV__ERR(errno);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -89,7 +89,9 @@ extern char** environ;
 
 #if defined(__linux__)
 # include <sys/syscall.h>
-# define uv__accept4 accept4
+# ifdef UV_HAVE_ACCEPT4
+#  define uv__accept4 accept4
+# endif
 #endif
 
 static int uv__run_pending(uv_loop_t* loop);
@@ -1017,7 +1019,7 @@ int uv__open_cloexec(const char* path, int flags) {
 
 
 int uv__dup2_cloexec(int oldfd, int newfd) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__linux__)
+#if defined(UV_HAVE_DUP3)
   int r;
 
   r = dup3(oldfd, newfd, O_CLOEXEC);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -79,7 +79,7 @@
     defined(__NetBSD__)
 # include <sys/param.h>
 # include <sys/mount.h>
-#elif defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__)
+#elif defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__) || defined(__QNX__) 
 # include <sys/statvfs.h>
 #else
 # include <sys/statfs.h>
@@ -629,7 +629,7 @@ static int uv__fs_closedir(uv_fs_t* req) {
 
 static int uv__fs_statfs(uv_fs_t* req) {
   uv_statfs_t* stat_fs;
-#if defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__)
+#if defined(__sun) || defined(__MVS__) || defined(__NetBSD__) || defined(__HAIKU__) || defined(__QNX__)
   struct statvfs buf;
 
   if (0 != statvfs(req->path, &buf))
@@ -646,7 +646,7 @@ static int uv__fs_statfs(uv_fs_t* req) {
     return -1;
   }
 
-#if defined(__sun) || defined(__MVS__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__HAIKU__)
+#if defined(__sun) || defined(__MVS__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__HAIKU__) || defined(__QNX__)
   stat_fs->f_type = 0;  /* f_type is not supported. */
 #else
   stat_fs->f_type = buf.f_type;

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -90,11 +90,11 @@ int uv__platform_loop_init(uv_loop_t* loop) {
    * a.k.a. Lollipop. Since EPOLL_CLOEXEC is an alias for O_CLOEXEC on all
    * architectures, we just use that instead.
    */
-#if defined(__ANDROID_API__) && __ANDROID_API__ < 21
+#if defined(UV_HAVE_EPOLL_CREATE1)
+  fd = epoll_create1(O_CLOEXEC);
+#else
   fd = -1;
   errno = ENOSYS;
-#else
-  fd = epoll_create1(O_CLOEXEC);
 #endif
 
   /* epoll_create1() can fail either because it's not implemented (old kernel)

--- a/src/unix/linux-inotify.c
+++ b/src/unix/linux-inotify.c
@@ -70,8 +70,11 @@ static int init_inotify(uv_loop_t* loop) {
 
   if (loop->inotify_fd != -1)
     return 0;
-
+#if defined(UV_HAVE_INOTIFY_INIT1)
   fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+#else
+  fd = inotify_init();
+#endif
   if (fd < 0)
     return UV__ERR(errno);
 

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -43,6 +43,9 @@ extern char **environ;
 #if defined(__linux__) || defined(__GLIBC__)
 # include <grp.h>
 #endif
+#ifndef SOCK_CLOEXEC
+# define SOCK_CLOEXEC 0
+#endif
 
 
 static void uv__chld(uv_signal_t* handle, int signum) {
@@ -140,7 +143,7 @@ static int uv__make_socketpair(int fds[2]) {
 
 
 int uv__make_pipe(int fds[2], int flags) {
-#if defined(__FreeBSD__) || defined(__linux__)
+#if defined(UV_HAVE_PIPE2)
   if (pipe2(fds, flags | O_CLOEXEC))
     return UV__ERR(errno);
 

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -854,7 +854,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
 }
 
 
-#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__ANDROID__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__ANDROID__) && !defined(__QNX__)
 static int uv__udp_set_source_membership4(uv_udp_t* handle,
                                           const struct sockaddr_in* multicast_addr,
                                           const char* interface_addr,
@@ -1031,7 +1031,7 @@ int uv_udp_set_source_membership(uv_udp_t* handle,
                                  const char* interface_addr,
                                  const char* source_addr,
                                  uv_membership membership) {
-#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__ANDROID__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__ANDROID__) && !defined(__QNX__)
   int err;
   union uv__sockaddr mcast_addr;
   union uv__sockaddr src_addr;
@@ -1138,7 +1138,7 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
  * and use the general uv__setsockopt_maybe_char call on other platforms.
  */
 #if defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__QNX__)
 
   return uv__setsockopt(handle,
                         IP_TTL,
@@ -1147,7 +1147,7 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
                         sizeof(ttl));
 
 #else /* !(defined(__sun) || defined(_AIX) || defined (__OpenBSD__) ||
-           defined(__MVS__)) */
+           defined(__MVS__)) || defined(__QNX__) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_TTL,
@@ -1155,7 +1155,7 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
                                    ttl);
 
 #endif /* defined(__sun) || defined(_AIX) || defined (__OpenBSD__) ||
-          defined(__MVS__) */
+          defined(__MVS__) || defined(__QNX__) */
 }
 
 
@@ -1167,7 +1167,7 @@ int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
 #if defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__QNX__)
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_TTL,
@@ -1175,7 +1175,7 @@ int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
                           &ttl,
                           sizeof(ttl));
 #endif /* defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
-    defined(__MVS__) */
+    defined(__MVS__) || defined(__QNX__)*/
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_TTL,
@@ -1192,7 +1192,7 @@ int uv_udp_set_multicast_loop(uv_udp_t* handle, int on) {
  * and use the general uv__setsockopt_maybe_char call otherwise.
  */
 #if defined(__sun) || defined(_AIX) || defined(__OpenBSD__) || \
-    defined(__MVS__)
+    defined(__MVS__) || defined(__QNX__)
   if (handle->flags & UV_HANDLE_IPV6)
     return uv__setsockopt(handle,
                           IP_MULTICAST_LOOP,
@@ -1200,7 +1200,7 @@ int uv_udp_set_multicast_loop(uv_udp_t* handle, int on) {
                           &on,
                           sizeof(on));
 #endif /* defined(__sun) || defined(_AIX) ||defined(__OpenBSD__) ||
-    defined(__MVS__) */
+    defined(__MVS__) || defined(__QNX__) */
 
   return uv__setsockopt_maybe_char(handle,
                                    IP_MULTICAST_LOOP,

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -41,6 +41,7 @@
 #include "uv/tree.h"
 #include "queue.h"
 #include "strscpy.h"
+#include "config.h"
 
 #if EDOM > 0
 # define UV__ERR(x) (-(x))


### PR DESCRIPTION
Fix:
#865 porting to qnx

include/uv/errno.h:
EALREADY, EINVAL and EBUSY is same value on QNX

Add cmake checks for few files:
- sys/eventfd.h
- sys/statvfs.h 
- sys/statfs.h 

and some functions: 

- accept4
- dup3
- pipe2
- epoll_create1 
- inotify_init1
- eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)