### PR TITLE
Enable full ICMP error reporting on Linux

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -54,6 +54,14 @@ Data types
              */
             UV_UDP_MMSG_FREE = 16,
             /*
+             * Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+             * This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+             * Linux. This stops the Linux kernel from supressing some ICMP error messages
+             * and enables full ICMP error reporting for faster failover.
+             * This flag is no-op on platforms other than Linux.
+             */
+            UV_UDP_LINUX_RECVERR = 32,
+            /*
             * Indicates that recvmmsg should be used, if available.
             */
             UV_UDP_RECVMMSG = 256
@@ -178,7 +186,8 @@ API
         with the address and port to bind to.
 
     :param flags: Indicate how the socket will be bound,
-        ``UV_UDP_IPV6ONLY`` and ``UV_UDP_REUSEADDR`` are supported.
+        ``UV_UDP_IPV6ONLY``, ``UV_UDP_REUSEADDR``, and ``UV_UDP_RECVERR``
+        are supported.
 
     :returns: 0 on success, or an error code < 0 on failure.
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -626,7 +626,14 @@ enum uv_udp_flags {
    * in uv_udp_recv_cb, nread will always be 0 and addr will always be NULL.
    */
   UV_UDP_MMSG_FREE = 16,
-
+  /*
+   * Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+   * This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+   * Linux. This stops the Linux kernel from supressing some ICMP error messages
+   * and enables full ICMP error reporting for faster failover.
+   * This flag is no-op on platforms other than Linux.
+   */
+  UV_UDP_LINUX_RECVERR = 32,
   /*
    * Indicates that recvmmsg should be used, if available.
    */

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -504,6 +504,28 @@ static int uv__set_reuse(int fd) {
   return 0;
 }
 
+/*
+ * The Linux kernel suppresses some ICMP error messages by default for UDP
+ * sockets. Setting IP_RECVERR/IPV6_RECVERR on the socket enables full ICMP
+ * error reporting, hopefully resulting in faster failover to working name
+ * servers.
+ */
+static int uv__set_recverr(int fd, sa_family_t ss_family) {
+#if defined(__linux__)
+  int yes;
+
+  yes = 1;
+  if (ss_family == AF_INET) {
+    if (setsockopt(fd, IPPROTO_IP, IP_RECVERR, &yes, sizeof(yes)))
+      return UV__ERR(errno);
+  } else if (ss_family == AF_INET6) {
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &yes, sizeof(yes)))
+       return UV__ERR(errno);
+  }
+#endif
+  return 0;
+}
+
 
 int uv__udp_bind(uv_udp_t* handle,
                  const struct sockaddr* addr,
@@ -514,7 +536,7 @@ int uv__udp_bind(uv_udp_t* handle,
   int fd;
 
   /* Check for bad flags. */
-  if (flags & ~(UV_UDP_IPV6ONLY | UV_UDP_REUSEADDR))
+  if (flags & ~(UV_UDP_IPV6ONLY | UV_UDP_REUSEADDR | UV_UDP_LINUX_RECVERR))
     return UV_EINVAL;
 
   /* Cannot set IPv6-only mode on non-IPv6 socket. */
@@ -528,6 +550,12 @@ int uv__udp_bind(uv_udp_t* handle,
       return err;
     fd = err;
     handle->io_watcher.fd = fd;
+  }
+
+  if (flags & UV_UDP_LINUX_RECVERR) {
+    err = uv__set_recverr(fd, addr->sa_family);
+    if (err)
+      return err;
   }
 
   if (flags & UV_UDP_REUSEADDR) {

--- a/test/task.h
+++ b/test/task.h
@@ -52,6 +52,7 @@
 
 #define TEST_PORT 9123
 #define TEST_PORT_2 9124
+#define TEST_PORT_3 9125
 
 #ifdef _WIN32
 # define TEST_PIPENAME "\\\\?\\pipe\\uv-test"

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -27,9 +27,10 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &client)
+  ASSERT((uv_udp_t*)(handle) == &client || (uv_udp_t*)(handle) == &client2)
 
 static uv_udp_t client;
+static uv_udp_t client2;
 static uv_timer_t timer;
 
 static int send_cb_called;
@@ -37,6 +38,7 @@ static int recv_cb_called;
 static int close_cb_called;
 static int alloc_cb_called;
 static int timer_cb_called;
+static int can_recverr;
 
 
 static void alloc_cb(uv_handle_t* handle,
@@ -44,7 +46,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
   alloc_cb_called++;
@@ -52,7 +54,7 @@ static void alloc_cb(uv_handle_t* handle,
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(1 == uv_is_closing(handle));
+  ASSERT_EQ(1, uv_is_closing(handle));
   close_cb_called++;
 }
 
@@ -60,10 +62,17 @@ static void close_cb(uv_handle_t* handle) {
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
   send_cb_called++;
 }
 
+static void send_cb_recverr(uv_udp_send_t* req, int status) {
+  ASSERT_PTR_NE(req, NULL);
+  ASSERT(status == 0 || status == UV_ECONNREFUSED);
+  CHECK_HANDLE(req->handle);
+  send_cb_called++;
+}
 
 static void recv_cb(uv_udp_t* handle,
                        ssize_t nread,
@@ -85,9 +94,11 @@ static void recv_cb(uv_udp_t* handle,
 
 
 static void timer_cb(uv_timer_t* h) {
-  ASSERT(h == &timer);
+  ASSERT_PTR_EQ(h, &timer);
   timer_cb_called++;
   uv_close((uv_handle_t*) &client, close_cb);
+  if (can_recverr)
+    uv_close((uv_handle_t*) &client2, close_cb);
   uv_close((uv_handle_t*) h, close_cb);
 }
 
@@ -95,27 +106,33 @@ static void timer_cb(uv_timer_t* h) {
 TEST_IMPL(udp_send_unreachable) {
   struct sockaddr_in addr;
   struct sockaddr_in addr2;
-  uv_udp_send_t req1, req2;
+  struct sockaddr_in addr3;
+  uv_udp_send_t req1, req2, req3, req4;
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
+#ifdef __linux__
+  can_recverr = 1;
+#endif
+
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT_3, &addr3));
 
   r = uv_timer_init( uv_default_loop(), &timer );
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start( &timer, timer_cb, 1000, 0 );
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -126,7 +143,7 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -136,14 +153,48 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
+
+  if (can_recverr) {
+    r = uv_udp_init(uv_default_loop(), &client2);
+    ASSERT_EQ(r, 0);
+
+    r = uv_udp_bind(&client2,
+                    (const struct sockaddr*) &addr3,
+                    UV_UDP_LINUX_RECVERR);
+    ASSERT_EQ(r, 0);
+
+    r = uv_udp_recv_start(&client2, alloc_cb, recv_cb);
+    ASSERT_EQ(r, 0);
+
+    /* client sends "PING", then "PANG" */
+    buf = uv_buf_init("PING", 4);
+
+    r = uv_udp_send(&req3,
+                    &client2,
+                    &buf,
+                    1,
+                    (const struct sockaddr*) &addr,
+                    send_cb_recverr);
+    ASSERT_EQ(r, 0);
+
+    buf = uv_buf_init("PANG", 4);
+
+    r = uv_udp_send(&req4,
+                    &client2,
+                    &buf,
+                    1,
+                    (const struct sockaddr*) &addr,
+                    send_cb_recverr);
+    ASSERT_EQ(r, 0);
+  }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 2);
-  ASSERT(recv_cb_called == alloc_cb_called);
-  ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(send_cb_called, (long)(can_recverr ? 4 : 2));
+  ASSERT_EQ(recv_cb_called, alloc_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(close_cb_called, (long)(can_recverr ? 3 : 2));
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
The Linux kernel suppresses some ICMP error messages by default for UDP
sockets. This commit sets `IP_RECVERR`/`IPV6_RECVERR` on the socket to enable full
ICMP error reporting, hopefully resulting in faster failover to working UDP servers
(DNS servers would be one of the benefactors).

Here's a little background on the issue: https://gitlab.isc.org/isc-projects/bind9/-/issues/835 as reported to BIND 9.

Linux's implementation does not report what it considers "transient" conditions, which is defined as Destination Host Unreachable, Destination Network Unreachable, Source Route Failed and Message Too Big.

libuv should set `setsockopt(fd, IPPROTO_IP, IP_RECVERR, &(int){ 1 }, sizeof(int));`, so the applications using libuv can react much more quickly to network events.

More links / references:
* libc bug and discussion: https://sourceware.org/bugzilla/show_bug.cgi?id=24047
* libc patch: https://sourceware.org/legacy-ml/libc-alpha/2019-02/msg00602.html
* systemd bug and discussion: https://github.com/systemd/systemd/issues/10345
* systemd patch: https://github.com/systemd/systemd/pull/10425
* dns operations discussion: https://lists.dns-oarc.net/pipermail/dns-operations/2019-January/018271.html
* Linux kernel bug and discussion: https://bugzilla.kernel.org/show_bug.cgi?id=202355
* Linux manpage documentation bug: https://bugzilla.kernel.org/show_bug.cgi?id=202369
