### PR TITLE
Fix cmake: do not require libkvm on FreeBSD and OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
   list(APPEND uv_sources src/unix/posix-hrtime.c src/unix/bsd-proctitle.c)
-  list(APPEND uv_libraries kvm)
 endif()
 
 if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|NetBSD|OpenBSD")
@@ -244,6 +243,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
   list(APPEND uv_sources src/unix/netbsd.c)
+  list(APPEND uv_libraries kvm)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")


### PR DESCRIPTION
After 4987b6325b40b4bb06e8597956da0f0d0c5dbcbb and 22fc92856d8a354b7f26ca7fe2d3597a2bd57865 `libkvm` is actually not required for build on FreeBSD and OpenBSD, but cmake script adds it to the list of libraries anyway. 