### PR TITLE
win: Clang compatibility & solving SystemFunction036 undefined reference

### DIFF
--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -77,7 +77,7 @@ int uv_fs_poll_start(uv_fs_poll_t* handle,
 
   loop = handle->loop;
   len = strlen(path);
-  ctx = uv__calloc(1, sizeof(*ctx) + len);
+  ctx = (struct poll_ctx *)uv__calloc(1, sizeof(*ctx) + len);
 
   if (ctx == NULL)
     return UV_ENOMEM;
@@ -101,7 +101,7 @@ int uv_fs_poll_start(uv_fs_poll_t* handle,
     goto error;
 
   if (handle->poll_ctx != NULL)
-    ctx->previous = handle->poll_ctx;
+    ctx->previous = (struct poll_ctx *)handle->poll_ctx;
   handle->poll_ctx = ctx;
   uv__handle_start(handle);
 
@@ -119,7 +119,7 @@ int uv_fs_poll_stop(uv_fs_poll_t* handle) {
   if (!uv_is_active((uv_handle_t*)handle))
     return 0;
 
-  ctx = handle->poll_ctx;
+  ctx = (struct poll_ctx *)handle->poll_ctx;
   assert(ctx != NULL);
   assert(ctx->parent_handle == handle);
 
@@ -144,7 +144,7 @@ int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buffer, size_t* size) {
     return UV_EINVAL;
   }
 
-  ctx = handle->poll_ctx;
+  ctx = (struct poll_ctx *)handle->poll_ctx;
   assert(ctx != NULL);
 
   required_len = strlen(ctx->path);
@@ -244,7 +244,7 @@ static void timer_close_cb(uv_handle_t* timer) {
     if (handle->poll_ctx == NULL && uv__is_closing(handle))
       uv__make_close_pending((uv_handle_t*)handle);
   } else {
-    for (last = handle->poll_ctx, it = last->previous;
+    for (last = (struct poll_ctx *)handle->poll_ctx, it = last->previous;
          it != ctx;
          last = it, it = it->previous) {
       assert(last->previous != NULL);

--- a/src/inet.c
+++ b/src/inet.c
@@ -40,9 +40,9 @@ static int inet_pton6(const char *src, unsigned char *dst);
 int uv_inet_ntop(int af, const void* src, char* dst, size_t size) {
   switch (af) {
   case AF_INET:
-    return (inet_ntop4(src, dst, size));
+    return (inet_ntop4((const unsigned char *)src, dst, size));
   case AF_INET6:
-    return (inet_ntop6(src, dst, size));
+    return (inet_ntop6((const unsigned char *)src, dst, size));
   default:
     return UV_EAFNOSUPPORT;
   }
@@ -153,7 +153,7 @@ int uv_inet_pton(int af, const char* src, void* dst) {
 
   switch (af) {
   case AF_INET:
-    return (inet_pton4(src, dst));
+    return (inet_pton4(src, (unsigned char *)dst));
   case AF_INET6: {
     int len;
     char tmp[UV__INET6_ADDRSTRLEN], *s, *p;
@@ -167,7 +167,7 @@ int uv_inet_pton(int af, const char* src, void* dst) {
       memcpy(s, src, len);
       s[len] = '\0';
     }
-    return inet_pton6(s, dst);
+    return inet_pton6(s, (unsigned char *)dst);
   }
   default:
     return UV_EAFNOSUPPORT;

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -201,7 +201,7 @@ static void init_threads(void) {
 
   threads = default_threads;
   if (nthreads > ARRAY_SIZE(default_threads)) {
-    threads = uv__malloc(nthreads * sizeof(threads[0]));
+    threads = (uv_thread_t *)uv__malloc(nthreads * sizeof(threads[0]));
     if (threads == NULL) {
       nthreads = ARRAY_SIZE(default_threads);
       threads = default_threads;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -54,10 +54,10 @@ static uv__allocator_t uv__allocator = {
 
 char* uv__strdup(const char* s) {
   size_t len = strlen(s) + 1;
-  char* m = uv__malloc(len);
+  char* m = (char *)uv__malloc(len);
   if (m == NULL)
     return NULL;
-  return memcpy(m, s, len);
+  return (char *)memcpy(m, s, len);
 }
 
 char* uv__strndup(const char* s, size_t n) {
@@ -65,11 +65,11 @@ char* uv__strndup(const char* s, size_t n) {
   size_t len = strlen(s);
   if (n < len)
     len = n;
-  m = uv__malloc(len + 1);
+  m = (char *)uv__malloc(len + 1);
   if (m == NULL)
     return NULL;
   m[len] = '\0';
-  return memcpy(m, s, len);
+  return (char *)memcpy(m, s, len);
 }
 
 void* uv__malloc(size_t size) {
@@ -637,7 +637,7 @@ void uv__fs_scandir_cleanup(uv_fs_t* req) {
 
   unsigned int* nbufs = uv__get_nbufs(req);
 
-  dents = req->ptr;
+  dents = (uv__dirent_t **)req->ptr;
   if (*nbufs > 0 && *nbufs != (unsigned int) req->result)
     (*nbufs)--;
   for (; *nbufs < (unsigned int) req->result; (*nbufs)++)
@@ -664,7 +664,7 @@ int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent) {
   nbufs = uv__get_nbufs(req);
   assert(nbufs);
 
-  dents = req->ptr;
+  dents = (uv__dirent_t **)req->ptr;
 
   /* Free previous entity */
   if (*nbufs > 0)
@@ -729,7 +729,7 @@ void uv__fs_readdir_cleanup(uv_fs_t* req) {
   if (req->ptr == NULL)
     return;
 
-  dir = req->ptr;
+  dir = (uv_dir_t *)req->ptr;
   dirents = dir->dirents;
   req->ptr = NULL;
 
@@ -775,7 +775,7 @@ uv_loop_t* uv_default_loop(void) {
 uv_loop_t* uv_loop_new(void) {
   uv_loop_t* loop;
 
-  loop = uv__malloc(sizeof(*loop));
+  loop = (uv_loop_t *)uv__malloc(sizeof(*loop));
   if (loop == NULL)
     return NULL;
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -96,7 +96,7 @@ static int uv__loops_add(uv_loop_t* loop) {
 
   if (uv__loops_size == uv__loops_capacity) {
     new_capacity = uv__loops_capacity + UV__LOOPS_CHUNK_SIZE;
-    new_loops = uv__realloc(uv__loops, sizeof(uv_loop_t*) * new_capacity);
+    new_loops = (uv_loop_t **)uv__realloc(uv__loops, sizeof(uv_loop_t*) * new_capacity);
     if (!new_loops)
       goto failed_loops_realloc;
     uv__loops = new_loops;
@@ -149,7 +149,7 @@ static void uv__loops_remove(uv_loop_t* loop) {
   smaller_capacity = uv__loops_capacity / 2;
   if (uv__loops_size >= smaller_capacity)
     goto loop_removed;
-  new_loops = uv__realloc(uv__loops, sizeof(uv_loop_t*) * smaller_capacity);
+  new_loops = (uv_loop_t **)uv__realloc(uv__loops, sizeof(uv_loop_t*) * smaller_capacity);
   if (!new_loops)
     goto loop_removed;
   uv__loops = new_loops;
@@ -248,7 +248,7 @@ int uv_loop_init(uv_loop_t* loop) {
 
   loop->endgame_handles = NULL;
 
-  loop->timer_heap = timer_heap = uv__malloc(sizeof(*timer_heap));
+  loop->timer_heap = timer_heap = (struct heap *)uv__malloc(sizeof(*timer_heap));
   if (timer_heap == NULL) {
     err = UV_ENOMEM;
     goto fail_timers_alloc;

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -73,7 +73,7 @@ static void uv_relative_path(const WCHAR* filename,
   if (dirlen > 0 && dir[dirlen - 1] == '\\')
     dirlen--;
   relpathlen = filenamelen - dirlen - 1;
-  *relpath = uv__malloc((relpathlen + 1) * sizeof(WCHAR));
+  *relpath = (WCHAR *)uv__malloc((relpathlen + 1) * sizeof(WCHAR));
   if (!*relpath)
     uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
   wcsncpy(*relpath, filename + dirlen + 1, relpathlen);
@@ -242,7 +242,7 @@ int uv_fs_event_start(uv_fs_event_t* handle,
     if (short_path_buffer_len == 0) {
       goto short_path_done;
     }
-    short_path_buffer = uv__malloc(short_path_buffer_len * sizeof(WCHAR));
+    short_path_buffer = (WCHAR *)uv__malloc(short_path_buffer_len * sizeof(WCHAR));
     if (short_path_buffer == NULL) {
       goto short_path_done;
     }

--- a/src/win/fs-fd-hash-inl.h
+++ b/src/win/fs-fd-hash-inl.h
@@ -124,7 +124,7 @@ INLINE static void uv__fd_hash_add(int fd, struct uv__fd_info_s* info) {
 
     if (bucket_ptr->size != 0 && i == 0) {
       struct uv__fd_hash_entry_group_s* new_group_ptr =
-        uv__malloc(sizeof(*new_group_ptr));
+        (struct uv__fd_hash_entry_group_s *)uv__malloc(sizeof(*new_group_ptr));
       if (new_group_ptr == NULL) {
         uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
       }

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -294,7 +294,7 @@ static int fs__wide_to_utf8(WCHAR* w_source_ptr,
     return 0;
   }
 
-  target = uv__malloc(target_len + 1);
+  target = (char *)uv__malloc(target_len + 1);
   if (target == NULL) {
     SetLastError(ERROR_OUTOFMEMORY);
     return -1;
@@ -1454,7 +1454,7 @@ void fs__scandir(uv_fs_t* req) {
         size_t new_dirents_size =
             dirents_size == 0 ? dirents_initial_size : dirents_size << 1;
         uv__dirent_t** new_dirents =
-            uv__realloc(dirents, new_dirents_size * sizeof *dirents);
+            (uv__dirent_t **)uv__realloc(dirents, new_dirents_size * sizeof *dirents);
 
         if (new_dirents == NULL)
           goto out_of_memory_error;
@@ -1467,7 +1467,7 @@ void fs__scandir(uv_fs_t* req) {
        * includes room for the first character of the filename, but `utf8_len`
        * doesn't count the NULL terminator at this point.
        */
-      dirent = uv__malloc(sizeof *dirent + utf8_len);
+      dirent = (uv__dirent_t *)uv__malloc(sizeof *dirent + utf8_len);
       if (dirent == NULL)
         goto out_of_memory_error;
 
@@ -1578,7 +1578,7 @@ void fs__opendir(uv_fs_t* req) {
     goto error;
   }
 
-  dir = uv__malloc(sizeof(*dir));
+  dir = (uv_dir_t *)uv__malloc(sizeof(*dir));
   if (dir == NULL) {
     SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
     goto error;
@@ -1593,7 +1593,7 @@ void fs__opendir(uv_fs_t* req) {
   else
     fmt = L"%s\\*";
 
-  find_path = uv__malloc(sizeof(WCHAR) * (len + 4));
+  find_path = (WCHAR *)uv__malloc(sizeof(WCHAR) * (len + 4));
   if (find_path == NULL) {
     SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
     goto error;
@@ -1630,7 +1630,7 @@ void fs__readdir(uv_fs_t* req) {
   int r;
 
   req->flags |= UV_FS_FREE_PTR;
-  dir = req->ptr;
+  dir = (uv_dir_t *)req->ptr;
   dirents = dir->dirents;
   memset(dirents, 0, dir->nentries * sizeof(*dir->dirents));
   find_data = &dir->find_data;
@@ -1687,7 +1687,7 @@ error:
 void fs__closedir(uv_fs_t* req) {
   uv_dir_t* dir;
 
-  dir = req->ptr;
+  dir = (uv_dir_t *)req->ptr;
   FindClose(dir->dir_handle);
   uv__free(req->ptr);
   SET_REQ_RESULT(req, 0);
@@ -2609,7 +2609,7 @@ static ssize_t fs__realpath_handle(HANDLE handle, char** realpath_ptr) {
     return -1;
   }
 
-  w_realpath_buf = uv__malloc((w_realpath_len + 1) * sizeof(WCHAR));
+  w_realpath_buf = (WCHAR *)uv__malloc((w_realpath_len + 1) * sizeof(WCHAR));
   if (w_realpath_buf == NULL) {
     SetLastError(ERROR_OUTOFMEMORY);
     return -1;
@@ -2720,7 +2720,7 @@ retry_get_disk_free_space:
     }
 
     len = MAX_PATH + 1;
-    pathw = uv__malloc(len * sizeof(*pathw));
+    pathw = (WCHAR *)uv__malloc(len * sizeof(*pathw));
     if (pathw == NULL) {
       SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
       return;
@@ -2736,7 +2736,7 @@ retry_get_full_path_name:
       return;
     } else if (ret > len) {
       len = ret;
-      pathw = uv__reallocf(pathw, len * sizeof(*pathw));
+      pathw = (WCHAR *)uv__reallocf(pathw, len * sizeof(*pathw));
       if (pathw == NULL) {
         SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
         return;
@@ -2752,7 +2752,7 @@ retry_get_full_path_name:
     uv__free(pathw);
   }
 
-  stat_fs = uv__malloc(sizeof(*stat_fs));
+  stat_fs = (uv_statfs_t *)uv__malloc(sizeof(*stat_fs));
   if (stat_fs == NULL) {
     SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
     return;
@@ -2911,7 +2911,7 @@ int uv_fs_read(uv_loop_t* loop,
   req->fs.info.nbufs = nbufs;
   req->fs.info.bufs = req->fs.info.bufsml;
   if (nbufs > ARRAY_SIZE(req->fs.info.bufsml))
-    req->fs.info.bufs = uv__malloc(nbufs * sizeof(*bufs));
+    req->fs.info.bufs = (uv_buf_t *)uv__malloc(nbufs * sizeof(*bufs));
 
   if (req->fs.info.bufs == NULL) {
     SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);
@@ -2944,7 +2944,7 @@ int uv_fs_write(uv_loop_t* loop,
   req->fs.info.nbufs = nbufs;
   req->fs.info.bufs = req->fs.info.bufsml;
   if (nbufs > ARRAY_SIZE(req->fs.info.bufsml))
-    req->fs.info.bufs = uv__malloc(nbufs * sizeof(*bufs));
+    req->fs.info.bufs = (uv_buf_t *)uv__malloc(nbufs * sizeof(*bufs));
 
   if (req->fs.info.bufs == NULL) {
     SET_REQ_UV_ERROR(req, UV_ENOMEM, ERROR_OUTOFMEMORY);

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -266,7 +266,7 @@ void uv__fs_poll_endgame(uv_loop_t* loop, uv_fs_poll_t* handle);
  */
 void uv__util_init(void);
 
-uint64_t uv__hrtime(unsigned int scale);
+uint64_t uv__hrtime(double scale);
 __declspec(noreturn) void uv_fatal_error(const int errorno, const char* syscall);
 int uv__getpwuid_r(uv_passwd_t* pwd);
 int uv__convert_utf16_to_utf8(const WCHAR* utf16, int utf16len, char** utf8);

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1283,7 +1283,7 @@ static int uv__build_coalesced_write_req(uv_write_t* user_req,
                        data_length;                  /* (c) */
 
   /* Allocate buffer. */
-  heap_buffer = uv__malloc(heap_buffer_length);
+  heap_buffer = (char *)uv__malloc(heap_buffer_length);
   if (heap_buffer == NULL)
     return ERROR_NOT_ENOUGH_MEMORY; /* Maps to UV_ENOMEM. */
 
@@ -1528,7 +1528,7 @@ int uv__pipe_write_ipc(uv_loop_t* loop,
     bufs = stack_bufs;
   } else {
     /* Use heap-allocated buffer array. */
-    bufs = uv__calloc(buf_count, sizeof(uv_buf_t));
+    bufs = (uv_buf_t *)uv__calloc(buf_count, sizeof(uv_buf_t));
     if (bufs == NULL)
       return ERROR_NOT_ENOUGH_MEMORY; /* Maps to UV_ENOMEM. */
   }
@@ -2189,7 +2189,7 @@ static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size)
                                       FileNameInformation);
   if (nt_status == STATUS_BUFFER_OVERFLOW) {
     name_size = sizeof(*name_info) + tmp_name_info.FileNameLength;
-    name_info = uv__malloc(name_size);
+    name_info = (FILE_NAME_INFORMATION *)uv__malloc(name_size);
     if (!name_info) {
       *size = 0;
       err = UV_ENOMEM;

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -632,8 +632,8 @@ int env_strncmp(const wchar_t* a, int na, const wchar_t* b) {
   assert(b_eq);
   nb = b_eq - b;
 
-  A = alloca((na+1) * sizeof(wchar_t));
-  B = alloca((nb+1) * sizeof(wchar_t));
+  A = (wchar_t *)alloca((na+1) * sizeof(wchar_t));
+  B = (wchar_t *)alloca((nb+1) * sizeof(wchar_t));
 
   r = LCMapStringW(LOCALE_INVARIANT, LCMAP_UPPERCASE, a, na, A, na);
   assert(r==na);
@@ -716,7 +716,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   if (dst_copy == NULL && env_len > 0) {
     return ERROR_OUTOFMEMORY;
   }
-  env_copy = alloca(env_block_count * sizeof(WCHAR*));
+  env_copy = (WCHAR **)alloca(env_block_count * sizeof(WCHAR*));
 
   ptr = dst_copy;
   ptr_copy = env_copy;
@@ -770,7 +770,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   }
 
   /* final pass: copy, in sort order, and inserting required variables */
-  dst = uv__malloc((1+env_len) * sizeof(WCHAR));
+  dst = (WCHAR *)uv__malloc((1+env_len) * sizeof(WCHAR));
   if (!dst) {
     uv__free(dst_copy);
     return ERROR_OUTOFMEMORY;

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -615,7 +615,7 @@ int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
 
   if (handle->tcp.serv.accept_reqs == NULL) {
     handle->tcp.serv.accept_reqs =
-      uv__malloc(uv_simultaneous_server_accepts * sizeof(uv_tcp_accept_t));
+      (uv_tcp_accept_t *)uv__malloc(uv_simultaneous_server_accepts * sizeof(uv_tcp_accept_t));
     if (!handle->tcp.serv.accept_reqs) {
       uv_fatal_error(ERROR_OUTOFMEMORY, "uv__malloc");
     }

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -98,7 +98,7 @@ static UINT __stdcall uv__thread_start(void* arg) {
   struct thread_ctx *ctx_p;
   struct thread_ctx ctx;
 
-  ctx_p = arg;
+  ctx_p = (struct thread_ctx *)arg;
   ctx = *ctx_p;
   uv__free(ctx_p);
 
@@ -141,7 +141,7 @@ int uv_thread_create_ex(uv_thread_t* tid,
       return UV_EINVAL;
   }
 
-  ctx = uv__malloc(sizeof(*ctx));
+  ctx = (struct thread_ctx *)uv__malloc(sizeof(*ctx));
   if (ctx == NULL)
     return UV_ENOMEM;
 


### PR DESCRIPTION
Clang throws errors for void * to x* cast
ex in fs.c, line 297 : 
`target = uv__malloc(target_len + 1);`
to 
`target = (char *)uv__malloc(target_len + 1);`

On Windows, SystemFunction036 is not resolved, works with : 
```
#define SystemFunction036 NTAPI SystemFunction036
#include <ntsecapi.h>
#undef SystemFunction036
```