### PR TITLE
make VS 2010 happy about STATIC_ASSERT

### DIFF
--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -57,12 +57,8 @@ extern int snprintf(char*, size_t, const char*, ...);
 #define container_of(ptr, type, member) \
   ((type *) ((char *) (ptr) - offsetof(type, member)))
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1600)
-#define STATIC_ASSERT(expr) static_assert( (expr), # expr )
-#else
 #define STATIC_ASSERT(expr)                                                   \
   void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
-#endif
 
 /* Handle flags. Some flags are specific to Windows or UNIX. */
 enum {

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -57,8 +57,12 @@ extern int snprintf(char*, size_t, const char*, ...);
 #define container_of(ptr, type, member) \
   ((type *) ((char *) (ptr) - offsetof(type, member)))
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1600)
+#define STATIC_ASSERT(expr) static_assert( (expr), # expr )
+#else
 #define STATIC_ASSERT(expr)                                                   \
   void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
+#endif
 
 /* Handle flags. Some flags are specific to Windows or UNIX. */
 enum {

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -752,6 +752,9 @@ int uv__udp_set_source_membership6(uv_udp_t* handle,
   int optname;
   int err;
 
+  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
+  STATIC_ASSERT(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
+
   if ((handle->flags & UV_HANDLE_BOUND) && !(handle->flags & UV_HANDLE_IPV6))
     return UV_EINVAL;
 
@@ -774,8 +777,6 @@ int uv__udp_set_source_membership6(uv_udp_t* handle,
     mreq.gsr_interface = 0;
   }
 
-  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
-  STATIC_ASSERT(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
   memcpy(&mreq.gsr_group, multicast_addr, sizeof(*multicast_addr));
   memcpy(&mreq.gsr_source, source_addr, sizeof(*source_addr));
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -492,6 +492,7 @@ uint64_t uv_hrtime(void) {
 
 uint64_t uv__hrtime(unsigned int scale) {
   LARGE_INTEGER counter;
+  double scaled_freq, result;
 
   assert(hrtime_frequency_ != 0);
   assert(scale != 0);
@@ -504,8 +505,8 @@ uint64_t uv__hrtime(unsigned int scale) {
    * performance counter interval, integer math could cause this computation
    * to overflow. Therefore we resort to floating point math.
    */
-  double scaled_freq = (double)hrtime_frequency_ / scale;
-  double result = (double) counter.QuadPart / scaled_freq;
+  scaled_freq = (double)hrtime_frequency_ / scale;
+  result = (double) counter.QuadPart / scaled_freq;
   return (uint64_t) result;
 }
 


### PR DESCRIPTION
make VS 2010 happy about STATIC_ASSERT

```
  void uv__static_assert(int static_assert_failed[1]);
```

In function, if we add a function declaration in middle of code, the compiler will consider an error,
```
udp.c(776): error C2143: syntax error : missing ';' before 'type'
```
