### PR TITLE
win,tty: fix deadlock caused by inconsistent state

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -517,6 +517,7 @@ static DWORD CALLBACK uv_tty_line_read_thread(void* data) {
   status = InterlockedExchange(&uv__read_console_status, IN_PROGRESS);
   if (status == TRAP_REQUESTED) {
     SET_REQ_SUCCESS(req);
+    InterlockedExchange(&uv__read_console_status, COMPLETED);
     req->u.io.overlapped.InternalHigh = 0;
     POST_COMPLETION_FOR_REQ(loop, req);
     return 0;


### PR DESCRIPTION
Hi,
This deadlocks is affecting nodejs in the way described in this issue:
https://github.com/nodejs/node/issues/32999

in short, the REPL module calls **uv_tty_set_mode** 2 times when processing a line of code.

since libuv handles user input in [chunks of 1024 bytes](https://github.com/libuv/libuv/blob/v1.x/src/win/tty.c#L909), copying and pasting more than 1024 bytes with some line breaks will cause nodejs to call **uv_tty_set_mode** while having pending data.

**uv_tty_set_mode** calls **uv_tty_read_stop** which calls **uv__cancel_read_console** and due to a race condition bug (described in the commit message) that prevents a semaphore to be released, the program deadlocks [here](https://github.com/libuv/libuv/blob/v1.x/src/win/tty.c#L393)

thanks @bzoz for giving insights of how the REPL module and tty works
and thanks to @powershellwhizz for uncovering the issue