### PR TITLE
build: don't .gitignore m4/ax_pthread.m4

### DIFF
--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,4 +1,5 @@
 # Ignore libtoolize-generated files.
 *.m4
 !as_case.m4
+!ax_pthread.m4
 !libuv-check-flags.m4


### PR DESCRIPTION
It was reported that the addition of that file without adding an
exception to m4/.gitignore breaks the tarball autotools build because
the file isn't distributed.

Fixes: https://github.com/libuv/libuv/issues/2862