### PR TITLE
To avoid warning in valgrind

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -351,11 +351,13 @@ static int uv__signal_start(uv_signal_t* handle,
                             uv_signal_cb signal_cb,
                             int signum,
                             int oneshot) {
-  sigset_t saved_sigmask = 0;
+  sigset_t saved_sigmask;
   int err;
   uv_signal_t* first_handle;
 
   assert(!uv__is_closing(handle));
+
+  sigemptyset(&saved_sigmask);
 
   /* If the user supplies signum == 0, then return an error already. If the
    * signum is otherwise invalid then uv__signal_register will find out
@@ -517,7 +519,7 @@ int uv_signal_stop(uv_signal_t* handle) {
 
 static void uv__signal_stop(uv_signal_t* handle) {
   uv_signal_t* removed_handle;
-  sigset_t saved_sigmask = 0;
+  sigset_t saved_sigmask;
   uv_signal_t* first_handle;
   int rem_oneshot;
   int first_oneshot;
@@ -526,6 +528,8 @@ static void uv__signal_stop(uv_signal_t* handle) {
   /* If the watcher wasn't started, this is a no-op. */
   if (handle->signum == 0)
     return;
+
+  sigemptyset(&saved_sigmask);
 
   uv__signal_block_and_lock(&saved_sigmask);
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -143,7 +143,7 @@ static void uv__signal_block_and_lock(sigset_t* saved_sigmask) {
   if (sigfillset(&new_mask))
     abort();
 
-  /*  to shut up valgrind */
+  /* to shut up valgrind */
   sigemptyset(saved_sigmask);
   if (pthread_sigmask(SIG_SETMASK, &new_mask, saved_sigmask))
     abort();

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -143,6 +143,8 @@ static void uv__signal_block_and_lock(sigset_t* saved_sigmask) {
   if (sigfillset(&new_mask))
     abort();
 
+  /*  to shut up valgrind */
+  sigemptyset(saved_sigmask);
   if (pthread_sigmask(SIG_SETMASK, &new_mask, saved_sigmask))
     abort();
 
@@ -357,8 +359,6 @@ static int uv__signal_start(uv_signal_t* handle,
 
   assert(!uv__is_closing(handle));
 
-  sigemptyset(&saved_sigmask);
-
   /* If the user supplies signum == 0, then return an error already. If the
    * signum is otherwise invalid then uv__signal_register will find out
    * eventually.
@@ -528,8 +528,6 @@ static void uv__signal_stop(uv_signal_t* handle) {
   /* If the watcher wasn't started, this is a no-op. */
   if (handle->signum == 0)
     return;
-
-  sigemptyset(&saved_sigmask);
 
   uv__signal_block_and_lock(&saved_sigmask);
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -351,7 +351,7 @@ static int uv__signal_start(uv_signal_t* handle,
                             uv_signal_cb signal_cb,
                             int signum,
                             int oneshot) {
-  sigset_t saved_sigmask;
+  sigset_t saved_sigmask = 0;
   int err;
   uv_signal_t* first_handle;
 
@@ -517,7 +517,7 @@ int uv_signal_stop(uv_signal_t* handle) {
 
 static void uv__signal_stop(uv_signal_t* handle) {
   uv_signal_t* removed_handle;
-  sigset_t saved_sigmask;
+  sigset_t saved_sigmask = 0;
   uv_signal_t* first_handle;
   int rem_oneshot;
   int first_oneshot;


### PR DESCRIPTION
To remove `Syscall param __pthread_sigmask(set) points to uninitialised byte(s)` warning in valgrind.