### PR TITLE
net:support TCP_KEEPINTVL,TCP_KEEPCNT,TCP_USER_TIMEOUT for tcp keep-a…

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -556,6 +556,12 @@ UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
 UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle,
                                int enable,
                                unsigned int delay);
+ UV_EXTERN int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                                   int enable,
+                                   unsigned int delay,
+                                   unsigned int interval,
+                                   unsigned int count);
+UV_EXTERN int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout);
 UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
 
 enum uv_tcp_flags {

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -235,6 +235,12 @@ int uv__open_cloexec(const char* path, int flags);
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 int uv__tcp_nodelay(int fd, int on);
 int uv__tcp_keepalive(int fd, int on, unsigned int delay);
+int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                        int enable,
+                        unsigned int delay,
+                        unsigned int interval,
+                        unsigned int count);
+int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout);
 
 /* pipe */
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -407,6 +407,64 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
 }
 
 
+int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout) {
+  #ifdef TCP_USER_TIMEOUT
+    int fd = uv__stream_fd(handle);
+    if (fd != -1 && setsockopt(fd,
+                               IPPROTO_TCP,
+                               TCP_USER_TIMEOUT,
+                               &timeout,
+                               sizeof(timeout))) {
+      return UV__ERR(errno); 
+    }
+  #endif
+	return 0;
+} 
+
+int uv__tcp_keepalive_ex(int fd,
+                         int on, 
+                         unsigned int delay,
+                         unsigned int interval,
+                         unsigned int count) {
+  if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
+    return UV__ERR(errno);
+
+#ifdef TCP_KEEPIDLE
+    if (on && delay &&setsockopt(fd,
+                                 IPPROTO_TCP,
+                                 TCP_KEEPIDLE,
+                                 &delay,
+                                 sizeof(delay)))
+      return UV__ERR(errno);
+#endif
+#ifdef TCP_KEEPINTVL
+    if (on && interval && setsockopt(fd,
+                                     IPPROTO_TCP,
+                                     TCP_KEEPINTVL,
+                                     &interval,
+                                     sizeof(interval)))
+      return UV__ERR(errno);
+#endif
+#ifdef TCP_KEEPCNT
+    if (on && count && setsockopt(fd,
+                                  IPPROTO_TCP,
+                                  TCP_KEEPCNT,
+                                  &count,
+                                  sizeof(count)))
+      return UV__ERR(errno);
+#endif
+  /* Solaris/SmartOS, if you don't support keep-alive,
+   * then don't advertise it in your system headers...
+   */
+  /* FIXME(bnoordhuis) That's possibly because sizeof(delay) should be 1. */
+#if defined(TCP_KEEPALIVE) && !defined(__sun)
+  if (on && setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &delay, sizeof(delay)))
+    return UV__ERR(errno);
+#endif
+
+  return 0;
+}
+
 int uv_tcp_nodelay(uv_tcp_t* handle, int on) {
   int err;
 
@@ -424,6 +482,31 @@ int uv_tcp_nodelay(uv_tcp_t* handle, int on) {
   return 0;
 }
 
+
+int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                        int on,
+                        unsigned int delay,
+                        unsigned int interval,
+                        unsigned int count) {
+  int err;
+
+  if (uv__stream_fd(handle) != -1) {
+    err =uv__tcp_keepalive_ex(uv__stream_fd(handle), on, delay, interval, count);
+    if (err)
+      return err;
+  }
+
+  if (on)
+    handle->flags |= UV_HANDLE_TCP_KEEPALIVE;
+  else
+    handle->flags &= ~UV_HANDLE_TCP_KEEPALIVE;
+
+  /* TODO Store delay if uv__stream_fd(handle) == -1 but don't want to enlarge
+   *      uv_tcp_t with an int that's almost never used...
+   */
+
+  return 0;
+}
 
 int uv_tcp_keepalive(uv_tcp_t* handle, int on, unsigned int delay) {
   int err;

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -68,7 +68,7 @@ static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsign
 
   if (enable && setsockopt(socket,
                            IPPROTO_TCP,
-                           TCP_KEEPALIVE,
+                           TCP_KEEPIDLE,
                            (const char*)&delay,
                            sizeof delay) == -1) {
     return WSAGetLastError();
@@ -1280,6 +1280,80 @@ int uv_tcp_nodelay(uv_tcp_t* handle, int enable) {
   return 0;
 }
 
+/* windows don't support this */
+int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout) {
+	return 0;
+} 
+
+static int uv__tcp_keepalive_ex(uv_tcp_t* handle, 
+                                SOCKET socket, 
+                                int enable, 
+                                unsigned int delay, 
+                                unsigned int interval, 
+                                unsigned int count) {
+  if (setsockopt(socket,
+                 SOL_SOCKET,
+                 SO_KEEPALIVE,
+                 (const char*)&enable,
+                 sizeof enable) == -1) {
+    return WSAGetLastError();
+  }
+
+ #ifdef TCP_KEEPIDLE
+  if (enable && delay && setsockopt(socket,
+                                    IPPROTO_TCP,
+                                    TCP_KEEPIDLE,
+                                    (const char*)&delay,
+                                    sizeof delay) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+#ifdef TCP_KEEPINTVL
+  if (enable && interval && setsockopt(socket,
+                                       IPPROTO_TCP,
+                                       TCP_KEEPINTVL,
+                                       (const char*)&interval,
+                                       sizeof interval) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+#ifdef TCP_KEEPCNT
+  if (enable && count && setsockopt(socket,
+                                    IPPROTO_TCP,
+                                    TCP_KEEPCNT,
+                                    (const char*)&count,
+                                    sizeof count) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+
+  return 0;
+}
+
+
+int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                        int enable,
+                        unsigned int delay,
+                        unsigned int interval,
+                        unsigned int count) {
+  int err;
+
+  if (handle->socket != INVALID_SOCKET) {
+    err = uv__tcp_keepalive_ex(handle, handle->socket, enable, delay, interval, count);
+    if (err)
+      return err;
+  }
+
+  if (enable) {
+    handle->flags |= UV_HANDLE_TCP_KEEPALIVE;
+  } else {
+    handle->flags &= ~UV_HANDLE_TCP_KEEPALIVE;
+  }
+
+  /* TODO: Store delay if handle->socket isn't created yet. */
+
+  return 0;
+}
 
 int uv_tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay) {
   int err;

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -42,6 +42,12 @@ TEST_IMPL(tcp_flags) {
   r = uv_tcp_keepalive(&handle, 1, 60);
   ASSERT(r == 0);
 
+  r = uv_tcp_keepalive_ex(&handle, 1, 60, 60, 60);
+  ASSERT(r == 0);
+
+  r = uv_tcp_timeout(&handle, 1000);
+  ASSERT(r == 0);
+
   uv_close((uv_handle_t*)&handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);


### PR DESCRIPTION
…live in nodejs

except TCP_KEEPIDLE, linux provide TCP_KEEPINTVL,TCP_KEEPCNT,TCP_USER_TIMEOUT for tcp keep-alive.

support this in nodejs,and users can control tcp keep-alive more flexibly