### PR TITLE
win,tty: win10 supports utf-16 surrogate pairs

### DIFF
--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -72,6 +72,8 @@ typedef struct {
   uint32_t delayed_error;
 } uv__ipc_socket_xfer_info_t;
 
+extern int is_windows_10_or_greater;
+
 int uv_tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb);
 int uv_tcp_accept(uv_tcp_t* server, uv_tcp_t* client);
 int uv_tcp_read_start(uv_tcp_t* handle, uv_alloc_cb alloc_cb,

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2123,9 +2123,9 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
       }
 
       /* We wouldn't mind emitting utf-16 surrogate pairs. Too bad, the windows
-       * console doesn't really support UTF-16, so just emit the replacement
-       * character. */
-      if (utf8_codepoint > 0xffff) {
+       * console before Windows 10 doesn't really support UTF-16, so just emit
+       * the replacement character. */
+      if (!is_windows_10_or_greater && utf8_codepoint > 0xffff) {
         utf8_codepoint = UNICODE_REPLACEMENT_CHARACTER;
       }
 

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2155,6 +2155,12 @@ static int uv_tty_write_bufs(uv_tty_t* handle,
         ENSURE_BUFFER_SPACE(1);
         utf16_buf[utf16_buf_used++] = (WCHAR) utf8_codepoint;
         previous_eol = 0;
+      } else {
+        ENSURE_BUFFER_SPACE(2);
+        utf8_codepoint -= 0x10000;
+        utf16_buf[utf16_buf_used++] = (WCHAR) (utf8_codepoint / 0x400 + 0xD800);
+        utf16_buf[utf16_buf_used++] = (WCHAR) (utf8_codepoint % 0x400 + 0xDC00);
+        previous_eol = 0;
       }
     }
   }

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -20,10 +20,12 @@
  */
 
 #include <assert.h>
+#include <string.h>
 
 #include "uv.h"
 #include "internal.h"
 
+int is_windows_10_or_greater;
 
 /* Ntdll function pointers */
 sRtlGetVersion pRtlGetVersion;
@@ -51,6 +53,7 @@ void uv_winapi_init(void) {
   HMODULE powrprof_module;
   HMODULE user32_module;
   HMODULE kernel32_module;
+  OSVERSIONINFOW info;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
@@ -59,6 +62,12 @@ void uv_winapi_init(void) {
 
   pRtlGetVersion = (sRtlGetVersion) GetProcAddress(ntdll_module,
                                                    "RtlGetVersion");
+  if (pRtlGetVersion != NULL) {
+    memset(&info, 0, sizeof(info));
+    info.dwOSVersionInfoSize = sizeof(info);
+    pRtlGetVersion(&info);
+    is_windows_10_or_greater = (info.dwMajorVersion >= 10);
+  }
 
   pRtlNtStatusToDosError = (sRtlNtStatusToDosError) GetProcAddress(
       ntdll_module,


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/2909
CI: https://ci.nodejs.org/job/libuv-test-commit/1944/