### PR TITLE
darwin: work around missing hw.cpufrequency sysctl

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -198,9 +198,13 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     return UV__ERR(errno);
   }
 
+  /* hw.cpufrequency seems to be missing on darwin/arm64 (Apple Silicon)
+   * but it should be okay to report 0, that's why we ignore errors.
+   * See https://github.com/libuv/libuv/issues/2911.
+   */
+  cpuspeed = 0;
   size = sizeof(cpuspeed);
-  if (sysctlbyname("hw.cpufrequency", &cpuspeed, &size, NULL, 0))
-    return UV__ERR(errno);
+  sysctlbyname("hw.cpufrequency", &cpuspeed, &size, NULL, 0);
 
   if (host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numcpus,
                           (processor_info_array_t*)&info,


### PR DESCRIPTION
The hw.cpufrequency sysctl seems to be missing on darwin/arm64
(Apple Silicon) but it should be okay to report 0, that's why
we ignore errors from this commit onward.

Fixes: https://github.com/libuv/libuv/issues/2911
CI: https://ci.nodejs.org/job/libuv-test-commit/1945/