### PR TITLE
darwin: use IOKit for uv_cpu_info

### DIFF
--- a/src/unix/darwin-stub.h
+++ b/src/unix/darwin-stub.h
@@ -27,6 +27,7 @@
 struct CFArrayCallBacks;
 struct CFRunLoopSourceContext;
 struct FSEventStreamContext;
+struct CFRange;
 
 typedef double CFAbsoluteTime;
 typedef double CFTimeInterval;
@@ -42,12 +43,22 @@ typedef unsigned CFStringEncoding;
 typedef void* CFAllocatorRef;
 typedef void* CFArrayRef;
 typedef void* CFBundleRef;
+typedef void* CFDataRef;
 typedef void* CFDictionaryRef;
+typedef void* CFMutableDictionaryRef;
+typedef struct CFRange CFRange;
 typedef void* CFRunLoopRef;
 typedef void* CFRunLoopSourceRef;
 typedef void* CFStringRef;
 typedef void* CFTypeRef;
 typedef void* FSEventStreamRef;
+
+typedef uint32_t IOOptionBits;
+typedef unsigned int io_iterator_t;
+typedef unsigned int io_object_t;
+typedef unsigned int io_service_t;
+typedef unsigned int io_registry_entry_t;
+
 
 typedef void (*FSEventStreamCallback)(const FSEventStreamRef,
                                       void*,
@@ -67,6 +78,11 @@ struct FSEventStreamContext {
   CFIndex version;
   void* info;
   void* pad[3];
+};
+
+struct CFRange {
+  CFIndex location;
+  CFIndex length;
 };
 
 static const CFStringEncoding kCFStringEncodingUTF8 = 0x8000100;

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -274,8 +274,8 @@ static int uv__get_cpu_speed(uint64_t* speed) {
                                             0);
     if (data) {
       const UInt8* raw = pCFDataGetBytePtr(data);
-      if (strncmp((char*)raw, "cpu", 3) == 0
-        || strncmp((char*)raw, "processor", 9) == 0) {
+      if (strncmp((char*)raw, "cpu", 3) == 0 ||
+          strncmp((char*)raw, "processor", 9) == 0) {
         CFDataRef freq_ref;
         freq_ref = pIORegistryEntryCreateCFProperty(service,
                                                     clock_frequency_str,


### PR DESCRIPTION
This switches uv_cpu_info from using sysctlbyname to
using IOKit to get the speed of the processors.
macOS on ARM does not currently have the hw.cpufrequency
sysctl. We are able to reliable get the clock frequency
on all architectures by using IOKit.

Fixes: https://github.com/libuv/libuv/issues/2911