### PR TITLE
doc: add error constants

### DIFF
--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -319,6 +319,18 @@ Error constants
 
     too many links
 
+.. c:macro:: UV_ENOTTY
+
+    inappropriate ioctl for device
+
+.. c:macro:: UV_EFTYPE
+
+    inappropriate file type or format
+
+.. c:macro:: UV_EILSEQ
+
+    illegal byte sequence
+
 
 API
 ---


### PR DESCRIPTION
added some error constants to doc
<code>UV_ENOTTY</code>, <code>UV_EFTYPE</code>, <code>UV_EILSEQ</code>