### PR TITLE
fs: clobber req->path on uv_fs_mkstemp() error

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -350,7 +350,7 @@ static int uv__fs_mkstemp(uv_fs_t* req) {
 
 clobber:
   if (r < 0)
-    *(path) = '\0';
+    path[0] = '\0';
   return r;
 }
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -306,6 +306,7 @@ static int uv__fs_mkstemp(uv_fs_t* req) {
   if (path_length < pattern_size ||
       strcmp(path + path_length - pattern_size, pattern)) {
     errno = EINVAL;
+    r = -1;
     goto clobber;
   }
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1242,6 +1242,7 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func func) {
   unsigned int tries, i;
   size_t len;
   uint64_t v;
+  char *path = req->path;
 
   len = wcslen(req->file.pathw);
   ep = req->file.pathw + len;
@@ -1265,8 +1266,8 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func func) {
 
     if (func(req)) {
       if (req->result >= 0) {
-        len = strlen(req->path);
-        wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
+        len = strlen(path);
+        wcstombs(path + len - num_x, ep - num_x, num_x);
       }
       return;
     }
@@ -1275,7 +1276,7 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func func) {
   SET_REQ_RESULT(req, -1);
 
 clobber:
-  (char) *(req->path) = '\0';
+  path[0] = '\0';
 }
 
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1242,8 +1242,9 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func func) {
   unsigned int tries, i;
   size_t len;
   uint64_t v;
-  char *path = req->path;
-
+  char* path;
+  
+  path = req->path;
   len = wcslen(req->file.pathw);
   ep = req->file.pathw + len;
   if (len < num_x || wcsncmp(ep - num_x, L"XXXXXX", num_x)) {

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1271,7 +1271,6 @@ TEST_IMPL(fs_mkstemp) {
   int r;
   int fd;
   const char path_template[] = "test_file_XXXXXX";
-  const char test_file[] = "test_file";
   uv_fs_t req;
 
   loop = uv_default_loop();
@@ -1291,10 +1290,10 @@ TEST_IMPL(fs_mkstemp) {
   ASSERT(strcmp(mkstemp_req1.path, mkstemp_req2.path) != 0);
 
   /* invalid template returns EINVAL */
-  ASSERT(uv_fs_mkstemp(NULL, &mkstemp_req3, test_file, NULL) == UV_EINVAL);
+  ASSERT_EQ(UV_EINVAL, uv_fs_mkstemp(NULL, &mkstemp_req3, "test_file", NULL));
 
   /* Make sure that path is empty string */
-  ASSERT(strlen(mkstemp_req3.path) == 0);
+  ASSERT_EQ(0, strlen(mkstemp_req3.path));
 
   /* We can write to the opened file */
   iov = uv_buf_init(test_buf, sizeof(test_buf));

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1271,6 +1271,7 @@ TEST_IMPL(fs_mkstemp) {
   int r;
   int fd;
   const char path_template[] = "test_file_XXXXXX";
+  const char test_file[] = "test_file";
   uv_fs_t req;
 
   loop = uv_default_loop();
@@ -1290,7 +1291,10 @@ TEST_IMPL(fs_mkstemp) {
   ASSERT(strcmp(mkstemp_req1.path, mkstemp_req2.path) != 0);
 
   /* invalid template returns EINVAL */
-  ASSERT(uv_fs_mkstemp(NULL, &mkstemp_req3, "test_file", NULL) == UV_EINVAL);
+  ASSERT(uv_fs_mkstemp(NULL, &mkstemp_req3, test_file, NULL) == UV_EINVAL);
+
+  /* Make sure that path is empty string */
+  ASSERT(strlen(mkstemp_req3.path) == 0);
 
   /* We can write to the opened file */
   iov = uv_buf_init(test_buf, sizeof(test_buf));


### PR DESCRIPTION
Contents of template variable passed for posix call mkstemp on error
code EINVAL is unknown. On AIX platform, template will get clobbered
on EINVAL and any attempt to read template might result in error.

In libuv, req->path is passed directly to the mkstemp call and
behavior of this string on error is platform dependent. To avoid
portability issues, it's better to have a common behavior on all
platform. For both unix and windows platform libuv will rewrite path
with with an empty string on all error cases.

Ref: https://github.com/libuv/libuv/issues/2913
