### PR TITLE
build: add more failed test for qemu version bump

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
           sudo dpkg -i $DEB
       - name: Install ${{ matrix.config.toolchain }}
         run: |
+          sudo apt update
           sudo apt install ${{ matrix.config.toolchain }} -y
       - name: Build
         run: |

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -39,6 +39,7 @@ static int fail_cb_called;
 static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
                                 int status,
                                 struct addrinfo* res) {
+
   ASSERT(fail_cb_called == 0);
   ASSERT(status < 0);
   ASSERT(res == NULL);
@@ -81,6 +82,11 @@ static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle,
 
 
 TEST_IMPL(getaddrinfo_fail) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+  
   uv_getaddrinfo_t req;
 
   ASSERT(UV_EINVAL == uv_getaddrinfo(uv_default_loop(),
@@ -127,6 +133,11 @@ TEST_IMPL(getaddrinfo_fail_sync) {
 
 
 TEST_IMPL(getaddrinfo_basic) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+
   int r;
   getaddrinfo_handle = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
 
@@ -168,6 +179,11 @@ TEST_IMPL(getaddrinfo_basic_sync) {
 
 
 TEST_IMPL(getaddrinfo_concurrent) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+  
   int i, r;
   int* data;
 

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -46,6 +46,11 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
 
 
 TEST_IMPL(getnameinfo_basic_ip4) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+
   int r;
 
   r = uv_ip4_addr(address_ip4, port, &addr4);
@@ -87,6 +92,11 @@ TEST_IMPL(getnameinfo_basic_ip4_sync) {
 
 
 TEST_IMPL(getnameinfo_basic_ip6) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+  
   int r;
 
   r = uv_ip6_addr(address_ip6, port, &addr6);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -167,6 +167,11 @@ TEST_IMPL(thread_create) {
  * that each "finished" callback is run in its originating thread.
  */
 TEST_IMPL(threadpool_multiple_event_loops) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+  
   struct test_thread threads[8];
   size_t i;
   int r;

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -422,6 +422,11 @@ TEST_IMPL(tty_file) {
 }
 
 TEST_IMPL(tty_pty) {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+
 #if defined(__APPLE__)                            || \
     defined(__DragonFly__)                        || \
     defined(__FreeBSD__)                          || \


### PR DESCRIPTION
Fix: #2937

`qemu-user-static_4.2-3ubuntu9_amd64.deb` and `qemu-user-static_4.2-3ubuntu8_amd64.deb` works fine.
But `qemu-user-static_4.2-3ubuntu10_amd64.deb` has regressions, and break the tests.
And ubuntu don't keep old deb files.

In the long run:
* will qemu team will make to test libuv in their workflow.
* should we switch to docker build to make test more stable ? we can install qemu in docker, and the version will be stable. And preinstall all toolchains, looks like ubuntu makes a bug on installing 
 deps https://github.com/libuv/libuv/pull/2939/checks?check_run_id=949787423

