### PR TITLE
test: give hrtime test a custom 20s timeout

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -857,7 +857,7 @@ TASK_LIST_START
 
   TEST_ENTRY  (tmpdir)
 
-  TEST_ENTRY_CUSTOM (hrtime, 0, 0, 10000)
+  TEST_ENTRY_CUSTOM (hrtime, 0, 0, 20000)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
   TEST_ENTRY_CUSTOM (getaddrinfo_fail_sync, 0, 0, 10000)


### PR DESCRIPTION
The test is supposed to complete in about 3.5s but it can
hit the 10s timeout when run on a system with high load.

Fixes: https://github.com/libuv/libuv/issues/2342 (hopefully?)
Refs: https://github.com/libuv/libuv/pull/2345
CI: https://ci.nodejs.org/job/libuv-test-commit-osx-cmake/170/
CI: https://ci.nodejs.org/job/libuv-test-commit-osx-cmake/171/