### PR TITLE
test: fix thread race in process_title_threadsafe

### DIFF
--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -39,10 +39,13 @@ static const char* titles[] = {
 };
 
 static void getter_thread_body(void* arg) {
+  uv_sem_t* getter_sem;
   char buffer[512];
   size_t len;
 
-  for (;;) {
+  getter_sem = arg;
+
+  while (UV_EAGAIN == uv_sem_trywait(getter_sem)) {
     ASSERT(0 == uv_get_process_title(buffer, sizeof(buffer)));
 
     /* The maximum size of the process title on some platforms depends on
@@ -78,6 +81,7 @@ static void setter_thread_body(void* arg) {
 TEST_IMPL(process_title_threadsafe) {
   uv_thread_t setter_threads[4];
   uv_thread_t getter_thread;
+  uv_sem_t getter_sem;
   int i;
 
 #if defined(__sun) || defined(__CYGWIN__) || defined(__MSYS__) || \
@@ -86,13 +90,20 @@ TEST_IMPL(process_title_threadsafe) {
 #endif
 
   ASSERT(0 == uv_set_process_title(titles[0]));
-  ASSERT(0 == uv_thread_create(&getter_thread, getter_thread_body, NULL));
+
+  ASSERT_EQ(0, uv_sem_init(&getter_sem, 0));
+  ASSERT_EQ(0,
+            uv_thread_create(&getter_thread, getter_thread_body, &getter_sem));
 
   for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
     ASSERT(0 == uv_thread_create(&setter_threads[i], setter_thread_body, NULL));
 
   for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
     ASSERT(0 == uv_thread_join(&setter_threads[i]));
+
+  uv_sem_post(&getter_sem);
+  ASSERT_EQ(0, uv_thread_join(&getter_thread));
+  uv_sem_destroy(&getter_sem);
 
   return 0;
 }


### PR DESCRIPTION
Libuv calls uv__process_title_cleanup() on shutdown, which raced with
one of the threads from the test that calls uv_get_process_title() in
an infinite loop. Change the test to properly shut down the thread
before exiting.

Refs: https://github.com/libuv/libuv/pull/2853#issuecomment-665259082
CI: https://ci.nodejs.org/job/libuv-test-commit/1978/