### PR TITLE
doc: fix most sphinx warnings

### DIFF
--- a/docs/src/async.rst
+++ b/docs/src/async.rst
@@ -51,7 +51,7 @@ API
         loop thread.
 
     .. note::
-        :c:func:`uv_async_send` is `async-signal-safe <http://man7.org/linux/man-pages/man7/signal-safety.7.html>`_.
+        :c:func:`uv_async_send` is `async-signal-safe <https://man7.org/linux/man-pages/man7/signal-safety.7.html>`_.
         It's safe to call this function from a signal handler.
 
     .. warning::

--- a/docs/src/errors.rst
+++ b/docs/src/errors.rst
@@ -335,7 +335,7 @@ Error constants
 API
 ---
 
-.. c:function:: UV_ERRNO_MAP(iter_macro)
+.. c:macro:: UV_ERRNO_MAP(iter_macro)
 
     Macro that expands to a series of invocations of `iter_macro` for
     each of the error constants above. `iter_macro` is invoked with two

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -58,7 +58,7 @@ Data types
             uv_timespec_t st_birthtim;
         } uv_stat_t;
 
-.. c:type:: uv_fs_type
+.. c:enum:: uv_fs_type
 
     File system request type.
 
@@ -122,7 +122,7 @@ Data types
             uint64_t f_spare[4];
         } uv_statfs_t;
 
-.. c:type:: uv_dirent_t
+.. c:enum:: uv_dirent_t
 
     Cross platform (reduced) equivalent of ``struct dirent``.
     Used in :c:func:`uv_fs_scandir_next`.

--- a/docs/src/guide/filesystem.rst
+++ b/docs/src/guide/filesystem.rst
@@ -33,7 +33,7 @@ A file descriptor is obtained using
     int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags, int mode, uv_fs_cb cb)
 
 ``flags`` and ``mode`` are standard
-`Unix flags <http://man7.org/linux/man-pages/man2/open.2.html>`_.
+`Unix flags <https://man7.org/linux/man-pages/man2/open.2.html>`_.
 libuv takes care of converting to the appropriate Windows flags.
 
 File descriptors are closed using

--- a/docs/src/guide/networking.rst
+++ b/docs/src/guide/networking.rst
@@ -200,7 +200,7 @@ Freenode to see an example of DNS resolution.
 If ``uv_getaddrinfo`` returns non-zero, something went wrong in the setup and
 your callback won't be invoked at all. All arguments can be freed immediately
 after ``uv_getaddrinfo`` returns. The `hostname`, `servname` and `hints`
-structures are documented in `the getaddrinfo man page <getaddrinfo>`_. The
+structures are documented in `the getaddrinfo man page <getaddrinfo_>`_. The
 callback can be ``NULL`` in which case the function will run synchronously.
 
 In the resolver callback, you can pick any IP from the linked list of ``struct
@@ -235,7 +235,7 @@ interface has multiple IPv4/IPv6 addresses, the name will be reported multiple
 times, with each address being reported once.
 
 .. _c-ares: https://c-ares.haxx.se
-.. _getaddrinfo: https://www.kernel.org/doc/man-pages/online/pages/man3/getaddrinfo.3.html
+.. _getaddrinfo: https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
 
 .. _User Datagram Protocol: https://en.wikipedia.org/wiki/User_Datagram_Protocol
 .. _DHCP: https://tools.ietf.org/html/rfc2131

--- a/docs/src/guide/processes.rst
+++ b/docs/src/guide/processes.rst
@@ -266,10 +266,10 @@ Domain Socket`_, or derived from `mkfifo(1)`_, or it could actually be a
 This is intended for the purpose of allowing multiple libuv processes to
 communicate with IPC. This is discussed below.
 
-.. _pipe(7): http://man7.org/linux/man-pages/man7/pipe.7.html
-.. _mkfifo(1): http://man7.org/linux/man-pages/man1/mkfifo.1.html
-.. _socketpair(2): http://man7.org/linux/man-pages/man2/socketpair.2.html
-.. _Unix Domain Socket: http://man7.org/linux/man-pages/man7/unix.7.html
+.. _pipe(7): https://man7.org/linux/man-pages/man7/pipe.7.html
+.. _mkfifo(1): https://man7.org/linux/man-pages/man1/mkfifo.1.html
+.. _socketpair(2): https://man7.org/linux/man-pages/man2/socketpair.2.html
+.. _Unix Domain Socket: https://man7.org/linux/man-pages/man7/unix.7.html
 .. _Named Pipe: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
 
 

--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -243,7 +243,7 @@ We let libcurl directly write the data to a file, but much more is possible if
 you so desire.
 
 ``start_timeout`` will be called immediately the first time by libcurl, so
-things are set in motion. This simply starts a libuv `timer <Timers>`_ which
+things are set in motion. This simply starts a libuv `timer <#timers>`_ which
 drives ``curl_multi_socket_action`` with ``CURL_SOCKET_TIMEOUT`` whenever it
 times out. ``curl_multi_socket_action`` is what drives libcurl, and what we
 call whenever sockets change state. But before we go into that, we need to poll

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -20,7 +20,7 @@ Data types
 
     The base libuv handle type.
 
-.. c:type:: uv_handle_type
+.. c:enum:: uv_handle_type
 
     The kind of the libuv handle.
 
@@ -104,7 +104,7 @@ Public members
 API
 ---
 
-.. c:function:: UV_HANDLE_TYPE_MAP(iter_macro)
+.. c:macro:: UV_HANDLE_TYPE_MAP(iter_macro)
 
     Macro that expands to a series of invocations of `iter_macro` for
     each of the handle types. `iter_macro` is invoked with two

--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -16,7 +16,7 @@ Data types
 
     Loop data type.
 
-.. c:type:: uv_run_mode
+.. c:enum:: uv_run_mode
 
     Mode used to run the loop with :c:func:`uv_run`.
 

--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -102,7 +102,7 @@ Data types
             } data;
         } uv_stdio_container_t;
 
-.. c:type:: uv_stdio_flags
+.. c:enum:: uv_stdio_flags
 
     Flags specifying how a stdio should be transmitted to the child process.
 
@@ -131,43 +131,43 @@ Data types
 Public members
 ^^^^^^^^^^^^^^
 
-.. c:member:: uv_process_t.pid
+.. c:member:: int uv_process_t.pid
 
     The PID of the spawned process. It's set after calling :c:func:`uv_spawn`.
 
 .. note::
     The :c:type:`uv_handle_t` members also apply.
 
-.. c:member:: uv_process_options_t.exit_cb
+.. c:member:: uv_exit_cb uv_process_options_t.exit_cb
 
     Callback called after the process exits.
 
-.. c:member:: uv_process_options_t.file
+.. c:member:: const char* uv_process_options_t.file
 
     Path pointing to the program to be executed.
 
-.. c:member:: uv_process_options_t.args
+.. c:member:: char** uv_process_options_t.args
 
     Command line arguments. args[0] should be the path to the program. On
     Windows this uses `CreateProcess` which concatenates the arguments into a
     string this can cause some strange errors. See the
     ``UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS`` flag on :c:type:`uv_process_flags`.
 
-.. c:member:: uv_process_options_t.env
+.. c:member:: char** uv_process_options_t.env
 
     Environment for the new process. If NULL the parents environment is used.
 
-.. c:member:: uv_process_options_t.cwd
+.. c:member:: const char* uv_process_options_t.cwd
 
     Current working directory for the subprocess.
 
-.. c:member:: uv_process_options_t.flags
+.. c:member:: unsigned int uv_process_options_t.flags
 
     Various flags that control how :c:func:`uv_spawn` behaves. See
     :c:type:`uv_process_flags`.
 
-.. c:member:: uv_process_options_t.stdio_count
-.. c:member:: uv_process_options_t.stdio
+.. c:member:: int uv_process_options_t.stdio_count
+.. c:member:: uv_stdio_container_t* uv_process_options_t.stdio
 
     The `stdio` field points to an array of :c:type:`uv_stdio_container_t`
     structs that describe the file descriptors that will be made available to
@@ -178,8 +178,8 @@ Public members
         On Windows file descriptors greater than 2 are available to the child process only if
         the child processes uses the MSVCRT runtime.
 
-.. c:member:: uv_process_options_t.uid
-.. c:member:: uv_process_options_t.gid
+.. c:member:: uv_uid_t uv_process_options_t.uid
+.. c:member:: uv_gid_t uv_process_options_t.gid
 
     Libuv can change the child process' user/group id. This happens only when
     the appropriate bits are set in the flags fields.
@@ -188,14 +188,13 @@ Public members
         This is not supported on Windows, :c:func:`uv_spawn` will fail and set the error
         to ``UV_ENOTSUP``.
 
-.. c:member:: uv_stdio_container_t.flags
+.. c:member:: uv_stdio_flags uv_stdio_container_t.flags
 
-    Flags specifying how the stdio container should be passed to the child. See
-    :c:type:`uv_stdio_flags`.
+    Flags specifying how the stdio container should be passed to the child.
 
-.. c:member:: uv_stdio_container_t.data
+.. c:member:: union @0 uv_stdio_container_t.data
 
-    Union containing either the stream or fd to be passed on to the child
+    Union containing either the `stream` or `fd` to be passed on to the child
     process.
 
 

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -53,7 +53,7 @@ Public members
 API
 ---
 
-.. c:function:: UV_REQ_TYPE_MAP(iter_macro)
+.. c:macro:: UV_REQ_TYPE_MAP(iter_macro)
 
     Macro that expands to a series of invocations of `iter_macro` for
     each of the request types. `iter_macro` is invoked with two

--- a/docs/src/sphinx-plugins/manpage.py
+++ b/docs/src/sphinx-plugins/manpage.py
@@ -18,7 +18,7 @@ from string import Template
 def make_link_node(rawtext, app, name, manpage_num, options):
     ref = app.config.man_url_regex
     if not ref:
-        ref = "http://man7.org/linux/man-pages/man%s/%s.%s.html" %(manpage_num, name, manpage_num)
+        ref = "https://man7.org/linux/man-pages/man%s/%s.%s.html" %(manpage_num, name, manpage_num)
     else:
         s = Template(ref)
         ref = s.substitute(num=manpage_num, topic=name)

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -16,7 +16,7 @@ Data types
 
     TTY handle type.
 
-.. c:type:: uv_tty_mode_t
+.. c:enum:: uv_tty_mode_t
 
     .. versionadded:: 1.2.0
 
@@ -33,7 +33,8 @@ Data types
           UV_TTY_MODE_IO
       } uv_tty_mode_t;
 
-.. c:type:: uv_tty_vtermstate_t
+.. c:enum:: uv_tty_vtermstate_t
+
     Console virtual terminal mode type:
 
     ::

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -88,7 +88,7 @@ Data types
         nothing to read, and with `nread` == 0 and `addr` != NULL when an empty UDP packet is
         received.
 
-.. c:type:: uv_membership
+.. c:enum:: uv_membership
 
     Membership type for a multicast address.
 


### PR DESCRIPTION
sphinx didn't like that the syntax of these was wrong, leading to loss of formatting in the html, and other minor nits.

I left this one, since I don't really like the valid syntax version (the [] should be on the right of the variable name):
```
docs/src/dns.rst:54: WARNING: Error in declarator or parameters
Invalid C declaration: Expected identifier in nested name. [error at 4]
  char[NI_MAXHOST] uv_getnameinfo_t.host
  ----^
docs/src/dns.rst:60: WARNING: Error in declarator or parameters
Invalid C declaration: Expected identifier in nested name. [error at 4]
  char[NI_MAXSERV] uv_getnameinfo_t.service
  ----^
```