### PR TITLE
unix: don't use _POSIX_PATH_MAX

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -62,9 +62,7 @@
 # include <AvailabilityMacros.h>
 #endif
 
-#if defined(_POSIX_PATH_MAX)
-# define UV__PATH_MAX _POSIX_PATH_MAX
-#elif defined(PATH_MAX)
+#if defined(PATH_MAX)
 # define UV__PATH_MAX PATH_MAX
 #else
 # define UV__PATH_MAX 8192


### PR DESCRIPTION
Libuv was using _POSIX_PATH_MAX wrong. Bug introduced in commit b56d279b
("unix: do not require PATH_MAX to be defined") from September 2018.

_POSIX_PATH_MAX is the minimum max path size guaranteed by POSIX, not
the actual max path size of the system libuv runs on. _POSIX_PATH_MAX
is always 256, the real max is often much bigger.

This commit fixes buffer overruns when processing very long paths in
uv_fs_readlink() and uv_fs_realpath() because libuv was not allocating
enough memory to store the result.

Fixes: https://github.com/libuv/libuv/issues/2965
CI: https://ci.nodejs.org/job/libuv-test-commit/2012/