### PR TITLE
unix,stream: don't clear writable flag on shutdown

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1278,7 +1278,10 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* stream, uv_shutdown_cb cb) {
   req->cb = cb;
   stream->shutdown_req = req;
   stream->flags |= UV_HANDLE_SHUTTING;
+  /* TODO(cjihrig): The following line should be uncommented.
+     Refs: https://github.com/libuv/libuv/issues/2943
   stream->flags &= ~UV_HANDLE_WRITABLE;
+  */
 
   uv__io_start(stream->loop, &stream->io_watcher, POLLOUT);
   uv__stream_osx_interrupt_select(stream);

--- a/test/test-not-writable-after-shutdown.c
+++ b/test/test-not-writable-after-shutdown.c
@@ -39,7 +39,11 @@ static void connect_cb(uv_connect_t* req, int status) {
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   ASSERT(r == 0);
 
+#ifdef _WIN32
+  /* TODO(cjihrig): This assertion should happen on all platforms.
+     Refs: https://github.com/libuv/libuv/issues/2943 */
   ASSERT(0 == uv_is_writable(req->handle));
+#endif
 }
 
 TEST_IMPL(not_writable_after_shutdown) {


### PR DESCRIPTION
12be29f correctly updated uv_shutdown() to clear the writable
flag on Unix platforms. However, the change is causing test
failures in Node.js. This commit reverts the change so that the
1.39.0 release is unblocked.