### PR TITLE
fs: use WTF-8 on Windows

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -353,6 +353,7 @@ TEST_DECLARE   (fs_exclusive_sharing_mode)
 TEST_DECLARE   (fs_file_flag_no_buffering)
 TEST_DECLARE   (fs_open_readonly_acl)
 TEST_DECLARE   (fs_fchmod_archive_readonly)
+TEST_DECLARE   (fs_wtf)
 #endif
 TEST_DECLARE   (strscpy)
 TEST_DECLARE   (threadpool_queue_work_simple)
@@ -916,6 +917,7 @@ TASK_LIST_START
   TEST_ENTRY  (fs_file_flag_no_buffering)
   TEST_ENTRY  (fs_open_readonly_acl)
   TEST_ENTRY  (fs_fchmod_archive_readonly)
+  TEST_ENTRY  (fs_wtf)
 #endif
   TEST_ENTRY  (get_osfhandle_valid_handle)
   TEST_ENTRY  (open_osfhandle_valid_handle)


### PR DESCRIPTION
I got tired of waiting on https://github.com/libuv/libuv/pull/2192, so I just applied the code review suggestions made by @vtjnash. Hopefully I'm doing the return error codes right, but if not, let me know what else to do here.

There were a couple of formatting recommendations for long function signatures that I did not follow since lining wrapped up arguments with the opening parens does not seem to be the existing style in this file. Instead, I indented the wrapped arguments to be indented once after the normal function body level, which seems to be how the rest of this file is formatted. If the other format is preferable, it would be better to make a separate cosmetic PR to fix that.