### PR TITLE
src: suppress user_timeout maybe-uninitialized

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -220,6 +220,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int i;
   int user_timeout;
   int reset_timeout;
+  user_timeout = 0;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -220,7 +220,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int i;
   int user_timeout;
   int reset_timeout;
-  user_timeout = 0;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -282,6 +281,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     timeout = 0;
   } else {
     reset_timeout = 0;
+    user_timeout = 0;
   }
 
   /* You could argue there is a dependency between these two but


### PR DESCRIPTION
This commit initializes `user_timeout` in `uv__io_poll` to avoid a
maybe-uninitialized warning:
```console
$ cmake .. -DCMAKE_C_FLAGS="-Wmaybe-uninitialized -O3"
...
[ 14%] Building C object CMakeFiles/uv.dir/src/unix/tty.c.o
/libuv/libuv/src/unix/linux-core.c: In function ‘uv__io_poll’:
/libuv/libuv/src/unix/linux-core.c:351:10: warning:
‘user_timeout’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  351 |       if (timeout == -1)
      |          ^

```