### PR TITLE
Remove _WIN32 guards on threadpool.c

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -161,7 +161,6 @@ static void post(QUEUE* q, enum uv__work_kind kind) {
 
 
 void uv__threadpool_cleanup(void) {
-#ifndef _WIN32
   unsigned int i;
 
   if (nthreads == 0)
@@ -181,7 +180,6 @@ void uv__threadpool_cleanup(void) {
 
   threads = NULL;
   nthreads = 0;
-#endif
 }
 
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -872,7 +872,11 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 }
 
 
-#ifdef __GNUC__  /* Also covers __clang__ and __INTEL_COMPILER. */
+/* Also covers __clang__ and __INTEL_COMPILER. Disabled on Windows because
+ * threads have already been forcibly terminated by the operating system
+ * by the time destructors run, ergo, it's not safe to try to clean them up.
+ */
+#if defined(__GNUC__) && !defined(_WIN32)
 __attribute__((destructor))
 #endif
 void uv_library_shutdown(void) {


### PR DESCRIPTION
The _WIN32 guards appear to be remnants of another time. Begone with them!

/cc @bnoordhuis @cjihrig @addaleax 

Fixes: https://github.com/libuv/libuv/issues/2980
Refs: https://github.com/nodejs/node/pull/35021
Signed-off-by: James M Snell <jasnell@gmail.com>