### PR TITLE
udp: ensure that suggested_size in alloc_cb of recv_start is 1 max size dgram

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -393,6 +393,11 @@ API
 
     :returns: 0 on success, or an error code < 0 on failure.
 
+    .. note::
+        When using :man:`recvmmsg(2)`, the number of messages received at a time is limited
+        by the number of max size dgrams that will fit into the buffer allocated in `alloc_cb`, and
+        `suggested_size` in `alloc_cb` for udp_recv is always set to the size of 1 max size dgram.
+
     .. versionchanged:: 1.35.0 added support for :man:`recvmmsg(2)` on supported platforms).
                         The use of this feature requires a buffer larger than
                         2 * 64KB to be passed to `alloc_cb`.

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -32,8 +32,6 @@
 #endif
 #include <sys/un.h>
 
-#define UV__UDP_DGRAM_MAXSIZE (64 * 1024)
-
 #if defined(IPV6_JOIN_GROUP) && !defined(IPV6_ADD_MEMBERSHIP)
 # define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
 #endif

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -68,6 +68,8 @@ extern int snprintf(char*, size_t, const char*, ...);
 #define uv__store_relaxed(p, v) do *p = v; while (0)
 #endif
 
+#define UV__UDP_DGRAM_MAXSIZE (64 * 1024)
+
 /* Handle flags. Some flags are specific to Windows or UNIX. */
 enum {
   /* Used by all handles. */

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -284,7 +284,7 @@ static void uv_udp_queue_recv(uv_loop_t* loop, uv_udp_t* handle) {
     handle->flags &= ~UV_HANDLE_ZERO_READ;
 
     handle->recv_buffer = uv_buf_init(NULL, 0);
-    handle->alloc_cb((uv_handle_t*) handle, 65536, &handle->recv_buffer);
+    handle->alloc_cb((uv_handle_t*) handle, UV__UDP_DGRAM_MAXSIZE, &handle->recv_buffer);
     if (handle->recv_buffer.base == NULL || handle->recv_buffer.len == 0) {
       handle->recv_cb(handle, UV_ENOBUFS, &handle->recv_buffer, NULL, 0);
       return;
@@ -501,7 +501,7 @@ void uv_process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
     /* Do a nonblocking receive.
      * TODO: try to read multiple datagrams at once. FIONREAD maybe? */
     buf = uv_buf_init(NULL, 0);
-    handle->alloc_cb((uv_handle_t*) handle, 65536, &buf);
+    handle->alloc_cb((uv_handle_t*) handle, UV__UDP_DGRAM_MAXSIZE, &buf);
     if (buf.base == NULL || buf.len == 0) {
       handle->recv_cb(handle, UV_ENOBUFS, &buf, NULL, 0);
       goto done;


### PR DESCRIPTION
Note: I'm not super convinced this is totally necessary/the best way to do this.

The intention here is to make working with recvmmsg more straight-forward, since internally Libuv expects buffers that are multiples of UV__UDP_DGRAM_MAXSIZE, but previously that wasn't totally obvious (from my perspective at least).

This would be the final part of #2822. If merged, closes #2822.