### PR TITLE
include: remove incorrect UV__ERR() for EPROTO

### DIFF
--- a/include/uv/errno.h
+++ b/include/uv/errno.h
@@ -317,7 +317,7 @@
 #if defined(EPROTO) && !defined(_WIN32)
 # define UV__EPROTO UV__ERR(EPROTO)
 #else
-# define UV__EPROTO UV__ERR(-4046)
+# define UV__EPROTO (-4046)
 #endif
 
 #if defined(EPROTONOSUPPORT) && !defined(_WIN32)


### PR DESCRIPTION
https://github.com/libuv/libuv/pull/2979 negated the value of
UV__EPROTO on platforms that don't define EPROTO, but it didn't
remove the surrounding UV__ERR() call. This was causing numerous
test failures in Node.js.