### PR TITLE
check busy async handles in next pass instead of spinning

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -382,6 +382,9 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     if ((mode == UV_RUN_ONCE && !ran_pending) || mode == UV_RUN_DEFAULT)
       timeout = uv_backend_timeout(loop);
 
+    if (uv__async_prepare_busy(loop) && timeout != 0)
+      timeout = 1;
+
     uv__io_poll(loop, timeout);
 
     /* Run one final update on the provider_idle_time in case uv__io_poll

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -209,6 +209,7 @@ int uv__fd_exists(uv_loop_t* loop, int fd);
 /* async */
 void uv__async_stop(uv_loop_t* loop);
 int uv__async_fork(uv_loop_t* loop);
+int uv__async_prepare_busy(uv_loop_t* loop);
 
 
 /* loop */


### PR DESCRIPTION
This is with regards to changes made in #2231 and #2772 that use a spinlock to wait for the sending thread to complete.
In my application, I don't use async handles directly but the libuv threadpool does. I noticed some latency spikes which disappear when I revert to v1.28.

I was wondering why we couldn't just let the loop signal itself to check the busy async handles in the next pass? This would avoid wasting cpu cycles especially when the sender thread got pre-empted.
