### PR TITLE
restore prctl on Linux

### DIFF
--- a/src/unix/proctitle.c
+++ b/src/unix/proctitle.c
@@ -119,6 +119,7 @@ int uv_set_process_title(const char* title) {
   memcpy(pt->str, title, len);
   memset(pt->str + len, '\0', pt->cap - len);
   pt->len = len;
+  uv__set_process_title(pt->str);
 
   uv_mutex_unlock(&process_title_mutex);
 


### PR DESCRIPTION
I don't think that removing the prctl call on Linux was intentional?
see nodejs/node#35503