### PR TITLE
build: move IBM i to Tier 2 in supported platforms list

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -7,11 +7,11 @@
 | Windows | Tier 1 | >= Windows 7 | MSVC 2008 and later are supported |
 | FreeBSD | Tier 1 | >= 10 | |
 | AIX | Tier 2 | >= 6 | Maintainers: @libuv/aix |
+| IBM i | Tier 2 | >= IBM i 7.2 | Maintainers: @libuv/ibmi |
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |
 | Linux with musl | Tier 2 | musl >= 1.0 | |
 | SmartOS | Tier 2 | >= 14.4 | Maintainers: @libuv/smartos |
 | Android | Tier 3 | NDK >= r15b | |
-| IBM i | Tier 3 | >= IBM i 7.2 | Maintainers: @libuv/ibmi |
 | MinGW | Tier 3 | MinGW32 and MinGW-w64 | |
 | SunOS | Tier 3 | Solaris 121 and later | |
 | Other | Tier 3 | N/A | |


### PR DESCRIPTION
I think an upgrade to Tier 2 (alongside AIX and z/OS) is justified. The @libuv/ibmi team is committed to the future of libuv and Node.js on the platform. 