### PR TITLE
unix: improve comment

### DIFF
--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -42,8 +42,8 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
     return 1;
 #if !defined(__CYGWIN__) && !defined(__MSYS__)
   /*
-   * If `exclude_type` is `UV__EXCLUDE_IFPHYS`, just see whether `sa_family`
-   * equals to `AF_LINK` or not. Otherwise, the result depends on the operation
+   * If `exclude_type` is `UV__EXCLUDE_IFPHYS`, return whether `sa_family`
+   * equals `AF_LINK`. Otherwise, the result depends on the operating
    * system with `AF_LINK` or `PF_INET`.
    */
   if (exclude_type == UV__EXCLUDE_IFPHYS)
@@ -53,7 +53,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
     defined(__HAIKU__)
   /*
    * On BSD getifaddrs returns information related to the raw underlying
-   * devices.  We're not interested in this information.
+   * devices. We're not interested in this information.
    */
   if (ent->ifa_addr->sa_family == AF_LINK)
     return 1;


### PR DESCRIPTION
While going through the source code, I found a comment that referred to `operation system`. Probably the committer meant `operating system`. So I reworded the sentence a bit. Also I removed a double space in another comment nearby.