### PR TITLE
unix: replace ternary with if...else

### DIFF
--- a/src/unix/bsd-proctitle.c
+++ b/src/unix/bsd-proctitle.c
@@ -45,7 +45,10 @@ void uv__process_title_cleanup(void) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  process_title = argc > 0 ? uv__strdup(argv[0]) : NULL;
+  if (argc > 0)
+    process_title = uv__strdup(argv[0]);
+  else
+    process_title = NULL;
   return argv;
 }
 


### PR DESCRIPTION
>Libuv house style generally doesn't use ternaries.

_Originally posted by @bnoordhuis in https://github.com/libuv/libuv/pull/1375#discussion_r122406531_
So I replaced a ternary I came across with the corresponding if...else logic.