### PR TITLE
unix,win: initialize timer `timeout` field

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -58,6 +58,7 @@ static int timer_less_than(const struct heap_node* ha,
 int uv_timer_init(uv_loop_t* loop, uv_timer_t* handle) {
   uv__handle_init(loop, (uv_handle_t*)handle, UV_TIMER);
   handle->timer_cb = NULL;
+  handle->timeout = 0;
   handle->repeat = 0;
   return 0;
 }


### PR DESCRIPTION
With the addition of `uv_timer_get_due_in()` it's observable with tools like
valgrind that the `timer->timeout` field isn't initialized until the timer
is started.

Fixes the following valgrind warning when running the `timer_init` test:

    ==325215== Conditional jump or move depends on uninitialised value(s)
    ==325215==    at 0x1B0131: uv_timer_get_due_in (timer.c:134)
    ==325215==    by 0x19AF09: run_test_timer_init (test-timer.c:164)
    ==325215==    by 0x119FF1: run_test_part (runner.c:376)
    ==325215==    by 0x11875D: main (run-tests.c:68)
    ==325215==
    ==325215== Conditional jump or move depends on uninitialised value(s)
    ==325215==    at 0x19AF1F: run_test_timer_init (test-timer.c:164)
    ==325215==    by 0x119FF1: run_test_part (runner.c:376)
    ==325215==    by 0x11875D: main (run-tests.c:68)

Fixes: https://github.com/libuv/libuv/issues/3020