### PR TITLE
Use ASSERT_EQ() macro in tests

### DIFF
--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -103,8 +103,8 @@ static int test_async(int nthreads) {
 
   for (i = 0; i < nthreads; i++) {
     ctx = threads + i;
-    ASSERT(ctx->worker_sent == NUM_PINGS);
-    ASSERT(ctx->worker_seen == NUM_PINGS);
+    ASSERT_EQ(ctx->worker_sent, NUM_PINGS);
+    ASSERT_EQ(ctx->worker_seen, NUM_PINGS);
     ASSERT(ctx->main_sent == (unsigned int) NUM_PINGS);
     ASSERT(ctx->main_seen == (unsigned int) NUM_PINGS);
   }

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -105,8 +105,8 @@ static int test_async(int nthreads) {
     ctx = threads + i;
     ASSERT_EQ(ctx->worker_sent, NUM_PINGS);
     ASSERT_EQ(ctx->worker_seen, NUM_PINGS);
-    ASSERT(ctx->main_sent == (unsigned int) NUM_PINGS);
-    ASSERT(ctx->main_seen == (unsigned int) NUM_PINGS);
+    ASSERT_EQ(ctx->main_sent, (unsigned int) NUM_PINGS);
+    ASSERT_EQ(ctx->main_seen, (unsigned int) NUM_PINGS);
   }
 
   printf("async%d: %.2f sec (%s/sec)\n",

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -80,8 +80,8 @@ BENCHMARK_IMPL(getaddrinfo) {
   uv_update_time(loop);
   end_time = uv_now(loop);
 
-  ASSERT(calls_initiated == TOTAL_CALLS);
-  ASSERT(calls_completed == TOTAL_CALLS);
+  ASSERT_EQ(calls_initiated, TOTAL_CALLS);
+  ASSERT_EQ(calls_completed, TOTAL_CALLS);
 
   fprintf(stderr, "getaddrinfo: %.0f req/s\n",
           (double) calls_completed / (double) (end_time - start_time) * 1000.0);

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -43,7 +43,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle);
 
 static void getaddrinfo_cb(uv_getaddrinfo_t* handle, int status,
     struct addrinfo* res) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   calls_completed++;
   if (calls_initiated < TOTAL_CALLS) {
     getaddrinfo_initiate(handle);
@@ -59,7 +59,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle) {
   calls_initiated++;
 
   r = uv_getaddrinfo(loop, handle, &getaddrinfo_cb, name, NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 

--- a/test/benchmark-loop-count.c
+++ b/test/benchmark-loop-count.c
@@ -60,7 +60,7 @@ BENCHMARK_IMPL(loop_count) {
   uv_run(loop, UV_RUN_DEFAULT);
   ns = uv_hrtime() - ns;
 
-  ASSERT(ticks == NUM_TICKS);
+  ASSERT_EQ(ticks, NUM_TICKS);
 
   fprintf(stderr, "loop_count: %d ticks in %.2fs (%.0f/s)\n",
           NUM_TICKS,

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -71,8 +71,8 @@ BENCHMARK_IMPL(million_timers) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   after_all = uv_hrtime();
 
-  ASSERT(timer_cb_called == NUM_TIMERS);
-  ASSERT(close_cb_called == NUM_TIMERS);
+  ASSERT_EQ(timer_cb_called, NUM_TIMERS);
+  ASSERT_EQ(close_cb_called, NUM_TIMERS);
   free(timers);
 
   fprintf(stderr, "%.2f seconds total\n", (after_all - before_all) / 1e9);

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -292,7 +292,7 @@ static void sv_connection_cb(uv_stream_t* server_handle, int status) {
   struct server_ctx* ctx;
 
   ctx = container_of(server_handle, struct server_ctx, server_handle);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   storage = malloc(sizeof(*storage));
   ASSERT(storage != NULL);

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -153,7 +153,7 @@ static void ipc_close_cb(uv_handle_t* handle) {
 static void ipc_connect_cb(uv_connect_t* req, int status) {
   struct ipc_client_ctx* ctx;
   ctx = container_of(req, struct ipc_client_ctx, connect_req);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(0 == uv_read_start((uv_stream_t*) &ctx->ipc_pipe,
                             ipc_alloc_cb,
                             ipc_read_cb));
@@ -330,7 +330,7 @@ static void sv_read_cb(uv_stream_t* handle,
 static void cl_connect_cb(uv_connect_t* req, int status) {
   struct client_ctx* ctx = container_of(req, struct client_ctx, connect_req);
   uv_idle_start(&ctx->idle_handle, cl_idle_cb);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 }
 
 

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -322,7 +322,7 @@ static void sv_alloc_cb(uv_handle_t* handle,
 static void sv_read_cb(uv_stream_t* handle,
                        ssize_t nread,
                        const uv_buf_t* buf) {
-  ASSERT(nread == UV_EOF);
+  ASSERT_EQ(nread, UV_EOF);
   uv_close((uv_handle_t*) handle, (uv_close_cb) free);
 }
 

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -90,7 +90,7 @@ static void pinger_close_cb(uv_handle_t* handle) {
 
 
 static void pinger_write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   free(req);
 }
@@ -110,14 +110,14 @@ static void pinger_write_ping(pinger_t* pinger) {
 
 
 static void pinger_shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   pinger_shutdown_cb_called++;
 
   /*
    * The close callback has not been triggered yet. We must wait for EOF
    * until we close the connection.
    */
-  ASSERT(completed_pingers == 0);
+  ASSERT_EQ(completed_pingers, 0);
 }
 
 
@@ -166,7 +166,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
 static void pinger_connect_cb(uv_connect_t* req, int status) {
   pinger_t *pinger = (pinger_t*)req->handle->data;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   pinger_write_ping(pinger);
 

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -130,7 +130,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
   pinger = (pinger_t*)tcp->data;
 
   if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     if (buf->base) {
       buf_free(buf);

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -136,7 +136,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
       buf_free(buf);
     }
 
-    ASSERT(pinger_shutdown_cb_called == 1);
+    ASSERT_EQ(pinger_shutdown_cb_called, 1);
     uv_close((uv_handle_t*)tcp, pinger_close_cb);
 
     return;
@@ -214,7 +214,7 @@ BENCHMARK_IMPL(ping_pongs) {
   pinger_new();
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(completed_pingers == 1);
+  ASSERT_EQ(completed_pingers, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -144,7 +144,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
 
   /* Now we count the pings */
   for (i = 0; i < nread; i++) {
-    ASSERT(buf->base[i] == PING[pinger->state]);
+    ASSERT_EQ(buf->base[i], PING[pinger->state]);
     pinger->state = (pinger->state + 1) % (sizeof(PING) - 1);
     if (pinger->state == 0) {
       pinger->pongs++;

--- a/test/benchmark-ping-udp.c
+++ b/test/benchmark-ping-udp.c
@@ -121,7 +121,7 @@ static void udp_pinger_new(void) {
 
   /* Try to do NUM_PINGS ping-pongs (connection-less). */
   r = uv_udp_init(loop, &pinger->udp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   pinger->udp.data = pinger;
 

--- a/test/benchmark-ping-udp.c
+++ b/test/benchmark-ping-udp.c
@@ -96,7 +96,7 @@ static void pinger_read_cb(uv_udp_t* udp,
 
   /* Now we count the pings */
   for (i = 0; i < nread; i++) {
-    ASSERT(buf->base[i] == PING[pinger->state]);
+    ASSERT_EQ(buf->base[i], PING[pinger->state]);
     pinger->state = (pinger->state + 1) % (sizeof(PING) - 1);
     if (pinger->state == 0) {
       pinger->pongs++;

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -115,7 +115,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   }
 
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   conn = (conn_rec*)req->data;
   ASSERT(conn != NULL);
@@ -125,13 +125,13 @@ static void connect_cb(uv_connect_t* req, int status) {
 #endif
 
   r = uv_read_start(&conn->stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = buffer;
   buf.len = sizeof(buffer) - 1;
 
   r = uv_write(&conn->write_req, &conn->stream, &buf, 1, after_write);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -200,7 +200,7 @@ static void tcp_make_connect(conn_rec* p) {
   tp = (tcp_conn_rec*) p;
 
   r = uv_tcp_init(loop, (uv_tcp_t*)&p->stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
@@ -227,7 +227,7 @@ static void pipe_make_connect(conn_rec* p) {
   int r;
 
   r = uv_pipe_init(loop, (uv_pipe_t*)&p->stream, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_connect(&((pipe_conn_rec*) p)->conn_req,
                   (uv_pipe_t*) &p->stream,

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -278,7 +278,7 @@ static void connection_cb(uv_stream_t* s, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(server == s);
+  ASSERT_EQ(server, s);
   ASSERT_EQ(status, 0);
 
   if (type == TCP) {

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -159,9 +159,9 @@ static void start_stats_collection(void) {
   /* Show-stats timer */
   stats_left = STATS_COUNT;
   r = uv_timer_init(loop, &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, show_stats, STATS_INTERVAL, STATS_INTERVAL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_update_time(loop);
   start_time = uv_now(loop);
@@ -170,7 +170,7 @@ static void start_stats_collection(void) {
 
 static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
   if (nrecv_total == 0) {
-    ASSERT(start_time == 0);
+    ASSERT_EQ(start_time, 0);
     uv_update_time(loop);
     start_time = uv_now(loop);
   }
@@ -188,7 +188,7 @@ static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   req_free((uv_req_t*) req);
 
@@ -209,7 +209,7 @@ static void do_write(uv_stream_t* stream) {
 
   req = (uv_write_t*) req_alloc();
   r = uv_write(req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -220,7 +220,7 @@ static void connect_cb(uv_connect_t* req, int status) {
     fprintf(stderr, "%s", uv_strerror(status));
     fflush(stderr);
   }
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   write_sockets++;
   req_free((uv_req_t*) req);
@@ -253,19 +253,19 @@ static void maybe_connect_some(void) {
       tcp = &tcp_write_handles[max_connect_socket++];
 
       r = uv_tcp_init(loop, tcp);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       req = (uv_connect_t*) req_alloc();
       r = uv_tcp_connect(req,
                          tcp,
                          (const struct sockaddr*) &connect_addr,
                          connect_cb);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     } else {
       pipe = &pipe_write_handles[max_connect_socket++];
 
       r = uv_pipe_init(loop, pipe, 0);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       req = (uv_connect_t*) req_alloc();
       uv_pipe_connect(req, pipe, TEST_PIPENAME, connect_cb);
@@ -279,23 +279,23 @@ static void connection_cb(uv_stream_t* s, int status) {
   int r;
 
   ASSERT(server == s);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   if (type == TCP) {
     stream = (uv_stream_t*)malloc(sizeof(uv_tcp_t));
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   } else {
     stream = (uv_stream_t*)malloc(sizeof(uv_pipe_t));
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   r = uv_accept(s, stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start(stream, buf_alloc, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   read_sockets++;
   max_read_sockets++;
@@ -384,11 +384,11 @@ HELPER_IMPL(tcp_pump_server) {
   /* Server */
   server = (uv_stream_t*)&tcpServer;
   r = uv_tcp_init(loop, &tcpServer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&tcpServer, (const struct sockaddr*) &listen_addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&tcpServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -405,11 +405,11 @@ HELPER_IMPL(pipe_pump_server) {
   /* Server */
   server = (uv_stream_t*)&pipeServer;
   r = uv_pipe_init(loop, &pipeServer, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&pipeServer, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&pipeServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -58,7 +58,7 @@ static void maybe_spawn(void) {
 
 
 static void process_close_cb(uv_handle_t* handle) {
-  ASSERT(process_open == 1);
+  ASSERT_EQ(process_open, 1);
   process_open = 0;
   maybe_spawn();
 }
@@ -67,7 +67,7 @@ static void process_close_cb(uv_handle_t* handle) {
 static void exit_cb(uv_process_t* process,
                     int64_t exit_status,
                     int term_signal) {
-  ASSERT(exit_status == 42);
+  ASSERT_EQ(exit_status, 42);
   ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*)process, process_close_cb);
 }
@@ -82,7 +82,7 @@ static void on_alloc(uv_handle_t* handle,
 
 
 static void pipe_close_cb(uv_handle_t* pipe) {
-  ASSERT(pipe_open == 1);
+  ASSERT_EQ(pipe_open, 1);
   pipe_open = 0;
   maybe_spawn();
 }
@@ -90,7 +90,7 @@ static void pipe_close_cb(uv_handle_t* pipe) {
 
 static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT(pipe_open == 1);
+    ASSERT_EQ(pipe_open, 1);
     output_used += nread;
   } else if (nread < 0) {
     if (nread == UV_EOF) {

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -68,7 +68,7 @@ static void exit_cb(uv_process_t* process,
                     int64_t exit_status,
                     int term_signal) {
   ASSERT(exit_status == 42);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*)process, process_close_cb);
 }
 
@@ -104,8 +104,8 @@ static void spawn(void) {
   uv_stdio_container_t stdio[2];
   int r;
 
-  ASSERT(process_open == 0);
-  ASSERT(pipe_open == 0);
+  ASSERT_EQ(process_open, 0);
+  ASSERT_EQ(pipe_open, 0);
 
   args[0] = exepath;
   args[1] = "spawn_helper";
@@ -123,14 +123,14 @@ static void spawn(void) {
   options.stdio[1].data.stream = (uv_stream_t*)&out;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   process_open = 1;
   pipe_open = 1;
   output_used = 0;
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -141,7 +141,7 @@ BENCHMARK_IMPL(spawn) {
   loop = uv_default_loop();
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
 
   uv_update_time(loop);
@@ -150,7 +150,7 @@ BENCHMARK_IMPL(spawn) {
   spawn();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_update_time(loop);
   end_time = uv_now(loop);

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -130,10 +130,10 @@ BENCHMARK_IMPL(tcp_write_batch) {
 
   stop = uv_hrtime();
 
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
   ASSERT(write_cb_called == NUM_WRITE_REQS);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   printf("%ld write requests in %.2fs.\n",
          (long)NUM_WRITE_REQS,

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -55,7 +55,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i;
   int r;
 
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
+  ASSERT_EQ(req->handle, (uv_stream_t*)&tcp_client);
 
   for (i = 0; i < NUM_WRITE_REQS; i++) {
     w = &write_reqs[i];
@@ -78,7 +78,7 @@ static void write_cb(uv_write_t* req, int status) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
+  ASSERT_EQ(req->handle, (uv_stream_t*)&tcp_client);
   ASSERT_EQ(req->handle->write_queue_size, 0);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
@@ -89,7 +89,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*)&tcp_client);
+  ASSERT_EQ(handle, (uv_handle_t*)&tcp_client);
   close_cb_called++;
 }
 

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -79,7 +79,7 @@ static void write_cb(uv_write_t* req, int status) {
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT(req->handle == (uv_stream_t*)&tcp_client);
-  ASSERT(req->handle->write_queue_size == 0);
+  ASSERT_EQ(req->handle->write_queue_size, 0);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
   free(write_reqs);

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -131,7 +131,7 @@ BENCHMARK_IMPL(tcp_write_batch) {
   stop = uv_hrtime();
 
   ASSERT_EQ(connect_cb_called, 1);
-  ASSERT(write_cb_called == NUM_WRITE_REQS);
+  ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
   ASSERT_EQ(shutdown_cb_called, 1);
   ASSERT_EQ(close_cb_called, 1);
 

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -60,11 +60,11 @@ static void connect_cb(uv_connect_t* req, int status) {
   for (i = 0; i < NUM_WRITE_REQS; i++) {
     w = &write_reqs[i];
     r = uv_write(&w->req, req->handle, &w->buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connect_cb_called++;
 }
@@ -72,7 +72,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
@@ -115,18 +115,18 @@ BENCHMARK_IMPL(tcp_write_batch) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   start = uv_hrtime();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   stop = uv_hrtime();
 

--- a/test/benchmark-thread.c
+++ b/test/benchmark-thread.c
@@ -31,7 +31,7 @@ static volatile int num_threads;
 
 
 static void thread_entry(void* arg) {
-  ASSERT(arg == (void *) 42);
+  ASSERT_EQ(arg, (void *) 42);
   num_threads++;
   /* FIXME write barrier? */
 }

--- a/test/benchmark-thread.c
+++ b/test/benchmark-thread.c
@@ -55,7 +55,7 @@ BENCHMARK_IMPL(thread_create) {
 
   duration = (uv_hrtime() - start_time) / 1e9;
 
-  ASSERT(num_threads == NUM_THREADS);
+  ASSERT_EQ(num_threads, NUM_THREADS);
 
   printf("%d threads created in %.2f seconds (%.0f/s)\n",
       NUM_THREADS, duration, NUM_THREADS / duration);

--- a/test/benchmark-thread.c
+++ b/test/benchmark-thread.c
@@ -47,10 +47,10 @@ BENCHMARK_IMPL(thread_create) {
 
   for (i = 0; i < NUM_THREADS; i++) {
     r = uv_thread_create(&tid, thread_entry, (void *) 42);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_thread_join(&tid);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   duration = (uv_hrtime() - start_time) / 1e9;

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -75,7 +75,7 @@ static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
 
   if (status != 0) {
-    ASSERT(status == UV_ECANCELED);
+    ASSERT_EQ(status, UV_ECANCELED);
     return;
   }
 
@@ -115,11 +115,11 @@ static void recv_cb(uv_udp_t* handle,
     return;
 
   if (nread < 0) {
-    ASSERT(nread == UV_ECANCELED);
+    ASSERT_EQ(nread, UV_ECANCELED);
     return;
   }
 
-  ASSERT(addr->sa_family == AF_INET);
+  ASSERT_EQ(addr->sa_family, AF_INET);
   ASSERT(!memcmp(buf->base, EXPECTED, nread));
 
   recv_cb_called++;

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -44,7 +44,7 @@ static void connection_cb(uv_stream_t* stream, int status) {
   int r;
 
   ASSERT_EQ(status, 0);
-  ASSERT(stream == (uv_stream_t*)&tcp_server);
+  ASSERT_EQ(stream, (uv_stream_t*)&tcp_server);
 
   conn = malloc(sizeof *conn);
   ASSERT(conn != NULL);

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -43,20 +43,20 @@ static void connection_cb(uv_stream_t* stream, int status) {
   conn_rec* conn;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(stream == (uv_stream_t*)&tcp_server);
 
   conn = malloc(sizeof *conn);
   ASSERT(conn != NULL);
 
   r = uv_tcp_init(stream->loop, &conn->handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(stream, (uv_stream_t*)&conn->handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&conn->handle, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -81,7 +81,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   conn = container_of(stream, conn_rec, handle);
 
   r = uv_shutdown(&conn->shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -106,13 +106,13 @@ HELPER_IMPL(tcp4_blackhole_server) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(0 && "Blackhole server dropped out of event loop.");

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -76,7 +76,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   if (nread >= 0)
     return;
 
-  ASSERT(nread == UV_EOF);
+  ASSERT_EQ(nread, UV_EOF);
 
   conn = container_of(stream, conn_rec, handle);
 

--- a/test/dns-server.c
+++ b/test/dns-server.c
@@ -277,7 +277,7 @@ static void on_connection(uv_stream_t* server, int status) {
   dnshandle* handle;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   handle = (dnshandle*) malloc(sizeof *handle);
   ASSERT(handle != NULL);
@@ -288,13 +288,13 @@ static void on_connection(uv_stream_t* server, int status) {
   handle->state.prevbuf_rem = 0;
 
   r = uv_tcp_init(loop, (uv_tcp_t*)handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)handle, buf_alloc, after_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 

--- a/test/dns-server.c
+++ b/test/dns-server.c
@@ -238,7 +238,7 @@ static void after_read(uv_stream_t* handle,
 
   if (nread < 0) {
     /* Error or EOF */
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     if (buf->base) {
       free(buf->base);

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -79,7 +79,7 @@ static void after_read(uv_stream_t* handle,
 
   if (nread < 0) {
     /* Error or EOF */
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     free(buf->base);
     sreq = malloc(sizeof* sreq);
@@ -216,7 +216,7 @@ static void on_recv(uv_udp_t* handle,
   }
 
   ASSERT(nread > 0);
-  ASSERT(addr->sa_family == AF_INET);
+  ASSERT_EQ(addr->sa_family, AF_INET);
 
   uv_udp_send_t* req = send_alloc();
   ASSERT(req != NULL);

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -150,21 +150,21 @@ static void on_connection(uv_stream_t* server, int status) {
   if (status != 0) {
     fprintf(stderr, "Connect error %s\n", uv_err_name(status));
   }
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   switch (serverType) {
   case TCP:
     stream = malloc(sizeof(uv_tcp_t));
     ASSERT(stream != NULL);
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     break;
 
   case PIPE:
     stream = malloc(sizeof(uv_pipe_t));
     ASSERT(stream != NULL);
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     break;
 
   default:
@@ -176,10 +176,10 @@ static void on_connection(uv_stream_t* server, int status) {
   stream->data = server;
 
   r = uv_accept(server, stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start(stream, echo_alloc, after_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -198,7 +198,7 @@ static uv_udp_send_t* send_alloc(void) {
 
 static void on_send(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   req->data = send_freelist;
   send_freelist = req;
 }

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -184,7 +184,7 @@ static void on_connection(uv_stream_t* server, int status) {
 
 
 static void on_server_close(uv_handle_t* handle) {
-  ASSERT(handle == server);
+  ASSERT_EQ(handle, server);
 }
 
 static uv_udp_send_t* send_alloc(void) {

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -277,7 +277,7 @@ static int maybe_run_test(int argc, char **argv) {
 #else
     CPU_ZERO(&cpuset);
     r = pthread_getaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     for (i = 0; i < cpumask_size; ++i) {
       ASSERT(CPU_ISSET(i, &cpuset) == (i == cpu));
     }

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -45,26 +45,26 @@ TEST_IMPL(active) {
   uv_timer_t timer;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* uv_is_active() and uv_is_closing() should always return either 0 or 1. */
   ASSERT(0 == uv_is_active((uv_handle_t*) &timer));
   ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(1 == uv_is_active((uv_handle_t*) &timer));
   ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_stop(&timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_is_active((uv_handle_t*) &timer));
   ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(1 == uv_is_active((uv_handle_t*) &timer));
   ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
@@ -75,7 +75,7 @@ TEST_IMPL(active) {
   ASSERT(1 == uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(close_cb_called == 1);
 

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -77,7 +77,7 @@ TEST_IMPL(active) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-async-multi.c
+++ b/test/test-async-multi.c
@@ -38,7 +38,7 @@ void close_cb(uv_handle_t* handle) {
 
 
 void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == UV_ENOENT);
+  ASSERT_EQ(status, UV_ENOENT);
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
 

--- a/test/test-async-multi.c
+++ b/test/test-async-multi.c
@@ -78,8 +78,8 @@ TEST_IMPL(async_multi) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(async_cb_called == 2);
-  ASSERT(close_cb_called == 4);
+  ASSERT_EQ(async_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 4);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -36,7 +36,7 @@ static void thread_cb(void* dummy) {
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT(check_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
   uv_close((uv_handle_t*) &async_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   check_cb_called++;

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -58,7 +58,7 @@ TEST_IMPL(async_null_cb) {
   ASSERT(0 == uv_thread_create(&thread, thread_cb, NULL));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(0 == uv_thread_join(&thread));
-  ASSERT(1 == check_cb_called);
+  ASSERT_EQ(check_cb_called, 1);
   MAKE_VALGRIND_HAPPY();
   return 0;
 }

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -124,8 +124,8 @@ TEST_IMPL(async) {
   ASSERT_EQ(r, 0);
 
   ASSERT(prepare_cb_called > 0);
-  ASSERT(async_cb_called == 3);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(async_cb_called, 3);
+  ASSERT_EQ(close_cb_called, 2);
 
   ASSERT(0 == uv_thread_join(&thread));
 

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -49,7 +49,7 @@ static void thread_cb(void *arg) {
     }
 
     r = uv_async_send(&async);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     /* Work around a bug in Valgrind.
      *
@@ -100,7 +100,7 @@ static void prepare_cb(uv_prepare_t* handle) {
     return;
 
   r = uv_thread_create(&thread, thread_cb, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_mutex_unlock(&mutex);
 }
 
@@ -109,19 +109,19 @@ TEST_IMPL(async) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_mutex_lock(&mutex);
 
   r = uv_prepare_init(uv_default_loop(), &prepare);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare, prepare_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_async_init(uv_default_loop(), &async, async_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(prepare_cb_called > 0);
   ASSERT(async_cb_called == 3);

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -78,7 +78,7 @@ static void close_cb(uv_handle_t* handle) {
 static void async_cb(uv_async_t* handle) {
   int n;
 
-  ASSERT(handle == &async);
+  ASSERT_EQ(handle, &async);
 
   uv_mutex_lock(&mutex);
   n = ++async_cb_called;
@@ -94,7 +94,7 @@ static void async_cb(uv_async_t* handle) {
 static void prepare_cb(uv_prepare_t* handle) {
   int r;
 
-  ASSERT(handle == &prepare);
+  ASSERT_EQ(handle, &prepare);
 
   if (prepare_cb_called++)
     return;

--- a/test/test-buf.c
+++ b/test/test-buf.c
@@ -35,10 +35,10 @@ TEST_IMPL(buf_large) {
   ASSERT_EQ(iobuf->iov_len, buf.len);
 
   /* Verify that uv_buf_t is ABI-compatible with struct iovec. */
-  ASSERT(sizeof(uv_buf_t) == sizeof(struct iovec));
-  ASSERT(sizeof(&((uv_buf_t*) 0)->base) ==
-         sizeof(((struct iovec*) 0)->iov_base));
-  ASSERT(sizeof(&((uv_buf_t*) 0)->len) == sizeof(((struct iovec*) 0)->iov_len));
+  ASSERT_EQ(sizeof(uv_buf_t), sizeof(struct iovec));
+  ASSERT_EQ(sizeof(&((uv_buf_t*) 0)->base),
+            sizeof(((struct iovec*) 0)->iov_base));
+  ASSERT_EQ(sizeof(&((uv_buf_t*) 0)->len), sizeof(((struct iovec*) 0)->iov_len));
   ASSERT(offsetof(uv_buf_t, base) == offsetof(struct iovec, iov_base));
   ASSERT(offsetof(uv_buf_t, len) == offsetof(struct iovec, iov_len));
 #endif

--- a/test/test-buf.c
+++ b/test/test-buf.c
@@ -22,7 +22,7 @@ TEST_IMPL(buf_large) {
   uv_buf_t buf;
 
   buf = uv_buf_init(NULL, SIZE_MAX);
-  ASSERT(buf.len == SIZE_MAX);
+  ASSERT_EQ(buf.len, SIZE_MAX);
 #ifdef _WIN32
   WSABUF* wbuf;
 

--- a/test/test-buf.c
+++ b/test/test-buf.c
@@ -27,12 +27,12 @@ TEST_IMPL(buf_large) {
   WSABUF* wbuf;
 
   wbuf = (WSABUF*) &buf;
-  ASSERT(wbuf->len == buf.len);
+  ASSERT_EQ(wbuf->len, buf.len);
 #else
   struct iovec* iobuf;
 
   iobuf = (struct iovec*) &buf;
-  ASSERT(iobuf->iov_len == buf.len);
+  ASSERT_EQ(iobuf->iov_len, buf.len);
 
   /* Verify that uv_buf_t is ABI-compatible with struct iovec. */
   ASSERT(sizeof(uv_buf_t) == sizeof(struct iovec));

--- a/test/test-buf.c
+++ b/test/test-buf.c
@@ -39,8 +39,8 @@ TEST_IMPL(buf_large) {
   ASSERT_EQ(sizeof(&((uv_buf_t*) 0)->base),
             sizeof(((struct iovec*) 0)->iov_base));
   ASSERT_EQ(sizeof(&((uv_buf_t*) 0)->len), sizeof(((struct iovec*) 0)->iov_len));
-  ASSERT(offsetof(uv_buf_t, base) == offsetof(struct iovec, iov_base));
-  ASSERT(offsetof(uv_buf_t, len) == offsetof(struct iovec, iov_len));
+  ASSERT_EQ(offsetof(uv_buf_t, base), offsetof(struct iovec, iov_base));
+  ASSERT_EQ(offsetof(uv_buf_t, len),  offsetof(struct iovec, iov_len));
 #endif
 
   return 0;

--- a/test/test-callback-order.c
+++ b/test/test-callback-order.c
@@ -39,7 +39,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(idle_cb_called == 1);
+  ASSERT_EQ(idle_cb_called, 1);
   ASSERT_EQ(timer_cb_called, 0);
   uv_timer_stop(handle);
   timer_cb_called++;
@@ -69,8 +69,8 @@ TEST_IMPL(callback_order) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(idle_cb_called == 1);
-  ASSERT(timer_cb_called == 1);
+  ASSERT_EQ(idle_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-callback-order.c
+++ b/test/test-callback-order.c
@@ -31,8 +31,8 @@ static uv_timer_t timer_handle;
 
 /* idle_cb should run before timer_cb */
 static void idle_cb(uv_idle_t* handle) {
-  ASSERT(idle_cb_called == 0);
-  ASSERT(timer_cb_called == 0);
+  ASSERT_EQ(idle_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
   uv_idle_stop(handle);
   idle_cb_called++;
 }
@@ -40,7 +40,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 static void timer_cb(uv_timer_t* handle) {
   ASSERT(idle_cb_called == 1);
-  ASSERT(timer_cb_called == 0);
+  ASSERT_EQ(timer_cb_called, 0);
   uv_timer_stop(handle);
   timer_cb_called++;
 }
@@ -64,8 +64,8 @@ TEST_IMPL(callback_order) {
   uv_idle_init(loop, &idle);
   uv_idle_start(&idle, next_tick);
 
-  ASSERT(idle_cb_called == 0);
-  ASSERT(timer_cb_called == 0);
+  ASSERT_EQ(idle_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -60,7 +60,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "shutdown_cb must be called from a fresh stack");
 
   shutdown_cb_called++;
@@ -125,7 +125,7 @@ static void timer_cb(uv_timer_t* handle) {
 static void write_cb(uv_write_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "write_cb must be called from a fresh stack");
 
   puts("Data written. 500ms timeout...");
@@ -136,9 +136,9 @@ static void write_cb(uv_write_t* req, int status) {
    * for the backend to use dirty stack for calling read_cb. */
   nested++;
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   nested--;
 
   write_cb_called++;
@@ -150,7 +150,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   puts("Connected. Write some data to echo server...");
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "connect_cb must be called from a fresh stack");
 
   nested++;
@@ -191,7 +191,7 @@ TEST_IMPL(callback_stack) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(nested == 0);
+  ASSERT_EQ(nested, 0);
   ASSERT(connect_cb_called == 1 && "connect_cb must be called exactly once");
   ASSERT(write_cb_called == 1 && "write_cb must be called exactly once");
   ASSERT(timer_cb_called == 1 && "timer_cb must be called exactly once");

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -105,7 +105,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_EQ(handle, &timer);
   ASSERT(nested == 0 && "timer_cb must be called from a fresh stack");
 
   puts("Timeout complete. Now read data...");

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -195,7 +195,7 @@ TEST_IMPL(callback_stack) {
   ASSERT(connect_cb_called == 1 && "connect_cb must be called exactly once");
   ASSERT(write_cb_called == 1 && "write_cb must be called exactly once");
   ASSERT(timer_cb_called == 1 && "timer_cb must be called exactly once");
-  ASSERT(bytes_received == sizeof MESSAGE);
+  ASSERT_EQ(bytes_received, sizeof MESSAGE);
   ASSERT(shutdown_cb_called == 1 && "shutdown_cb must be called exactly once");
   ASSERT(close_cb_called == 2 && "close_cb must be called exactly twice");
 

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -77,7 +77,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     return;
 
   } else if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     nested++;
     uv_close((uv_handle_t*)tcp, close_cb);

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -41,7 +41,7 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
     uv_read_stop(handle);
     break;
   case 2:
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t *) handle, NULL);
     break;
   default:

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -62,11 +62,11 @@ TEST_IMPL(close_fd) {
   fd[1] = -1;
   ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == read_cb_called);
+  ASSERT_EQ(read_cb_called, 1);
   ASSERT(0 == uv_is_active((const uv_handle_t *) &pipe_handle));
   ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(2 == read_cb_called);
+  ASSERT_EQ(read_cb_called, 2);
   ASSERT(0 != uv_is_closing((const uv_handle_t *) &pipe_handle));
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -37,7 +37,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   switch (++read_cb_called) {
   case 1:
-    ASSERT(nread == 1);
+    ASSERT_EQ(nread, 1);
     uv_read_stop(handle);
     break;
   case 2:

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -39,9 +39,9 @@ static void close_cb(uv_handle_t* handle) {
 
 /* check_cb should run before any close_cb */
 static void check_cb(uv_check_t* handle) {
-  ASSERT(check_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
   ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &timer_handle2, close_cb);
   check_cb_called++;
@@ -65,9 +65,9 @@ TEST_IMPL(close_order) {
   uv_timer_init(loop, &timer_handle2);
   uv_timer_start(&timer_handle2, timer_cb, 100000, 0);
 
-  ASSERT(check_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(timer_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -40,7 +40,7 @@ static void close_cb(uv_handle_t* handle) {
 /* check_cb should run before any close_cb */
 static void check_cb(uv_check_t* handle) {
   ASSERT_EQ(check_cb_called, 0);
-  ASSERT(timer_cb_called == 1);
+  ASSERT_EQ(timer_cb_called, 1);
   ASSERT_EQ(close_cb_called, 0);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &timer_handle2, close_cb);
@@ -71,9 +71,9 @@ TEST_IMPL(close_order) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(check_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(timer_cb_called == 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(timer_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -176,7 +176,7 @@ static int condvar_timedwait(worker_config* c, const int* flag) {
   /* Wait until I get a non-spurious signal. */
   do {
     r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(1 * 1e9)); /* 1 s */
-    ASSERT(r == 0); /* Should not time out. */
+    ASSERT_EQ(r, 0); /* Should not time out. */
   } while (*flag == 0);
   ASSERT(*flag == 1);
 

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -251,7 +251,7 @@ TEST_IMPL(condvar_5) {
   uv_mutex_unlock(&wc.mutex);
 
   /* It timed out. */
-  ASSERT(r == UV_ETIMEDOUT);
+  ASSERT_EQ(r, UV_ETIMEDOUT);
 
   /* It must have taken at least timeout, modulo system timer ticks.
    * But it should not take too much longer.

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -87,7 +87,7 @@ static void condvar_signal(worker_config* c, int* flag) {
   uv_mutex_lock(&c->mutex);
 
   /* Help waiter differentiate between spurious and legitimate wakeup. */
-  ASSERT(*flag == 0);
+  ASSERT_EQ(*flag, 0);
   *flag = 1;
 
   if (c->use_broadcast)

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -113,7 +113,7 @@ static int condvar_wait(worker_config* c, const int* flag) {
   do {
     uv_cond_wait(&c->cond, &c->mutex);
   } while (*flag == 0);
-  ASSERT(*flag == 1);
+  ASSERT_EQ(*flag, 1);
 
   uv_mutex_unlock(&c->mutex);
 
@@ -178,7 +178,7 @@ static int condvar_timedwait(worker_config* c, const int* flag) {
     r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(1 * 1e9)); /* 1 s */
     ASSERT_EQ(r, 0); /* Should not time out. */
   } while (*flag == 0);
-  ASSERT(*flag == 1);
+  ASSERT_EQ(*flag, 1);
 
   uv_mutex_unlock(&c->mutex);
 

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -55,7 +55,7 @@ static void timer_cb(uv_timer_t* handle) {
    * uv_close the handle manually.
    */
   ASSERT_EQ(close_cb_calls, 0);
-  ASSERT(connect_cb_calls == 1);
+  ASSERT_EQ(connect_cb_calls, 1);
 
   /* Close the tcp handle. */
   uv_close((uv_handle_t*)&tcp, on_close);
@@ -110,8 +110,8 @@ static void connection_fail(uv_connect_cb connect_cb) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_calls == 1);
-  ASSERT(close_cb_calls == 1);
+  ASSERT_EQ(connect_cb_calls, 1);
+  ASSERT_EQ(close_cb_calls, 1);
 }
 
 
@@ -153,8 +153,8 @@ TEST_IMPL(connection_fail_doesnt_auto_close) {
 
   connection_fail(on_connect_without_close);
 
-  ASSERT(timer_close_cb_calls == 1);
-  ASSERT(timer_cb_calls == 1);
+  ASSERT_EQ(timer_close_cb_calls, 1);
+  ASSERT_EQ(timer_cb_calls, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -54,7 +54,7 @@ static void timer_cb(uv_timer_t* handle) {
    * but libuv hasn't automatically closed the socket. The user must
    * uv_close the handle manually.
    */
-  ASSERT(close_cb_calls == 0);
+  ASSERT_EQ(close_cb_calls, 0);
   ASSERT(connect_cb_calls == 1);
 
   /* Close the tcp handle. */
@@ -70,7 +70,7 @@ static void on_connect_with_close(uv_connect_t *req, int status) {
   ASSERT(status == UV_ECONNREFUSED);
   connect_cb_calls++;
 
-  ASSERT(close_cb_calls == 0);
+  ASSERT_EQ(close_cb_calls, 0);
   uv_close((uv_handle_t*)req->handle, on_close);
 }
 
@@ -81,7 +81,7 @@ static void on_connect_without_close(uv_connect_t *req, int status) {
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 
-  ASSERT(close_cb_calls == 0);
+  ASSERT_EQ(close_cb_calls, 0);
 }
 
 
@@ -127,8 +127,8 @@ TEST_IMPL(connection_fail) {
 
   connection_fail(on_connect_with_close);
 
-  ASSERT(timer_close_cb_calls == 0);
-  ASSERT(timer_cb_calls == 0);
+  ASSERT_EQ(timer_close_cb_calls, 0);
+  ASSERT_EQ(timer_cb_calls, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -149,7 +149,7 @@ TEST_IMPL(connection_fail_doesnt_auto_close) {
   int r;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connection_fail(on_connect_without_close);
 

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -67,7 +67,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 static void on_connect_with_close(uv_connect_t *req, int status) {
   ASSERT((uv_stream_t*) &tcp == req->handle);
-  ASSERT(status == UV_ECONNREFUSED);
+  ASSERT_EQ(status, UV_ECONNREFUSED);
   connect_cb_calls++;
 
   ASSERT_EQ(close_cb_calls, 0);
@@ -76,7 +76,7 @@ static void on_connect_with_close(uv_connect_t *req, int status) {
 
 
 static void on_connect_without_close(uv_connect_t *req, int status) {
-  ASSERT(status == UV_ECONNREFUSED);
+  ASSERT_EQ(status, UV_ECONNREFUSED);
   connect_cb_calls++;
 
   uv_timer_start(&timer, timer_cb, 100, 0);

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -66,7 +66,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void on_connect_with_close(uv_connect_t *req, int status) {
-  ASSERT((uv_stream_t*) &tcp == req->handle);
+  ASSERT_EQ((uv_stream_t*) &tcp, req->handle);
   ASSERT_EQ(status, UV_ECONNREFUSED);
   connect_cb_calls++;
 

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -39,16 +39,16 @@ TEST_IMPL(cwd_and_chdir) {
 
   size1 = sizeof buffer_orig;
   err = uv_cwd(buffer_orig, &size1);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   ASSERT(size1 > 0);
   ASSERT(buffer_orig[size1] != '/');
 
   err = uv_chdir(buffer_orig);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   size2 = sizeof buffer_new;
   err = uv_cwd(buffer_new, &size2);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   ASSERT(size1 == size2);
   ASSERT(strcmp(buffer_orig, buffer_new) == 0);

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -34,7 +34,7 @@ TEST_IMPL(cwd_and_chdir) {
 
   size1 = 1;
   err = uv_cwd(buffer_orig, &size1);
-  ASSERT(err == UV_ENOBUFS);
+  ASSERT_EQ(err, UV_ENOBUFS);
   ASSERT(size1 > 1);
 
   size1 = sizeof buffer_orig;

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -50,7 +50,7 @@ TEST_IMPL(cwd_and_chdir) {
   err = uv_cwd(buffer_new, &size2);
   ASSERT_EQ(err, 0);
 
-  ASSERT(size1 == size2);
+  ASSERT_EQ(size1, size2);
   ASSERT(strcmp(buffer_orig, buffer_new) == 0);
 
   return 0;

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -42,7 +42,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT(0 == uv_timer_init(loop, &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
   ASSERT(0 == uv_loop_close(loop));
 
   loop = uv_default_loop();
@@ -51,7 +51,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT(0 == uv_timer_init(loop, &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(2 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 2);
   ASSERT(0 == uv_loop_close(loop));
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -54,11 +54,11 @@ static void do_accept(uv_timer_t* timer_handle) {
   ASSERT(accepted_handle != NULL);
 
   r = uv_tcp_init(uv_default_loop(), accepted_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   server = (uv_tcp_t*)timer_handle->data;
   r = uv_accept((uv_stream_t*)server, (uv_stream_t*)accepted_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   do_accept_called++;
 
@@ -79,19 +79,19 @@ static void connection_cb(uv_stream_t* tcp, int status) {
   int r;
   uv_timer_t* timer_handle;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   timer_handle = (uv_timer_t*)malloc(sizeof *timer_handle);
   ASSERT(timer_handle != NULL);
 
   /* Accept the client after 1 second */
   r = uv_timer_init(uv_default_loop(), timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   timer_handle->data = tcp;
 
   r = uv_timer_start(timer_handle, do_accept, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connection_cb_called++;
 }
@@ -106,12 +106,12 @@ static void start_server(void) {
   ASSERT(server != NULL);
 
   r = uv_tcp_init(uv_default_loop(), server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -123,7 +123,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (nread >= 0) {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   } else {
     ASSERT(tcp != NULL);
     ASSERT(nread == UV_EOF);
@@ -136,12 +136,12 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* Not that the server will send anything, but otherwise we'll never know
    * when the server closes the connection. */
   r = uv_read_start((uv_stream_t*)(req->handle), alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connect_cb_called++;
 
@@ -160,13 +160,13 @@ static void client_connect(void) {
   ASSERT(connect_req != NULL);
 
   r = uv_tcp_init(uv_default_loop(), client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(connect_req,
                      client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -126,7 +126,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     ASSERT_EQ(nread, 0);
   } else {
     ASSERT(tcp != NULL);
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*)tcp, close_cb);
   }
 }

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -179,10 +179,10 @@ TEST_IMPL(delayed_accept) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == 2);
-  ASSERT(do_accept_called == 2);
-  ASSERT(connect_cb_called == 2);
-  ASSERT(close_cb_called == 7);
+  ASSERT_EQ(connection_cb_called, 2);
+  ASSERT_EQ(do_accept_called, 2);
+  ASSERT_EQ(connect_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 7);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -38,7 +38,7 @@ TEST_IMPL(dlerror) {
   ASSERT(strstr(msg, dlerror_no_error) != NULL);
 
   r = uv_dlopen(path, &lib);
-  ASSERT(r == -1);
+  ASSERT_EQ(r, -1);
 
   msg = uv_dlerror(&lib);
   ASSERT(msg != NULL);

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -54,7 +54,7 @@ static void thread_main(void* arg) {
     nwritten = write(pipe_fds[1], test_buf, sizeof(test_buf));
   while (nwritten == -1 && errno == EINTR);
 
-  ASSERT(nwritten == sizeof(test_buf));
+  ASSERT_EQ(nwritten, sizeof(test_buf));
 }
 
 static void sig_func(uv_signal_t* handle, int signum) {
@@ -78,7 +78,7 @@ TEST_IMPL(eintr_handling) {
 
   nread = uv_fs_read(loop, &read_req, pipe_fds[0], &iov, 1, -1, NULL);
 
-  ASSERT(nread == sizeof(test_buf));
+  ASSERT_EQ(nread, sizeof(test_buf));
   ASSERT(0 == strcmp(buf, test_buf));
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -163,7 +163,7 @@ TEST_IMPL(embed) {
   uv_thread_join(&embed_thread);
   uv_loop_close(&external);
 
-  ASSERT(embed_timer_called == 1);
+  ASSERT_EQ(embed_timer_called, 1);
 
   return 0;
 #else

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -54,7 +54,7 @@ TEST_IMPL(emfile) {
   /* Lower the file descriptor limit and use up all fds save one. */
   limits.rlim_cur = limits.rlim_max = maxfd + 1;
   if (setrlimit(RLIMIT_NOFILE, &limits)) {
-    ASSERT(errno == EPERM);  /* Valgrind blocks the setrlimit() call. */
+    ASSERT_EQ(errno, EPERM);  /* Valgrind blocks the setrlimit() call. */
     RETURN_SKIP("setrlimit(RLIMIT_NOFILE) failed, running under valgrind?");
   }
 
@@ -72,7 +72,7 @@ TEST_IMPL(emfile) {
   ASSERT(first_fd > 0);
 
   while (dup(0) != -1 || errno == EINTR);
-  ASSERT(errno == EMFILE);
+  ASSERT_EQ(errno, EMFILE);
   close(maxfd);
 
   /* Now connect and use up the last available file descriptor.  The EMFILE

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -84,7 +84,7 @@ TEST_IMPL(emfile) {
                              (const struct sockaddr*) &addr,
                              connect_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == connect_cb_called);
+  ASSERT_EQ(connect_cb_called, 1);
 
   /* Close the dups again. Ignore errors in the unlikely event that the
    * file descriptors were not contiguous.
@@ -108,7 +108,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   /* |status| should equal 0 because the connection should have been accepted,
    * it's just that the server immediately closes it again.
    */
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   connect_cb_called += 1;
   uv_close((uv_handle_t*) &server_handle, NULL);
   uv_close((uv_handle_t*) &client_handle, NULL);

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -35,27 +35,27 @@ TEST_IMPL(env_vars) {
 
   /* Reject invalid inputs when setting an environment variable */
   r = uv_os_setenv(NULL, "foo");
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_setenv(name, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_setenv(NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Reject invalid inputs when retrieving an environment variable */
   size = BUF_SIZE;
   r = uv_os_getenv(NULL, buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_getenv(name, NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_getenv(name, buf, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   size = 0;
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Reject invalid inputs when deleting an environment variable */
   r = uv_os_unsetenv(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Successfully set an environment variable */
   r = uv_os_setenv(name, "123456789");
@@ -73,8 +73,8 @@ TEST_IMPL(env_vars) {
   size = BUF_SIZE - 1;
   buf[0] = '\0';
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_ENOBUFS);
-  ASSERT(size == BUF_SIZE);
+  ASSERT_EQ(r, UV_ENOBUFS);
+  ASSERT_EQ(size, BUF_SIZE);
 
   /* Successfully delete an environment variable */
   r = uv_os_unsetenv(name);
@@ -82,7 +82,7 @@ TEST_IMPL(env_vars) {
 
   /* Return UV_ENOENT retrieving an environment variable that does not exist */
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
 
   /* Successfully delete an environment variable that does not exist */
   r = uv_os_unsetenv(name);

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -129,7 +129,7 @@ TEST_IMPL(env_vars) {
     }
   }
 
-  ASSERT(found == 2);
+  ASSERT_EQ(found, 2);
 #ifdef _WIN32
   ASSERT(found_win_special > 0);
 #endif

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -67,7 +67,7 @@ TEST_IMPL(env_vars) {
   r = uv_os_getenv(name, buf, &size);
   ASSERT_EQ(r, 0);
   ASSERT(strcmp(buf, "123456789") == 0);
-  ASSERT(size == BUF_SIZE - 1);
+  ASSERT_EQ(size, BUF_SIZE - 1);
 
   /* Return UV_ENOBUFS if the buffer cannot hold the environment variable */
   size = BUF_SIZE - 1;

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -59,13 +59,13 @@ TEST_IMPL(env_vars) {
 
   /* Successfully set an environment variable */
   r = uv_os_setenv(name, "123456789");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Successfully read an environment variable */
   size = BUF_SIZE;
   buf[0] = '\0';
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(strcmp(buf, "123456789") == 0);
   ASSERT(size == BUF_SIZE - 1);
 
@@ -78,7 +78,7 @@ TEST_IMPL(env_vars) {
 
   /* Successfully delete an environment variable */
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Return UV_ENOENT retrieving an environment variable that does not exist */
   r = uv_os_getenv(name, buf, &size);
@@ -86,31 +86,31 @@ TEST_IMPL(env_vars) {
 
   /* Successfully delete an environment variable that does not exist */
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Setting an environment variable to the empty string does not delete it. */
   r = uv_os_setenv(name, "");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   size = BUF_SIZE;
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == 0);
-  ASSERT(size == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(size, 0);
   ASSERT(strlen(buf) == 0);
 
   /* Check getting all env variables. */
   r = uv_os_setenv(name, "123456789");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_os_setenv(name2, "");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   /* Create a special environment variable on Windows in case there are no
      naturally occurring ones. */
   r = uv_os_setenv("=Z:", "\\");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   r = uv_os_environ(&envitems, &envcount);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(envcount > 0);
 
   found = 0;
@@ -137,10 +137,10 @@ TEST_IMPL(env_vars) {
   uv_os_free_environ(envitems, envcount);
 
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_os_unsetenv(name2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 1; i <= 4; i++) {
     size_t n;

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -85,7 +85,7 @@ static void assert_wait_child(pid_t child_pid) {
   ASSERT_EQ(child_pid, waited_pid);
   ASSERT(WIFEXITED(child_stat)); /* Clean exit, not a signal. */
   ASSERT(!WIFSIGNALED(child_stat));
-  ASSERT(0 == WEXITSTATUS(child_stat));
+  ASSERT_EQ(WEXITSTATUS(child_stat), 0);
 }
 
 

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -441,8 +441,8 @@ static void assert_watch_file_current_dir(uv_loop_t* const loop, int file_or_dir
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(timer_cb_touch_called == 1);
-  ASSERT(fs_event_cb_called == 1);
+  ASSERT_EQ(timer_cb_touch_called, 1);
+  ASSERT_EQ(fs_event_cb_called, 1);
 
   /* Cleanup */
   remove("watch_file");
@@ -586,8 +586,8 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
     printf("Running loop in child \n");
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(timer_cb_touch_called == 1);
-    ASSERT(fs_event_cb_called == 1);
+    ASSERT_EQ(timer_cb_touch_called, 1);
+    ASSERT_EQ(fs_event_cb_called, 1);
 
     /* Cleanup */
     remove("watch_file");
@@ -630,8 +630,8 @@ static void assert_run_work(uv_loop_t* const loop) {
   printf("Running in %d\n", getpid());
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 1);
-  ASSERT(after_work_cb_count == 1);
+  ASSERT_EQ(work_cb_count, 1);
+  ASSERT_EQ(after_work_cb_count, 1);
 
   /* cleanup  */
   work_cb_count = 0;

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -52,7 +52,7 @@ static void socket_cb(uv_poll_t* poll, int status, int events) {
   ASSERT(UV_READABLE == (events & UV_READABLE));
   if (socket_cb_read_fd) {
     cnt = read(socket_cb_read_fd, socket_cb_read_buf, socket_cb_read_size);
-    ASSERT(cnt == socket_cb_read_size);
+    ASSERT_EQ(cnt, socket_cb_read_size);
   }
   uv_close((uv_handle_t*) poll, NULL);
 }
@@ -82,7 +82,7 @@ static void assert_wait_child(pid_t child_pid) {
   if (waited_pid == -1) {
     perror("Failed to wait");
   }
-  ASSERT(child_pid == waited_pid);
+  ASSERT_EQ(child_pid, waited_pid);
   ASSERT(WIFEXITED(child_stat)); /* Clean exit, not a signal. */
   ASSERT(!WIFSIGNALED(child_stat));
   ASSERT(0 == WEXITSTATUS(child_stat));
@@ -266,7 +266,7 @@ TEST_IMPL(fork_signal_to_child) {
     ASSERT(0 != uv_loop_alive(uv_default_loop()));
     printf("Running loop in child\n");
     ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-    ASSERT(SIGUSR1 == fork_signal_cb_called);
+    ASSERT_EQ(SIGUSR1, fork_signal_cb_called);
   }
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -353,11 +353,11 @@ static void create_file(const char* name) {
   uv_fs_t req;
 
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -369,7 +369,7 @@ static void touch_file(const char* name) {
   uv_buf_t buf;
 
   r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
@@ -379,7 +379,7 @@ static void touch_file(const char* name) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -399,9 +399,9 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
                                          const char* filename,
                                          int events,
                                          int status) {
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
   ++fs_event_cb_called;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 #if defined(__APPLE__) || defined(__linux__)
   ASSERT(strcmp(filename, "watch_file") == 0);
 #else
@@ -421,23 +421,23 @@ static void assert_watch_file_current_dir(uv_loop_t* const loop, int file_or_dir
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   /* watching a dir is the only way to get fsevents involved on apple
      platforms */
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         file_or_dir == 1 ? "." : "watch_file",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(timer_cb_touch_called == 0);
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(timer_cb_touch_called, 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -558,15 +558,15 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         "watch_file",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   child_pid = fork();
   ASSERT(child_pid != -1);
@@ -579,10 +579,10 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
     ASSERT(0 == uv_loop_fork(loop));
 
     r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
-    ASSERT(timer_cb_touch_called == 0);
-    ASSERT(fs_event_cb_called == 0);
+    ASSERT_EQ(timer_cb_touch_called, 0);
+    ASSERT_EQ(fs_event_cb_called, 0);
     printf("Running loop in child \n");
     uv_run(loop, UV_RUN_DEFAULT);
 
@@ -613,7 +613,7 @@ static void work_cb(uv_work_t* req) {
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   after_work_cb_count++;
 }
 
@@ -622,11 +622,11 @@ static void assert_run_work(uv_loop_t* const loop) {
   uv_work_t work_req;
   int r;
 
-  ASSERT(work_cb_count == 0);
-  ASSERT(after_work_cb_count == 0);
+  ASSERT_EQ(work_cb_count, 0);
+  ASSERT_EQ(after_work_cb_count, 0);
   printf("Queue in %d\n", getpid());
   r = uv_queue_work(loop, &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   printf("Running in %d\n", getpid());
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -61,8 +61,8 @@ static void handle_result(uv_fs_t* req) {
   uv_fs_req_cleanup(&stat_req);
   r = uv_fs_stat(NULL, &stat_req, dst, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(stat_req.statbuf.st_size == size);
-  ASSERT(stat_req.statbuf.st_mode == mode);
+  ASSERT_EQ(stat_req.statbuf.st_size, size);
+  ASSERT_EQ(stat_req.statbuf.st_mode, mode);
   uv_fs_req_cleanup(&stat_req);
   uv_fs_req_cleanup(req);
   result_check_count++;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -51,7 +51,7 @@ static void handle_result(uv_fs_t* req) {
   int r;
 
   ASSERT(req->fs_type == UV_FS_COPYFILE);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
 
   /* Verify that the file size and mode are the same. */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -175,9 +175,9 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
   ASSERT_EQ(r, 0);
-  ASSERT(result_check_count == 5);
+  ASSERT_EQ(result_check_count, 5);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(result_check_count == 6);
+  ASSERT_EQ(result_check_count, 6);
 
   /* If the flags are invalid, the loop should not be kept open */
   unlink(dst);

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -50,7 +50,7 @@ static void handle_result(uv_fs_t* req) {
   uint64_t mode;
   int r;
 
-  ASSERT(req->fs_type == UV_FS_COPYFILE);
+  ASSERT_EQ(req->fs_type, UV_FS_COPYFILE);
   ASSERT_EQ(req->result, 0);
 
   /* Verify that the file size and mode are the same. */
@@ -107,15 +107,15 @@ TEST_IMPL(fs_copyfile) {
 
   /* Fails with EINVAL if bad flags are passed. */
   r = uv_fs_copyfile(NULL, &req, src, dst, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&req);
 
   /* Fails with ENOENT if source does not exist. */
   unlink(src);
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(req.result == UV_ENOENT);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
   uv_fs_req_cleanup(&req);
   /* The destination should not exist. */
   r = uv_fs_stat(NULL, &req, dst, NULL);
@@ -154,7 +154,7 @@ TEST_IMPL(fs_copyfile) {
 
   /* Fails to overwrites existing file. */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_EXCL, NULL);
-  ASSERT(r == UV_EEXIST);
+  ASSERT_EQ(r, UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
   /* Truncates when an existing destination is larger than the source file. */
@@ -182,7 +182,7 @@ TEST_IMPL(fs_copyfile) {
   /* If the flags are invalid, the loop should not be kept open */
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
 
   /* Copies file using UV_FS_COPYFILE_FICLONE. */
@@ -208,8 +208,8 @@ TEST_IMPL(fs_copyfile) {
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
   /* On IBMi PASE, qsecofr users can overwrite read-only files */
 # ifndef __PASE__
-  ASSERT(req.result == UV_EACCES);
-  ASSERT(r == UV_EACCES);
+  ASSERT_EQ(req.result, UV_EACCES);
+  ASSERT_EQ(r, UV_EACCES);
 # endif
   uv_fs_req_cleanup(&req);
 #endif

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -55,12 +55,12 @@ static void handle_result(uv_fs_t* req) {
 
   /* Verify that the file size and mode are the same. */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   size = stat_req.statbuf.st_size;
   mode = stat_req.statbuf.st_mode;
   uv_fs_req_cleanup(&stat_req);
   r = uv_fs_stat(NULL, &stat_req, dst, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(stat_req.statbuf.st_size == size);
   ASSERT(stat_req.statbuf.st_mode == mode);
   uv_fs_req_cleanup(&stat_req);
@@ -79,7 +79,7 @@ static void touch_file(const char* name, unsigned int size) {
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT | O_TRUNC,
                  S_IWUSR | S_IRUSR, NULL);
   uv_fs_req_cleanup(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t) req.result;
 
   buf = uv_buf_init("a", 1);
@@ -93,7 +93,7 @@ static void touch_file(const char* name, unsigned int size) {
 
   r = uv_fs_close(NULL, &req, file, NULL);
   uv_fs_req_cleanup(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -125,7 +125,7 @@ TEST_IMPL(fs_copyfile) {
   /* Succeeds if src and dst files are identical. */
   touch_file(src, 12);
   r = uv_fs_copyfile(NULL, &req, src, src, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
   /* Verify that the src file did not get truncated. */
   r = uv_fs_stat(NULL, &req, src, NULL);
@@ -137,19 +137,19 @@ TEST_IMPL(fs_copyfile) {
   /* Copies file synchronously. Creates new file. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies a file of size zero. */
   unlink(dst);
   touch_file(src, 0);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies file synchronously. Overwrites existing file. */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Fails to overwrites existing file. */
@@ -160,21 +160,21 @@ TEST_IMPL(fs_copyfile) {
   /* Truncates when an existing destination is larger than the source file. */
   touch_file(src, 1);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies a larger file. */
   unlink(dst);
   touch_file(src, 4096 * 2);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
   unlink(src);
 
   /* Copies file asynchronously */
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(result_check_count == 5);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 6);
@@ -188,7 +188,7 @@ TEST_IMPL(fs_copyfile) {
   /* Copies file using UV_FS_COPYFILE_FICLONE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -449,7 +449,7 @@ TEST_IMPL(fs_event_watch_dir) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(fs_event_cb_called == fs_event_created + fs_event_removed);
+  ASSERT_EQ(fs_event_cb_called, fs_event_created + fs_event_removed);
   ASSERT_EQ(close_cb_called, 2);
 
   /* Cleanup */
@@ -509,7 +509,7 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(fs_multievent_cb_called == fs_event_created + fs_event_removed);
+  ASSERT_EQ(fs_multievent_cb_called, fs_event_created + fs_event_removed);
   ASSERT_EQ(fs_event_cb_called, 3);
   ASSERT_EQ(close_cb_called, 3);
 

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -450,7 +450,7 @@ TEST_IMPL(fs_event_watch_dir) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(fs_event_cb_called == fs_event_created + fs_event_removed);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   /* Cleanup */
   fs_event_unlink_files(NULL);
@@ -510,8 +510,8 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(fs_multievent_cb_called == fs_event_created + fs_event_removed);
-  ASSERT(fs_event_cb_called == 3);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(fs_event_cb_called, 3);
+  ASSERT_EQ(close_cb_called, 3);
 
   /* Cleanup */
   fs_event_unlink_files_in_subdir(NULL);
@@ -558,9 +558,9 @@ TEST_IMPL(fs_event_watch_dir_short_path) {
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(fs_event_cb_called == 1);
-    ASSERT(timer_cb_called == 1);
-    ASSERT(close_cb_called == 1);
+    ASSERT_EQ(fs_event_cb_called, 1);
+    ASSERT_EQ(timer_cb_called, 1);
+    ASSERT_EQ(close_cb_called, 1);
   }
 
   /* Cleanup */
@@ -604,9 +604,9 @@ TEST_IMPL(fs_event_watch_file) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(fs_event_cb_called == 1);
-  ASSERT(timer_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(fs_event_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   /* Cleanup */
   remove("watch_dir/file2");
@@ -659,7 +659,7 @@ TEST_IMPL(fs_event_watch_file_exact_path) {
   ASSERT_EQ(r, 0);
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(timer_cb_exact_called == 2);
+  ASSERT_EQ(timer_cb_exact_called, 2);
 
   /* Cleanup */
   remove("watch_dir/file.js");
@@ -736,9 +736,9 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(timer_cb_touch_called == 1);
-  ASSERT(fs_event_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(timer_cb_touch_called, 1);
+  ASSERT_EQ(fs_event_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   /* Cleanup */
   remove("watch_file");
@@ -802,7 +802,7 @@ TEST_IMPL(fs_event_no_callback_after_close) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(fs_event_cb_called, 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   /* Cleanup */
   remove("watch_dir/file1");
@@ -839,7 +839,7 @@ TEST_IMPL(fs_event_no_callback_on_close) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(fs_event_cb_called, 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   /* Cleanup */
   remove("watch_dir/file1");
@@ -881,7 +881,7 @@ TEST_IMPL(fs_event_immediate_close) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -912,7 +912,7 @@ TEST_IMPL(fs_event_close_with_pending_event) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   /* Clean up */
   remove("watch_dir/file");
@@ -952,8 +952,8 @@ TEST_IMPL(fs_event_close_in_callback) {
 
   uv_run(loop, UV_RUN_ONCE);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(fs_event_cb_called == 3);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(fs_event_cb_called, 3);
 
   /* Clean up */
   fs_event_unlink_files(NULL);
@@ -991,7 +991,7 @@ TEST_IMPL(fs_event_start_and_close) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   remove("watch_dir/");
   MAKE_VALGRIND_HAPPY();
@@ -1042,7 +1042,7 @@ TEST_IMPL(fs_event_getpath) {
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(close_cb_called == 1);
+    ASSERT_EQ(close_cb_called, 1);
     close_cb_called = 0;
   }
 
@@ -1130,7 +1130,7 @@ TEST_IMPL(fs_event_error_reporting) {
 
     close_cb_called = 0;
     uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT(close_cb_called == 1);
+    ASSERT_EQ(close_cb_called, 1);
 
     uv_loop_close(loop);
   } while (i-- != 0);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -134,7 +134,7 @@ static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   ++fs_event_cb_called;
   ASSERT(handle == &fs_event);
   ASSERT_EQ(status, 0);
-  ASSERT(events == UV_CHANGE);
+  ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "file1") == 0);
   #else
@@ -324,7 +324,7 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   ++fs_event_cb_called;
   ASSERT(handle == &fs_event);
   ASSERT_EQ(status, 0);
-  ASSERT(events == UV_CHANGE);
+  ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "file2") == 0);
   #else
@@ -351,7 +351,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
 
   ASSERT(handle == &fs_event);
   ASSERT_EQ(status, 0);
-  ASSERT(events == UV_CHANGE);
+  ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "watch_file") == 0);
   #else
@@ -1024,12 +1024,12 @@ TEST_IMPL(fs_event_getpath) {
     ASSERT_EQ(r, 0);
     len = sizeof buf;
     r = uv_fs_event_getpath(&fs_event, buf, &len);
-    ASSERT(r == UV_EINVAL);
+    ASSERT_EQ(r, UV_EINVAL);
     r = uv_fs_event_start(&fs_event, fail_cb, watch_dir[i], 0);
     ASSERT_EQ(r, 0);
     len = 0;
     r = uv_fs_event_getpath(&fs_event, buf, &len);
-    ASSERT(r == UV_ENOBUFS);
+    ASSERT_EQ(r, UV_ENOBUFS);
     ASSERT(len < sizeof buf); /* sanity check */
     ASSERT(len == strlen(watch_dir[i]) + 1);
     r = uv_fs_event_getpath(&fs_event, buf, &len);
@@ -1117,7 +1117,7 @@ TEST_IMPL(fs_event_error_reporting) {
   }
 
   /* At least one loop should fail */
-  ASSERT(fs_event_error_reported == UV_EMFILE);
+  ASSERT_EQ(fs_event_error_reported, UV_EMFILE);
 
   /* Stop and close all events, and destroy loops */
   do {

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -312,7 +312,7 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
     ASSERT(0 == uv_timer_start(&timer, fs_event_unlink_files_in_subdir, 1, 0));
   } else if (fs_multievent_cb_called == 2 * fs_event_file_count) {
     /* Once we've processed all create and delete events, stop watching */
-    ASSERT(fs_event_removed == fs_event_file_count);
+    ASSERT_EQ(fs_event_removed, fs_event_file_count);
     uv_close((uv_handle_t*) &timer, close_cb);
     uv_close((uv_handle_t*) handle, close_cb);
   }

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -132,7 +132,7 @@ static void fail_cb(uv_fs_event_t* handle,
 static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   int events, int status) {
   ++fs_event_cb_called;
-  ASSERT(handle == &fs_event);
+  ASSERT_EQ(handle, &fs_event);
   ASSERT_EQ(status, 0);
   ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
@@ -202,7 +202,7 @@ static void fs_event_cb_dir_multi_file(uv_fs_event_t* handle,
                                        int events,
                                        int status) {
   fs_event_cb_called++;
-  ASSERT(handle == &fs_event);
+  ASSERT_EQ(handle, &fs_event);
   ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
@@ -292,7 +292,7 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
     return;
 
   fs_multievent_cb_called++;
-  ASSERT(handle == &fs_event);
+  ASSERT_EQ(handle, &fs_event);
   ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
@@ -322,7 +322,7 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
 static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   int events, int status) {
   ++fs_event_cb_called;
-  ASSERT(handle == &fs_event);
+  ASSERT_EQ(handle, &fs_event);
   ASSERT_EQ(status, 0);
   ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
@@ -349,7 +349,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   ASSERT_EQ(fs_event_cb_called, 0);
   ++fs_event_cb_called;
 
-  ASSERT(handle == &fs_event);
+  ASSERT_EQ(handle, &fs_event);
   ASSERT_EQ(status, 0);
   ASSERT_EQ(events, UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -88,11 +88,11 @@ static void create_file(const char* name) {
   uv_fs_t req;
 
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -103,7 +103,7 @@ static void touch_file(const char* name) {
   uv_buf_t buf;
 
   r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t)req.result;
   uv_fs_req_cleanup(&req);
 
@@ -113,7 +113,7 @@ static void touch_file(const char* name) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -133,7 +133,7 @@ static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   int events, int status) {
   ++fs_event_cb_called;
   ASSERT(handle == &fs_event);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "file1") == 0);
@@ -180,7 +180,7 @@ static void fs_event_unlink_files(uv_timer_t* handle) {
     for (i = 0; i < 16; i++) {
       r = remove(fs_event_get_filename(i));
       if (handle != NULL)
-        ASSERT(r == 0);
+        ASSERT_EQ(r, 0);
     }
   } else {
     /* Make sure we're not attempting to remove files we do not intend */
@@ -203,7 +203,7 @@ static void fs_event_cb_dir_multi_file(uv_fs_event_t* handle,
                                        int status) {
   fs_event_cb_called++;
   ASSERT(handle == &fs_event);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strncmp(filename, file_prefix, sizeof(file_prefix) - 1) == 0);
@@ -256,7 +256,7 @@ static void fs_event_unlink_files_in_subdir(uv_timer_t* handle) {
     for (i = 0; i < 16; i++) {
       r = remove(fs_event_get_filename_in_subdir(i));
       if (handle != NULL)
-        ASSERT(r == 0);
+        ASSERT_EQ(r, 0);
     }
   } else {
     /* Make sure we're not attempting to remove files we do not intend */
@@ -293,7 +293,7 @@ static void fs_event_cb_dir_multi_file_in_subdir(uv_fs_event_t* handle,
 
   fs_multievent_cb_called++;
   ASSERT(handle == &fs_event);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strncmp(filename,
@@ -323,7 +323,7 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   int events, int status) {
   ++fs_event_cb_called;
   ASSERT(handle == &fs_event);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "file2") == 0);
@@ -346,11 +346,11 @@ static void timer_cb_close_handle(uv_timer_t* timer) {
 
 static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   const char* filename, int events, int status) {
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
   ++fs_event_cb_called;
 
   ASSERT(handle == &fs_event);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events == UV_CHANGE);
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT(strcmp(filename, "watch_file") == 0);
@@ -392,7 +392,7 @@ static void timer_cb_exact(uv_timer_t* handle) {
   } else {
     uv_close((uv_handle_t*)handle, NULL);
     r = uv_fs_event_stop(&fs_event);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_close((uv_handle_t*) &fs_event, NULL);
   }
 
@@ -410,7 +410,7 @@ static void fs_event_cb_close(uv_fs_event_t* handle,
                               const char* filename,
                               int events,
                               int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(fs_event_cb_called < 3);
   ++fs_event_cb_called;
@@ -439,13 +439,13 @@ TEST_IMPL(fs_event_watch_dir) {
   create_dir("watch_dir");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_cb_dir_multi_file, "watch_dir", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, fs_event_create_files, 100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -480,27 +480,27 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
   create_dir("watch_dir/subdir");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_dir_multi_file_in_subdir,
                         "watch_dir",
                         UV_FS_EVENT_RECURSIVE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, fs_event_create_files_in_subdir, 100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   /* Also try to watch the root directory.
    * This will be noisier, so we're just checking for any couple events to happen. */
   r = uv_fs_event_init(loop, &fs_event_root);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event_root,
                         fs_event_cb_close,
                         "/",
                         UV_FS_EVENT_RECURSIVE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #else
   fs_event_cb_called += 3;
   close_cb_called += 1;
@@ -548,13 +548,13 @@ TEST_IMPL(fs_event_watch_dir_short_path) {
   has_shortnames = uv_fs_stat(NULL, &req, "watch_~1", NULL) != UV_ENOENT;
   if (has_shortnames) {
     r = uv_fs_event_init(loop, &fs_event);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_fs_event_start(&fs_event, fs_event_cb_dir, "watch_~1", 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_timer_init(loop, &timer);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_timer_start(&timer, timer_cb_file, 100, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_run(loop, UV_RUN_DEFAULT);
 
@@ -594,13 +594,13 @@ TEST_IMPL(fs_event_watch_file) {
   create_file("watch_dir/file2");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_cb_file, "watch_dir/file2", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, timer_cb_file, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -650,15 +650,15 @@ TEST_IMPL(fs_event_watch_file_exact_path) {
 #endif
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_fail, "watch_dir/file.jsx", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, timer_cb_exact, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(timer_cb_exact_called == 2);
 
   /* Cleanup */
@@ -716,23 +716,23 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
 #endif
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         "watch_file",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb_touch, 1100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(timer_cb_touch_called == 0);
-  ASSERT(fs_event_cb_called == 0);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(timer_cb_touch_called, 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -761,11 +761,11 @@ TEST_IMPL(fs_event_watch_file_root_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fail_cb, path, 0);
   if (r == UV_ENOENT)
     RETURN_SKIP("bootsect.bak doesn't exist in system root.\n");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &fs_event, NULL);
 
@@ -789,19 +789,19 @@ TEST_IMPL(fs_event_no_callback_after_close) {
   create_file("watch_dir/file1");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file,
                         "watch_dir/file1",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 
   uv_close((uv_handle_t*)&fs_event, close_cb);
   touch_file("watch_dir/file1");
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
   ASSERT(close_cb_called == 1);
 
   /* Cleanup */
@@ -827,18 +827,18 @@ TEST_IMPL(fs_event_no_callback_on_close) {
   create_file("watch_dir/file1");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file,
                         "watch_dir/file1",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&fs_event, close_cb);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
   ASSERT(close_cb_called == 1);
 
   /* Cleanup */
@@ -854,9 +854,9 @@ static void timer_cb(uv_timer_t* handle) {
   int r;
 
   r = uv_fs_event_init(handle->loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_fail, ".", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&fs_event, close_cb);
   uv_close((uv_handle_t*)handle, close_cb);
@@ -874,10 +874,10 @@ TEST_IMPL(fs_event_immediate_close) {
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -901,9 +901,9 @@ TEST_IMPL(fs_event_close_with_pending_event) {
   create_file("watch_dir/file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_fail, "watch_dir", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Generate an fs event. */
   touch_file("watch_dir/file");
@@ -937,14 +937,14 @@ TEST_IMPL(fs_event_close_in_callback) {
   create_dir("watch_dir");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_cb_close, "watch_dir", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, fs_event_create_files, 100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -977,14 +977,14 @@ TEST_IMPL(fs_event_start_and_close) {
   create_dir("watch_dir");
 
   r = uv_fs_event_init(loop, &fs_event1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event1, fs_event_cb_dir, "watch_dir", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_event_init(loop, &fs_event2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event2, fs_event_cb_dir, "watch_dir", 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &fs_event2, close_cb);
   uv_close((uv_handle_t*) &fs_event1, close_cb);
@@ -1021,23 +1021,23 @@ TEST_IMPL(fs_event_getpath) {
 
   for (i = 0; i < ARRAY_SIZE(watch_dir); i++) {
     r = uv_fs_event_init(loop, &fs_event);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     len = sizeof buf;
     r = uv_fs_event_getpath(&fs_event, buf, &len);
     ASSERT(r == UV_EINVAL);
     r = uv_fs_event_start(&fs_event, fail_cb, watch_dir[i], 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     len = 0;
     r = uv_fs_event_getpath(&fs_event, buf, &len);
     ASSERT(r == UV_ENOBUFS);
     ASSERT(len < sizeof buf); /* sanity check */
     ASSERT(len == strlen(watch_dir[i]) + 1);
     r = uv_fs_event_getpath(&fs_event, buf, &len);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(len == strlen(watch_dir[i]));
     ASSERT(strcmp(buf, watch_dir[i]) == 0);
     r = uv_fs_event_stop(&fs_event);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_close((uv_handle_t*) &fs_event, close_cb);
 
     uv_run(loop, UV_RUN_DEFAULT);
@@ -1161,7 +1161,7 @@ TEST_IMPL(fs_event_watch_invalid_path) {
 
   loop = uv_default_loop();
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event, fs_event_cb_file, "<:;", 0);
   ASSERT(r != 0);
   ASSERT(uv_is_active((uv_handle_t*) &fs_event) == 0);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -1110,8 +1110,8 @@ TEST_IMPL(fs_event_error_reporting) {
     ASSERT(0 == uv_timer_init(loop, &timer));
     ASSERT(0 == uv_timer_start(&timer, timer_cb_nop, 2, 0));
     uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT(1 == timer_cb_called);
-    ASSERT(1 == close_cb_called);
+    ASSERT_EQ(timer_cb_called, 1);
+    ASSERT_EQ(close_cb_called, 1);
     if (fs_event_error_reported != 0)
       break;
   }

--- a/test/test-fs-fd-hash.c
+++ b/test/test-fs-fd-hash.c
@@ -106,7 +106,7 @@ TEST_IMPL(fs_fd_hash) {
   {
     struct uv__fd_info_s info = { 0 };
     ASSERT(uv__fd_hash_get((uv_os_fd_t) 0, &info));
-    ASSERT(info.flags == FD_DIFF + FD_DIFF);
+    ASSERT_EQ(info.flags, FD_DIFF + FD_DIFF);
   }
   {
     /* Leave as it was, will be again tested below */

--- a/test/test-fs-fd-hash.c
+++ b/test/test-fs-fd-hash.c
@@ -43,7 +43,7 @@ void assert_nonexistent(uv_os_fd_t fd) {
 void assert_existent(uv_os_fd_t fd) {
   struct uv__fd_info_s info = { 0 };
   ASSERT(uv__fd_hash_get(fd, &info));
-  ASSERT(info.flags == (intptr_t) fd + FD_DIFF);
+  ASSERT_EQ(info.flags, (intptr_t) fd + FD_DIFF);
 }
 
 void assert_insertion(uv_os_fd_t fd) {
@@ -58,7 +58,7 @@ void assert_removal(uv_os_fd_t fd) {
   struct uv__fd_info_s info = { 0 };
   assert_existent(fd);
   uv__fd_hash_remove(fd, &info);
-  ASSERT(info.flags == (intptr_t) fd + FD_DIFF);
+  ASSERT_EQ(info.flags, (intptr_t) fd + FD_DIFF);
   assert_nonexistent(fd);
 }
 

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -69,7 +69,7 @@ static void setup(void) {
   uv_fs_req_cleanup(&rmdir_req);
 
   r = uv_fs_mkdir(NULL, &mkdir_req, empty_dir, 0755, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(mkdir_req.result == 0);
   uv_fs_req_cleanup(&mkdir_req);
 }
@@ -92,13 +92,13 @@ static void refresh(void) {
 
   r = uv_fs_open(NULL, &open_req, empty_file,
     UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req.result >= 0);
   file = (uv_os_fd_t) open_req.result;
   uv_fs_req_cleanup(&open_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -107,7 +107,7 @@ static void refresh(void) {
 
   r = uv_fs_open(NULL, &open_req, dummy_file,
     UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req.result >= 0);
   file = (uv_os_fd_t) open_req.result;
   uv_fs_req_cleanup(&open_req);
@@ -119,7 +119,7 @@ static void refresh(void) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 }
@@ -184,13 +184,13 @@ static void writeExpect(char *file, char *expected, int size) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Check contents */
   r = uv_fs_open(NULL, &open_req, file, UV_FS_O_RDONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req.result >= 0);
   fd = (uv_os_fd_t) open_req.result;
   uv_fs_req_cleanup(&open_req);
@@ -203,7 +203,7 @@ static void writeExpect(char *file, char *expected, int size) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -231,7 +231,7 @@ static void writeFail(char *file, int error) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -254,7 +254,7 @@ static void readExpect(char *file, char *expected, int size) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -282,7 +282,7 @@ static void readFail(char *file, int error) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -70,7 +70,7 @@ static void setup(void) {
 
   r = uv_fs_mkdir(NULL, &mkdir_req, empty_dir, 0755, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(mkdir_req.result == 0);
+  ASSERT_EQ(mkdir_req.result, 0);
   uv_fs_req_cleanup(&mkdir_req);
 }
 
@@ -99,7 +99,7 @@ static void refresh(void) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* dummy_file */
@@ -120,7 +120,7 @@ static void refresh(void) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 }
 
@@ -185,7 +185,7 @@ static void writeExpect(char *file, char *expected, int size) {
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Check contents */
@@ -204,7 +204,7 @@ static void writeExpect(char *file, char *expected, int size) {
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -232,7 +232,7 @@ static void writeFail(char *file, int error) {
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -255,7 +255,7 @@ static void readExpect(char *file, char *expected, int size) {
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -283,7 +283,7 @@ static void readFail(char *file, int error) {
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -138,14 +138,14 @@ static void openFail(char *file, int error) {
   refresh();
 
   r = uv_fs_open(NULL, &open_req, file, flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == error);
-  ASSERT(open_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(open_req.result, error);
   uv_fs_req_cleanup(&open_req);
 
   /* Ensure the first call does not create the file */
   r = uv_fs_open(NULL, &open_req, file, flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == error);
-  ASSERT(open_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(open_req.result, error);
   uv_fs_req_cleanup(&open_req);
 
   cleanup();
@@ -197,8 +197,8 @@ static void writeExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == size);
-  ASSERT(read_req.result == size);
+  ASSERT_EQ(r, size);
+  ASSERT_EQ(read_req.result, size);
   ASSERT(strncmp(buf, expected, size) == 0);
   uv_fs_req_cleanup(&read_req);
 
@@ -220,14 +220,14 @@ static void writeFail(char *file, int error) {
 
   iov = uv_buf_init("z", 1);
   r = uv_fs_write(NULL, &write_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(write_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(write_req.result, error);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init("z", 1);
   r = uv_fs_write(NULL, &write_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(write_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(write_req.result, error);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);
@@ -248,8 +248,8 @@ static void readExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == size);
-  ASSERT(read_req.result == size);
+  ASSERT_EQ(r, size);
+  ASSERT_EQ(read_req.result, size);
   ASSERT(strncmp(buf, expected, size) == 0);
   uv_fs_req_cleanup(&read_req);
 
@@ -271,14 +271,14 @@ static void readFail(char *file, int error) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(read_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(read_req.result, error);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(read_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(read_req.result, error);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -114,8 +114,8 @@ static void refresh(void) {
 
   iov = uv_buf_init("a", 1);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
@@ -173,14 +173,14 @@ static void writeExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init("b", 1);
   r = uv_fs_write(NULL, &write_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init("c", 1);
   r = uv_fs_write(NULL, &write_req, fd, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, fd, NULL);

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -103,7 +103,7 @@ static void poll_cb(uv_fs_poll_t* handle,
 
   memset(&zero_statbuf, 0, sizeof(zero_statbuf));
 
-  ASSERT(handle == &poll_handle);
+  ASSERT_EQ(handle, &poll_handle);
   ASSERT(1 == uv_is_active((uv_handle_t*) handle));
   ASSERT(prev != NULL);
   ASSERT(curr != NULL);

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -110,7 +110,7 @@ static void poll_cb(uv_fs_poll_t* handle,
 
   switch (poll_cb_called++) {
   case 0:
-    ASSERT(status == UV_ENOENT);
+    ASSERT_EQ(status, UV_ENOENT);
     ASSERT(0 == memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 == memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     touch_file(FIXTURE);
@@ -138,7 +138,7 @@ static void poll_cb(uv_fs_poll_t* handle,
     break;
 
   case 4:
-    ASSERT(status == UV_ENOENT);
+    ASSERT_EQ(status, UV_ENOENT);
     ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 == memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     uv_close((uv_handle_t*)handle, close_cb);

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -160,9 +160,9 @@ TEST_IMPL(fs_poll) {
   ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(poll_cb_called == 5);
-  ASSERT(timer_cb_called == 2);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(poll_cb_called, 5);
+  ASSERT_EQ(timer_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -190,7 +190,7 @@ TEST_IMPL(fs_poll_getpath) {
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -210,7 +210,7 @@ TEST_IMPL(fs_poll_close_request) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT(0 == uv_loop_close(&loop));
 
@@ -236,7 +236,7 @@ TEST_IMPL(fs_poll_close_request_multi_start_stop) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT(0 == uv_loop_close(&loop));
 
@@ -262,7 +262,7 @@ TEST_IMPL(fs_poll_close_request_multi_stop_start) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT(0 == uv_loop_close(&loop));
 
@@ -291,7 +291,7 @@ TEST_IMPL(fs_poll_close_request_stop_when_active) {
   /* Clean up after the test. */
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT(0 == uv_loop_close(&loop));
 

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -183,7 +183,7 @@ TEST_IMPL(fs_poll_getpath) {
   len = sizeof buf;
   ASSERT(0 == uv_fs_poll_getpath(&poll_handle, buf, &len));
   ASSERT(buf[len - 1] != 0);
-  ASSERT(buf[len] == '\0');
+  ASSERT_EQ(buf[len], '\0');
   ASSERT(0 == memcmp(buf, FIXTURE, len));
 
   uv_close((uv_handle_t*) &poll_handle, close_cb);

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -117,21 +117,21 @@ static void poll_cb(uv_fs_poll_t* handle,
     break;
 
   case 1:
-    ASSERT(status == 0);
+    ASSERT_EQ(status, 0);
     ASSERT(0 == memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 20, 0));
     break;
 
   case 2:
-    ASSERT(status == 0);
+    ASSERT_EQ(status, 0);
     ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 200, 0));
     break;
 
   case 3:
-    ASSERT(status == 0);
+    ASSERT_EQ(status, 0);
     ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     remove(FIXTURE);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -67,7 +67,7 @@ static void empty_readdir_cb(uv_fs_t* req) {
                      &closedir_req,
                      dir,
                      empty_closedir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void empty_opendir_cb(uv_fs_t* req) {
@@ -85,7 +85,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     empty_readdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(req);
   ++empty_opendir_cb_count;
 }
@@ -115,7 +115,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
                     &opendir_req,
                     path,
                     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == 0);
   ASSERT(opendir_req.ptr != NULL);
@@ -130,7 +130,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
                                   &readdir_req,
                                   dir,
                                   NULL);
-  ASSERT(nb_entries_read == 0);
+  ASSERT_EQ(nb_entries_read, 0);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -147,11 +147,11 @@ TEST_IMPL(fs_readdir_empty_dir) {
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
 
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, empty_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(empty_opendir_cb_count == 0);
-  ASSERT(empty_closedir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(empty_opendir_cb_count, 0);
+  ASSERT_EQ(empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(empty_opendir_cb_count == 1);
   ASSERT(empty_closedir_cb_count == 1);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
@@ -202,10 +202,10 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
                     &opendir_req,
                     path,
                     non_existing_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(non_existing_opendir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_existing_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(non_existing_opendir_cb_count == 1);
 
   MAKE_VALGRIND_HAPPY();
@@ -253,10 +253,10 @@ TEST_IMPL(fs_readdir_file) {
 
   /* Testing the async flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, file_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(file_opendir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(file_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(file_opendir_cb_count == 1);
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -336,7 +336,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     non_empty_readdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(req);
   ++non_empty_opendir_cb_count;
 }
@@ -354,7 +354,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   cleanup_test_files();
 
   r = uv_fs_mkdir(uv_default_loop(), &mkdir_req, "test_dir", 0755, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Create two files synchronously. */
   r = uv_fs_open(uv_default_loop(),
@@ -362,12 +362,12 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                  "test_dir/file1",
                  O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(create_req.result >= 0);
   file = (uv_os_fd_t) create_req.result;
   uv_fs_req_cleanup(&create_req);
   r = uv_fs_close(uv_default_loop(), &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(uv_default_loop(),
@@ -375,12 +375,12 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                  "test_dir/file2",
                  O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(create_req.result >= 0);
   file = (uv_os_fd_t) create_req.result;
   uv_fs_req_cleanup(&create_req);
   r = uv_fs_close(uv_default_loop(), &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_mkdir(uv_default_loop(),
@@ -388,7 +388,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                   "test_dir/test_subdir",
                   0755,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&mkdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -396,7 +396,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
 
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, "test_dir", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == 0);
   ASSERT(opendir_req.ptr != NULL);
@@ -444,11 +444,11 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                     &opendir_req,
                     "test_dir",
                     non_empty_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(non_empty_opendir_cb_count == 0);
-  ASSERT(non_empty_closedir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_empty_opendir_cb_count, 0);
+  ASSERT_EQ(non_empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(non_empty_opendir_cb_count == 1);
   ASSERT(non_empty_closedir_cb_count == 1);
 

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -49,7 +49,7 @@ static void cleanup_test_files(void) {
 static void empty_closedir_cb(uv_fs_t* req) {
   ASSERT(req == &closedir_req);
   ASSERT(req->fs_type == UV_FS_CLOSEDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ++empty_closedir_cb_count;
   uv_fs_req_cleanup(req);
 }
@@ -60,7 +60,7 @@ static void empty_readdir_cb(uv_fs_t* req) {
 
   ASSERT(req == &readdir_req);
   ASSERT(req->fs_type == UV_FS_READDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   dir = req->ptr;
   uv_fs_req_cleanup(req);
   r = uv_fs_closedir(uv_default_loop(),
@@ -76,7 +76,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
 
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
   dir = req->ptr;
   dir->dirents = dirents;
@@ -117,7 +117,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
                     NULL);
   ASSERT_EQ(r, 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == 0);
+  ASSERT_EQ(opendir_req.result, 0);
   ASSERT(opendir_req.ptr != NULL);
   dir = opendir_req.ptr;
   uv_fs_req_cleanup(&opendir_req);
@@ -136,7 +136,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT(closedir_req.result == 0);
+  ASSERT_EQ(closedir_req.result, 0);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */
@@ -274,7 +274,7 @@ static int non_empty_closedir_cb_count;
 
 static void non_empty_closedir_cb(uv_fs_t* req) {
   ASSERT(req == &closedir_req);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   uv_fs_req_cleanup(req);
   ++non_empty_closedir_cb_count;
 }
@@ -325,7 +325,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
 
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
 
   dir = req->ptr;
@@ -398,7 +398,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, "test_dir", NULL);
   ASSERT_EQ(r, 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == 0);
+  ASSERT_EQ(opendir_req.result, 0);
   ASSERT(opendir_req.ptr != NULL);
 
   entries_count = 0;
@@ -432,7 +432,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT(closedir_req.result == 0);
+  ASSERT_EQ(closedir_req.result, 0);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -301,11 +301,11 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
            strcmp(dirents[0].name, "test_subdir") == 0);
 #ifdef HAVE_DIRENT_TYPES
     if (!strcmp(dirents[0].name, "test_subdir"))
-      ASSERT(dirents[0].type == UV_DIRENT_DIR);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_DIR);
     else
-      ASSERT(dirents[0].type == UV_DIRENT_FILE);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_FILE);
 #else
-    ASSERT(dirents[0].type == UV_DIRENT_UNKNOWN);
+    ASSERT_EQ(dirents[0].type, UV_DIRENT_UNKNOWN);
 #endif /* HAVE_DIRENT_TYPES */
 
     ++non_empty_readdir_cb_count;
@@ -416,11 +416,11 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
          strcmp(dirents[0].name, "test_subdir") == 0);
 #ifdef HAVE_DIRENT_TYPES
     if (!strcmp(dirents[0].name, "test_subdir"))
-      ASSERT(dirents[0].type == UV_DIRENT_DIR);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_DIR);
     else
-      ASSERT(dirents[0].type == UV_DIRENT_FILE);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_FILE);
 #else
-    ASSERT(dirents[0].type == UV_DIRENT_UNKNOWN);
+    ASSERT_EQ(dirents[0].type, UV_DIRENT_UNKNOWN);
 #endif /* HAVE_DIRENT_TYPES */
     uv_fs_req_cleanup(&readdir_req);
     ++entries_count;

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -152,8 +152,8 @@ TEST_IMPL(fs_readdir_empty_dir) {
   ASSERT_EQ(empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(empty_opendir_cb_count == 1);
-  ASSERT(empty_closedir_cb_count == 1);
+  ASSERT_EQ(empty_opendir_cb_count, 1);
+  ASSERT_EQ(empty_closedir_cb_count, 1);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
   uv_fs_req_cleanup(&rmdir_req);
   MAKE_VALGRIND_HAPPY();
@@ -206,7 +206,7 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
   ASSERT_EQ(non_existing_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(non_existing_opendir_cb_count == 1);
+  ASSERT_EQ(non_existing_opendir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -257,7 +257,7 @@ TEST_IMPL(fs_readdir_file) {
   ASSERT_EQ(file_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(file_opendir_cb_count == 1);
+  ASSERT_EQ(file_opendir_cb_count, 1);
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
@@ -288,13 +288,13 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
 
   if (req->result == 0) {
     uv_fs_req_cleanup(req);
-    ASSERT(non_empty_readdir_cb_count == 3);
+    ASSERT_EQ(non_empty_readdir_cb_count, 3);
     uv_fs_closedir(uv_default_loop(),
                    &closedir_req,
                    dir,
                    non_empty_closedir_cb);
   } else {
-    ASSERT(req->result == 1);
+    ASSERT_EQ(req->result, 1);
     ASSERT(dir->dirents == dirents);
     ASSERT(strcmp(dirents[0].name, "file1") == 0 ||
            strcmp(dirents[0].name, "file2") == 0 ||
@@ -426,7 +426,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
     ++entries_count;
   }
 
-  ASSERT(entries_count == 3);
+  ASSERT_EQ(entries_count, 3);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -449,8 +449,8 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   ASSERT_EQ(non_empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(non_empty_opendir_cb_count == 1);
-  ASSERT(non_empty_closedir_cb_count == 1);
+  ASSERT_EQ(non_empty_opendir_cb_count, 1);
+  ASSERT_EQ(non_empty_closedir_cb_count, 1);
 
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, "test_subdir", NULL);
   uv_fs_req_cleanup(&rmdir_req);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -47,7 +47,7 @@ static void cleanup_test_files(void) {
 }
 
 static void empty_closedir_cb(uv_fs_t* req) {
-  ASSERT(req == &closedir_req);
+  ASSERT_EQ(req, &closedir_req);
   ASSERT_EQ(req->fs_type, UV_FS_CLOSEDIR);
   ASSERT_EQ(req->result, 0);
   ++empty_closedir_cb_count;
@@ -58,7 +58,7 @@ static void empty_readdir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &readdir_req);
+  ASSERT_EQ(req, &readdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_READDIR);
   ASSERT_EQ(req->result, 0);
   dir = req->ptr;
@@ -74,7 +74,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &opendir_req);
+  ASSERT_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
@@ -168,7 +168,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
 static int non_existing_opendir_cb_count;
 
 static void non_existing_opendir_cb(uv_fs_t* req) {
-  ASSERT(req == &opendir_req);
+  ASSERT_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, UV_ENOENT);
   ASSERT_EQ(req->ptr, NULL);
@@ -220,7 +220,7 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
 static int file_opendir_cb_count;
 
 static void file_opendir_cb(uv_fs_t* req) {
-  ASSERT(req == &opendir_req);
+  ASSERT_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, UV_ENOTDIR);
   ASSERT_EQ(req->ptr, NULL);
@@ -273,7 +273,7 @@ static int non_empty_readdir_cb_count;
 static int non_empty_closedir_cb_count;
 
 static void non_empty_closedir_cb(uv_fs_t* req) {
-  ASSERT(req == &closedir_req);
+  ASSERT_EQ(req, &closedir_req);
   ASSERT_EQ(req->result, 0);
   uv_fs_req_cleanup(req);
   ++non_empty_closedir_cb_count;
@@ -282,7 +282,7 @@ static void non_empty_closedir_cb(uv_fs_t* req) {
 static void non_empty_readdir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
 
-  ASSERT(req == &readdir_req);
+  ASSERT_EQ(req, &readdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_READDIR);
   dir = req->ptr;
 
@@ -323,7 +323,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &opendir_req);
+  ASSERT_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -295,7 +295,7 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
                    non_empty_closedir_cb);
   } else {
     ASSERT_EQ(req->result, 1);
-    ASSERT(dir->dirents == dirents);
+    ASSERT_EQ(dir->dirents, dirents);
     ASSERT(strcmp(dirents[0].name, "file1") == 0 ||
            strcmp(dirents[0].name, "file2") == 0 ||
            strcmp(dirents[0].name, "test_subdir") == 0);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -48,7 +48,7 @@ static void cleanup_test_files(void) {
 
 static void empty_closedir_cb(uv_fs_t* req) {
   ASSERT(req == &closedir_req);
-  ASSERT(req->fs_type == UV_FS_CLOSEDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_CLOSEDIR);
   ASSERT_EQ(req->result, 0);
   ++empty_closedir_cb_count;
   uv_fs_req_cleanup(req);
@@ -59,7 +59,7 @@ static void empty_readdir_cb(uv_fs_t* req) {
   int r;
 
   ASSERT(req == &readdir_req);
-  ASSERT(req->fs_type == UV_FS_READDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_READDIR);
   ASSERT_EQ(req->result, 0);
   dir = req->ptr;
   uv_fs_req_cleanup(req);
@@ -75,7 +75,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
   int r;
 
   ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
   dir = req->ptr;
@@ -116,7 +116,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
                     path,
                     NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(opendir_req.result, 0);
   ASSERT(opendir_req.ptr != NULL);
   dir = opendir_req.ptr;
@@ -169,9 +169,9 @@ static int non_existing_opendir_cb_count;
 
 static void non_existing_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == UV_ENOENT);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, UV_ENOENT);
+  ASSERT_EQ(req->ptr, NULL);
 
   uv_fs_req_cleanup(req);
   ++non_existing_opendir_cb_count;
@@ -188,10 +188,10 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
 
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == UV_ENOENT);
-  ASSERT(opendir_req.ptr == NULL);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, UV_ENOENT);
+  ASSERT_EQ(opendir_req.ptr, NULL);
   uv_fs_req_cleanup(&opendir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -221,9 +221,9 @@ static int file_opendir_cb_count;
 
 static void file_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == UV_ENOTDIR);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, UV_ENOTDIR);
+  ASSERT_EQ(req->ptr, NULL);
 
   uv_fs_req_cleanup(req);
   ++file_opendir_cb_count;
@@ -241,10 +241,10 @@ TEST_IMPL(fs_readdir_file) {
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, NULL);
 
-  ASSERT(r == UV_ENOTDIR);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == UV_ENOTDIR);
-  ASSERT(opendir_req.ptr == NULL);
+  ASSERT_EQ(r, UV_ENOTDIR);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, UV_ENOTDIR);
+  ASSERT_EQ(opendir_req.ptr, NULL);
 
   uv_fs_req_cleanup(&opendir_req);
 
@@ -283,7 +283,7 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
 
   ASSERT(req == &readdir_req);
-  ASSERT(req->fs_type == UV_FS_READDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_READDIR);
   dir = req->ptr;
 
   if (req->result == 0) {
@@ -324,7 +324,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
   int r;
 
   ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
 
@@ -397,7 +397,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, "test_dir", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
   ASSERT_EQ(opendir_req.result, 0);
   ASSERT(opendir_req.ptr != NULL);
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -625,7 +625,7 @@ static void scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
   ASSERT(req == &scandir_req);
   ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == 2);
+  ASSERT_EQ(req->result, 2);
   ASSERT(req->ptr);
 
   while (UV_EOF != uv_fs_scandir_next(req, &dent)) {
@@ -689,7 +689,7 @@ static void stat_cb(uv_fs_t* req) {
 static void sendfile_cb(uv_fs_t* req) {
   ASSERT(req == &sendfile_req);
   ASSERT(req->fs_type == UV_FS_SENDFILE);
-  ASSERT(req->result == 65546);
+  ASSERT_EQ(req->result, 65546);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -742,7 +742,7 @@ TEST_IMPL(fs_file_noent) {
 
   ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   /* TODO add EACCES test */
 
@@ -770,7 +770,7 @@ TEST_IMPL(fs_file_nametoolong) {
 
   ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -810,7 +810,7 @@ TEST_IMPL(fs_file_loop) {
 
   ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   unlink("test_symlink");
 
@@ -923,45 +923,45 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(fsync_cb_count == 1);
-  ASSERT(fdatasync_cb_count == 1);
-  ASSERT(close_cb_count == 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(fsync_cb_count, 1);
+  ASSERT_EQ(fdatasync_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 1);
 
   r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", rename_cb);
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(close_cb_count == 1);
-  ASSERT(rename_cb_count == 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 1);
+  ASSERT_EQ(rename_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
-  ASSERT(read_cb_count == 1);
-  ASSERT(close_cb_count == 2);
-  ASSERT(rename_cb_count == 1);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(ftruncate_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(read_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 2);
+  ASSERT_EQ(rename_cb_count, 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(ftruncate_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 2);
-  ASSERT(read_cb_count == 2);
-  ASSERT(close_cb_count == 3);
-  ASSERT(rename_cb_count == 1);
-  ASSERT(unlink_cb_count == 1);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(ftruncate_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 2);
+  ASSERT_EQ(read_cb_count, 2);
+  ASSERT_EQ(close_cb_count, 3);
+  ASSERT_EQ(rename_cb_count, 1);
+  ASSERT_EQ(unlink_cb_count, 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(ftruncate_cb_count, 1);
 
   /* Cleanup. */
   unlink("test_file");
@@ -1120,7 +1120,7 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdir_cb_count == 1);
+  ASSERT_EQ(mkdir_cb_count, 1);
 
   /* Create 2 files synchronously. */
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
@@ -1145,12 +1145,12 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   /* sync uv_fs_scandir */
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
@@ -1175,22 +1175,22 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(stat_cb_count == 4);
+  ASSERT_EQ(stat_cb_count, 4);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file1", unlink_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(unlink_cb_count == 1);
+  ASSERT_EQ(unlink_cb_count, 1);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file2", unlink_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(unlink_cb_count == 2);
+  ASSERT_EQ(unlink_cb_count, 2);
 
   r = uv_fs_rmdir(loop, &rmdir_req, "test_dir", rmdir_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(rmdir_cb_count == 1);
+  ASSERT_EQ(rmdir_cb_count, 1);
 
   /* Cleanup */
   unlink("test_dir/file1");
@@ -1241,7 +1241,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(sendfile_cb_count == 1);
+  ASSERT_EQ(sendfile_cb_count, 1);
 
   r = uv_fs_close(NULL, &close_req, file1, NULL);
   ASSERT_EQ(r, 0);
@@ -1291,7 +1291,7 @@ TEST_IMPL(fs_mkdtemp) {
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdtemp_cb_count == 1);
+  ASSERT_EQ(mkdtemp_cb_count, 1);
 
   /* sync mkdtemp */
   r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
@@ -1324,7 +1324,7 @@ TEST_IMPL(fs_mkstemp) {
   ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkstemp_cb_count == 1);
+  ASSERT_EQ(mkstemp_cb_count, 1);
 
   /* sync mkstemp */
   r = uv_fs_mkstemp(NULL, &mkstemp_req2, path_template, NULL);
@@ -1515,7 +1515,7 @@ TEST_IMPL(fs_fstat) {
   r = uv_fs_fstat(loop, &req, file, fstat_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fstat_cb_count == 1);
+  ASSERT_EQ(fstat_cb_count, 1);
 
 
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -1558,7 +1558,7 @@ TEST_IMPL(fs_access) {
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(access_cb_count == 1);
+  ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Create file */
@@ -1579,7 +1579,7 @@ TEST_IMPL(fs_access) {
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(access_cb_count == 1);
+  ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
@@ -1671,7 +1671,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_chmod(loop, &req, "test_file", 0200, chmod_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chmod_cb_count == 1);
+  ASSERT_EQ(chmod_cb_count, 1);
   chmod_cb_count = 0; /* reset for the next test */
 #endif
 
@@ -1683,7 +1683,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_chmod(loop, &req, "test_file", 0400, chmod_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chmod_cb_count == 1);
+  ASSERT_EQ(chmod_cb_count, 1);
 
   /* async fchmod */
   {
@@ -1693,7 +1693,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_fchmod(loop, &req, file, 0600, fchmod_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fchmod_cb_count == 1);
+  ASSERT_EQ(fchmod_cb_count, 1);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -1873,7 +1873,7 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chown_cb_count == 1);
+  ASSERT_EQ(chown_cb_count, 1);
 
 #ifndef __MVS__
   /* chown to root (fail) */
@@ -1881,14 +1881,14 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chown_cb_count == 1);
+  ASSERT_EQ(chown_cb_count, 1);
 #endif
 
   /* async fchown */
   r = uv_fs_fchown(loop, &req, file, -1, -1, fchown_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fchown_cb_count == 1);
+  ASSERT_EQ(fchown_cb_count, 1);
 
 #ifndef __HAIKU__
   /* Haiku doesn't support hardlink */
@@ -1908,7 +1908,7 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_lchown(loop, &req, "test_file_link", -1, -1, lchown_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(lchown_cb_count == 1);
+  ASSERT_EQ(lchown_cb_count, 1);
 #endif
 
   /* Close file */
@@ -1993,7 +1993,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(link_cb_count == 1);
+  ASSERT_EQ(link_cb_count, 1);
 
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
   ASSERT_EQ(r, 0);
@@ -2036,7 +2036,7 @@ TEST_IMPL(fs_readlink) {
   loop = uv_default_loop();
   ASSERT(0 == uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(dummy_cb_count == 1);
+  ASSERT_EQ(dummy_cb_count, 1);
   ASSERT(req.ptr == NULL);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -2057,7 +2057,7 @@ TEST_IMPL(fs_realpath) {
   loop = uv_default_loop();
   ASSERT(0 == uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(dummy_cb_count == 1);
+  ASSERT_EQ(dummy_cb_count, 1);
   ASSERT(req.ptr == NULL);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -2194,7 +2194,7 @@ TEST_IMPL(fs_symlink) {
                     symlink_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(symlink_cb_count == 1);
+  ASSERT_EQ(symlink_cb_count, 1);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
   ASSERT_EQ(r, 0);
@@ -2227,12 +2227,12 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_readlink(loop, &req, "test_file_symlink2_symlink", readlink_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(readlink_cb_count == 1);
+  ASSERT_EQ(readlink_cb_count, 1);
 
   r = uv_fs_realpath(loop, &req, "test_file", realpath_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(realpath_cb_count == 1);
+  ASSERT_EQ(realpath_cb_count, 1);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -2359,8 +2359,8 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
@@ -2379,8 +2379,8 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
@@ -2486,8 +2486,8 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
 */
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 1);
-  ASSERT(scandir_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(scandir_req.result, 1);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     ASSERT(strcmp(dent.name, "test_file") == 0);
@@ -2617,7 +2617,7 @@ TEST_IMPL(fs_utime) {
   r = uv_fs_utime(loop, &utime_req, path, atime, mtime, utime_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(utime_cb_count == 1);
+  ASSERT_EQ(utime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2685,7 +2685,7 @@ TEST_IMPL(fs_utime_ex) {
   r = uv_fs_utime_ex(loop, &utime_req, path, btime, atime, mtime, utime_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(utime_cb_count == 1);
+  ASSERT_EQ(utime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2798,7 +2798,7 @@ TEST_IMPL(fs_futime) {
   r = uv_fs_futime(loop, &futime_req, file, atime, mtime, futime_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(futime_cb_count == 1);
+  ASSERT_EQ(futime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2882,7 +2882,7 @@ TEST_IMPL(fs_futime_ex) {
   r = uv_fs_futime_ex(loop, &futime_req, file, btime, atime, mtime, futime_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(futime_cb_count == 1);
+  ASSERT_EQ(futime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2947,7 +2947,7 @@ TEST_IMPL(fs_lutime) {
 #endif
   ASSERT_EQ(r, 0);
   lutime_cb(&req);
-  ASSERT(lutime_cb_count == 1);
+  ASSERT_EQ(lutime_cb_count, 1);
 
   /* Test the asynchronous version. */
   atime = mtime = 1291404900; /* 2010-12-03 20:35:00 */
@@ -2959,7 +2959,7 @@ TEST_IMPL(fs_lutime) {
   r = uv_fs_lutime(loop, &req, symlink_path, atime, mtime, lutime_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(lutime_cb_count == 2);
+  ASSERT_EQ(lutime_cb_count, 2);
 
   /* Cleanup. */
   unlink(path);
@@ -3013,7 +3013,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
 
   ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   uv_fs_rmdir(NULL, &req, path, NULL);
   uv_fs_req_cleanup(&req);
@@ -3050,7 +3050,7 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
 
   ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -3072,7 +3072,7 @@ TEST_IMPL(fs_scandir_file) {
 
   ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -3103,7 +3103,7 @@ TEST_IMPL(fs_open_dir) {
 
   ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -3165,8 +3165,8 @@ static void fs_file_open_append(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   printf("read = %d\n", r);
-  ASSERT(r == 26);
-  ASSERT(read_req.result == 26);
+  ASSERT_EQ(r, 26);
+  ASSERT_EQ(read_req.result, 26);
   ASSERT(memcmp(buf,
                 "test-buffer\n\0test-buffer\n\0",
                 sizeof("test-buffer\n\0test-buffer\n\0") - 1) == 0);
@@ -3290,7 +3290,7 @@ static void fs_read_bufs(int add_flags) {
                            2,  /* 2x 256 bytes. */
                            0,  /* Positional read. */
                            NULL));
-  ASSERT(read_req.result == 446);
+  ASSERT_EQ(read_req.result, 446);
   uv_fs_req_cleanup(&read_req);
 
   ASSERT(190 == uv_fs_read(NULL,
@@ -3723,7 +3723,7 @@ TEST_IMPL(fs_read_dir) {
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdir_cb_count == 1);
+  ASSERT_EQ(mkdir_cb_count, 1);
   /* Setup Done Here */
 
   /* Get a file descriptor for the directory */
@@ -4066,13 +4066,13 @@ static void fs_file_pos_common(uv_os_fd_t file) {
 
   iov = uv_buf_init("abc", 3);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 3);
+  ASSERT_EQ(r, 3);
   uv_fs_req_cleanup(&write_req);
 
   /* Read with offset should not change the position */
   iov = uv_buf_init(buf, 1);
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   ASSERT(buf[0] == 'b');
   uv_fs_req_cleanup(&read_req);
 
@@ -4084,7 +4084,7 @@ static void fs_file_pos_common(uv_os_fd_t file) {
   /* Write without offset should change the position */
   iov = uv_buf_init("d", 1);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -4145,7 +4145,7 @@ static void fs_file_pos_write(int add_flags) {
   /* Write with offset should not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -4187,12 +4187,12 @@ static void fs_file_pos_append(int add_flags) {
    * but does not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   ASSERT(buf[0] == 'e');
   uv_fs_req_cleanup(&read_req);
 
@@ -4576,13 +4576,13 @@ TEST_IMPL(fs_statfs) {
   r = uv_fs_statfs(NULL, &req, ".", NULL);
   ASSERT_EQ(r, 0);
   statfs_cb(&req);
-  ASSERT(statfs_cb_count == 1);
+  ASSERT_EQ(statfs_cb_count, 1);
 
   /* Test the asynchronous version. */
   r = uv_fs_statfs(loop, &req, ".", statfs_cb);
   ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(statfs_cb_count == 2);
+  ASSERT_EQ(statfs_cb_count, 2);
 
   return 0;
 }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -4073,7 +4073,7 @@ static void fs_file_pos_common(uv_os_fd_t file) {
   iov = uv_buf_init(buf, 1);
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, 1, NULL);
   ASSERT_EQ(r, 1);
-  ASSERT(buf[0] == 'b');
+  ASSERT_EQ(buf[0], 'b');
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -4193,7 +4193,7 @@ static void fs_file_pos_append(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT_EQ(r, 1);
-  ASSERT(buf[0] == 'e');
+  ASSERT_EQ(buf[0], 'e');
   uv_fs_req_cleanup(&read_req);
 
   fs_file_pos_close_check(file, "abcde", 5);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -341,7 +341,7 @@ static void fstat_cb(uv_fs_t* req) {
   uv_stat_t* s = req->ptr;
   ASSERT_EQ(req->fs_type, UV_FS_FSTAT);
   ASSERT_EQ(req->result, 0);
-  ASSERT(s->st_size == sizeof(test_buf));
+  ASSERT_EQ(s->st_size, sizeof(test_buf));
   uv_fs_req_cleanup(req);
   fstat_cb_count++;
 }
@@ -1346,8 +1346,8 @@ TEST_IMPL(fs_mkstemp) {
   /* We can write to the opened file */
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, fd1, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   /* Cleanup */
@@ -1424,8 +1424,8 @@ TEST_IMPL(fs_fstat) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
@@ -1433,7 +1433,7 @@ TEST_IMPL(fs_fstat) {
   ASSERT_EQ(r, 0);
   ASSERT_EQ(req.result, 0);
   s = req.ptr;
-  ASSERT(s->st_size == sizeof(test_buf));
+  ASSERT_EQ(s->st_size, sizeof(test_buf));
 
 #ifndef _WIN32
   r = fstat(file, &t);
@@ -1632,8 +1632,8 @@ TEST_IMPL(fs_chmod) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
 #ifndef _WIN32
@@ -1738,8 +1738,8 @@ TEST_IMPL(fs_unlink_readonly) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   /* Close file */
@@ -1801,8 +1801,8 @@ TEST_IMPL(fs_unlink_archive_readonly) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -1954,8 +1954,8 @@ TEST_IMPL(fs_link) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   /* Close file */
@@ -2106,8 +2106,8 @@ TEST_IMPL(fs_symlink) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   /* Close file */
@@ -3432,7 +3432,7 @@ static void fs_write_multiple_bufs(int add_flags) {
   ASSERT(uv_test_lseek(file, 0, SEEK_CUR) == 0);
   r = uv_fs_read(NULL, &read_req, file, iovs, 2, -1, NULL);
   ASSERT(r >= 0);
-  ASSERT(read_req.result == sizeof(test_buf) + sizeof(test_buf2));
+  ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
   ASSERT(strcmp(buf, test_buf) == 0);
   ASSERT(strcmp(buf2, test_buf2) == 0);
   uv_fs_req_cleanup(&read_req);
@@ -3453,9 +3453,9 @@ static void fs_write_multiple_bufs(int add_flags) {
     uv_fs_req_cleanup(&read_req);
     r = uv_fs_read(NULL, &read_req, file, &iovs[1], 1, read_req.result, NULL);
     ASSERT(r >= 0);
-    ASSERT(read_req.result == sizeof(test_buf2));
+    ASSERT_EQ(read_req.result, sizeof(test_buf2));
   } else {
-    ASSERT(read_req.result == sizeof(test_buf) + sizeof(test_buf2));
+    ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
   }
   ASSERT(strcmp(buf, test_buf) == 0);
   ASSERT(strcmp(buf2, test_buf2) == 0);
@@ -3527,7 +3527,7 @@ static void fs_write_alotof_bufs(int add_flags) {
                   -1,
                   NULL);
   ASSERT(r >= 0);
-  ASSERT((size_t) write_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_EQ((size_t) write_req.result, sizeof(test_buf) * iovcount);
   uv_fs_req_cleanup(&write_req);
 
   /* Read the strings back to separate buffers. */
@@ -3554,7 +3554,7 @@ static void fs_write_alotof_bufs(int add_flags) {
   if (iovcount > iovmax)
     iovcount = iovmax;
   ASSERT(r >= 0);
-  ASSERT((size_t) read_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_EQ((size_t) read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
     ASSERT(strncmp(buffer + index * sizeof(test_buf),
@@ -3649,7 +3649,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                   offset,
                   NULL);
   ASSERT(r >= 0);
-  ASSERT((size_t) write_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_EQ((size_t) write_req.result, sizeof(test_buf) * iovcount);
   uv_fs_req_cleanup(&write_req);
 
   /* Read the strings back to separate buffers. */
@@ -3667,7 +3667,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
     iovcount = 1; /* Infer that preadv is not available. */
   else if (iovcount > iovmax)
     iovcount = iovmax;
-  ASSERT((size_t) read_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_EQ((size_t) read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
     ASSERT(strncmp(buffer + index * sizeof(test_buf),
@@ -4034,7 +4034,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, 0, NULL);
-  ASSERT(r == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
 
   ASSERT(uv_test_lseek(file, 0, SEEK_CUR) == 0);
 
@@ -4042,7 +4042,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, 0, NULL);
-  ASSERT(r == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
   ASSERT(strcmp(buf, test_buf) == 0);
 
   ASSERT(uv_test_lseek(file, 0, SEEK_CUR) == 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1252,8 +1252,8 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
 
   ASSERT(0 == stat("test_file", &s1));
   ASSERT(0 == stat("test_file2", &s2));
-  ASSERT(s1.st_size == s2.st_size);
-  ASSERT(s2.st_size == expected_size);
+  ASSERT_EQ(s1.st_size, s2.st_size);
+  ASSERT_EQ(s2.st_size, expected_size);
 
   /* Cleanup. */
   unlink("test_file");
@@ -3633,8 +3633,8 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
 
   iov = uv_buf_init(filler, filler_len);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == filler_len);
-  ASSERT(write_req.result == filler_len);
+  ASSERT_EQ(r, filler_len);
+  ASSERT_EQ(write_req.result, filler_len);
   uv_fs_req_cleanup(&write_req);
   offset = (int64_t) r;
 
@@ -3807,7 +3807,7 @@ static void thread_main(void* arg) {
     if (ctx->doread) {
       result = write(ctx->fd, data, nbytes);
       /* Should not see EINTR (or other errors) */
-      ASSERT(result == nbytes);
+      ASSERT_EQ(result, nbytes);
     } else {
       result = read(ctx->fd, data, nbytes);
       /* Should not see EINTR (or other errors),
@@ -3899,8 +3899,8 @@ static void test_fs_partial(int doread) {
   } else {
     int result;
     result = uv_fs_write(loop, &write_req, pipe_fds[1], iovs, iovcount, -1, NULL);
-    ASSERT(write_req.result == result);
-    ASSERT(result == ctx.size);
+    ASSERT_EQ(write_req.result, result);
+    ASSERT_EQ(result, ctx.size);
     uv_fs_req_cleanup(&write_req);
   }
 
@@ -4110,7 +4110,7 @@ static void fs_file_pos_close_check(uv_os_fd_t file, const char *contents, int s
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == size);
+  ASSERT_EQ(r, size);
   ASSERT(strncmp(buf, contents, size) == 0);
   uv_fs_req_cleanup(&read_req);
 
@@ -4338,7 +4338,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT(r < 0);
-  ASSERT(open_req2.result == r);
+  ASSERT_EQ(open_req2.result, r);
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1409,8 +1409,8 @@ TEST_IMPL(fs_fstat) {
   ASSERT_EQ(req.result, 0);
   s = req.ptr;
 # if defined(__APPLE__)
-  ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
-  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtimespec.tv_nsec);
+  ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtimespec.tv_sec);
+  ASSERT_EQ(s->st_birthtim.tv_nsec, t.st_birthtimespec.tv_nsec);
 # elif defined(__linux__)
   /* If statx() is supported, the birth time should be equal to the change time
    * because we just created the file. On older kernels, it's set to zero.
@@ -1450,26 +1450,26 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_blksize == (uint64_t) t.st_blksize);
   ASSERT(s->st_blocks == (uint64_t) t.st_blocks);
 #if defined(__APPLE__)
-  ASSERT(s->st_atim.tv_sec == t.st_atimespec.tv_sec);
-  ASSERT(s->st_atim.tv_nsec == t.st_atimespec.tv_nsec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtimespec.tv_sec);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtimespec.tv_nsec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctimespec.tv_sec);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atimespec.tv_sec);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimespec.tv_nsec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtimespec.tv_sec);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtimespec.tv_nsec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctimespec.tv_sec);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctimespec.tv_nsec);
 #elif defined(_AIX)
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
   ASSERT_EQ(s->st_atim.tv_nsec, 0);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
   ASSERT_EQ(s->st_mtim.tv_nsec, 0);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
   ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #elif defined(__ANDROID__)
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == t.st_atimensec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtimensec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctimensec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimensec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtimensec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctimensec);
 #elif defined(__sun)           || \
       defined(__DragonFly__)   || \
       defined(__FreeBSD__)     || \
@@ -1480,30 +1480,30 @@ TEST_IMPL(fs_fstat) {
       defined(_SVID_SOURCE)    || \
       defined(_XOPEN_SOURCE)   || \
       defined(_DEFAULT_SOURCE)
-  ASSERT(s->st_atim.tv_sec == t.st_atim.tv_sec);
-  ASSERT(s->st_atim.tv_nsec == t.st_atim.tv_nsec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtim.tv_sec);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtim.tv_nsec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctim.tv_sec);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctim.tv_nsec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atim.tv_sec);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atim.tv_nsec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtim.tv_sec);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtim.tv_nsec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctim.tv_sec);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctim.tv_nsec);
 # if defined(__FreeBSD__)    || \
      defined(__NetBSD__)
-  ASSERT(s->st_birthtim.tv_sec == t.st_birthtim.tv_sec);
-  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtim.tv_nsec);
+  ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtim.tv_sec);
+  ASSERT_EQ(s->st_birthtim.tv_nsec, t.st_birthtim.tv_nsec);
 # endif
 #else
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
   ASSERT_EQ(s->st_atim.tv_nsec, 0);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
   ASSERT_EQ(s->st_mtim.tv_nsec, 0);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
   ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #endif
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
-  ASSERT(s->st_flags == t.st_flags);
-  ASSERT(s->st_gen == t.st_gen);
+  ASSERT_EQ(s->st_flags, t.st_flags);
+  ASSERT_EQ(s->st_gen, t.st_gen);
 #else
   ASSERT_EQ(s->st_flags, 0);
   ASSERT_EQ(s->st_gen, 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -853,8 +853,8 @@ static void check_utime_ex(const char* path,
   }
 #endif
 
-  ASSERT(s->st_atim.tv_sec + (s->st_atim.tv_nsec / 1000000000.0) == atime);
-  ASSERT(s->st_mtim.tv_sec + (s->st_mtim.tv_nsec / 1000000000.0) == mtime);
+  ASSERT_EQ(s->st_atim.tv_sec + (s->st_atim.tv_nsec / 1000000000.0), atime);
+  ASSERT_EQ(s->st_mtim.tv_sec + (s->st_mtim.tv_nsec / 1000000000.0), mtime);
 
   uv_fs_req_cleanup(&req);
 }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1439,16 +1439,16 @@ TEST_IMPL(fs_fstat) {
   r = fstat(file, &t);
   ASSERT_EQ(r, 0);
 
-  ASSERT(s->st_dev == (uint64_t) t.st_dev);
-  ASSERT(s->st_mode == (uint64_t) t.st_mode);
-  ASSERT(s->st_nlink == (uint64_t) t.st_nlink);
-  ASSERT(s->st_uid == (uint64_t) t.st_uid);
-  ASSERT(s->st_gid == (uint64_t) t.st_gid);
-  ASSERT(s->st_rdev == (uint64_t) t.st_rdev);
-  ASSERT(s->st_ino == (uint64_t) t.st_ino);
-  ASSERT(s->st_size == (uint64_t) t.st_size);
-  ASSERT(s->st_blksize == (uint64_t) t.st_blksize);
-  ASSERT(s->st_blocks == (uint64_t) t.st_blocks);
+  ASSERT_EQ(s->st_dev, (uint64_t) t.st_dev);
+  ASSERT_EQ(s->st_mode, (uint64_t) t.st_mode);
+  ASSERT_EQ(s->st_nlink, (uint64_t) t.st_nlink);
+  ASSERT_EQ(s->st_uid, (uint64_t) t.st_uid);
+  ASSERT_EQ(s->st_gid, (uint64_t) t.st_gid);
+  ASSERT_EQ(s->st_rdev, (uint64_t) t.st_rdev);
+  ASSERT_EQ(s->st_ino, (uint64_t) t.st_ino);
+  ASSERT_EQ(s->st_size, (uint64_t) t.st_size);
+  ASSERT_EQ(s->st_blksize, (uint64_t) t.st_blksize);
+  ASSERT_EQ(s->st_blocks, (uint64_t) t.st_blocks);
 #if defined(__APPLE__)
   ASSERT_EQ(s->st_atim.tv_sec, t.st_atimespec.tv_sec);
   ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimespec.tv_nsec);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -187,7 +187,7 @@ static void check_permission(const char* filename, unsigned int mode) {
 
   r = uv_fs_stat(NULL, &req, filename, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
 
   s = &req.statbuf;
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
@@ -212,7 +212,7 @@ static void dummy_cb(uv_fs_t* req) {
 
 static void link_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_LINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   link_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -220,14 +220,14 @@ static void link_cb(uv_fs_t* req) {
 
 static void symlink_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_SYMLINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   symlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void readlink_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_READLINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(strcmp(req->ptr, "test_file_symlink2") == 0);
   readlink_cb_count++;
   uv_fs_req_cleanup(req);
@@ -238,7 +238,7 @@ static void realpath_cb(uv_fs_t* req) {
   char test_file_abs_buf[PATHMAX];
   size_t test_file_abs_size = sizeof(test_file_abs_buf);
   ASSERT(req->fs_type == UV_FS_REALPATH);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
 
   uv_cwd(test_file_abs_buf, &test_file_abs_size);
 #ifdef _WIN32
@@ -262,7 +262,7 @@ static void access_cb(uv_fs_t* req) {
 
 static void fchmod_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_FCHMOD);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   fchmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -271,7 +271,7 @@ static void fchmod_cb(uv_fs_t* req) {
 
 static void chmod_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_CHMOD);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   chmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -280,7 +280,7 @@ static void chmod_cb(uv_fs_t* req) {
 
 static void fchown_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_FCHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   fchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -288,14 +288,14 @@ static void fchown_cb(uv_fs_t* req) {
 
 static void chown_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_CHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   chown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void lchown_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_LCHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   lchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -304,13 +304,13 @@ static void chown_root_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_CHOWN);
 #if defined(_WIN32) || defined(__MSYS__)
   /* On windows, chown is a no-op and always succeeds. */
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
 #else
   /* On unix, chown'ing the root directory is not allowed -
    * unless you're root, of course.
    */
   if (geteuid() == 0)
-    ASSERT(req->result == 0);
+    ASSERT_EQ(req->result, 0);
   else
 #   if defined(__CYGWIN__)
     /* On Cygwin, uid 0 is invalid (no root). */
@@ -332,7 +332,7 @@ static void chown_root_cb(uv_fs_t* req) {
 static void unlink_cb(uv_fs_t* req) {
   ASSERT(req == &unlink_req);
   ASSERT(req->fs_type == UV_FS_UNLINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   unlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -340,7 +340,7 @@ static void unlink_cb(uv_fs_t* req) {
 static void fstat_cb(uv_fs_t* req) {
   uv_stat_t* s = req->ptr;
   ASSERT(req->fs_type == UV_FS_FSTAT);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(s->st_size == sizeof(test_buf));
   uv_fs_req_cleanup(req);
   fstat_cb_count++;
@@ -351,13 +351,13 @@ static void statfs_cb(uv_fs_t* req) {
   uv_statfs_t* stats;
 
   ASSERT(req->fs_type == UV_FS_STATFS);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
   stats = req->ptr;
 
 #if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
   defined(__OpenBSD__) || defined(__NetBSD__)
-  ASSERT(stats->f_type == 0);
+  ASSERT_EQ(stats->f_type, 0);
 #else
   ASSERT(stats->f_type > 0);
 #endif
@@ -368,8 +368,8 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT(stats->f_bavail <= stats->f_bfree);
 
 #ifdef _WIN32
-  ASSERT(stats->f_files == 0);
-  ASSERT(stats->f_ffree == 0);
+  ASSERT_EQ(stats->f_files, 0);
+  ASSERT_EQ(stats->f_ffree, 0);
 #else
   /* There is no assertion for stats->f_files that makes sense, so ignore it. */
   ASSERT(stats->f_ffree <= stats->f_files);
@@ -384,7 +384,7 @@ static void close_cb(uv_fs_t* req) {
   int r;
   ASSERT(req == &close_req);
   ASSERT(req->fs_type == UV_FS_CLOSE);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   close_cb_count++;
   uv_fs_req_cleanup(req);
   if (close_cb_count == 3) {
@@ -399,7 +399,7 @@ static void ftruncate_cb(uv_fs_t* req) {
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &ftruncate_req);
   ASSERT(req->fs_type == UV_FS_FTRUNCATE);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, file, close_cb);
@@ -468,7 +468,7 @@ static void fsync_cb(uv_fs_t* req) {
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &fsync_req);
   ASSERT(req->fs_type == UV_FS_FSYNC);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, file, close_cb);
@@ -481,7 +481,7 @@ static void fdatasync_cb(uv_fs_t* req) {
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &fdatasync_req);
   ASSERT(req->fs_type == UV_FS_FDATASYNC);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fsync(loop, &fsync_req, file, fsync_cb);
@@ -519,7 +519,7 @@ static void create_cb(uv_fs_t* req) {
 static void rename_cb(uv_fs_t* req) {
   ASSERT(req == &rename_req);
   ASSERT(req->fs_type == UV_FS_RENAME);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   rename_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -528,7 +528,7 @@ static void rename_cb(uv_fs_t* req) {
 static void mkdir_cb(uv_fs_t* req) {
   ASSERT(req == &mkdir_req);
   ASSERT(req->fs_type == UV_FS_MKDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   mkdir_cb_count++;
   ASSERT(req->path);
   ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
@@ -540,7 +540,7 @@ static void check_mkdtemp_result(uv_fs_t* req) {
   int r;
 
   ASSERT(req->fs_type == UV_FS_MKDTEMP);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->path);
   ASSERT(strlen(req->path) == 15);
   ASSERT(memcmp(req->path, "test_dir_", 9) == 0);
@@ -591,7 +591,7 @@ static void mkstemp_cb(uv_fs_t* req) {
 static void rmdir_cb(uv_fs_t* req) {
   ASSERT(req == &rmdir_req);
   ASSERT(req->fs_type == UV_FS_RMDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   rmdir_cb_count++;
   ASSERT(req->path);
   ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
@@ -645,7 +645,7 @@ static void empty_scandir_cb(uv_fs_t* req) {
 
   ASSERT(req == &scandir_req);
   ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr == NULL);
   ASSERT(UV_EOF == uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
@@ -678,7 +678,7 @@ static void file_scandir_cb(uv_fs_t* req) {
 static void stat_cb(uv_fs_t* req) {
   ASSERT(req == &stat_req);
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr);
   stat_cb_count++;
   uv_fs_req_cleanup(req);
@@ -698,7 +698,7 @@ static void sendfile_cb(uv_fs_t* req) {
 static void sendfile_nodata_cb(uv_fs_t* req) {
   ASSERT(req == &sendfile_req);
   ASSERT(req->fs_type == UV_FS_SENDFILE);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -834,7 +834,7 @@ static void check_utime_ex(const char* path,
     r = uv_fs_stat(loop, &req, path, NULL);
 
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   s = &req.statbuf;
 
 #if defined(__APPLE__) || defined(_WIN32)
@@ -869,7 +869,7 @@ static void utime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
   ASSERT(req == &utime_req);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->fs_type == UV_FS_UTIME);
 
   c = req->data;
@@ -884,7 +884,7 @@ static void futime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
   ASSERT(req == &futime_req);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->fs_type == UV_FS_FUTIME);
 
   c = req->data;
@@ -898,7 +898,7 @@ static void futime_cb(uv_fs_t* req) {
 static void lutime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->fs_type == UV_FS_LUTIME);
 
   c = req->data;
@@ -997,7 +997,7 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | add_flags, 0, NULL);
@@ -1015,17 +1015,17 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_ftruncate(NULL, &ftruncate_req, file, 7, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(ftruncate_req.result == 0);
+  ASSERT_EQ(ftruncate_req.result, 0);
   uv_fs_req_cleanup(&ftruncate_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(rename_req.result == 0);
+  ASSERT_EQ(rename_req.result, 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY | add_flags, 0,
@@ -1045,12 +1045,12 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_unlink(NULL, &unlink_req, "test_file2", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(unlink_req.result == 0);
+  ASSERT_EQ(unlink_req.result, 0);
   uv_fs_req_cleanup(&unlink_req);
 
   /* Cleanup */
@@ -1085,12 +1085,12 @@ static void fs_file_write_null_buffer(int add_flags) {
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(write_req.result == 0);
+  ASSERT_EQ(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   unlink("test_file");
@@ -1406,7 +1406,7 @@ TEST_IMPL(fs_fstat) {
 #ifndef _WIN32
   ASSERT(0 == fstat(file, &t));
   ASSERT(0 == uv_fs_fstat(NULL, &req, file, NULL));
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   s = req.ptr;
 # if defined(__APPLE__)
   ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
@@ -1431,7 +1431,7 @@ TEST_IMPL(fs_fstat) {
   memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
   r = uv_fs_fstat(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   s = req.ptr;
   ASSERT(s->st_size == sizeof(test_buf));
 
@@ -1458,11 +1458,11 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
 #elif defined(_AIX)
   ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == 0);
+  ASSERT_EQ(s->st_atim.tv_nsec, 0);
   ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == 0);
+  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
   ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == 0);
+  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #elif defined(__ANDROID__)
   ASSERT(s->st_atim.tv_sec == t.st_atime);
   ASSERT(s->st_atim.tv_nsec == t.st_atimensec);
@@ -1493,11 +1493,11 @@ TEST_IMPL(fs_fstat) {
 # endif
 #else
   ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == 0);
+  ASSERT_EQ(s->st_atim.tv_nsec, 0);
   ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == 0);
+  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
   ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == 0);
+  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #endif
 #endif
 
@@ -1505,8 +1505,8 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_flags == t.st_flags);
   ASSERT(s->st_gen == t.st_gen);
 #else
-  ASSERT(s->st_flags == 0);
-  ASSERT(s->st_gen == 0);
+  ASSERT_EQ(s->st_flags, 0);
+  ASSERT_EQ(s->st_gen, 0);
 #endif
 
   uv_fs_req_cleanup(&req);
@@ -1520,7 +1520,7 @@ TEST_IMPL(fs_fstat) {
 
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1572,7 +1572,7 @@ TEST_IMPL(fs_access) {
   /* File should exist */
   r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
@@ -1585,7 +1585,7 @@ TEST_IMPL(fs_access) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* Directory access */
@@ -1595,7 +1595,7 @@ TEST_IMPL(fs_access) {
 
   r = uv_fs_access(NULL, &req, "test_dir", W_OK, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1640,7 +1640,7 @@ TEST_IMPL(fs_chmod) {
   /* Make the file write-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0200, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0200);
@@ -1649,7 +1649,7 @@ TEST_IMPL(fs_chmod) {
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
@@ -1657,7 +1657,7 @@ TEST_IMPL(fs_chmod) {
   /* Make the file read+write with sync uv_fs_fchmod */
   r = uv_fs_fchmod(NULL, &req, file, 0600, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0600);
@@ -1698,7 +1698,7 @@ TEST_IMPL(fs_chmod) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1745,13 +1745,13 @@ TEST_IMPL(fs_unlink_readonly) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
@@ -1759,7 +1759,7 @@ TEST_IMPL(fs_unlink_readonly) {
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1807,7 +1807,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
 
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* Make the file read-only and clear archive flag */
@@ -1820,7 +1820,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1860,13 +1860,13 @@ TEST_IMPL(fs_chown) {
   /* sync chown */
   r = uv_fs_chown(NULL, &req, "test_file", -1, -1, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync fchown */
   r = uv_fs_fchown(NULL, &req, file, -1, -1, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* async chown */
@@ -1895,13 +1895,13 @@ TEST_IMPL(fs_chown) {
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync lchown */
   r = uv_fs_lchown(NULL, &req, "test_file_link", -1, -1, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* async lchown */
@@ -1914,7 +1914,7 @@ TEST_IMPL(fs_chown) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1961,13 +1961,13 @@ TEST_IMPL(fs_link) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
@@ -1986,7 +1986,7 @@ TEST_IMPL(fs_link) {
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* async link */
@@ -2011,7 +2011,7 @@ TEST_IMPL(fs_link) {
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -2113,7 +2113,7 @@ TEST_IMPL(fs_symlink) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync symlink */
@@ -2136,7 +2136,7 @@ TEST_IMPL(fs_symlink) {
   }
 #endif
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
@@ -2155,7 +2155,7 @@ TEST_IMPL(fs_symlink) {
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_symlink(NULL,
@@ -2212,7 +2212,7 @@ TEST_IMPL(fs_symlink) {
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_symlink(NULL,
@@ -2295,7 +2295,7 @@ int test_symlink_dir_impl(int type) {
   }
   fprintf(stderr, "r == %i\n", r);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, "test_dir_symlink", NULL);
@@ -2582,7 +2582,7 @@ TEST_IMPL(fs_utime) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
@@ -2598,12 +2598,12 @@ TEST_IMPL(fs_utime) {
 
   r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   uv_fs_req_cleanup(&req);
 
@@ -2649,7 +2649,7 @@ TEST_IMPL(fs_utime_ex) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   atime = btime = mtime = 400497753; /* 1982-09-10 11:22:33 */
@@ -2665,12 +2665,12 @@ TEST_IMPL(fs_utime_ex) {
 
   r = uv_fs_utime_ex(NULL, &req, path, btime, atime, mtime, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   check_utime_ex(path, btime, atime, mtime, 0);
   uv_fs_req_cleanup(&req);
 
@@ -2751,7 +2751,7 @@ TEST_IMPL(fs_futime) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   atime = mtime = 400497753; /* 1982-09-10 11:22:33 */
@@ -2777,13 +2777,13 @@ TEST_IMPL(fs_futime) {
   RETURN_SKIP("futime not supported on Cygwin");
 #else
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   uv_fs_req_cleanup(&req);
 
@@ -2833,7 +2833,7 @@ TEST_IMPL(fs_futime_ex) {
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   atime = btime = mtime = 400497753; /* 1982-09-10 11:22:33 */
@@ -2860,13 +2860,13 @@ TEST_IMPL(fs_futime_ex) {
   RETURN_SKIP("futime not supported on Cygwin");
 #else
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   check_utime_ex(path, btime, atime, mtime, 0);
   uv_fs_req_cleanup(&req);
 
@@ -2924,7 +2924,7 @@ TEST_IMPL(fs_lutime) {
   }
 #endif
   ASSERT_EQ(s, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* Test the synchronous version. */
@@ -3003,7 +3003,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(req.result, 0);
   ASSERT(req.ptr == NULL);
   ASSERT(UV_EOF == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
@@ -3134,7 +3134,7 @@ static void fs_file_open_append(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
@@ -3152,7 +3152,7 @@ static void fs_file_open_append(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags,
@@ -3174,7 +3174,7 @@ static void fs_file_open_append(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3214,7 +3214,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
@@ -3226,12 +3226,12 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(rename_req.result == 0);
+  ASSERT_EQ(rename_req.result, 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
@@ -3250,7 +3250,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3307,7 +3307,7 @@ static void fs_read_bufs(int add_flags) {
   ASSERT(0 == memcmp(bufs[1].base + 128, bufs[3].base, 190 - 128));
 
   ASSERT(0 == uv_fs_close(NULL, &close_req, file, NULL));
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 }
 TEST_IMPL(fs_read_bufs) {
@@ -3346,7 +3346,7 @@ static void fs_read_file_eof(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3368,12 +3368,12 @@ static void fs_read_file_eof(int add_flags) {
   r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  read_req.result, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3414,7 +3414,7 @@ static void fs_write_multiple_bufs(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3440,7 +3440,7 @@ static void fs_write_multiple_bufs(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   /* Read the strings back to separate buffers. */
@@ -3465,12 +3465,12 @@ static void fs_write_multiple_bufs(int add_flags) {
   r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  sizeof(test_buf) + sizeof(test_buf2), NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3540,7 +3540,7 @@ static void fs_write_alotof_bufs(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3574,12 +3574,12 @@ static void fs_write_alotof_bufs(int add_flags) {
                  -1,
                  NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3692,12 +3692,12 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  offset + write_req.result,
                  NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4343,7 +4343,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL,
@@ -4359,7 +4359,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4397,7 +4397,7 @@ TEST_IMPL(fs_file_flag_no_buffering) {
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* FILE_APPEND_DATA and FILE_FLAG_NO_BUFFERING are mutually exclusive: */
@@ -4467,7 +4467,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     uv_fs_req_cleanup(&open_req1);
     r = uv_fs_close(NULL, &close_req, (uv_os_fd_t) open_req1.result, NULL);
     ASSERT_EQ(r, 0);
-    ASSERT(close_req.result == 0);
+    ASSERT_EQ(close_req.result, 0);
     uv_fs_req_cleanup(&close_req);
 
     /* Set up ACL */
@@ -4539,7 +4539,7 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     uv_fs_req_cleanup(&req);
     r = uv_fs_fchmod(NULL, &req, file, S_IWUSR, NULL);
     ASSERT_EQ(r, 0);
-    ASSERT(req.result == 0);
+    ASSERT_EQ(req.result, 0);
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
     ASSERT_EQ(r, 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -330,7 +330,7 @@ static void chown_root_cb(uv_fs_t* req) {
 }
 
 static void unlink_cb(uv_fs_t* req) {
-  ASSERT(req == &unlink_req);
+  ASSERT_EQ(req, &unlink_req);
   ASSERT_EQ(req->fs_type, UV_FS_UNLINK);
   ASSERT_EQ(req->result, 0);
   unlink_cb_count++;
@@ -382,7 +382,7 @@ static void statfs_cb(uv_fs_t* req) {
 
 static void close_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &close_req);
+  ASSERT_EQ(req, &close_req);
   ASSERT_EQ(req->fs_type, UV_FS_CLOSE);
   ASSERT_EQ(req->result, 0);
   close_cb_count++;
@@ -397,7 +397,7 @@ static void close_cb(uv_fs_t* req) {
 static void ftruncate_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &ftruncate_req);
+  ASSERT_EQ(req, &ftruncate_req);
   ASSERT_EQ(req->fs_type, UV_FS_FTRUNCATE);
   ASSERT_EQ(req->result, 0);
   ftruncate_cb_count++;
@@ -413,7 +413,7 @@ static void fail_cb(uv_fs_t* req) {
 static void read_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &read_req);
+  ASSERT_EQ(req, &read_req);
   ASSERT_EQ(req->fs_type, UV_FS_READ);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
   read_cb_count++;
@@ -433,7 +433,7 @@ static void read_cb(uv_fs_t* req) {
 static void open_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &open_req1);
+  ASSERT_EQ(req, &open_req1);
   ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
@@ -466,7 +466,7 @@ static void open_cb_simple(uv_fs_t* req) {
 static void fsync_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &fsync_req);
+  ASSERT_EQ(req, &fsync_req);
   ASSERT_EQ(req->fs_type, UV_FS_FSYNC);
   ASSERT_EQ(req->result, 0);
   fsync_cb_count++;
@@ -479,7 +479,7 @@ static void fsync_cb(uv_fs_t* req) {
 static void fdatasync_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &fdatasync_req);
+  ASSERT_EQ(req, &fdatasync_req);
   ASSERT_EQ(req->fs_type, UV_FS_FDATASYNC);
   ASSERT_EQ(req->result, 0);
   fdatasync_cb_count++;
@@ -492,7 +492,7 @@ static void fdatasync_cb(uv_fs_t* req) {
 static void write_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &write_req);
+  ASSERT_EQ(req, &write_req);
   ASSERT_EQ(req->fs_type, UV_FS_WRITE);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
   write_cb_count++;
@@ -505,7 +505,7 @@ static void write_cb(uv_fs_t* req) {
 static void create_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
-  ASSERT(req == &open_req1);
+  ASSERT_EQ(req, &open_req1);
   ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   ASSERT(req->result >= 0);
   create_cb_count++;
@@ -517,7 +517,7 @@ static void create_cb(uv_fs_t* req) {
 
 
 static void rename_cb(uv_fs_t* req) {
-  ASSERT(req == &rename_req);
+  ASSERT_EQ(req, &rename_req);
   ASSERT_EQ(req->fs_type, UV_FS_RENAME);
   ASSERT_EQ(req->result, 0);
   rename_cb_count++;
@@ -526,7 +526,7 @@ static void rename_cb(uv_fs_t* req) {
 
 
 static void mkdir_cb(uv_fs_t* req) {
-  ASSERT(req == &mkdir_req);
+  ASSERT_EQ(req, &mkdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_MKDIR);
   ASSERT_EQ(req->result, 0);
   mkdir_cb_count++;
@@ -556,7 +556,7 @@ static void check_mkdtemp_result(uv_fs_t* req) {
 
 
 static void mkdtemp_cb(uv_fs_t* req) {
-  ASSERT(req == &mkdtemp_req1);
+  ASSERT_EQ(req, &mkdtemp_req1);
   check_mkdtemp_result(req);
   mkdtemp_cb_count++;
 }
@@ -582,14 +582,14 @@ static void check_mkstemp_result(uv_fs_t* req) {
 
 
 static void mkstemp_cb(uv_fs_t* req) {
-  ASSERT(req == &mkstemp_req1);
+  ASSERT_EQ(req, &mkstemp_req1);
   check_mkstemp_result(req);
   mkstemp_cb_count++;
 }
 
 
 static void rmdir_cb(uv_fs_t* req) {
-  ASSERT(req == &rmdir_req);
+  ASSERT_EQ(req, &rmdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_RMDIR);
   ASSERT_EQ(req->result, 0);
   rmdir_cb_count++;
@@ -623,7 +623,7 @@ static void assert_is_file_type(uv_dirent_t dent) {
 
 static void scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
-  ASSERT(req == &scandir_req);
+  ASSERT_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, 2);
   ASSERT(req->ptr);
@@ -643,7 +643,7 @@ static void scandir_cb(uv_fs_t* req) {
 static void empty_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
-  ASSERT(req == &scandir_req);
+  ASSERT_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, 0);
   ASSERT_EQ(req->ptr, NULL);
@@ -655,7 +655,7 @@ static void empty_scandir_cb(uv_fs_t* req) {
 static void non_existent_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
-  ASSERT(req == &scandir_req);
+  ASSERT_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, UV_ENOENT);
   ASSERT_EQ(req->ptr, NULL);
@@ -666,7 +666,7 @@ static void non_existent_scandir_cb(uv_fs_t* req) {
 
 
 static void file_scandir_cb(uv_fs_t* req) {
-  ASSERT(req == &scandir_req);
+  ASSERT_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, UV_ENOTDIR);
   ASSERT_EQ(req->ptr, NULL);
@@ -676,7 +676,7 @@ static void file_scandir_cb(uv_fs_t* req) {
 
 
 static void stat_cb(uv_fs_t* req) {
-  ASSERT(req == &stat_req);
+  ASSERT_EQ(req, &stat_req);
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr);
@@ -687,7 +687,7 @@ static void stat_cb(uv_fs_t* req) {
 
 
 static void sendfile_cb(uv_fs_t* req) {
-  ASSERT(req == &sendfile_req);
+  ASSERT_EQ(req, &sendfile_req);
   ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
   ASSERT_EQ(req->result, 65546);
   sendfile_cb_count++;
@@ -696,7 +696,7 @@ static void sendfile_cb(uv_fs_t* req) {
 
 
 static void sendfile_nodata_cb(uv_fs_t* req) {
-  ASSERT(req == &sendfile_req);
+  ASSERT_EQ(req, &sendfile_req);
   ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
   ASSERT_EQ(req->result, 0);
   sendfile_cb_count++;
@@ -868,7 +868,7 @@ static void check_utime(const char* path, double atime, double mtime, int test_l
 static void utime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req == &utime_req);
+  ASSERT_EQ(req, &utime_req);
   ASSERT_EQ(req->result, 0);
   ASSERT_EQ(req->fs_type, UV_FS_UTIME);
 
@@ -883,7 +883,7 @@ static void utime_cb(uv_fs_t* req) {
 static void futime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req == &futime_req);
+  ASSERT_EQ(req, &futime_req);
   ASSERT_EQ(req->result, 0);
   ASSERT_EQ(req->fs_type, UV_FS_FUTIME);
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -211,7 +211,7 @@ static void dummy_cb(uv_fs_t* req) {
 
 
 static void link_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_LINK);
+  ASSERT_EQ(req->fs_type, UV_FS_LINK);
   ASSERT_EQ(req->result, 0);
   link_cb_count++;
   uv_fs_req_cleanup(req);
@@ -219,14 +219,14 @@ static void link_cb(uv_fs_t* req) {
 
 
 static void symlink_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_SYMLINK);
+  ASSERT_EQ(req->fs_type, UV_FS_SYMLINK);
   ASSERT_EQ(req->result, 0);
   symlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void readlink_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_READLINK);
+  ASSERT_EQ(req->fs_type, UV_FS_READLINK);
   ASSERT_EQ(req->result, 0);
   ASSERT(strcmp(req->ptr, "test_file_symlink2") == 0);
   readlink_cb_count++;
@@ -237,7 +237,7 @@ static void readlink_cb(uv_fs_t* req) {
 static void realpath_cb(uv_fs_t* req) {
   char test_file_abs_buf[PATHMAX];
   size_t test_file_abs_size = sizeof(test_file_abs_buf);
-  ASSERT(req->fs_type == UV_FS_REALPATH);
+  ASSERT_EQ(req->fs_type, UV_FS_REALPATH);
   ASSERT_EQ(req->result, 0);
 
   uv_cwd(test_file_abs_buf, &test_file_abs_size);
@@ -254,14 +254,14 @@ static void realpath_cb(uv_fs_t* req) {
 
 
 static void access_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_ACCESS);
+  ASSERT_EQ(req->fs_type, UV_FS_ACCESS);
   access_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void fchmod_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_FCHMOD);
+  ASSERT_EQ(req->fs_type, UV_FS_FCHMOD);
   ASSERT_EQ(req->result, 0);
   fchmod_cb_count++;
   uv_fs_req_cleanup(req);
@@ -270,7 +270,7 @@ static void fchmod_cb(uv_fs_t* req) {
 
 
 static void chmod_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHMOD);
+  ASSERT_EQ(req->fs_type, UV_FS_CHMOD);
   ASSERT_EQ(req->result, 0);
   chmod_cb_count++;
   uv_fs_req_cleanup(req);
@@ -279,7 +279,7 @@ static void chmod_cb(uv_fs_t* req) {
 
 
 static void fchown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_FCHOWN);
+  ASSERT_EQ(req->fs_type, UV_FS_FCHOWN);
   ASSERT_EQ(req->result, 0);
   fchown_cb_count++;
   uv_fs_req_cleanup(req);
@@ -287,21 +287,21 @@ static void fchown_cb(uv_fs_t* req) {
 
 
 static void chown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHOWN);
+  ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
   ASSERT_EQ(req->result, 0);
   chown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void lchown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_LCHOWN);
+  ASSERT_EQ(req->fs_type, UV_FS_LCHOWN);
   ASSERT_EQ(req->result, 0);
   lchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void chown_root_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHOWN);
+  ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
 #if defined(_WIN32) || defined(__MSYS__)
   /* On windows, chown is a no-op and always succeeds. */
   ASSERT_EQ(req->result, 0);
@@ -314,7 +314,7 @@ static void chown_root_cb(uv_fs_t* req) {
   else
 #   if defined(__CYGWIN__)
     /* On Cygwin, uid 0 is invalid (no root). */
-    ASSERT(req->result == UV_EINVAL);
+    ASSERT_EQ(req->result, UV_EINVAL);
 #   elif defined(__PASE__)
     /* On IBMi PASE, there is no root user. uid 0 is user qsecofr.
      * User may grant qsecofr's privileges, including changing 
@@ -322,7 +322,7 @@ static void chown_root_cb(uv_fs_t* req) {
      */
     ASSERT(req->result == 0 || req->result == UV_EPERM);
 #   else
-    ASSERT(req->result == UV_EPERM);
+    ASSERT_EQ(req->result, UV_EPERM);
 #   endif
 #endif
   chown_cb_count++;
@@ -331,7 +331,7 @@ static void chown_root_cb(uv_fs_t* req) {
 
 static void unlink_cb(uv_fs_t* req) {
   ASSERT(req == &unlink_req);
-  ASSERT(req->fs_type == UV_FS_UNLINK);
+  ASSERT_EQ(req->fs_type, UV_FS_UNLINK);
   ASSERT_EQ(req->result, 0);
   unlink_cb_count++;
   uv_fs_req_cleanup(req);
@@ -339,7 +339,7 @@ static void unlink_cb(uv_fs_t* req) {
 
 static void fstat_cb(uv_fs_t* req) {
   uv_stat_t* s = req->ptr;
-  ASSERT(req->fs_type == UV_FS_FSTAT);
+  ASSERT_EQ(req->fs_type, UV_FS_FSTAT);
   ASSERT_EQ(req->result, 0);
   ASSERT(s->st_size == sizeof(test_buf));
   uv_fs_req_cleanup(req);
@@ -350,7 +350,7 @@ static void fstat_cb(uv_fs_t* req) {
 static void statfs_cb(uv_fs_t* req) {
   uv_statfs_t* stats;
 
-  ASSERT(req->fs_type == UV_FS_STATFS);
+  ASSERT_EQ(req->fs_type, UV_FS_STATFS);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr != NULL);
   stats = req->ptr;
@@ -375,7 +375,7 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT(stats->f_ffree <= stats->f_files);
 #endif
   uv_fs_req_cleanup(req);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->ptr, NULL);
   statfs_cb_count++;
 }
 
@@ -383,7 +383,7 @@ static void statfs_cb(uv_fs_t* req) {
 static void close_cb(uv_fs_t* req) {
   int r;
   ASSERT(req == &close_req);
-  ASSERT(req->fs_type == UV_FS_CLOSE);
+  ASSERT_EQ(req->fs_type, UV_FS_CLOSE);
   ASSERT_EQ(req->result, 0);
   close_cb_count++;
   uv_fs_req_cleanup(req);
@@ -398,7 +398,7 @@ static void ftruncate_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &ftruncate_req);
-  ASSERT(req->fs_type == UV_FS_FTRUNCATE);
+  ASSERT_EQ(req->fs_type, UV_FS_FTRUNCATE);
   ASSERT_EQ(req->result, 0);
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
@@ -414,7 +414,7 @@ static void read_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &read_req);
-  ASSERT(req->fs_type == UV_FS_READ);
+  ASSERT_EQ(req->fs_type, UV_FS_READ);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
   read_cb_count++;
   uv_fs_req_cleanup(req);
@@ -434,7 +434,7 @@ static void open_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &open_req1);
-  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
     ASSERT(0);
@@ -452,7 +452,7 @@ static void open_cb(uv_fs_t* req) {
 
 
 static void open_cb_simple(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
     ASSERT(0);
@@ -467,7 +467,7 @@ static void fsync_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &fsync_req);
-  ASSERT(req->fs_type == UV_FS_FSYNC);
+  ASSERT_EQ(req->fs_type, UV_FS_FSYNC);
   ASSERT_EQ(req->result, 0);
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
@@ -480,7 +480,7 @@ static void fdatasync_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &fdatasync_req);
-  ASSERT(req->fs_type == UV_FS_FDATASYNC);
+  ASSERT_EQ(req->fs_type, UV_FS_FDATASYNC);
   ASSERT_EQ(req->result, 0);
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
@@ -493,7 +493,7 @@ static void write_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &write_req);
-  ASSERT(req->fs_type == UV_FS_WRITE);
+  ASSERT_EQ(req->fs_type, UV_FS_WRITE);
   ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
   write_cb_count++;
   uv_fs_req_cleanup(req);
@@ -506,7 +506,7 @@ static void create_cb(uv_fs_t* req) {
   int r;
   uv_os_fd_t file = (uv_os_fd_t) open_req1.result;
   ASSERT(req == &open_req1);
-  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   ASSERT(req->result >= 0);
   create_cb_count++;
   uv_fs_req_cleanup(req);
@@ -518,7 +518,7 @@ static void create_cb(uv_fs_t* req) {
 
 static void rename_cb(uv_fs_t* req) {
   ASSERT(req == &rename_req);
-  ASSERT(req->fs_type == UV_FS_RENAME);
+  ASSERT_EQ(req->fs_type, UV_FS_RENAME);
   ASSERT_EQ(req->result, 0);
   rename_cb_count++;
   uv_fs_req_cleanup(req);
@@ -527,7 +527,7 @@ static void rename_cb(uv_fs_t* req) {
 
 static void mkdir_cb(uv_fs_t* req) {
   ASSERT(req == &mkdir_req);
-  ASSERT(req->fs_type == UV_FS_MKDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_MKDIR);
   ASSERT_EQ(req->result, 0);
   mkdir_cb_count++;
   ASSERT(req->path);
@@ -539,7 +539,7 @@ static void mkdir_cb(uv_fs_t* req) {
 static void check_mkdtemp_result(uv_fs_t* req) {
   int r;
 
-  ASSERT(req->fs_type == UV_FS_MKDTEMP);
+  ASSERT_EQ(req->fs_type, UV_FS_MKDTEMP);
   ASSERT_EQ(req->result, 0);
   ASSERT(req->path);
   ASSERT(strlen(req->path) == 15);
@@ -565,7 +565,7 @@ static void mkdtemp_cb(uv_fs_t* req) {
 static void check_mkstemp_result(uv_fs_t* req) {
   int r;
 
-  ASSERT(req->fs_type == UV_FS_MKSTEMP);
+  ASSERT_EQ(req->fs_type, UV_FS_MKSTEMP);
   ASSERT(req->result >= 0);
   ASSERT(req->path);
   ASSERT(strlen(req->path) == 16);
@@ -590,7 +590,7 @@ static void mkstemp_cb(uv_fs_t* req) {
 
 static void rmdir_cb(uv_fs_t* req) {
   ASSERT(req == &rmdir_req);
-  ASSERT(req->fs_type == UV_FS_RMDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_RMDIR);
   ASSERT_EQ(req->result, 0);
   rmdir_cb_count++;
   ASSERT(req->path);
@@ -611,12 +611,12 @@ static void assert_is_file_type(uv_dirent_t dent) {
    *     https://github.com/libuv/libuv/issues/501
    */
   #if defined(__APPLE__) || defined(_WIN32)
-    ASSERT(dent.type == UV_DIRENT_FILE);
+    ASSERT_EQ(dent.type, UV_DIRENT_FILE);
   #else
     ASSERT(dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN);
   #endif
 #else
-  ASSERT(dent.type == UV_DIRENT_UNKNOWN);
+  ASSERT_EQ(dent.type, UV_DIRENT_UNKNOWN);
 #endif
 }
 
@@ -624,7 +624,7 @@ static void assert_is_file_type(uv_dirent_t dent) {
 static void scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
   ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, 2);
   ASSERT(req->ptr);
 
@@ -644,9 +644,9 @@ static void empty_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
   ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
   ASSERT_EQ(req->result, 0);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->ptr, NULL);
   ASSERT(UV_EOF == uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
@@ -656,9 +656,9 @@ static void non_existent_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
   ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == UV_ENOENT);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, UV_ENOENT);
+  ASSERT_EQ(req->ptr, NULL);
   ASSERT(UV_ENOENT == uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
@@ -667,9 +667,9 @@ static void non_existent_scandir_cb(uv_fs_t* req) {
 
 static void file_scandir_cb(uv_fs_t* req) {
   ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == UV_ENOTDIR);
-  ASSERT(req->ptr == NULL);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, UV_ENOTDIR);
+  ASSERT_EQ(req->ptr, NULL);
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
 }
@@ -688,7 +688,7 @@ static void stat_cb(uv_fs_t* req) {
 
 static void sendfile_cb(uv_fs_t* req) {
   ASSERT(req == &sendfile_req);
-  ASSERT(req->fs_type == UV_FS_SENDFILE);
+  ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
   ASSERT_EQ(req->result, 65546);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
@@ -697,7 +697,7 @@ static void sendfile_cb(uv_fs_t* req) {
 
 static void sendfile_nodata_cb(uv_fs_t* req) {
   ASSERT(req == &sendfile_req);
-  ASSERT(req->fs_type == UV_FS_SENDFILE);
+  ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
   ASSERT_EQ(req->result, 0);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
@@ -705,22 +705,22 @@ static void sendfile_nodata_cb(uv_fs_t* req) {
 
 
 static void open_noent_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ENOENT);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ENOENT);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void open_nametoolong_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ENAMETOOLONG);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ENAMETOOLONG);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void open_loop_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ELOOP);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ELOOP);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -733,8 +733,8 @@ TEST_IMPL(fs_file_noent) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &req, "does_not_exist", O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, open_noent_cb);
@@ -761,8 +761,8 @@ TEST_IMPL(fs_file_nametoolong) {
   name[TOO_LONG_NAME_LENGTH] = 0;
 
   r = uv_fs_open(NULL, &req, name, O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ENAMETOOLONG);
-  ASSERT(req.result == UV_ENAMETOOLONG);
+  ASSERT_EQ(r, UV_ENAMETOOLONG);
+  ASSERT_EQ(req.result, UV_ENAMETOOLONG);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, name, O_RDONLY, 0, open_nametoolong_cb);
@@ -801,8 +801,8 @@ TEST_IMPL(fs_file_loop) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ELOOP);
-  ASSERT(req.result == UV_ELOOP);
+  ASSERT_EQ(r, UV_ELOOP);
+  ASSERT_EQ(req.result, UV_ELOOP);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, open_loop_cb);
@@ -870,7 +870,7 @@ static void utime_cb(uv_fs_t* req) {
 
   ASSERT(req == &utime_req);
   ASSERT_EQ(req->result, 0);
-  ASSERT(req->fs_type == UV_FS_UTIME);
+  ASSERT_EQ(req->fs_type, UV_FS_UTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
@@ -885,7 +885,7 @@ static void futime_cb(uv_fs_t* req) {
 
   ASSERT(req == &futime_req);
   ASSERT_EQ(req->result, 0);
-  ASSERT(req->fs_type == UV_FS_FUTIME);
+  ASSERT_EQ(req->fs_type, UV_FS_FUTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
@@ -899,7 +899,7 @@ static void lutime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
   ASSERT_EQ(req->result, 0);
-  ASSERT(req->fs_type == UV_FS_LUTIME);
+  ASSERT_EQ(req->fs_type, UV_FS_LUTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 1);
@@ -2037,13 +2037,13 @@ TEST_IMPL(fs_readlink) {
   ASSERT(0 == uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(dummy_cb_count, 1);
-  ASSERT(req.ptr == NULL);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.ptr, NULL);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   ASSERT(UV_ENOENT == uv_fs_readlink(NULL, &req, "no_such_file", NULL));
-  ASSERT(req.ptr == NULL);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.ptr, NULL);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY();
@@ -2058,13 +2058,13 @@ TEST_IMPL(fs_realpath) {
   ASSERT(0 == uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(dummy_cb_count, 1);
-  ASSERT(req.ptr == NULL);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.ptr, NULL);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   ASSERT(UV_ENOENT == uv_fs_realpath(NULL, &req, "no_such_file", NULL));
-  ASSERT(req.ptr == NULL);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.ptr, NULL);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY();
@@ -2375,7 +2375,7 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
@@ -2495,7 +2495,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
        as links because it doesn't open the file and verify the reparse
        point tag. The PowerShell Get-ChildItem command shares this
        behavior, so it's reasonable to leave it as is. */
-    ASSERT(dent.type == UV_DIRENT_LINK);
+    ASSERT_EQ(dent.type, UV_DIRENT_LINK);
   }
   uv_fs_req_cleanup(&scandir_req);
   ASSERT(!scandir_req.ptr);
@@ -2773,7 +2773,7 @@ TEST_IMPL(fs_futime) {
 
   r = uv_fs_futime(NULL, &req, file, atime, mtime, NULL);
 #if defined(__CYGWIN__) || defined(__MSYS__)
-  ASSERT(r == UV_ENOSYS);
+  ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
   ASSERT_EQ(r, 0);
@@ -2856,7 +2856,7 @@ TEST_IMPL(fs_futime_ex) {
 
   r = uv_fs_futime_ex(NULL, &req, file, btime, atime, mtime, NULL);
 #if defined(__CYGWIN__) || defined(__MSYS__)
-  ASSERT(r == UV_ENOSYS);
+  ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
   ASSERT_EQ(r, 0);
@@ -2942,7 +2942,7 @@ TEST_IMPL(fs_lutime) {
   r = uv_fs_lutime(NULL, &req, symlink_path, atime, mtime, NULL);
 #if (defined(_AIX) && !defined(_AIX71)) ||                                    \
      defined(__MVS__)
-  ASSERT(r == UV_ENOSYS);
+  ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("lutime is not implemented for z/OS and AIX versions below 7.1");
 #endif
   ASSERT_EQ(r, 0);
@@ -2977,8 +2977,8 @@ TEST_IMPL(fs_stat_missing_path) {
   loop = uv_default_loop();
 
   r = uv_fs_stat(NULL, &req, "non_existent_file", NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY();
@@ -3004,7 +3004,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(req.result, 0);
-  ASSERT(req.ptr == NULL);
+  ASSERT_EQ(req.ptr, NULL);
   ASSERT(UV_EOF == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
@@ -3039,9 +3039,9 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   memset(&req, 0xdb, sizeof(req));
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
-  ASSERT(req.ptr == NULL);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
+  ASSERT_EQ(req.ptr, NULL);
   ASSERT(UV_ENOENT == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
@@ -3064,7 +3064,7 @@ TEST_IMPL(fs_scandir_file) {
   loop = uv_default_loop();
 
   r = uv_fs_scandir(NULL, &scandir_req, path, 0, NULL);
-  ASSERT(r == UV_ENOTDIR);
+  ASSERT_EQ(r, UV_ENOTDIR);
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, file_scandir_cb);
@@ -3091,7 +3091,7 @@ TEST_IMPL(fs_open_dir) {
   r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
   ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
-  ASSERT(req.ptr == NULL);
+  ASSERT_EQ(req.ptr, NULL);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
@@ -3755,7 +3755,7 @@ TEST_IMPL(fs_read_dir) {
    */
   ASSERT((r >= 0) || (r == UV_EISDIR));
 #else
-  ASSERT(r == UV_EISDIR);
+  ASSERT_EQ(r, UV_EISDIR);
 #endif
   uv_fs_req_cleanup(&read_req);
 
@@ -3892,7 +3892,7 @@ static void test_fs_partial(int doread) {
         iovcount -= read_iovcount;
         nread += result;
       } else {
-        ASSERT(result == UV_EINTR);
+        ASSERT_EQ(result, UV_EINTR);
       }
       uv_fs_req_cleanup(&read_req);
     }
@@ -3943,57 +3943,57 @@ TEST_IMPL(fs_read_write_null_arguments) {
   int r;
 
   r = uv_fs_read(NULL, &read_req, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_write(NULL, &write_req, 0, NULL, 0, -1, NULL);
   /* Validate some memory management on failed input validation before sending
      fs work to the thread pool. */
-  ASSERT(r == UV_EINVAL);
-  ASSERT(write_req.path == NULL);
-  ASSERT(write_req.ptr == NULL);
+  ASSERT_EQ(r, UV_EINVAL);
+  ASSERT_EQ(write_req.path, NULL);
+  ASSERT_EQ(write_req.ptr, NULL);
 #ifdef _WIN32
-  ASSERT(write_req.file.pathw == NULL);
-  ASSERT(write_req.fs.info.new_pathw == NULL);
-  ASSERT(write_req.fs.info.bufs == NULL);
+  ASSERT_EQ(write_req.file.pathw, NULL);
+  ASSERT_EQ(write_req.fs.info.new_pathw, NULL);
+  ASSERT_EQ(write_req.fs.info.bufs, NULL);
 #else
-  ASSERT(write_req.new_path == NULL);
-  ASSERT(write_req.bufs == NULL);
+  ASSERT_EQ(write_req.new_path, NULL);
+  ASSERT_EQ(write_req.bufs, NULL);
 #endif
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_read(NULL, &read_req, 0, &iov, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, 0, &iov, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&write_req);
 
   /* If the arguments are invalid, the loop should not be kept open */
   loop = uv_default_loop();
 
   r = uv_fs_read(loop, &read_req, 0, NULL, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_write(loop, &write_req, 0, NULL, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_read(loop, &read_req, 0, &iov, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(loop, &write_req, 0, &iov, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
@@ -4006,8 +4006,8 @@ TEST_IMPL(fs_invalid_filename) {
   int r;
 
   r = uv_fs_open(NULL, &req, "foo??", O_RDONLY, 0, NULL);
-  ASSERT(r == UV_EINVAL);
-  ASSERT(req.result == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
+  ASSERT_EQ(req.result, UV_EINVAL);
   uv_fs_req_cleanup(&req);
 
   return 0;
@@ -4212,97 +4212,97 @@ TEST_IMPL(fs_null_req) {
   int r;
 
   r = uv_fs_open(NULL, NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_close(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_read(NULL, NULL, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_write(NULL, NULL, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_unlink(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkdir(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkdtemp(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkstemp(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_rmdir(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_scandir(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_link(NULL, NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_symlink(NULL, NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_readlink(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_realpath(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_chown(NULL, NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fchown(NULL, NULL, 0, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_stat(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_lstat(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fstat(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_rename(NULL, NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fsync(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fdatasync(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_ftruncate(NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_copyfile(NULL, NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_sendfile(NULL, NULL, 0, 0, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_access(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_chmod(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fchmod(NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_utime(NULL, NULL, NULL, 0.0, 0.0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_futime(NULL, NULL, 0, 0.0, 0.0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_statfs(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* This should be a no-op. */
   uv_fs_req_cleanup(NULL);
@@ -4407,8 +4407,8 @@ TEST_IMPL(fs_file_flag_no_buffering) {
                  UV_FS_O_APPEND | UV_FS_O_DIRECT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == UV_EINVAL);
-  ASSERT(open_req2.result == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
+  ASSERT_EQ(open_req2.result, UV_EINVAL);
   uv_fs_req_cleanup(&open_req2);
 
   /* Cleanup */
@@ -4560,7 +4560,7 @@ TEST_IMPL(fs_invalid_mkdir_name) {
 
   loop = uv_default_loop();
   r = uv_fs_mkdir(loop, &req, "invalid>", 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }
@@ -4597,9 +4597,9 @@ TEST_IMPL(fs_get_system_error) {
 
   system_error = uv_fs_get_system_error(&req);
 #ifdef _WIN32
-  ASSERT(system_error == ERROR_FILE_NOT_FOUND);
+  ASSERT_EQ(system_error, ERROR_FILE_NOT_FOUND);
 #else
-  ASSERT(system_error == ENOENT);
+  ASSERT_EQ(system_error, ENOENT);
 #endif
 
   return 0;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -186,7 +186,7 @@ static void check_permission(const char* filename, unsigned int mode) {
   uv_stat_t* s;
 
   r = uv_fs_stat(NULL, &req, filename, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
 
   s = &req.statbuf;
@@ -389,7 +389,7 @@ static void close_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   if (close_cb_count == 3) {
     r = uv_fs_unlink(loop, &unlink_req, "test_file2", unlink_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -403,7 +403,7 @@ static void ftruncate_cb(uv_fs_t* req) {
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, file, close_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void fail_cb(uv_fs_t* req) {
@@ -426,7 +426,7 @@ static void read_cb(uv_fs_t* req) {
     ASSERT(strcmp(buf, "test-bu") == 0);
     r = uv_fs_close(loop, &close_req, file, close_cb);
   }
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -447,7 +447,7 @@ static void open_cb(uv_fs_t* req) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(loop, &read_req, file, &iov, 1, -1,
       read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -472,7 +472,7 @@ static void fsync_cb(uv_fs_t* req) {
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, file, close_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -485,7 +485,7 @@ static void fdatasync_cb(uv_fs_t* req) {
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fsync(loop, &fsync_req, file, fsync_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -498,7 +498,7 @@ static void write_cb(uv_fs_t* req) {
   write_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fdatasync(loop, &fdatasync_req, file, fdatasync_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -512,7 +512,7 @@ static void create_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(loop, &write_req, file, &iov, 1, -1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -549,7 +549,7 @@ static void check_mkdtemp_result(uv_fs_t* req) {
 
   /* Check if req->path is actually a directory */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(((uv_stat_t*)stat_req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&stat_req);
 }
@@ -575,7 +575,7 @@ static void check_mkstemp_result(uv_fs_t* req) {
 
   /* Check if req->path is actually a file */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(stat_req.statbuf.st_mode & S_IFREG);
   uv_fs_req_cleanup(&stat_req);
 }
@@ -738,9 +738,9 @@ TEST_IMPL(fs_file_noent) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, open_noent_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
@@ -766,9 +766,9 @@ TEST_IMPL(fs_file_nametoolong) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, name, O_RDONLY, 0, open_nametoolong_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
@@ -797,7 +797,7 @@ TEST_IMPL(fs_file_loop) {
   if (r == UV_ENOENT)
     return 0;
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
@@ -806,9 +806,9 @@ TEST_IMPL(fs_file_loop) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, open_loop_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
@@ -833,7 +833,7 @@ static void check_utime_ex(const char* path,
   else
     r = uv_fs_stat(loop, &req, path, NULL);
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   s = &req.statbuf;
 
@@ -920,7 +920,7 @@ TEST_IMPL(fs_file_async) {
 
   r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IRUSR | S_IWUSR, create_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(create_cb_count == 1);
@@ -930,7 +930,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT(close_cb_count == 1);
 
   r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", rename_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(create_cb_count == 1);
@@ -939,7 +939,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT(rename_cb_count == 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
@@ -951,7 +951,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT(ftruncate_cb_count == 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 2);
@@ -984,7 +984,7 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_open(loop, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -996,12 +996,12 @@ static void fs_file_sync(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | add_flags, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -1014,23 +1014,23 @@ static void fs_file_sync(int add_flags) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_ftruncate(NULL, &ftruncate_req, file, 7, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(ftruncate_req.result == 0);
   uv_fs_req_cleanup(&ftruncate_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(rename_req.result == 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -1044,12 +1044,12 @@ static void fs_file_sync(int add_flags) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_unlink(NULL, &unlink_req, "test_file2", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(unlink_req.result == 0);
   uv_fs_req_cleanup(&unlink_req);
 
@@ -1077,19 +1077,19 @@ static void fs_file_write_null_buffer(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(write_req.result == 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -1117,7 +1117,7 @@ TEST_IMPL(fs_async_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(mkdir_cb_count == 1);
@@ -1125,24 +1125,24 @@ TEST_IMPL(fs_async_dir) {
   /* Create 2 files synchronously. */
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(loop, &scandir_req, "test_dir", 0, scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
@@ -1160,35 +1160,35 @@ TEST_IMPL(fs_async_dir) {
   ASSERT(!scandir_req.ptr);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(stat_cb_count == 4);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file1", unlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(unlink_cb_count == 1);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file2", unlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(unlink_cb_count == 2);
 
   r = uv_fs_rmdir(loop, &rmdir_req, "test_dir", rmdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(rmdir_cb_count == 1);
 
@@ -1220,34 +1220,34 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
     setup(f);
 
   r = close(f);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Test starts here. */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file1 = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req2.result >= 0);
   file2 = (uv_os_fd_t) open_req2.result;
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_sendfile(loop, &sendfile_req, file2, file1,
       0, 131072, cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT(sendfile_cb_count == 1);
 
   r = uv_fs_close(NULL, &close_req, file1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
   r = uv_fs_close(NULL, &close_req, file2, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   ASSERT(0 == stat("test_file", &s1));
@@ -1288,14 +1288,14 @@ TEST_IMPL(fs_mkdtemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdtemp(loop, &mkdtemp_req1, path_template, mkdtemp_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(mkdtemp_cb_count == 1);
 
   /* sync mkdtemp */
   r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_mkdtemp_result(&mkdtemp_req2);
 
   /* mkdtemp return different values on subsequent calls */
@@ -1321,14 +1321,14 @@ TEST_IMPL(fs_mkstemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkstemp(loop, &mkstemp_req1, path_template, mkstemp_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(mkstemp_cb_count == 1);
 
   /* sync mkstemp */
   r = uv_fs_mkstemp(NULL, &mkstemp_req2, path_template, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_mkstemp_result(&mkstemp_req2);
 
   fd1 = (uv_os_fd_t) mkstemp_req1.result;
@@ -1357,7 +1357,7 @@ TEST_IMPL(fs_mkstemp) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, mkstemp_req1.path, O_RDONLY, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   fd1 = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
@@ -1398,7 +1398,7 @@ TEST_IMPL(fs_fstat) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -1430,14 +1430,14 @@ TEST_IMPL(fs_fstat) {
 
   memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
   r = uv_fs_fstat(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   s = req.ptr;
   ASSERT(s->st_size == sizeof(test_buf));
 
 #ifndef _WIN32
   r = fstat(file, &t);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(s->st_dev == (uint64_t) t.st_dev);
   ASSERT(s->st_mode == (uint64_t) t.st_mode);
@@ -1513,13 +1513,13 @@ TEST_IMPL(fs_fstat) {
 
   /* Now do the uv_fs_fstat call asynchronously */
   r = uv_fs_fstat(loop, &req, file, fstat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fstat_cb_count == 1);
 
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1556,7 +1556,7 @@ TEST_IMPL(fs_access) {
 
   /* File should not exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(access_cb_count == 1);
   access_cb_count = 0; /* reset for the next test */
@@ -1564,37 +1564,37 @@ TEST_IMPL(fs_access) {
   /* Create file */
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
   r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(access_cb_count == 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* Directory access */
   r = uv_fs_mkdir(NULL, &req, "test_dir", 0777, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_access(NULL, &req, "test_dir", W_OK, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1625,7 +1625,7 @@ TEST_IMPL(fs_chmod) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -1639,7 +1639,7 @@ TEST_IMPL(fs_chmod) {
 #ifndef _WIN32
   /* Make the file write-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0200, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1648,7 +1648,7 @@ TEST_IMPL(fs_chmod) {
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1656,7 +1656,7 @@ TEST_IMPL(fs_chmod) {
 
   /* Make the file read+write with sync uv_fs_fchmod */
   r = uv_fs_fchmod(NULL, &req, file, 0600, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1669,7 +1669,7 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0200, chmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(chmod_cb_count == 1);
   chmod_cb_count = 0; /* reset for the next test */
@@ -1681,7 +1681,7 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0400, chmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(chmod_cb_count == 1);
 
@@ -1691,13 +1691,13 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_fchmod(loop, &req, file, 0600, fchmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fchmod_cb_count == 1);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1731,7 +1731,7 @@ TEST_IMPL(fs_unlink_readonly) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -1744,13 +1744,13 @@ TEST_IMPL(fs_unlink_readonly) {
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1758,7 +1758,7 @@ TEST_IMPL(fs_unlink_readonly) {
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1806,7 +1806,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1819,7 +1819,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1852,26 +1852,26 @@ TEST_IMPL(fs_chown) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* sync chown */
   r = uv_fs_chown(NULL, &req, "test_file", -1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* sync fchown */
   r = uv_fs_fchown(NULL, &req, file, -1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* async chown */
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(chown_cb_count == 1);
 
@@ -1879,14 +1879,14 @@ TEST_IMPL(fs_chown) {
   /* chown to root (fail) */
   chown_cb_count = 0;
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(chown_cb_count == 1);
 #endif
 
   /* async fchown */
   r = uv_fs_fchown(loop, &req, file, -1, -1, fchown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fchown_cb_count == 1);
 
@@ -1894,26 +1894,26 @@ TEST_IMPL(fs_chown) {
   /* Haiku doesn't support hardlink */
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* sync lchown */
   r = uv_fs_lchown(NULL, &req, "test_file_link", -1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* async lchown */
   r = uv_fs_lchown(loop, &req, "test_file_link", -1, -1, lchown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(lchown_cb_count == 1);
 #endif
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -1947,7 +1947,7 @@ TEST_IMPL(fs_link) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -1960,18 +1960,18 @@ TEST_IMPL(fs_link) {
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   link = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -1985,18 +1985,18 @@ TEST_IMPL(fs_link) {
 
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   /* async link */
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(link_cb_count == 1);
 
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   link = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2010,7 +2010,7 @@ TEST_IMPL(fs_link) {
 
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2099,7 +2099,7 @@ TEST_IMPL(fs_symlink) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2112,7 +2112,7 @@ TEST_IMPL(fs_symlink) {
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2135,12 +2135,12 @@ TEST_IMPL(fs_symlink) {
     }
   }
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   link = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2154,7 +2154,7 @@ TEST_IMPL(fs_symlink) {
 
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2164,7 +2164,7 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink_symlink",
                     0,
                     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
 #if defined(__MSYS__)
@@ -2172,12 +2172,12 @@ TEST_IMPL(fs_symlink) {
 #endif
 
   r = uv_fs_readlink(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(strcmp(req.ptr, "test_file_symlink") == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   ASSERT(stricmp(req.ptr, test_file_abs_buf) == 0);
 #else
@@ -2192,12 +2192,12 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2",
                     0,
                     symlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(symlink_cb_count == 1);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   link = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2211,7 +2211,7 @@ TEST_IMPL(fs_symlink) {
 
   /* Close link */
   r = uv_fs_close(NULL, &req, link, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2221,16 +2221,16 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2_symlink",
                     0,
                     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(loop, &req, "test_file_symlink2_symlink", readlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(readlink_cb_count == 1);
 
   r = uv_fs_realpath(loop, &req, "test_file", realpath_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(realpath_cb_count == 1);
 
@@ -2294,17 +2294,17 @@ int test_symlink_dir_impl(int type) {
                 "creation of directory symlinks");
   }
   fprintf(stderr, "r == %i\n", r);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #if defined(__MSYS__)
   RETURN_SKIP("symlink reading is not supported on MSYS2");
 #endif
@@ -2322,7 +2322,7 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   ASSERT(strcmp(req.ptr, test_dir + 4) == 0);
 #else
@@ -2331,7 +2331,7 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   ASSERT(strlen(req.ptr) == test_dir_abs_size - 5);
   ASSERT(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5) == 0);
@@ -2342,20 +2342,20 @@ int test_symlink_dir_impl(int type) {
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
@@ -2371,7 +2371,7 @@ int test_symlink_dir_impl(int type) {
 
   /* unlink will remove the directory symlink */
   r = uv_fs_unlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
@@ -2462,11 +2462,11 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   shared via SMB as "Macintosh HD".
 
   r = uv_fs_stat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 */
 
@@ -2477,11 +2477,11 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   the scope of this test.
 
   r = uv_fs_stat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 */
 
@@ -2574,14 +2574,14 @@ TEST_IMPL(fs_utime) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2597,12 +2597,12 @@ TEST_IMPL(fs_utime) {
 #endif
 
   r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   uv_fs_req_cleanup(&req);
@@ -2615,7 +2615,7 @@ TEST_IMPL(fs_utime) {
   /* async utime */
   utime_req.data = &checkme;
   r = uv_fs_utime(loop, &utime_req, path, atime, mtime, utime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(utime_cb_count == 1);
 
@@ -2641,14 +2641,14 @@ TEST_IMPL(fs_utime_ex) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2664,12 +2664,12 @@ TEST_IMPL(fs_utime_ex) {
 #endif
 
   r = uv_fs_utime_ex(NULL, &req, path, btime, atime, mtime, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   check_utime_ex(path, btime, atime, mtime, 0);
   uv_fs_req_cleanup(&req);
@@ -2683,7 +2683,7 @@ TEST_IMPL(fs_utime_ex) {
   /* async utime */
   utime_req.data = &checkme;
   r = uv_fs_utime_ex(loop, &utime_req, path, btime, atime, mtime, utime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(utime_cb_count == 1);
 
@@ -2700,26 +2700,26 @@ TEST_IMPL(fs_stat_root) {
   int r;
 
   r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\..\\..\\..\\..\\..\\..", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* stats the current directory on c: */
   r = uv_fs_stat(NULL, &stat_req, "c:", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "c:\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "\\\\?\\C:\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -2743,14 +2743,14 @@ TEST_IMPL(fs_futime) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2766,7 +2766,7 @@ TEST_IMPL(fs_futime) {
 #endif
 
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2776,13 +2776,13 @@ TEST_IMPL(fs_futime) {
   ASSERT(r == UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   uv_fs_req_cleanup(&req);
@@ -2796,7 +2796,7 @@ TEST_IMPL(fs_futime) {
   /* async futime */
   futime_req.data = &checkme;
   r = uv_fs_futime(loop, &futime_req, file, atime, mtime, futime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(futime_cb_count == 1);
 
@@ -2825,14 +2825,14 @@ TEST_IMPL(fs_futime_ex) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2849,7 +2849,7 @@ TEST_IMPL(fs_futime_ex) {
 #endif
 
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
@@ -2859,13 +2859,13 @@ TEST_IMPL(fs_futime_ex) {
   ASSERT(r == UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   check_utime_ex(path, btime, atime, mtime, 0);
   uv_fs_req_cleanup(&req);
@@ -2880,7 +2880,7 @@ TEST_IMPL(fs_futime_ex) {
   /* async futime */
   futime_req.data = &checkme;
   r = uv_fs_futime_ex(loop, &futime_req, file, btime, atime, mtime, futime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(futime_cb_count == 1);
 
@@ -2923,7 +2923,7 @@ TEST_IMPL(fs_lutime) {
         "Symlink creation requires elevated console (with admin rights)");
   }
 #endif
-  ASSERT(s == 0);
+  ASSERT_EQ(s, 0);
   ASSERT(req.result == 0);
   uv_fs_req_cleanup(&req);
 
@@ -2945,7 +2945,7 @@ TEST_IMPL(fs_lutime) {
   ASSERT(r == UV_ENOSYS);
   RETURN_SKIP("lutime is not implemented for z/OS and AIX versions below 7.1");
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   lutime_cb(&req);
   ASSERT(lutime_cb_count == 1);
 
@@ -2957,7 +2957,7 @@ TEST_IMPL(fs_lutime) {
   checkme.path = symlink_path;
 
   r = uv_fs_lutime(loop, &req, symlink_path, atime, mtime, lutime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(lutime_cb_count == 2);
 
@@ -3002,16 +3002,16 @@ TEST_IMPL(fs_scandir_empty_dir) {
   memset(&req, 0xdb, sizeof(req));
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result == 0);
   ASSERT(req.ptr == NULL);
   ASSERT(UV_EOF == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, empty_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
@@ -3046,9 +3046,9 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, non_existent_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
@@ -3068,9 +3068,9 @@ TEST_IMPL(fs_scandir_file) {
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, file_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
@@ -3089,19 +3089,19 @@ TEST_IMPL(fs_open_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(req.result >= 0);
   ASSERT(req.ptr == NULL);
   file = (uv_os_fd_t) req.result;
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_open(loop, &req, path, O_RDONLY, 0, open_cb_simple);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
@@ -3121,7 +3121,7 @@ static void fs_file_open_append(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3133,7 +3133,7 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3151,13 +3151,13 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags,
       S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3173,7 +3173,7 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3201,7 +3201,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3213,29 +3213,29 @@ TEST_IMPL(fs_rename_to_existing_file) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(rename_req.result == 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3249,7 +3249,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3333,7 +3333,7 @@ static void fs_read_file_eof(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3345,13 +3345,13 @@ static void fs_read_file_eof(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3367,12 +3367,12 @@ static void fs_read_file_eof(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  read_req.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3400,7 +3400,7 @@ static void fs_write_multiple_bufs(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3413,13 +3413,13 @@ static void fs_write_multiple_bufs(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3439,7 +3439,7 @@ static void fs_write_multiple_bufs(int add_flags) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
@@ -3464,12 +3464,12 @@ static void fs_write_multiple_bufs(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1,
                  sizeof(test_buf) + sizeof(test_buf2), NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3511,7 +3511,7 @@ static void fs_write_alotof_bufs(int add_flags) {
                  O_RDWR | O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3539,13 +3539,13 @@ static void fs_write_alotof_bufs(int add_flags) {
                               sizeof(test_buf));
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3573,12 +3573,12 @@ static void fs_write_alotof_bufs(int add_flags) {
                  1,
                  -1,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3626,7 +3626,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  O_RDWR | O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3678,7 +3678,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
   free(buffer);
 
   r = uv_fs_stat(NULL, &stat_req, "test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT((int64_t)((uv_stat_t*)stat_req.ptr)->st_size ==
          offset + (int64_t) write_req.result);
   uv_fs_req_cleanup(&stat_req);
@@ -3691,12 +3691,12 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  1,
                  offset + write_req.result,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(read_req.result == 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -3721,7 +3721,7 @@ TEST_IMPL(fs_read_dir) {
   /* Setup */
   rmdir("test_dir");
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(mkdir_cb_count == 1);
   /* Setup Done Here */
@@ -3733,7 +3733,7 @@ TEST_IMPL(fs_read_dir) {
                  UV_FS_O_RDONLY | UV_FS_O_DIRECTORY,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -3760,7 +3760,7 @@ TEST_IMPL(fs_read_dir) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3915,7 +3915,7 @@ static void test_fs_partial(int doread) {
   { /* Make sure we read everything that we wrote. */
       int result;
       result = uv_fs_read(loop, &read_req, pipe_fds[0], iovs, 1, -1, NULL);
-      ASSERT(result == 0);
+      ASSERT_EQ(result, 0);
       uv_fs_req_cleanup(&read_req);
   }
   ASSERT(0 == close(pipe_fds[0]));
@@ -4028,7 +4028,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&open_req1);
   file = (uv_os_fd_t) open_req1.result;
 
@@ -4050,7 +4050,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4078,7 +4078,7 @@ static void fs_file_pos_common(uv_os_fd_t file) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 
   /* Write without offset should change the position */
@@ -4089,7 +4089,7 @@ static void fs_file_pos_common(uv_os_fd_t file) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 }
 
@@ -4098,12 +4098,12 @@ static void fs_file_pos_close_check(uv_os_fd_t file, const char *contents, int s
 
   /* Close */
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Confirm file contents */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -4115,7 +4115,7 @@ static void fs_file_pos_close_check(uv_os_fd_t file, const char *contents, int s
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4135,7 +4135,7 @@ static void fs_file_pos_write(int add_flags) {
                  O_TRUNC | O_CREAT | O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -4150,7 +4150,7 @@ static void fs_file_pos_write(int add_flags) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, file, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 
   fs_file_pos_close_check(file, "aecd", 4);
@@ -4176,7 +4176,7 @@ static void fs_file_pos_append(int add_flags) {
                  O_APPEND | O_CREAT | O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -4326,7 +4326,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  O_RDWR | O_CREAT | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
@@ -4342,7 +4342,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -4352,13 +4352,13 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  O_RDONLY | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req2.result >= 0);
   file = (uv_os_fd_t) open_req2.result;
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -4390,13 +4390,13 @@ TEST_IMPL(fs_file_flag_no_buffering) {
                  UV_FS_O_RDWR | UV_FS_O_CREAT | UV_FS_O_DIRECT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(open_req1.result >= 0);
   file = (uv_os_fd_t) open_req1.result;
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(close_req.result == 0);
   uv_fs_req_cleanup(&close_req);
 
@@ -4449,7 +4449,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     /* Setup - clear the ACL and remove the file */
     loop = uv_default_loop();
     r = uv_os_get_passwd(&pwd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     call_icacls("icacls test_file_icacls /remove \"%s\" /inheritance:e",
                 pwd.username);
     uv_fs_chmod(loop, &req, "test_file_icacls", S_IWUSR, NULL);
@@ -4466,7 +4466,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     ASSERT(open_req1.result >= 0);
     uv_fs_req_cleanup(&open_req1);
     r = uv_fs_close(NULL, &close_req, (uv_os_fd_t) open_req1.result, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(close_req.result == 0);
     uv_fs_req_cleanup(&close_req);
 
@@ -4499,7 +4499,7 @@ TEST_IMPL(fs_open_readonly_acl) {
                 pwd.username);
     unlink("test_file_icacls");
     uv_os_free_passwd(&pwd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     MAKE_VALGRIND_HAPPY();
     return 0;
 }
@@ -4525,7 +4525,7 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     file = (uv_os_fd_t) req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_fs_req_cleanup(&req);
     /* Make the file read-only and clear archive flag */
     r = SetFileAttributes("test_file", FILE_ATTRIBUTE_READONLY);
@@ -4538,11 +4538,11 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     file = (uv_os_fd_t) req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_fchmod(NULL, &req, file, S_IWUSR, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(req.result == 0);
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_fs_req_cleanup(&req);
     check_permission("test_file", S_IWUSR);
 
@@ -4574,13 +4574,13 @@ TEST_IMPL(fs_statfs) {
 
   /* Test the synchronous version. */
   r = uv_fs_statfs(NULL, &req, ".", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   statfs_cb(&req);
   ASSERT(statfs_cb_count == 1);
 
   /* Test the asynchronous version. */
   r = uv_fs_statfs(loop, &req, ".", statfs_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(statfs_cb_count == 2);
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3300,7 +3300,7 @@ static void fs_read_bufs(int add_flags) {
                            2,  /* 2x 128 bytes. */
                            256,  /* Positional read. */
                            NULL));
-  ASSERT(read_req.result == /* 446 - 256 */ 190);
+  ASSERT_EQ(read_req.result, /* 446 - 256 */ 190);
   uv_fs_req_cleanup(&read_req);
 
   ASSERT(0 == memcmp(bufs[1].base + 0, bufs[2].base, 128));

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -62,14 +62,14 @@ TEST_IMPL(get_currentexe) {
   /* Negative tests */
   size = sizeof(buffer) / sizeof(buffer[0]);
   r = uv_exepath(NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_exepath(buffer, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   size = 0;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   memset(buffer, -1, sizeof(buffer));
 

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -75,15 +75,15 @@ TEST_IMPL(get_currentexe) {
 
   size = 1;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == 0);
-  ASSERT(size == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(size, 0);
   ASSERT(buffer[0] == '\0');
 
   memset(buffer, -1, sizeof(buffer));
 
   size = 2;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(size == 1);
   ASSERT(buffer[0] != '\0');
   ASSERT(buffer[1] == '\0');

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -77,7 +77,7 @@ TEST_IMPL(get_currentexe) {
   r = uv_exepath(buffer, &size);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(size, 0);
-  ASSERT(buffer[0] == '\0');
+  ASSERT_EQ(buffer[0], '\0');
 
   memset(buffer, -1, sizeof(buffer));
 
@@ -86,7 +86,7 @@ TEST_IMPL(get_currentexe) {
   ASSERT_EQ(r, 0);
   ASSERT_EQ(size, 1);
   ASSERT(buffer[0] != '\0');
-  ASSERT(buffer[1] == '\0');
+  ASSERT_EQ(buffer[1], '\0');
 
   /* Verify uv_exepath is not affected by uv_set_process_title(). */
   r = uv_set_process_title("foobar");

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -84,7 +84,7 @@ TEST_IMPL(get_currentexe) {
   size = 2;
   r = uv_exepath(buffer, &size);
   ASSERT_EQ(r, 0);
-  ASSERT(size == 1);
+  ASSERT_EQ(size, 1);
   ASSERT(buffer[0] != '\0');
   ASSERT(buffer[1] == '\0');
 

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -36,7 +36,7 @@ TEST_IMPL(get_memory) {
   ASSERT(total_mem > 0);
   /* On IBMi PASE, the amount of memory in use is always zero. */
 #ifdef __PASE__
-  ASSERT(total_mem == free_mem);
+  ASSERT_EQ(total_mem, free_mem);
 #else
   ASSERT(total_mem > free_mem);
 #endif

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -64,8 +64,8 @@ TEST_IMPL(get_passwd) {
 #endif
 
 #ifdef _WIN32
-  ASSERT(pwd.uid == -1);
-  ASSERT(pwd.gid == -1);
+  ASSERT_EQ(pwd.uid, -1);
+  ASSERT_EQ(pwd.gid, -1);
 #else
   ASSERT(pwd.uid >= 0);
   ASSERT(pwd.gid >= 0);

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -40,7 +40,7 @@ TEST_IMPL(get_passwd) {
   ASSERT(len > 0);
 
 #ifdef _WIN32
-  ASSERT(pwd.shell == NULL);
+  ASSERT_EQ(pwd.shell, NULL);
 #else
   len = strlen(pwd.shell);
 # ifndef __PASE__
@@ -74,22 +74,22 @@ TEST_IMPL(get_passwd) {
   /* Test uv_os_free_passwd() */
   uv_os_free_passwd(&pwd);
 
-  ASSERT(pwd.username == NULL);
-  ASSERT(pwd.shell == NULL);
-  ASSERT(pwd.homedir == NULL);
-  ASSERT(pwd.gecos == NULL);
+  ASSERT_EQ(pwd.username, NULL);
+  ASSERT_EQ(pwd.shell, NULL);
+  ASSERT_EQ(pwd.homedir, NULL);
+  ASSERT_EQ(pwd.gecos, NULL);
 
   /* Test a double free */
   uv_os_free_passwd(&pwd);
 
-  ASSERT(pwd.username == NULL);
-  ASSERT(pwd.shell == NULL);
-  ASSERT(pwd.homedir == NULL);
-  ASSERT(pwd.gecos == NULL);
+  ASSERT_EQ(pwd.username, NULL);
+  ASSERT_EQ(pwd.shell, NULL);
+  ASSERT_EQ(pwd.homedir, NULL);
+  ASSERT_EQ(pwd.gecos, NULL);
 
   /* Test invalid input */
   r = uv_os_get_passwd(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -35,7 +35,7 @@ TEST_IMPL(get_passwd) {
 
   /* Test the normal case */
   r = uv_os_get_passwd(&pwd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   len = strlen(pwd.username);
   ASSERT(len > 0);
 

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -53,12 +53,12 @@ TEST_IMPL(get_passwd) {
 
 #ifdef _WIN32
   if (len == 3 && pwd.homedir[1] == ':')
-    ASSERT(pwd.homedir[2] == '\\');
+    ASSERT_EQ(pwd.homedir[2], '\\');
   else
     ASSERT(pwd.homedir[len - 1] != '\\');
 #else
   if (len == 1)
-    ASSERT(pwd.homedir[0] == '/');
+    ASSERT_EQ(pwd.homedir[0], '/');
   else
     ASSERT(pwd.homedir[len - 1] != '/');
 #endif

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -42,7 +42,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
 
   ASSERT_EQ(fail_cb_called, 0);
   ASSERT(status < 0);
-  ASSERT(res == NULL);
+  ASSERT_EQ(res, NULL);
   uv_freeaddrinfo(res);  /* Should not crash. */
   fail_cb_called++;
 }

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -207,7 +207,7 @@ TEST_IMPL(getaddrinfo_concurrent) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   for (i = 0; i < CONCURRENT_COUNT; i++) {
-    ASSERT(callback_counts[i] == 1);
+    ASSERT_EQ(callback_counts[i], 1);
   }
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -66,7 +66,7 @@ static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle,
 
   for (i = 0; i < CONCURRENT_COUNT; i++) {
     if (&getaddrinfo_handles[i] == handle) {
-      ASSERT(i == *data);
+      ASSERT_EQ(i, *data);
 
       callback_counts[i]++;
       break;

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -40,7 +40,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
                                 int status,
                                 struct addrinfo* res) {
 
-  ASSERT(fail_cb_called == 0);
+  ASSERT_EQ(fail_cb_called, 0);
   ASSERT(status < 0);
   ASSERT(res == NULL);
   uv_freeaddrinfo(res);  /* Should not crash. */
@@ -147,7 +147,7 @@ TEST_IMPL(getaddrinfo_basic) {
                      name,
                      NULL,
                      NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -201,7 +201,7 @@ TEST_IMPL(getaddrinfo_concurrent) {
                        name,
                        NULL,
                        NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -51,7 +51,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
 static void getaddrinfo_basic_cb(uv_getaddrinfo_t* handle,
                                  int status,
                                  struct addrinfo* res) {
-  ASSERT(handle == getaddrinfo_handle);
+  ASSERT_EQ(handle, getaddrinfo_handle);
   getaddrinfo_cbs++;
   free(handle);
   uv_freeaddrinfo(res);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -104,7 +104,7 @@ TEST_IMPL(getaddrinfo_fail) {
                              NULL,
                              NULL));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(fail_cb_called == 1);
+  ASSERT_EQ(fail_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -151,7 +151,7 @@ TEST_IMPL(getaddrinfo_basic) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(getaddrinfo_cbs == 1);
+  ASSERT_EQ(getaddrinfo_cbs, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -52,7 +52,7 @@ TEST_IMPL(gethostname) {
   r = uv_os_gethostname(buf, &size);
   ASSERT_EQ(r, 0);
   ASSERT(size > 0 && size == strlen(buf));
-  ASSERT(size + 1 == enobufs_size);
+  ASSERT_EQ(size + 1, enobufs_size);
 
   return 0;
 }

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -44,7 +44,7 @@ TEST_IMPL(gethostname) {
   buf[0] = '\0';
   r = uv_os_gethostname(buf, &enobufs_size);
   ASSERT_EQ(r, UV_ENOBUFS);
-  ASSERT(buf[0] == '\0');
+  ASSERT_EQ(buf[0], '\0');
   ASSERT(enobufs_size > 1);
 
   /* Successfully get the hostname */

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -32,18 +32,18 @@ TEST_IMPL(gethostname) {
   /* Reject invalid inputs */
   size = 1;
   r = uv_os_gethostname(NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_gethostname(buf, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   size = 0;
   r = uv_os_gethostname(buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Return UV_ENOBUFS if the buffer cannot hold the hostname */
   enobufs_size = 1;
   buf[0] = '\0';
   r = uv_os_gethostname(buf, &enobufs_size);
-  ASSERT(r == UV_ENOBUFS);
+  ASSERT_EQ(r, UV_ENOBUFS);
   ASSERT(buf[0] == '\0');
   ASSERT(enobufs_size > 1);
 

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -50,7 +50,7 @@ TEST_IMPL(gethostname) {
   /* Successfully get the hostname */
   size = UV_MAXHOSTNAMESIZE;
   r = uv_os_gethostname(buf, &size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(size > 0 && size == strlen(buf));
   ASSERT(size + 1 == enobufs_size);
 

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -39,7 +39,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
                             const char* hostname,
                             const char* service) {
   ASSERT(handle != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(hostname != NULL);
   ASSERT(service != NULL);
 }
@@ -54,14 +54,14 @@ TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
   r = uv_ip4_addr(address_ip4, port, &addr4);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr4,
                      0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -100,14 +100,14 @@ TEST_IMPL(getnameinfo_basic_ip6) {
   int r;
 
   r = uv_ip6_addr(address_ip6, port, &addr6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr6,
                      0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -333,8 +333,8 @@ TEST_IMPL(getsockname_tcp) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(getsocknamecount == 3);
-  ASSERT(getpeernamecount == 3);
+  ASSERT_EQ(getsocknamecount, 3);
+  ASSERT_EQ(getpeernamecount, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -351,7 +351,7 @@ TEST_IMPL(getsockname_udp) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(getsocknamecount == 2);
+  ASSERT_EQ(getsocknamecount, 2);
 
   ASSERT_EQ(udp.send_queue_size, 0);
   ASSERT_EQ(udpServer.send_queue_size, 0);

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -86,8 +86,8 @@ static void check_sockname(struct sockaddr* addr, const char* compare_ip,
   ASSERT(0 == uv_ip4_addr(compare_ip, compare_port, &compare_addr));
 
   /* Both addresses should be ipv4 */
-  ASSERT(check_addr.sin_family == AF_INET);
-  ASSERT(compare_addr.sin_family == AF_INET);
+  ASSERT_EQ(check_addr.sin_family, AF_INET);
+  ASSERT_EQ(compare_addr.sin_family, AF_INET);
 
   /* Check if the ip matches */
   ASSERT(memcmp(&check_addr.sin_addr,
@@ -201,7 +201,7 @@ static int tcp_listener(void) {
 
   namelen = sizeof sockname;
   r = uv_tcp_getpeername(&tcpServer, &peername, &namelen);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
   getpeernamecount++;
 
   return 0;
@@ -229,7 +229,7 @@ static void tcp_connector(void) {
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&tcp, &sockname, &namelen);
   ASSERT(!r);
-  ASSERT(sockname.sa_family == AF_INET);
+  ASSERT_EQ(sockname.sa_family, AF_INET);
   connect_port = ntohs(((struct sockaddr_in*) &sockname)->sin_port);
   ASSERT(connect_port > 0);
 }

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -353,7 +353,7 @@ TEST_IMPL(getsockname_udp) {
 
   ASSERT(getsocknamecount == 2);
 
-  ASSERT(udp.send_queue_size == 0);
+  ASSERT_EQ(udp.send_queue_size, 0);
   ASSERT(udpServer.send_queue_size == 0);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -72,7 +72,7 @@ static void after_read(uv_stream_t* handle,
 
   req = (uv_shutdown_t*) malloc(sizeof *req);
   r = uv_shutdown(req, handle, after_shutdown);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -98,7 +98,7 @@ static void check_sockname(struct sockaddr* addr, const char* compare_ip,
   ASSERT(compare_port == 0 || check_addr.sin_port == compare_addr.sin_port);
 
   r = uv_ip4_name(&check_addr, (char*) check_ip, sizeof check_ip);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   printf("%s: %s:%d\n", context, check_ip, ntohs(check_addr.sin_port));
 }
@@ -113,34 +113,34 @@ static void on_connection(uv_stream_t* server, int status) {
   if (status != 0) {
     fprintf(stderr, "Connect error %s\n", uv_err_name(status));
   }
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   handle = malloc(sizeof(*handle));
   ASSERT(handle != NULL);
 
   r = uv_tcp_init(loop, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* associate server with stream */
   handle->data = server;
 
   r = uv_accept(server, (uv_stream_t*)handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(handle, &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&sockname, "127.0.0.1", server_port, "accepted socket");
   getsocknamecount++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername(handle, &peername, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&peername, "127.0.0.1", connect_port, "accepted socket peer");
   getpeernamecount++;
 
   r = uv_read_start((uv_stream_t*)handle, alloc, after_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -148,17 +148,17 @@ static void on_connect(uv_connect_t* req, int status) {
   struct sockaddr sockname, peername;
   int r, namelen;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname((uv_tcp_t*) req->handle, &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&sockname, "127.0.0.1", 0, "connected socket");
   getsocknamecount++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername((uv_tcp_t*) req->handle, &peername, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&peername, "127.0.0.1", server_port, "connected socket peer");
   getpeernamecount++;
 
@@ -195,7 +195,7 @@ static int tcp_listener(void) {
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&tcpServer, &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&sockname, "0.0.0.0", server_port, "server socket");
   getsocknamecount++;
 
@@ -254,7 +254,7 @@ static void udp_recv(uv_udp_t* handle,
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof(sockname);
   r = uv_udp_getsockname(&udp, &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&sockname, "0.0.0.0", 0, "udp receiving socket");
   getsocknamecount++;
 
@@ -291,12 +291,12 @@ static int udp_listener(void) {
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&udpServer, &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_sockname(&sockname, "0.0.0.0", server_port, "udp listener socket");
   getsocknamecount++;
 
   r = uv_udp_recv_start(&udpServer, alloc, udp_recv);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return 0;
 }

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -354,7 +354,7 @@ TEST_IMPL(getsockname_udp) {
   ASSERT(getsocknamecount == 2);
 
   ASSERT_EQ(udp.send_queue_size, 0);
-  ASSERT(udpServer.send_queue_size == 0);
+  ASSERT_EQ(udpServer.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -60,7 +60,7 @@ TEST_IMPL(getters_setters) {
   loop = malloc(uv_loop_size());
   ASSERT(loop != NULL);
   r = uv_loop_init(loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_loop_set_data(loop, &cookie1);
   ASSERT(loop->data == &cookie1);
@@ -84,13 +84,13 @@ TEST_IMPL(getters_setters) {
   uv_close((uv_handle_t*)pipe, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   fs = malloc(uv_req_size(UV_FS));
   uv_fs_stat(loop, fs, ".", NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(uv_req_get_loop((uv_req_t*)fs) == loop);
   ASSERT(uv_fs_get_type(fs) == UV_FS_STAT);
@@ -101,7 +101,7 @@ TEST_IMPL(getters_setters) {
   uv_fs_req_cleanup(fs);
 
   r = uv_loop_close(loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   free(pipe);
   free(fs);

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -28,7 +28,7 @@ TEST_IMPL(gettimeofday) {
 
   tv.tv_sec = 0;
   r = uv_gettimeofday(&tv);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(tv.tv_sec != 0);
 
   /* Test invalid input. */

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -33,7 +33,7 @@ TEST_IMPL(gettimeofday) {
 
   /* Test invalid input. */
   r = uv_gettimeofday(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -57,44 +57,44 @@ TEST_IMPL(handle_fileno) {
   r = uv_idle_init(loop, &idle);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &idle, &fd);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_close((uv_handle_t*) &idle, NULL);
 
   r = uv_tcp_init(loop, &tcp);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_tcp_bind(&tcp, (const struct sockaddr*) &addr, 0);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
   ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &tcp, NULL);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_udp_init(loop, &udp);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_udp_bind(&udp, (const struct sockaddr*) &addr, 0);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
   ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &udp, NULL);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_init(loop, &pipe, 0);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_pipe_bind(&pipe, TEST_PIPENAME);
   ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
   ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &pipe, NULL);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   tty_fd = get_tty_fd();
   if (tty_fd == (uv_os_fd_t)-1) {
@@ -109,7 +109,7 @@ TEST_IMPL(handle_fileno) {
     ASSERT_EQ(r, 0);
     uv_close((uv_handle_t*) &tty, NULL);
     r = uv_fileno((uv_handle_t*) &tty, &fd);
-    ASSERT(r == UV_EBADF);
+    ASSERT_EQ(r, UV_EBADF);
     ASSERT(!uv_is_readable((uv_stream_t*) &tty));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty));
   }

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -55,43 +55,43 @@ TEST_IMPL(handle_fileno) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_idle_init(loop, &idle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &idle, &fd);
   ASSERT(r == UV_EINVAL);
   uv_close((uv_handle_t*) &idle, NULL);
 
   r = uv_tcp_init(loop, &tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
   ASSERT(r == UV_EBADF);
   r = uv_tcp_bind(&tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &tcp, NULL);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
   ASSERT(r == UV_EBADF);
 
   r = uv_udp_init(loop, &udp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
   ASSERT(r == UV_EBADF);
   r = uv_udp_bind(&udp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &udp, NULL);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
   ASSERT(r == UV_EBADF);
 
   r = uv_pipe_init(loop, &pipe, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
   ASSERT(r == UV_EBADF);
   r = uv_pipe_bind(&pipe, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &pipe, NULL);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
   ASSERT(r == UV_EBADF);
@@ -102,11 +102,11 @@ TEST_IMPL(handle_fileno) {
     fflush(stderr);
   } else {
     r = uv_tty_init(loop, &tty, tty_fd, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(uv_is_readable((uv_stream_t*) &tty));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty));
     r = uv_fileno((uv_handle_t*) &tty, &fd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_close((uv_handle_t*) &tty, NULL);
     r = uv_fileno((uv_handle_t*) &tty, &fd);
     ASSERT(r == UV_EBADF);

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -36,7 +36,7 @@ TEST_IMPL(homedir) {
   homedir[0] = '\0';
   ASSERT(strlen(homedir) == 0);
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(strlen(homedir) == len);
   ASSERT(len > 0);
   ASSERT(homedir[len] == '\0');

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -56,17 +56,17 @@ TEST_IMPL(homedir) {
   /* Test the case where the buffer is too small */
   len = SMALLPATH;
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == UV_ENOBUFS);
+  ASSERT_EQ(r, UV_ENOBUFS);
   ASSERT(len > SMALLPATH);
 
   /* Test invalid inputs */
   r = uv_os_homedir(NULL, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_homedir(homedir, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   len = 0;
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -39,16 +39,16 @@ TEST_IMPL(homedir) {
   ASSERT_EQ(r, 0);
   ASSERT(strlen(homedir) == len);
   ASSERT(len > 0);
-  ASSERT(homedir[len] == '\0');
+  ASSERT_EQ(homedir[len], '\0');
 
 #ifdef _WIN32
   if (len == 3 && homedir[1] == ':')
-    ASSERT(homedir[2] == '\\');
+    ASSERT_EQ(homedir[2], '\\');
   else
     ASSERT(homedir[len - 1] != '\\');
 #else
   if (len == 1)
-    ASSERT(homedir[0] == '/');
+    ASSERT_EQ(homedir[0], '/');
   else
     ASSERT(homedir[len - 1] != '/');
 #endif

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -91,8 +91,8 @@ TEST_IMPL(idle_starvation) {
   ASSERT_EQ(r, 0);
 
   ASSERT(idle_cb_called > 0);
-  ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -73,22 +73,22 @@ TEST_IMPL(idle_starvation) {
   int r;
 
   r = uv_idle_init(uv_default_loop(), &idle_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_idle_start(&idle_handle, idle_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, timer_cb, 50, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(idle_cb_called > 0);
   ASSERT(timer_cb_called == 1);

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -39,7 +39,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_EQ(handle, &timer_handle);
 
   uv_close((uv_handle_t*) &idle_handle, close_cb);
   uv_close((uv_handle_t*) &check_handle, close_cb);
@@ -52,7 +52,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void idle_cb(uv_idle_t* handle) {
-  ASSERT(handle == &idle_handle);
+  ASSERT_EQ(handle, &idle_handle);
 
   idle_cb_called++;
   fprintf(stderr, "idle_cb %d\n", idle_cb_called);
@@ -61,7 +61,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT(handle == &check_handle);
+  ASSERT_EQ(handle, &check_handle);
 
   check_cb_called++;
   fprintf(stderr, "check_cb %d\n", check_cb_called);

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -113,11 +113,11 @@ TEST_IMPL(utf8_decode1) {
     char d2[256] = {0};                                                       \
     static const char s[] = "" input "";                                      \
     n = uv__idna_toascii(s, s + sizeof(s) - 1, d1, d1 + sizeof(d1));          \
-    ASSERT(n == sizeof(expected));                                            \
+    ASSERT_EQ(n, sizeof(expected));                                            \
     ASSERT(0 == memcmp(d1, expected, n));                                     \
     /* Sanity check: encoding twice should not change the output. */          \
     n = uv__idna_toascii(d1, d1 + strlen(d1), d2, d2 + sizeof(d2));           \
-    ASSERT(n == sizeof(expected));                                            \
+    ASSERT_EQ(n, sizeof(expected));                                            \
     ASSERT(0 == memcmp(d2, expected, n));                                     \
     ASSERT(0 == memcmp(d1, d2, sizeof(d2)));                                  \
   } while (0)

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -32,57 +32,57 @@ TEST_IMPL(utf8_decode1) {
   p = b;
   snprintf(b, sizeof(b), "%c\x7F", 0x00);
   ASSERT(0 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 1);
+  ASSERT_EQ(p, b + 1);
   ASSERT(127 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
+  ASSERT_EQ(p, b + 2);
 
   /* Two-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xC2\x80\xDF\xBF");
   ASSERT(128 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
+  ASSERT_EQ(p, b + 2);
   ASSERT(0x7FF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ(p, b + 4);
 
   /* Three-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xE0\xA0\x80\xEF\xBF\xBF");
   ASSERT(0x800 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 3);
+  ASSERT_EQ(p, b + 3);
   ASSERT(0xFFFF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 6);
+  ASSERT_EQ(p, b + 6);
 
   /* Four-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xF0\x90\x80\x80\xF4\x8F\xBF\xBF");
   ASSERT(0x10000 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ(p, b + 4);
   ASSERT(0x10FFFF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 8);
+  ASSERT_EQ(p, b + 8);
 
   /* Four-byte sequences > U+10FFFF; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xF4\x90\xC0\xC0\xF7\xBF\xBF\xBF");
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ(p, b + 4);
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 8);
+  ASSERT_EQ(p, b + 8);
 
   /* Overlong; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xC0\x80\xC1\x80");
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
+  ASSERT_EQ(p, b + 2);
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ(p, b + 4);
 
   /* Surrogate pairs; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xED\xA0\x80\xED\xA3\xBF");
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 3);
+  ASSERT_EQ(p, b + 3);
   ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 6);
+  ASSERT_EQ(p, b + 6);
 
   /* Simply illegal. */
   p = b;
@@ -90,7 +90,7 @@ TEST_IMPL(utf8_decode1) {
 
   for (i = 1; i <= 8; i++) {
     ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-    ASSERT(p == b + i);
+    ASSERT_EQ(p, b + i);
   }
 
   return 0;

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -43,7 +43,7 @@ TEST_IMPL(ip4_addr) {
   ASSERT(UV_EINVAL == uv_ip4_addr("255", TEST_PORT, &addr));
 
 #ifdef SIN6_LEN
-  ASSERT(addr.sin_len == sizeof(addr));
+  ASSERT_EQ(addr.sin_len, sizeof(addr));
 #endif
 
   /* for broken address family */

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -80,7 +80,7 @@ TEST_IMPL(ip6_addr_link_local) {
 
     interface_id_len = sizeof(interface_id);
     r = uv_if_indextoiid(iface_index, interface_id, &interface_id_len);
-    ASSERT(0 == r);
+    ASSERT_EQ(r, 0);
 #ifdef _WIN32
     /* On Windows, the interface identifier is the numeric string of the index. */
     ASSERT(strtoul(interface_id, NULL, 10) == iface_index);

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -105,7 +105,7 @@ TEST_IMPL(ip6_addr_link_local) {
     ASSERT(0 == uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
     fprintf(stderr, "Got scope_id 0x%02x\n", addr.sin6_scope_id);
     fflush(stderr);
-    ASSERT(iface_index == addr.sin6_scope_id);
+    ASSERT_EQ(iface_index, addr.sin6_scope_id);
   }
 
   uv_free_interface_addresses(addresses, count);

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -176,7 +176,7 @@ TEST_IMPL(ip6_invalid_interface) {
 TEST_IMPL(ip6_sin6_len) {
   struct sockaddr_in6 s;
   ASSERT(uv_ip6_addr("::", 0, &s) < 0);
-  ASSERT(s.sin6_len == sizeof(s));
+  ASSERT_EQ(s.sin6_len, sizeof(s));
   return 0;
 }
 #endif

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -98,7 +98,7 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   bytes_read += nread;
 
   for (i = 0; i < nread; i++)
-    ASSERT(buf->base[i] == BUFFER_CONTENT);
+    ASSERT_EQ(buf->base[i], BUFFER_CONTENT);
   free(buf->base);
 
   if (bytes_read >= XFER_SIZE) {

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -126,8 +126,8 @@ static void do_writes_and_reads(uv_stream_t* handle) {
   r = uv_run(handle->loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(bytes_written == XFER_SIZE);
-  ASSERT(bytes_read == XFER_SIZE);
+  ASSERT_EQ(bytes_written, XFER_SIZE);
+  ASSERT_EQ(bytes_read, XFER_SIZE);
 }
 
 TEST_IMPL(ipc_heavy_traffic_deadlock_bug) {

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -49,7 +49,7 @@ static size_t bytes_read;
 static void write_cb(uv_write_t* req, int status) {
   struct write_info* write_info =
       container_of(req, struct write_info, write_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   bytes_written += BUFFERS_PER_WRITE * BUFFER_SIZE;
   free(write_info);
 }
@@ -75,7 +75,7 @@ static void do_write(uv_stream_t* handle) {
 
   r = uv_write(
       &write_info->write_req, handle, bufs, BUFFERS_PER_WRITE, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -103,9 +103,9 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
   if (bytes_read >= XFER_SIZE) {
     r = uv_read_stop(handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_shutdown(&shutdown_req, handle, shutdown_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -121,10 +121,10 @@ static void do_writes_and_reads(uv_stream_t* handle) {
   }
 
   r = uv_read_start(handle, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(handle->loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(bytes_written == XFER_SIZE);
   ASSERT(bytes_read == XFER_SIZE);
@@ -146,9 +146,9 @@ int ipc_helper_heavy_traffic_deadlock_bug(void) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&pipe, uv_convert_fd_to_handle(0));
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   notify_parent_process();
   do_writes_and_reads((uv_stream_t*) &pipe);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -114,7 +114,7 @@ static void recv_cb(uv_stream_t* handle,
       ASSERT(uv_pipe_pending_count(pipe) > 0);
 
       pending = uv_pipe_pending_type(pipe);
-      ASSERT(pending == ctx.expected_type);
+      ASSERT_EQ(pending, ctx.expected_type);
 
       if (pending == UV_NAMED_PIPE)
         r = uv_pipe_init(ctx.channel.loop, &recv->pipe, 0);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -108,7 +108,7 @@ static void recv_cb(uv_stream_t* handle,
      * acceptable value. */
     if (nread == UV_EOF) {
       /* UV_EOF is only acceptable for the final recv_cb call */
-      ASSERT(recv_cb_count == 2);
+      ASSERT_EQ(recv_cb_count, 2);
     } else {
       ASSERT(nread >= 0);
       ASSERT(uv_pipe_pending_count(pipe) > 0);
@@ -189,7 +189,7 @@ static int run_test(int inprocess) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(recv_cb_count == 2);
+  ASSERT_EQ(recv_cb_count, 2);
 
   if (inprocess) {
     r = uv_thread_join(&tid);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -359,7 +359,7 @@ static void send_recv_start(void) {
 
 static void listen_cb(uv_stream_t* handle, int status) {
   int r;
-  ASSERT(handle == (uv_stream_t*)&ctx2.listen);
+  ASSERT_EQ(handle, (uv_stream_t*)&ctx2.listen);
   ASSERT_EQ(status, 0);
 
   r = uv_accept((uv_stream_t*)&ctx2.listen, (uv_stream_t*)&ctx2.channel);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -92,7 +92,7 @@ static void recv_cb(uv_stream_t* handle,
   union handles* recv;
 
   pipe = (uv_pipe_t*) handle;
-  ASSERT(pipe == &ctx.channel);
+  ASSERT_EQ(pipe, &ctx.channel);
 
   do {
     if (++recv_cb_count == 1) {
@@ -139,7 +139,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(req == &ctx.connect_req);
+  ASSERT_EQ(req, &ctx.connect_req);
   ASSERT_EQ(status, 0);
 
   buf = uv_buf_init(".", 1);
@@ -318,7 +318,7 @@ static void read_cb(uv_stream_t* handle,
       write_req = &ctx2.write_req2;
     }
 
-    ASSERT(pipe == &ctx2.channel);
+    ASSERT_EQ(pipe, &ctx2.channel);
     ASSERT(nread >= 0);
     ASSERT(uv_pipe_pending_count(pipe) > 0);
 

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -122,10 +122,10 @@ static void recv_cb(uv_stream_t* handle,
         r = uv_tcp_init(ctx.channel.loop, &recv->tcp);
       else
         abort();
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       r = uv_accept(handle, &recv->stream);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
   } while (uv_pipe_pending_count(pipe) > 0);
 
@@ -140,7 +140,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_buf_t buf;
 
   ASSERT(req == &ctx.connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   buf = uv_buf_init(".", 1);
   r = uv_write2(&ctx.write_req,
@@ -148,7 +148,7 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send.stream,
                 NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Perform two writes to the same pipe to make sure that on Windows we are
    * not running into issue 505:
@@ -159,10 +159,10 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send2.stream,
                 NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&ctx.channel, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static int run_test(int inprocess) {
@@ -172,12 +172,12 @@ static int run_test(int inprocess) {
 
   if (inprocess) {
     r = uv_thread_create(&tid, ipc_send_recv_helper_threadproc, (void *) 42);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_sleep(1000);
 
     r = uv_pipe_init(uv_default_loop(), &ctx.channel, 1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_pipe_connect(&ctx.connect_req, &ctx.channel, TEST_PIPENAME_3, connect_cb);
   } else {
@@ -187,13 +187,13 @@ static int run_test(int inprocess) {
   }
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(recv_cb_count == 2);
 
   if (inprocess) {
     r = uv_thread_join(&tid);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   return 0;
@@ -205,19 +205,19 @@ static int run_ipc_send_recv_pipe(int inprocess) {
   ctx.expected_type = UV_NAMED_PIPE;
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send.pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&ctx.send.pipe, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send2.pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&ctx.send2.pipe, TEST_PIPENAME_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_test(inprocess);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -246,19 +246,19 @@ static int run_ipc_send_recv_tcp(int inprocess) {
   ctx.expected_type = UV_TCP;
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send.tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send2.tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&ctx.send.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&ctx.send2.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_test(inprocess);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -282,7 +282,7 @@ TEST_IMPL(ipc_send_recv_tcp_inprocess) {
 /* Everything here runs in a child process or second thread. */
 
 static void write2_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* After two successful writes in the child process, allow the child
    * process to be closed. */
@@ -331,10 +331,10 @@ static void read_cb(uv_stream_t* handle,
       r = uv_tcp_init(ctx2.channel.loop, &recv->tcp);
     else
       abort();
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_accept(handle, &recv->stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     wrbuf = uv_buf_init(".", 1);
     r = uv_write2(write_req,
@@ -343,7 +343,7 @@ static void read_cb(uv_stream_t* handle,
                   1,
                   &recv->stream,
                   write2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   } while (uv_pipe_pending_count(pipe) > 0);
 }
 
@@ -354,16 +354,16 @@ static void send_recv_start(void) {
   ASSERT(0 == uv_is_closing((uv_handle_t*)&ctx2.channel));
 
   r = uv_read_start((uv_stream_t*)&ctx2.channel, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void listen_cb(uv_stream_t* handle, int status) {
   int r;
   ASSERT(handle == (uv_stream_t*)&ctx2.listen);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_accept((uv_stream_t*)&ctx2.listen, (uv_stream_t*)&ctx2.channel);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   send_recv_start();
 }
@@ -376,28 +376,28 @@ int run_ipc_send_recv_helper(uv_loop_t* loop, int inprocess) {
   memset(&ctx2, 0, sizeof(ctx2));
 
   r = uv_pipe_init(loop, &ctx2.listen, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(loop, &ctx2.channel, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (inprocess) {
     r = uv_pipe_bind(&ctx2.listen, TEST_PIPENAME_3);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_listen((uv_stream_t*)&ctx2.listen, SOMAXCONN, listen_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   } else {
     uv_os_fd_t stdin_handle = uv_convert_fd_to_handle(0);
     r = uv_pipe_open(&ctx2.channel, stdin_handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     send_recv_start();
   }
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return 0;
 }
@@ -409,7 +409,7 @@ int ipc_send_recv_helper(void) {
   int r;
 
   r = run_ipc_send_recv_helper(uv_default_loop(), 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -420,11 +420,11 @@ void ipc_send_recv_helper_threadproc(void* arg) {
   uv_loop_t loop;
 
   r = uv_loop_init(&loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_ipc_send_recv_helper(&loop, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_loop_close(&loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -37,7 +37,7 @@ static void work_cb(uv_work_t* req) {
 
 static void after_work_cb(uv_work_t* req, int status) {
   ASSERT(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -51,16 +51,16 @@ TEST_IMPL(loop_alive) {
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   /* loops with requests are alive */
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   return 0;

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -47,7 +47,7 @@ TEST_IMPL(loop_close) {
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(loop.data == (void*) &loop);
   ASSERT(0 == uv_loop_close(&loop));

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -36,7 +36,7 @@ TEST_IMPL(loop_close) {
 
   loop.data = &loop;
   ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(loop.data == (void*) &loop);
+  ASSERT_EQ(loop.data, (void*) &loop);
 
   uv_timer_init(&loop, &timer_handle);
   uv_timer_start(&timer_handle, timer_cb, 100, 100);
@@ -49,9 +49,9 @@ TEST_IMPL(loop_close) {
   r = uv_run(&loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(loop.data == (void*) &loop);
+  ASSERT_EQ(loop.data, (void*) &loop);
   ASSERT(0 == uv_loop_close(&loop));
-  ASSERT(loop.data == (void*) &loop);
+  ASSERT_EQ(loop.data, (void*) &loop);
 
   return 0;
 }

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -331,7 +331,7 @@ TEST_IMPL(loop_handles) {
   /* idle_1_cb should be called a lot */
   ASSERT_EQ(idle_1_close_cb_called, IDLE_COUNT);
 
-  ASSERT(idle_2_close_cb_called == idle_2_cb_started);
+  ASSERT_EQ(idle_2_close_cb_called, idle_2_cb_started);
   ASSERT_EQ(idle_2_is_active, 0);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -285,7 +285,7 @@ TEST_IMPL(loop_handles) {
   r = uv_prepare_init(uv_default_loop(), &prepare_1_handle);
   ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare_1_handle, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_prepare_start(&prepare_1_handle, prepare_1_cb);
   ASSERT_EQ(r, 0);
 
@@ -317,19 +317,19 @@ TEST_IMPL(loop_handles) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(loop_iteration == ITERATIONS);
+  ASSERT_EQ(loop_iteration, ITERATIONS);
 
-  ASSERT(prepare_1_cb_called == ITERATIONS);
+  ASSERT_EQ(prepare_1_cb_called, ITERATIONS);
   ASSERT_EQ(prepare_1_close_cb_called, 1);
 
   ASSERT(prepare_2_cb_called == ITERATIONS / 2);
   ASSERT_EQ(prepare_2_close_cb_called, 1);
 
-  ASSERT(check_cb_called == ITERATIONS);
+  ASSERT_EQ(check_cb_called, ITERATIONS);
   ASSERT_EQ(check_close_cb_called, 1);
 
   /* idle_1_cb should be called a lot */
-  ASSERT(idle_1_close_cb_called == IDLE_COUNT);
+  ASSERT_EQ(idle_1_close_cb_called, IDLE_COUNT);
 
   ASSERT(idle_2_close_cb_called == idle_2_cb_started);
   ASSERT_EQ(idle_2_is_active, 0);

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -322,7 +322,7 @@ TEST_IMPL(loop_handles) {
   ASSERT_EQ(prepare_1_cb_called, ITERATIONS);
   ASSERT_EQ(prepare_1_close_cb_called, 1);
 
-  ASSERT(prepare_2_cb_called == ITERATIONS / 2);
+  ASSERT_EQ(prepare_2_cb_called, ITERATIONS / 2);
   ASSERT_EQ(prepare_2_close_cb_called, 1);
 
   ASSERT_EQ(check_cb_called, ITERATIONS);

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -116,7 +116,7 @@ static void idle_2_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "IDLE_2_CLOSE_CB\n");
   fflush(stderr);
 
-  ASSERT(handle == (uv_handle_t*)&idle_2_handle);
+  ASSERT_EQ(handle, (uv_handle_t*)&idle_2_handle);
 
   ASSERT(idle_2_is_active);
 
@@ -179,7 +179,7 @@ static void idle_1_close_cb(uv_handle_t* handle) {
 static void prepare_1_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "PREPARE_1_CLOSE_CB");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&prepare_1_handle);
+  ASSERT_EQ(handle, (uv_handle_t*)&prepare_1_handle);
 
   prepare_1_close_cb_called++;
 }
@@ -188,7 +188,7 @@ static void prepare_1_close_cb(uv_handle_t* handle) {
 static void check_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "CHECK_CLOSE_CB\n");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&check_handle);
+  ASSERT_EQ(handle, (uv_handle_t*)&check_handle);
 
   check_close_cb_called++;
 }
@@ -197,7 +197,7 @@ static void check_close_cb(uv_handle_t* handle) {
 static void prepare_2_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "PREPARE_2_CLOSE_CB\n");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&prepare_2_handle);
+  ASSERT_EQ(handle, (uv_handle_t*)&prepare_2_handle);
 
   prepare_2_close_cb_called++;
 }

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -332,7 +332,7 @@ TEST_IMPL(loop_handles) {
   ASSERT(idle_1_close_cb_called == IDLE_COUNT);
 
   ASSERT(idle_2_close_cb_called == idle_2_cb_started);
-  ASSERT(idle_2_is_active == 0);
+  ASSERT_EQ(idle_2_is_active, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -108,7 +108,7 @@ static int idle_2_is_active = 0;
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_EQ(handle, &timer_handle);
 }
 
 
@@ -129,7 +129,7 @@ static void idle_2_cb(uv_idle_t* handle) {
   fprintf(stderr, "%s", "IDLE_2_CB\n");
   fflush(stderr);
 
-  ASSERT(handle == &idle_2_handle);
+  ASSERT_EQ(handle, &idle_2_handle);
 
   idle_2_cb_called++;
 
@@ -208,7 +208,7 @@ static void check_cb(uv_check_t* handle) {
 
   fprintf(stderr, "%s", "CHECK_CB\n");
   fflush(stderr);
-  ASSERT(handle == &check_handle);
+  ASSERT_EQ(handle, &check_handle);
 
   if (loop_iteration < ITERATIONS) {
     /* Make some idle watchers active */
@@ -244,7 +244,7 @@ static void prepare_2_cb(uv_prepare_t* handle) {
 
   fprintf(stderr, "%s", "PREPARE_2_CB\n");
   fflush(stderr);
-  ASSERT(handle == &prepare_2_handle);
+  ASSERT_EQ(handle, &prepare_2_handle);
 
   /* Prepare_2 gets started by prepare_1 when (loop_iteration % 2 == 0), and it
    * stops itself immediately. A started watcher is not queued until the next
@@ -264,7 +264,7 @@ static void prepare_1_cb(uv_prepare_t* handle) {
 
   fprintf(stderr, "%s", "PREPARE_1_CB\n");
   fflush(stderr);
-  ASSERT(handle == &prepare_1_handle);
+  ASSERT_EQ(handle, &prepare_1_handle);
 
   if (loop_iteration % 2 == 0) {
     r = uv_prepare_start(&prepare_2_handle, prepare_2_cb);

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -149,9 +149,9 @@ static void idle_1_cb(uv_idle_t* handle) {
   /* Init idle_2 and make it active */
   if (!idle_2_is_active && !uv_is_closing((uv_handle_t*)&idle_2_handle)) {
     r = uv_idle_init(uv_default_loop(), &idle_2_handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_idle_start(&idle_2_handle, idle_2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     idle_2_is_active = 1;
     idle_2_cb_started++;
   }
@@ -160,7 +160,7 @@ static void idle_1_cb(uv_idle_t* handle) {
 
   if (idle_1_cb_called % 5 == 0) {
     r = uv_idle_stop((uv_idle_t*)handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     idles_1_active--;
   }
 }
@@ -214,7 +214,7 @@ static void check_cb(uv_check_t* handle) {
     /* Make some idle watchers active */
     for (i = 0; i < 1 + (loop_iteration % IDLE_COUNT); i++) {
       r = uv_idle_start(&idle_1_handles[i], idle_1_cb);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
       idles_1_active++;
     }
 
@@ -253,7 +253,7 @@ static void prepare_2_cb(uv_prepare_t* handle) {
   ASSERT(loop_iteration % 2 != 0);
 
   r = uv_prepare_stop((uv_prepare_t*)handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   prepare_2_cb_called++;
 }
@@ -268,7 +268,7 @@ static void prepare_1_cb(uv_prepare_t* handle) {
 
   if (loop_iteration % 2 == 0) {
     r = uv_prepare_start(&prepare_2_handle, prepare_2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   prepare_1_cb_called++;
@@ -283,25 +283,25 @@ TEST_IMPL(loop_handles) {
   int r;
 
   r = uv_prepare_init(uv_default_loop(), &prepare_1_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare_1_handle, NULL);
   ASSERT(r == UV_EINVAL);
   r = uv_prepare_start(&prepare_1_handle, prepare_1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* initialize only, prepare_2 is started by prepare_1_cb */
   r = uv_prepare_init(uv_default_loop(), &prepare_2_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < IDLE_COUNT; i++) {
     /* initialize only, idle_1 handles are started by check_cb */
     r = uv_idle_init(uv_default_loop(), &idle_1_handles[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* don't init or start idle_2, both is done by idle_1_cb */
@@ -309,13 +309,13 @@ TEST_IMPL(loop_handles) {
   /* The timer callback is there to keep the event loop polling unref it as it
    * is not supposed to keep the loop alive */
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, timer_cb, TIMEOUT, TIMEOUT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_unref((uv_handle_t*)&timer_handle);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(loop_iteration == ITERATIONS);
 

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -320,13 +320,13 @@ TEST_IMPL(loop_handles) {
   ASSERT(loop_iteration == ITERATIONS);
 
   ASSERT(prepare_1_cb_called == ITERATIONS);
-  ASSERT(prepare_1_close_cb_called == 1);
+  ASSERT_EQ(prepare_1_close_cb_called, 1);
 
   ASSERT(prepare_2_cb_called == ITERATIONS / 2);
-  ASSERT(prepare_2_close_cb_called == 1);
+  ASSERT_EQ(prepare_2_close_cb_called, 1);
 
   ASSERT(check_cb_called == ITERATIONS);
-  ASSERT(check_close_cb_called == 1);
+  ASSERT_EQ(check_close_cb_called, 1);
 
   /* idle_1_cb should be called a lot */
   ASSERT(idle_1_close_cb_called == IDLE_COUNT);

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -63,7 +63,7 @@ TEST_IMPL(loop_stop) {
   ASSERT(prepare_called > 1);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(timer_called == 10);
   ASSERT(prepare_called == 10);
 

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -56,7 +56,7 @@ TEST_IMPL(loop_stop) {
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r != 0);
-  ASSERT(timer_called == 1);
+  ASSERT_EQ(timer_called, 1);
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
   ASSERT(r != 0);
@@ -64,8 +64,8 @@ TEST_IMPL(loop_stop) {
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(timer_called == 10);
-  ASSERT(prepare_called == 10);
+  ASSERT_EQ(timer_called, 10);
+  ASSERT_EQ(prepare_called, 10);
 
   return 0;
 }

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -30,7 +30,7 @@ static int num_ticks = 10;
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT(handle == &prepare_handle);
+  ASSERT_EQ(handle, &prepare_handle);
   prepare_called++;
   if (prepare_called == num_ticks)
     uv_prepare_stop(handle);
@@ -38,7 +38,7 @@ static void prepare_cb(uv_prepare_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_EQ(handle, &timer_handle);
   timer_called++;
   if (timer_called == 1)
     uv_stop(uv_default_loop());

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -44,18 +44,18 @@ TEST_IMPL(loop_backend_timeout) {
   int r;
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(!uv_loop_alive(loop));
   ASSERT(uv_backend_timeout(loop) == 0);
 
   r = uv_timer_start(&timer, cb, 1000, 0); /* 1 sec */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_backend_timeout(loop) > 100); /* 0.1 sec */
   ASSERT(uv_backend_timeout(loop) <= 1000); /* 1 sec */
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_backend_timeout(loop) == 0);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*)&server, close_cb);
   connection_cb_called++;
 }
@@ -51,22 +51,22 @@ static void start_server(void) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   free(req);
   uv_close((uv_handle_t*)&client, close_cb);
   connect_cb_called++;
@@ -82,13 +82,13 @@ static void client_connect(void) {
   ASSERT(connect_req != NULL);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -100,9 +100,9 @@ TEST_IMPL(multiple_listen) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -40,7 +40,7 @@ TEST_IMPL(thread_mutex) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_mutex_lock(&mutex);
   uv_mutex_unlock(&mutex);
@@ -55,7 +55,7 @@ TEST_IMPL(thread_mutex_recursive) {
   int r;
 
   r = uv_mutex_init_recursive(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_mutex_lock(&mutex);
   uv_mutex_lock(&mutex);
@@ -75,7 +75,7 @@ TEST_IMPL(thread_rwlock) {
   int r;
 
   r = uv_rwlock_init(&rwlock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_rwlock_rdlock(&rwlock);
   uv_rwlock_rdunlock(&rwlock);

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -101,7 +101,7 @@ static void synchronize(void) {
   synchronize_nowait();
   /* Wait for the other thread.  Guard against spurious wakeups. */
   for (current = step; current == step; uv_cond_wait(&condvar, &mutex));
-  ASSERT(step == current + 1);
+  ASSERT_EQ(step, current + 1);
 }
 
 

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -62,7 +62,7 @@ TEST_IMPL(osx_select) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
 
@@ -72,7 +72,7 @@ TEST_IMPL(osx_select) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -97,13 +97,13 @@ TEST_IMPL(osx_select_many_fds) {
   TEST_FILE_LIMIT(ARRAY_SIZE(tcps) + 100);
 
   r = uv_ip4_addr("127.0.0.1", 0, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < ARRAY_SIZE(tcps); i++) {
     r = uv_tcp_init(uv_default_loop(), &tcps[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_tcp_bind(&tcps[i], (const struct sockaddr *) &addr, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_unref((uv_handle_t*) &tcps[i]);
   }
 
@@ -115,10 +115,10 @@ TEST_IMPL(osx_select_many_fds) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate user-input */
   str = "got some input\n"
@@ -126,7 +126,7 @@ TEST_IMPL(osx_select_many_fds) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -77,7 +77,7 @@ TEST_IMPL(osx_select) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(read_count == 3);
+  ASSERT_EQ(read_count, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -131,7 +131,7 @@ TEST_IMPL(osx_select_many_fds) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(read_count == 3);
+  ASSERT_EQ(read_count, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -67,7 +67,7 @@ static void pinger_on_close(uv_handle_t* handle) {
 
 
 static void pinger_after_write(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   free(req);
 }
 
@@ -149,7 +149,7 @@ static void pinger_on_connect(uv_connect_t* req, int status) {
 
   pinger_on_connect_count++;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(1 == uv_is_readable(req->handle));
   ASSERT(1 == uv_is_writable(req->handle));
@@ -189,7 +189,7 @@ static void tcp_pinger_v6_new(int vectored_writes) {
   ASSERT(!r);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT(pinger_on_connect_count == 0);
+  ASSERT_EQ(pinger_on_connect_count, 0);
 }
 
 
@@ -219,7 +219,7 @@ static void tcp_pinger_new(int vectored_writes) {
   ASSERT(!r);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT(pinger_on_connect_count == 0);
+  ASSERT_EQ(pinger_on_connect_count, 0);
 }
 
 
@@ -244,7 +244,7 @@ static void pipe_pinger_new(int vectored_writes) {
       pinger_on_connect);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT(pinger_on_connect_count == 0);
+  ASSERT_EQ(pinger_on_connect_count, 0);
 }
 
 

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -111,7 +111,7 @@ static void pinger_read_cb(uv_stream_t* stream,
   pinger = (pinger_t*) stream->data;
 
   if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     puts("got EOF");
     free(buf->base);

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -58,7 +58,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void pinger_on_close(uv_handle_t* handle) {
   pinger_t* pinger = (pinger_t*)handle->data;
 
-  ASSERT(NUM_PINGS == pinger->pongs);
+  ASSERT_EQ(NUM_PINGS, pinger->pongs);
 
   free(pinger);
 

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -123,7 +123,7 @@ static void pinger_read_cb(uv_stream_t* stream,
 
   /* Now we count the pings */
   for (i = 0; i < nread; i++) {
-    ASSERT(buf->base[i] == PING[pinger->state]);
+    ASSERT_EQ(buf->base[i], PING[pinger->state]);
     pinger->state = (pinger->state + 1) % (sizeof(PING) - 1);
 
     if (pinger->state != 0)

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -250,7 +250,7 @@ static void pipe_pinger_new(int vectored_writes) {
 
 static int run_ping_pong_test(void) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(completed_pingers == 1);
+  ASSERT_EQ(completed_pingers, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -54,12 +54,12 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
   r = uv_pipe_init(uv_default_loop(), &server2, 0);
   ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server2, TEST_PIPENAME);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   r = uv_listen((uv_stream_t*)&server1, SOMAXCONN, NULL);
   ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, SOMAXCONN, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
@@ -81,7 +81,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
   ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&server, BAD_PIPENAME);
-  ASSERT(r == UV_EACCES);
+  ASSERT_EQ(r, UV_EACCES);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -103,7 +103,7 @@ TEST_IMPL(pipe_bind_error_inval) {
   r = uv_pipe_bind(&server, TEST_PIPENAME);
   ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, TEST_PIPENAME_2);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -127,7 +127,7 @@ TEST_IMPL(pipe_listen_without_bind) {
   ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -151,7 +151,7 @@ TEST_IMPL(pipe_bind_error_long_path) {
   r = uv_pipe_init(uv_default_loop(), &server, 0);
   ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, path);
-  ASSERT(r == UV_ENAMETOOLONG);
+  ASSERT_EQ(r, UV_ENAMETOOLONG);
 
   uv_close((uv_handle_t*)&server, close_cb);
 

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -47,17 +47,17 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server1, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &server2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server2, TEST_PIPENAME);
   ASSERT(r == UV_EADDRINUSE);
 
   r = uv_listen((uv_stream_t*)&server1, SOMAXCONN, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, SOMAXCONN, NULL);
   ASSERT(r == UV_EINVAL);
 
@@ -78,7 +78,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&server, BAD_PIPENAME);
   ASSERT(r == UV_EACCES);
@@ -99,9 +99,9 @@ TEST_IMPL(pipe_bind_error_inval) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, TEST_PIPENAME_2);
   ASSERT(r == UV_EINVAL);
 
@@ -124,7 +124,7 @@ TEST_IMPL(pipe_listen_without_bind) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
   ASSERT(r == UV_EINVAL);
@@ -149,7 +149,7 @@ TEST_IMPL(pipe_bind_error_long_path) {
   path[sizeof(path) - 1] = '\0';
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, path);
   ASSERT(r == UV_ENAMETOOLONG);
 

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -66,7 +66,7 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -87,7 +87,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -109,7 +109,7 @@ TEST_IMPL(pipe_bind_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -133,7 +133,7 @@ TEST_IMPL(pipe_listen_without_bind) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -157,7 +157,7 @@ TEST_IMPL(pipe_bind_error_long_path) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -57,7 +57,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
   uv_pipe_t stdin_pipe;
 
   r = pipe(fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if ((pid = fork()) == 0) {
     /*
@@ -74,13 +74,13 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
 
     /* Create a stream that reads from the pipe. */
     r = uv_pipe_init(uv_default_loop(), (uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_pipe_open((uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_read_start((uv_stream_t *)&stdin_pipe, alloc_buffer, read_stdin);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     /*
      * Because the other end of the pipe was closed, there should

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -70,7 +70,7 @@ TEST_IMPL(pipe_connect_bad_name) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&req, &client, BAD_PIPENAME, connect_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -90,7 +90,7 @@ TEST_IMPL(pipe_connect_to_file) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&req, &client, path, connect_cb_file);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -113,7 +113,7 @@ TEST_IMPL(pipe_connect_to_long_path) {
   path[sizeof(path) - 1] = '\0';
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&req, &client, path, connect_cb_long_path);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENOENT);
+  ASSERT_EQ(status, UV_ENOENT);
   uv_close((uv_handle_t*)connect_req->handle, close_cb);
   connect_cb_called++;
 }
@@ -58,7 +58,7 @@ static void connect_cb_file(uv_connect_t* connect_req, int status) {
 
 
 static void connect_cb_long_path(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENAMETOOLONG);
+  ASSERT_EQ(status, UV_ENAMETOOLONG);
   uv_close((uv_handle_t*)connect_req->handle, close_cb);
   connect_cb_called++;
 }

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -75,8 +75,8 @@ TEST_IMPL(pipe_connect_bad_name) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -95,8 +95,8 @@ TEST_IMPL(pipe_connect_to_file) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -118,8 +118,8 @@ TEST_IMPL(pipe_connect_to_long_path) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-connect-multiple.c
+++ b/test/test-pipe-connect-multiple.c
@@ -44,14 +44,14 @@ static uv_pipe_t connections[NUM_CLIENTS];
 static void connection_cb(uv_stream_t* server, int status) {
   int r;
   uv_pipe_t* conn;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   conn = &connections[connection_cb_called];
   r = uv_pipe_init(server->loop, conn, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (++connection_cb_called == NUM_CLIENTS &&
       connect_cb_called == NUM_CLIENTS) {
@@ -61,7 +61,7 @@ static void connection_cb(uv_stream_t* server, int status) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   if (++connect_cb_called == NUM_CLIENTS &&
       connection_cb_called == NUM_CLIENTS) {
     uv_stop(connect_req->handle->loop);
@@ -80,17 +80,17 @@ TEST_IMPL(pipe_connect_multiple) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &server_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&server_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server_handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < NUM_CLIENTS; i++) {
     r = uv_pipe_init(loop, &clients[i].pipe_handle, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_pipe_connect(&clients[i].conn_req,
                     &clients[i].pipe_handle,
                     TEST_PIPENAME,

--- a/test/test-pipe-connect-multiple.c
+++ b/test/test-pipe-connect-multiple.c
@@ -99,8 +99,8 @@ TEST_IMPL(pipe_connect_multiple) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == NUM_CLIENTS);
-  ASSERT(connect_cb_called == NUM_CLIENTS);
+  ASSERT_EQ(connection_cb_called, NUM_CLIENTS);
+  ASSERT_EQ(connect_cb_called, NUM_CLIENTS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -56,7 +56,7 @@ static void connect_cb(uv_connect_t* connect_req, int status) {
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT(handle == &prepare_handle);
+  ASSERT_EQ(handle, &prepare_handle);
   uv_pipe_connect(&conn_req, &pipe_handle, BAD_PIPENAME, connect_cb);
 }
 

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -65,15 +65,15 @@ TEST_IMPL(pipe_connect_on_prepare) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_prepare_init(uv_default_loop(), &prepare_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare_handle, prepare_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(close_cb_called == 2);
   ASSERT(connect_cb_called == 1);

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -48,7 +48,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENOENT);
+  ASSERT_EQ(status, UV_ENOENT);
   connect_cb_called++;
   uv_close((uv_handle_t*)&prepare_handle, close_cb);
   uv_close((uv_handle_t*)&pipe_handle, close_cb);

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -75,8 +75,8 @@ TEST_IMPL(pipe_connect_on_prepare) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -68,7 +68,8 @@ static void pipe_client_connect_cb(uv_connect_t* req, int status) {
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_client, buf, &len);
-  ASSERT(r == 0 && len == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(len, 0);
 
   pipe_client_connect_cb_called++;
 
@@ -142,7 +143,8 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_client, buf, &len);
-  ASSERT(r == 0 && len == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(len, 0);
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -57,11 +57,11 @@ static void pipe_client_connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(buf[len - 1] != 0);
   ASSERT(memcmp(buf, TEST_PIPENAME, len) == 0);
@@ -82,7 +82,7 @@ static void pipe_server_connection_cb(uv_stream_t* handle, int status) {
   /* This function *may* be called, depending on whether accept or the
    * connection callback is called first.
    */
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -99,7 +99,7 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT(loop != NULL);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
@@ -110,11 +110,11 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT(r == UV_EBADF);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(buf[len - 1] != 0);
   ASSERT(buf[len] == '\0');
@@ -125,10 +125,10 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT(r == UV_ENOTCONN);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(loop, &pipe_client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_client, buf, &len);
@@ -146,13 +146,13 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(buf[len - 1] != 0);
   ASSERT(memcmp(buf, TEST_PIPENAME, len) == 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(pipe_client_connect_cb_called == 1);
   ASSERT(pipe_close_cb_called == 2);
 
@@ -180,16 +180,16 @@ TEST_IMPL(pipe_getsockname_abstract) {
   memcpy(sun.sun_path, abstract_pipe, sizeof abstract_pipe);
 
   r = bind(sock, (struct sockaddr*)&sun, sun_len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &pipe_server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&pipe_server, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(memcmp(buf, abstract_pipe, sizeof abstract_pipe) == 0);
 
@@ -219,31 +219,31 @@ TEST_IMPL(pipe_getsockname_blocking) {
   ASSERT(r != 0);
 
   r = uv_pipe_init(uv_default_loop(), &pipe_client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&pipe_client, readh);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   Sleep(100);
   r = uv_read_stop((uv_stream_t*)&pipe_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   len1 = sizeof buf1;
   r = uv_pipe_getsockname(&pipe_client, buf1, &len1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(len1 == 0);  /* It's an annonymous pipe. */
 
   r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   Sleep(100);
 
   len2 = sizeof buf2;
   r = uv_pipe_getsockname(&pipe_client, buf2, &len2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(len2 == 0);  /* It's an annonymous pipe. */
 
   r = uv_read_stop((uv_stream_t*)&pipe_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(len1 == len2);
   ASSERT(memcmp(buf1, buf2, len1) == 0);

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -247,7 +247,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
   r = uv_read_stop((uv_stream_t*)&pipe_client);
   ASSERT_EQ(r, 0);
 
-  ASSERT(len1 == len2);
+  ASSERT_EQ(len1, len2);
   ASSERT(memcmp(buf1, buf2, len1) == 0);
 
   pipe_close_cb_called = 0;

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -231,7 +231,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
   len1 = sizeof buf1;
   r = uv_pipe_getsockname(&pipe_client, buf1, &len1);
   ASSERT_EQ(r, 0);
-  ASSERT(len1 == 0);  /* It's an annonymous pipe. */
+  ASSERT_EQ(len1, 0);  /* It's an annonymous pipe. */
 
   r = uv_read_start((uv_stream_t*)&pipe_client, NULL, NULL);
   ASSERT_EQ(r, 0);
@@ -240,7 +240,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
   len2 = sizeof buf2;
   r = uv_pipe_getsockname(&pipe_client, buf2, &len2);
   ASSERT_EQ(r, 0);
-  ASSERT(len2 == 0);  /* It's an annonymous pipe. */
+  ASSERT_EQ(len2, 0);  /* It's an annonymous pipe. */
 
   r = uv_read_stop((uv_stream_t*)&pipe_client);
   ASSERT_EQ(r, 0);

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -155,8 +155,8 @@ TEST_IMPL(pipe_getsockname) {
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(pipe_client_connect_cb_called == 1);
-  ASSERT(pipe_close_cb_called == 2);
+  ASSERT_EQ(pipe_client_connect_cb_called, 1);
+  ASSERT_EQ(pipe_close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -201,7 +201,7 @@ TEST_IMPL(pipe_getsockname_abstract) {
 
   close(sock);
 
-  ASSERT(pipe_close_cb_called == 1);
+  ASSERT_EQ(pipe_close_cb_called, 1);
   MAKE_VALGRIND_HAPPY();
   return 0;
 #else
@@ -255,7 +255,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(pipe_close_cb_called == 1);
+  ASSERT_EQ(pipe_close_cb_called, 1);
 
   CloseHandle(writeh);
 #endif

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -56,7 +56,7 @@ static void pipe_client_connect_cb(uv_connect_t* req, int status) {
   size_t len;
   int r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   len = sizeof buf;

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -104,11 +104,11 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_server, buf, &len);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
   ASSERT_EQ(r, 0);
@@ -123,7 +123,7 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_server, buf, &len);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
   ASSERT_EQ(r, 0);
@@ -133,11 +133,11 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_client, buf, &len);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   uv_pipe_connect(&connect_req, &pipe_client, TEST_PIPENAME, pipe_client_connect_cb);
 

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -118,7 +118,7 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT_EQ(r, 0);
 
   ASSERT(buf[len - 1] != 0);
-  ASSERT(buf[len] == '\0');
+  ASSERT_EQ(buf[len], '\0');
   ASSERT(memcmp(buf, TEST_PIPENAME, len) == 0);
 
   len = sizeof buf;

--- a/test/test-pipe-pending-instances.c
+++ b/test/test-pipe-pending-instances.c
@@ -37,22 +37,22 @@ TEST_IMPL(pipe_pending_instances) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_pending_instances(&pipe_handle, 8);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_pending_instances(&pipe_handle, 16);
 
   r = uv_listen((uv_stream_t*)&pipe_handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&pipe_handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -83,7 +83,7 @@ static void read_cb(uv_stream_t* handle,
 
   while (uv_pipe_pending_count(p) != 0) {
     pending = uv_pipe_pending_type(p);
-    ASSERT(pending == UV_NAMED_PIPE);
+    ASSERT_EQ(pending, UV_NAMED_PIPE);
 
     ASSERT(incoming_count < ARRAY_SIZE(incoming));
     inc = &incoming[incoming_count++];

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -118,7 +118,7 @@ TEST_IMPL(pipe_sendmsg) {
   ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
   for (i = 0; i < ARRAY_SIZE(send_fds); i += 2)
     ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, send_fds + i));
-  ASSERT(i == ARRAY_SIZE(send_fds));
+  ASSERT_EQ(i, ARRAY_SIZE(send_fds));
   ASSERT(0 == uv_pipe_init(uv_default_loop(), &p, 1));
   ASSERT(0 == uv_pipe_open(&p, fds[1]));
 
@@ -154,8 +154,8 @@ TEST_IMPL(pipe_sendmsg) {
   ASSERT_EQ(r, 1);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(ARRAY_SIZE(incoming) == incoming_count);
-  ASSERT(ARRAY_SIZE(incoming) + 1 == close_called);
+  ASSERT_EQ(incoming_count, ARRAY_SIZE(incoming));
+  ASSERT_EQ(close_called, ARRAY_SIZE(incoming) + 1);
   close(fds[0]);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -151,7 +151,7 @@ TEST_IMPL(pipe_sendmsg) {
   do
     r = sendmsg(fds[0], &msg, 0);
   while (r == -1 && errno == EINTR);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(ARRAY_SIZE(incoming) == incoming_count);

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -45,7 +45,7 @@ static void set_nonblocking(uv_os_sock_t sock) {
 #ifdef _WIN32
   unsigned long on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #else
   int flags = fcntl(sock, F_GETFL, 0);
   ASSERT(flags >= 0);

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -42,7 +42,7 @@ static void pipe_close_cb(uv_handle_t* handle) {
 
 
 static void pipe_client_connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   pipe_client_connect_cb_called++;

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -86,8 +86,8 @@ TEST_IMPL(pipe_server_close) {
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(pipe_client_connect_cb_called == 1);
-  ASSERT(pipe_close_cb_called == 2);
+  ASSERT_EQ(pipe_client_connect_cb_called, 1);
+  ASSERT_EQ(pipe_close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -43,7 +43,7 @@ static void pipe_close_cb(uv_handle_t* handle) {
 
 static void pipe_client_connect_cb(uv_connect_t* req, int status) {
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   pipe_client_connect_cb_called++;
 
@@ -56,7 +56,7 @@ static void pipe_server_connection_cb(uv_stream_t* handle, int status) {
   /* This function *may* be called, depending on whether accept or the
    * connection callback is called first.
    */
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -71,21 +71,21 @@ TEST_IMPL(pipe_server_close) {
   ASSERT(loop != NULL);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(loop, &pipe_client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_connect(&connect_req, &pipe_client, TEST_PIPENAME, pipe_client_connect_cb);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(pipe_client_connect_cb_called == 1);
   ASSERT(pipe_close_cb_called == 2);
 

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -76,14 +76,14 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(NULL, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_chmod(&pipe_handle, 12345678);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&pipe_handle, NULL);
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -34,10 +34,10 @@ TEST_IMPL(pipe_set_chmod) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* No easy way to test if this works, we will only make sure that the call is
    * successful. */
@@ -46,7 +46,7 @@ TEST_IMPL(pipe_set_chmod) {
     MAKE_VALGRIND_HAPPY();
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");
   }
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IRUSR);
@@ -55,7 +55,7 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IWUSR);
@@ -64,7 +64,7 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IRUSR);

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -88,7 +88,7 @@ TEST_IMPL(pipe_set_non_blocking) {
      * with the exact number of bytes that we wanted written.
      */
     n = uv_try_write((uv_stream_t*) &pipe_handle, &buf, 1);
-    ASSERT(n == sizeof(data));
+    ASSERT_EQ(n, sizeof(data));
     nwritten += n;
   }
 

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -54,7 +54,7 @@ static void thread_main(void* arg) {
     uv_fs_req_cleanup(&req);
   } while (n > 0 || (n == -1 && uv_errno == UV_EINTR));
 
-  ASSERT(n == 0);
+  ASSERT_EQ(n, 0);
 }
 
 TEST_IMPL(pipe_set_non_blocking) {

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -56,7 +56,7 @@ TEST_IMPL(platform_output) {
 
   err = uv_resident_set_memory(&rss);
 #if defined(__MSYS__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
   ASSERT_EQ(err, 0);
   printf("uv_resident_set_memory: %llu\n", (unsigned long long) rss);
@@ -64,7 +64,7 @@ TEST_IMPL(platform_output) {
 
   err = uv_uptime(&uptime);
 #if defined(__PASE__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
   ASSERT_EQ(err, 0);
   ASSERT(uptime > 0);
@@ -90,7 +90,7 @@ TEST_IMPL(platform_output) {
 
   err = uv_cpu_info(&cpus, &count);
 #if defined(__CYGWIN__) || defined(__MSYS__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
   ASSERT_EQ(err, 0);
 

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -46,19 +46,19 @@ TEST_IMPL(platform_output) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_get_process_title: %s\n", buffer);
 
   size = sizeof(buffer);
   err = uv_cwd(buffer, &size);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_cwd: %s\n", buffer);
 
   err = uv_resident_set_memory(&rss);
 #if defined(__MSYS__)
   ASSERT(err == UV_ENOSYS);
 #else
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_resident_set_memory: %llu\n", (unsigned long long) rss);
 #endif
 
@@ -66,13 +66,13 @@ TEST_IMPL(platform_output) {
 #if defined(__PASE__)
   ASSERT(err == UV_ENOSYS);
 #else
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   ASSERT(uptime > 0);
   printf("uv_uptime: %f\n", uptime);
 #endif
 
   err = uv_getrusage(&rusage);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   ASSERT(rusage.ru_utime.tv_sec >= 0);
   ASSERT(rusage.ru_utime.tv_usec >= 0);
   ASSERT(rusage.ru_stime.tv_sec >= 0);
@@ -92,7 +92,7 @@ TEST_IMPL(platform_output) {
 #if defined(__CYGWIN__) || defined(__MSYS__)
   ASSERT(err == UV_ENOSYS);
 #else
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   printf("uv_cpu_info:\n");
   for (i = 0; i < count; i++) {
@@ -111,7 +111,7 @@ TEST_IMPL(platform_output) {
   uv_free_cpu_info(cpus, count);
 
   err = uv_interface_addresses(&interfaces, &count);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   printf("uv_interface_addresses:\n");
   for (i = 0; i < count; i++) {
@@ -147,7 +147,7 @@ TEST_IMPL(platform_output) {
   uv_free_interface_addresses(interfaces, count);
 
   err = uv_os_get_passwd(&pwd);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   printf("uv_os_get_passwd:\n");
   printf("  euid: %ld\n", pwd.uid);
@@ -165,7 +165,7 @@ TEST_IMPL(platform_output) {
   printf("uv_os_getppid: %d\n", (int) ppid);
 
   err = uv_os_uname(&uname);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_os_uname:\n");
   printf("  sysname: %s\n", uname.sysname);
   printf("  release: %s\n", uname.release);

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -59,7 +59,7 @@ static void NO_INLINE close_socket_and_verify_stack(void) {
     data[i] = MARKER;
 
   r = closesocket(sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_sleep(VERIFY_AFTER);
 
@@ -79,32 +79,32 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
   ASSERT(sock != INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
   ASSERT(r != 0);
   ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
 
   r = uv_poll_init(uv_default_loop(), &handle, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_poll_start(&handle, UV_READABLE | UV_WRITABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &handle, close_cb);
 
   close_socket_and_verify_stack();
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(close_cb_called == 1);
 

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -64,7 +64,7 @@ static void NO_INLINE close_socket_and_verify_stack(void) {
   uv_sleep(VERIFY_AFTER);
 
   for (i = 0; i < ARRAY_SIZE(data); i++)
-    ASSERT(data[i] == MARKER);
+    ASSERT_EQ(data[i], MARKER);
 }
 #endif
 

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -106,7 +106,7 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -66,7 +66,7 @@ TEST_IMPL(poll_close) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == NUM_SOCKETS);
+  ASSERT_EQ(close_cb_called, NUM_SOCKETS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -50,7 +50,7 @@ TEST_IMPL(poll_close) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -39,11 +39,11 @@ static void close_cb(uv_handle_t* h) {
 static void poll_cb(uv_poll_t* h, int status, int events) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(h == &handle);
 
   r = uv_poll_start(&handle, UV_READABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   closesocket(sock);
   uv_close((uv_handle_t*) &handle, close_cb);
@@ -62,25 +62,25 @@ TEST_IMPL(poll_closesocket) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
   ASSERT(sock != INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
   ASSERT(r != 0);
   ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
 
   r = uv_poll_init(uv_default_loop(), &handle, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_poll_start(&handle, UV_WRITABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -84,7 +84,7 @@ TEST_IMPL(poll_closesocket) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -40,7 +40,7 @@ static void poll_cb(uv_poll_t* h, int status, int events) {
   int r;
 
   ASSERT_EQ(status, 0);
-  ASSERT(h == &handle);
+  ASSERT_EQ(h, &handle);
 
   r = uv_poll_start(&handle, UV_READABLE, poll_cb);
   ASSERT_EQ(r, 0);

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -96,7 +96,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {
-        ASSERT(n == 4);
+        ASSERT_EQ(n, 4);
         ASSERT(strncmp(buffer, "hello", n) == 0);
         cli_rd_check = 1;
         do {
@@ -104,7 +104,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
             n = recv(server_fd, &buffer, 5, 0);
           while (n == -1 && errno == EINTR);
           if (n > 0) {
-            ASSERT(n == 5);
+            ASSERT_EQ(n, 5);
             ASSERT(strncmp(buffer, "world", n) == 0);
             cli_rd_check = 2;
           }
@@ -191,13 +191,13 @@ TEST_IMPL(poll_oob) {
   ASSERT(ticks == kMaxTicks);
 
   /* Did client receive the POLLPRI message */
-  ASSERT(cli_pr_check == 1);
+  ASSERT_EQ(cli_pr_check, 1);
   /* Did client receive the POLLIN message */
-  ASSERT(cli_rd_check == 2);
+  ASSERT_EQ(cli_rd_check, 2);
   /* Could we write with POLLOUT and did the server receive our POLLOUT message
    * through POLLIN.
    */
-  ASSERT(srv_rd_check == 1);
+  ASSERT_EQ(srv_rd_check, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -92,7 +92,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       ASSERT(n >= 0 || errno != EINVAL);
       if (cli_rd_check == 1) {
         ASSERT(strncmp(buffer, "world", n) == 0);
-        ASSERT(5 == n);
+        ASSERT_EQ(n, 5);
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {
@@ -118,7 +118,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
         n = recv(server_fd, &buffer, 3, 0);
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
-      ASSERT(3 == n);
+      ASSERT_EQ(n, 3);
       ASSERT(strncmp(buffer, "foo", n) == 0);
       srv_rd_check = 1;
       uv_poll_stop(&poll_req[1]);
@@ -128,14 +128,14 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
     do {
       n = send(client_fd, "foo", 3, 0);
     } while (n < 0 && errno == EINTR);
-    ASSERT(3 == n);
+    ASSERT_EQ(n, 3);
   }
 }
 
 static void connection_cb(uv_stream_t* handle, int status) {
   int r;
 
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
   ASSERT(0 == uv_fileno((uv_handle_t*) &peer_handle, &server_fd));
   ASSERT(0 == uv_poll_init(uv_default_loop(), &poll_req[0], client_fd));
@@ -149,12 +149,12 @@ static void connection_cb(uv_stream_t* handle, int status) {
   do {
     r = send(server_fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   do {
     r = send(server_fd, "world", 5, 0);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   ASSERT(0 == uv_idle_start(&idle, idle_cb));
 }

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -188,7 +188,7 @@ TEST_IMPL(poll_oob) {
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(ticks == kMaxTicks);
+  ASSERT_EQ(ticks, kMaxTicks);
 
   /* Did client receive the POLLPRI message */
   ASSERT_EQ(cli_pr_check, 1);

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -184,7 +184,7 @@ TEST_IMPL(poll_oob) {
     errno = 0;
     r = connect(client_fd, (const struct sockaddr*)&addr, sizeof(addr));
   } while (r == -1 && errno == EINTR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -116,12 +116,12 @@ static uv_os_sock_t create_bound_socket (struct sockaddr_in bind_addr) {
     /* Allow reuse of the port. */
     int yes = 1;
     r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
   r = bind(sock, (const struct sockaddr*) &bind_addr, sizeof bind_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return sock;
 }
@@ -163,12 +163,12 @@ static connection_context_t* create_connection_context(
   r = uv_poll_init(uv_default_loop(), &context->poll_handle, sock);
   context->open_handles++;
   context->poll_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &context->timer_handle);
   context->open_handles++;
   context->timer_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return context;
 }
@@ -208,7 +208,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
   unsigned int new_events;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events & context->events);
   ASSERT(!(events & ~context->events));
 
@@ -403,7 +403,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
 #else
       r = shutdown(context->sock, SHUT_WR);
 #endif
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
       context->sent_fin = 1;
       new_events &= ~UV_WRITABLE;
     }
@@ -454,7 +454,7 @@ static void delay_timer_cb(uv_timer_t* timer) {
   r = uv_poll_start(&context->poll_handle,
                     context->events,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -471,7 +471,7 @@ static server_context_t* create_server_context(
 
   r = uv_poll_init(uv_default_loop(), &context->poll_handle, sock);
   context->poll_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return context;
 }
@@ -510,7 +510,7 @@ static void server_poll_cb(uv_poll_t* handle, int status, int events) {
   r = uv_poll_start(&connection_context->poll_handle,
                     UV_READABLE | UV_WRITABLE | UV_DISCONNECT,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (++server_context->connections == NUM_CLIENTS) {
     close_socket(server_context->sock);
@@ -530,10 +530,10 @@ static void start_server(void) {
   context = create_server_context(sock);
 
   r = listen(sock, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_poll_start(&context->poll_handle, UV_READABLE, server_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -554,7 +554,7 @@ static void start_client(void) {
   r = uv_poll_start(&context->poll_handle,
                     UV_READABLE | UV_WRITABLE | UV_DISCONNECT,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (struct sockaddr*) &server_addr, sizeof server_addr);
   ASSERT(r == 0 || got_eagain());
@@ -568,7 +568,7 @@ static void start_poll_test(void) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -578,7 +578,7 @@ static void start_poll_test(void) {
     start_client();
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Assert that at most five percent of the writable wakeups was spurious. */
   ASSERT(spurious_writable_wakeups == 0 ||

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -181,13 +181,13 @@ static void connection_close_cb(uv_handle_t* handle) {
     if (test_mode == DUPLEX || context->is_server_connection) {
       ASSERT(context->read == TRANSFER_BYTES);
     } else {
-      ASSERT(context->read == 0);
+      ASSERT_EQ(context->read, 0);
     }
 
     if (test_mode == DUPLEX || !context->is_server_connection) {
       ASSERT(context->sent == TRANSFER_BYTES);
     } else {
-      ASSERT(context->sent == 0);
+      ASSERT_EQ(context->sent, 0);
     }
 
     closed_connections++;

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -179,13 +179,13 @@ static void connection_close_cb(uv_handle_t* handle) {
 
   if (--context->open_handles == 0) {
     if (test_mode == DUPLEX || context->is_server_connection) {
-      ASSERT(context->read == TRANSFER_BYTES);
+      ASSERT_EQ(context->read, TRANSFER_BYTES);
     } else {
       ASSERT_EQ(context->read, 0);
     }
 
     if (test_mode == DUPLEX || !context->is_server_connection) {
-      ASSERT(context->sent == TRANSFER_BYTES);
+      ASSERT_EQ(context->sent, TRANSFER_BYTES);
     } else {
       ASSERT_EQ(context->sent, 0);
     }

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -585,9 +585,9 @@ static void start_poll_test(void) {
          (valid_writable_wakeups + spurious_writable_wakeups) /
          spurious_writable_wakeups > 20);
 
-  ASSERT(closed_connections == NUM_CLIENTS * 2);
+  ASSERT_EQ(closed_connections, NUM_CLIENTS * 2);
 #if !defined(__sun) && !defined(_AIX) && !defined(__MVS__)
-  ASSERT(disconnects == NUM_CLIENTS * 2);
+  ASSERT_EQ(disconnects, NUM_CLIENTS * 2);
 #endif
   MAKE_VALGRIND_HAPPY();
 }

--- a/test/test-process-priority.c
+++ b/test/test-process-priority.c
@@ -35,7 +35,7 @@ TEST_IMPL(process_priority) {
 
   /* Verify that passing a NULL pointer returns UV_EINVAL. */
   r = uv_os_getpriority(0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Verify that all valid values work. */
   for (i = UV_PRIORITY_HIGHEST; i <= UV_PRIORITY_LOW; i++) {
@@ -59,15 +59,15 @@ TEST_IMPL(process_priority) {
     if (i < UV_PRIORITY_HIGH)
       ASSERT(priority == UV_PRIORITY_HIGHEST || priority == UV_PRIORITY_HIGH);
     else if (i < UV_PRIORITY_ABOVE_NORMAL)
-      ASSERT(priority == UV_PRIORITY_HIGH);
+      ASSERT_EQ(priority, UV_PRIORITY_HIGH);
     else if (i < UV_PRIORITY_NORMAL)
-      ASSERT(priority == UV_PRIORITY_ABOVE_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_ABOVE_NORMAL);
     else if (i < UV_PRIORITY_BELOW_NORMAL)
-      ASSERT(priority == UV_PRIORITY_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_NORMAL);
     else if (i < UV_PRIORITY_LOW)
-      ASSERT(priority == UV_PRIORITY_BELOW_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_BELOW_NORMAL);
     else
-      ASSERT(priority == UV_PRIORITY_LOW);
+      ASSERT_EQ(priority, UV_PRIORITY_LOW);
 #endif
 
     /* Verify that the current PID and 0 are equivalent. */

--- a/test/test-process-priority.c
+++ b/test/test-process-priority.c
@@ -52,7 +52,7 @@ TEST_IMPL(process_priority) {
     /* Verify that the priority values match on Unix, and are range mapped
        on Windows. */
 #ifndef _WIN32
-    ASSERT(priority == i);
+    ASSERT_EQ(priority, i);
 #else
     /* On Windows, only elevated users can set UV_PRIORITY_HIGHEST. Other
        users will silently be set to UV_PRIORITY_HIGH. */
@@ -72,7 +72,7 @@ TEST_IMPL(process_priority) {
 
     /* Verify that the current PID and 0 are equivalent. */
     ASSERT(uv_os_getpriority(uv_os_getpid(), &r) == 0);
-    ASSERT(priority == r);
+    ASSERT_EQ(priority, r);
   }
 
   /* Verify that invalid priorities return UV_EINVAL. */

--- a/test/test-process-priority.c
+++ b/test/test-process-priority.c
@@ -46,7 +46,7 @@ TEST_IMPL(process_priority) {
     if (r == UV_EACCES)
       continue;
 
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(uv_os_getpriority(0, &priority) == 0);
 
     /* Verify that the priority values match on Unix, and are range mapped

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -47,15 +47,15 @@ static void uv_get_process_title_edge_cases(void) {
 
   /* Test a NULL buffer */
   r = uv_get_process_title(NULL, 100);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Test size of zero */
   r = uv_get_process_title(buffer, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Test for insufficient buffer size */
   r = uv_get_process_title(buffer, 1);
-  ASSERT(r == UV_ENOBUFS);
+  ASSERT_EQ(r, UV_ENOBUFS);
 }
 
 

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -29,13 +29,13 @@ static void set_title(const char* title) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   err = uv_set_process_title(title);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   ASSERT(strcmp(buffer, title) == 0);
 }
@@ -77,8 +77,8 @@ TEST_IMPL(process_title) {
 
 
 static void exit_cb(uv_process_t* process, int64_t status, int signo) {
-  ASSERT(status == 0);
-  ASSERT(signo == 0);
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(signo, 0);
   uv_close((uv_handle_t*) process, NULL);
 }
 

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -113,9 +113,9 @@ static const unsigned first_handle_number_fs_event = 0;
 
 #define END_ASSERTS(name)                                                     \
   do {                                                                        \
-    ASSERT(name##_cb_calls[0] == 1);                                          \
-    ASSERT(name##_cb_calls[1] == 0);                                          \
-    ASSERT(name##_cb_calls[2] == 1);                                          \
+    ASSERT_EQ(name##_cb_calls[0], 1);                                         \
+    ASSERT_EQ(name##_cb_calls[1], 0);                                         \
+    ASSERT_EQ(name##_cb_calls[2], 1);                                         \
   } while (0)
 
 DEFINE_GLOBALS_AND_CBS(idle, uv_idle_t* handle)

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -156,7 +156,7 @@ static void helper_timer_cb(uv_timer_t* thandle) {
   /* fire all fs_events */
   r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
   ASSERT_EQ(r, 0);
-  ASSERT(fs_req.result == 0);
+  ASSERT_EQ(fs_req.result, 0);
   ASSERT(fs_req.fs_type == UV_FS_UTIME);
   ASSERT(strcmp(fs_req.path, watched_dir) == 0);
   uv_fs_req_cleanup(&fs_req);

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -157,7 +157,7 @@ static void helper_timer_cb(uv_timer_t* thandle) {
   r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(fs_req.result, 0);
-  ASSERT(fs_req.fs_type == UV_FS_UTIME);
+  ASSERT_EQ(fs_req.fs_type, UV_FS_UTIME);
   ASSERT(strcmp(fs_req.path, watched_dir) == 0);
   uv_fs_req_cleanup(&fs_req);
 

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -188,14 +188,14 @@ TEST_IMPL(queue_foreach_delete) {
 #endif
 
   r = uv_run(loop, UV_RUN_NOWAIT);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
 
   END_ASSERTS(idle);
   END_ASSERTS(prepare);
   END_ASSERTS(check);
 
 #ifdef __linux__
-  ASSERT(helper_timer_cb_calls == 1);
+  ASSERT_EQ(helper_timer_cb_calls, 1);
 #endif
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -104,10 +104,10 @@ static const unsigned first_handle_number_fs_event = 0;
     for (i = 0; i < ARRAY_SIZE(name); i++) {                                  \
       int r;                                                                  \
       r = uv_##name##_init((loop), &(name)[i]);                               \
-      ASSERT(r == 0);                                                         \
+      ASSERT_EQ(r, 0);                                                         \
                                                                               \
       r = uv_##name##_start(&(name)[i], name##_cbs[i]);                       \
-      ASSERT(r == 0);                                                         \
+      ASSERT_EQ(r, 0);                                                         \
     }                                                                         \
   } while (0)
 
@@ -139,13 +139,13 @@ static void init_and_start_fs_events(uv_loop_t* loop) {
   for (i = 0; i < ARRAY_SIZE(fs_event); i++) {
     int r;
     r = uv_fs_event_init(loop, &fs_event[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_fs_event_start(&fs_event[i],
                           (uv_fs_event_cb)fs_event_cbs[i],
                           watched_dir,
                           0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -155,7 +155,7 @@ static void helper_timer_cb(uv_timer_t* thandle) {
 
   /* fire all fs_events */
   r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(fs_req.result == 0);
   ASSERT(fs_req.fs_type == UV_FS_UTIME);
   ASSERT(strcmp(fs_req.path, watched_dir) == 0);
@@ -181,10 +181,10 @@ TEST_IMPL(queue_foreach_delete) {
 
   /* helper timer to trigger async and fs_event callbacks */
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, helper_timer_cb, 0, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   r = uv_run(loop, UV_RUN_NOWAIT);

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -37,7 +37,7 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
   ASSERT(buf == (void*) scratch);
 
   if (random_cb_called == 0) {
-    ASSERT(buflen == 0);
+    ASSERT_EQ(buflen, 0);
     ASSERT(0 == memcmp(scratch, zero, sizeof(zero)));
   } else {
     ASSERT(buflen == sizeof(scratch));

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -40,7 +40,7 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
     ASSERT_EQ(buflen, 0);
     ASSERT(0 == memcmp(scratch, zero, sizeof(zero)));
   } else {
-    ASSERT(buflen == sizeof(scratch));
+    ASSERT_EQ(buflen, sizeof(scratch));
     /* Buy a lottery ticket if you manage to trip this assertion. */
     ASSERT(0 != memcmp(scratch, zero, sizeof(zero)));
   }

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -33,7 +33,7 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
 
   memset(zero, 0, sizeof(zero));
 
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(buf == (void*) scratch);
 
   if (random_cb_called == 0) {
@@ -59,16 +59,16 @@ TEST_IMPL(random_async) {
   ASSERT(UV_E2BIG == uv_random(loop, &req, scratch, -1, -1, random_cb));
 
   ASSERT(0 == uv_random(loop, &req, scratch, 0, 0, random_cb));
-  ASSERT(0 == random_cb_called);
+  ASSERT_EQ(random_cb_called, 0);
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == random_cb_called);
+  ASSERT_EQ(random_cb_called, 1);
 
   ASSERT(0 == uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
-  ASSERT(1 == random_cb_called);
+  ASSERT_EQ(random_cb_called, 1);
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(2 == random_cb_called);
+  ASSERT_EQ(random_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -34,7 +34,7 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
   memset(zero, 0, sizeof(zero));
 
   ASSERT_EQ(status, 0);
-  ASSERT(buf == (void*) scratch);
+  ASSERT_EQ(buf, (void*) scratch);
 
   if (random_cb_called == 0) {
     ASSERT_EQ(buflen, 0);

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -49,7 +49,7 @@ static void do_close(void* handle) {
   uv_close((uv_handle_t*)handle, close_cb);
   ASSERT_EQ(close_cb_called, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 }
 
 
@@ -250,7 +250,7 @@ TEST_IMPL(tcp_ref2b) {
   uv_unref((uv_handle_t*)&h);
   uv_close((uv_handle_t*)&h, close_cb);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
@@ -267,8 +267,8 @@ TEST_IMPL(tcp_ref3) {
                  connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -286,9 +286,9 @@ TEST_IMPL(tcp_ref4) {
                  connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -337,7 +337,7 @@ TEST_IMPL(udp_ref3) {
               (uv_udp_send_cb) req_cb);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(req_cb_called == 1);
+  ASSERT_EQ(req_cb_called, 1);
   do_close(&h);
 
   MAKE_VALGRIND_HAPPY();
@@ -374,8 +374,8 @@ TEST_IMPL(pipe_ref3) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -388,9 +388,9 @@ TEST_IMPL(pipe_ref4) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -69,13 +69,13 @@ static void req_cb(uv_handle_t* req, int status) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_EQ(req, &shutdown_req);
   shutdown_cb_called++;
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req == &write_req);
+  ASSERT_EQ(req, &write_req);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   write_cb_called++;
 }
@@ -83,7 +83,7 @@ static void write_cb(uv_write_t* req, int status) {
 
 static void connect_and_write(uv_connect_t* req, int status) {
   uv_buf_t buf = uv_buf_init(buffer, sizeof buffer);
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
   uv_write(&write_req, req->handle, &buf, 1, write_cb);
   connect_cb_called++;
@@ -92,7 +92,7 @@ static void connect_and_write(uv_connect_t* req, int status) {
 
 
 static void connect_and_shutdown(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   connect_cb_called++;

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -47,7 +47,7 @@ static void close_cb(uv_handle_t* handle) {
 static void do_close(void* handle) {
   close_cb_called = 0;
   uv_close((uv_handle_t*)handle, close_cb);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(close_cb_called == 1);
 }
@@ -84,7 +84,7 @@ static void write_cb(uv_write_t* req, int status) {
 static void connect_and_write(uv_connect_t* req, int status) {
   uv_buf_t buf = uv_buf_init(buffer, sizeof buffer);
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_write(&write_req, req->handle, &buf, 1, write_cb);
   connect_cb_called++;
 }
@@ -93,7 +93,7 @@ static void connect_and_write(uv_connect_t* req, int status) {
 
 static void connect_and_shutdown(uv_connect_t* req, int status) {
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   connect_cb_called++;
 }
@@ -410,7 +410,7 @@ TEST_IMPL(process_ref) {
   exepath_size = sizeof(exepath);
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   argv[0] = exepath;
   options.file = exepath;
@@ -418,13 +418,13 @@ TEST_IMPL(process_ref) {
   options.exit_cb = NULL;
 
   r = uv_spawn(uv_default_loop(), &h, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   r = uv_process_kill(&h, /* SIGTERM */ 15);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   do_close(&h);
 

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -27,7 +27,7 @@ static int timer_called = 0;
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_EQ(handle, &timer_handle);
   timer_called = 1;
 }
 

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -39,7 +39,7 @@ TEST_IMPL(run_nowait) {
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
   ASSERT(r != 0);
-  ASSERT(timer_called == 0);
+  ASSERT_EQ(timer_called, 0);
 
   return 0;
 }

--- a/test/test-run-once.c
+++ b/test/test-run-once.c
@@ -29,7 +29,7 @@ static int idle_counter;
 
 
 static void idle_cb(uv_idle_t* handle) {
-  ASSERT(handle == &idle_handle);
+  ASSERT_EQ(handle, &idle_handle);
 
   if (++idle_counter == NUM_TICKS)
     uv_idle_stop(handle);

--- a/test/test-run-once.c
+++ b/test/test-run-once.c
@@ -41,7 +41,7 @@ TEST_IMPL(run_once) {
   uv_idle_start(&idle_handle, idle_cb);
 
   while (uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(idle_counter == NUM_TICKS);
+  ASSERT_EQ(idle_counter, NUM_TICKS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-semaphore.c
+++ b/test/test-semaphore.c
@@ -59,7 +59,7 @@ TEST_IMPL(semaphore_1) {
 
   uv_sleep(100);
   uv_mutex_lock(&wc.mutex);
-  ASSERT(wc.posted == 1);
+  ASSERT_EQ(wc.posted, 1);
   uv_sem_wait(&wc.sem); /* should not block */
   uv_mutex_unlock(&wc.mutex); /* ergo, it should be ok to unlock after wait */
 

--- a/test/test-semaphore.c
+++ b/test/test-semaphore.c
@@ -40,7 +40,7 @@ static void worker(void* arg) {
     uv_sleep(c->delay);
 
   uv_mutex_lock(&c->mutex);
-  ASSERT(c->posted == 0);
+  ASSERT_EQ(c->posted, 0);
   uv_sem_post(&c->sem);
   c->posted = 1;
   uv_mutex_unlock(&c->mutex);

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -80,9 +80,9 @@ TEST_IMPL(shutdown_close_tcp) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -99,9 +99,9 @@ TEST_IMPL(shutdown_close_pipe) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -52,10 +52,10 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(0 == uv_is_closing((uv_handle_t*) req->handle));
   uv_close((uv_handle_t*) req->handle, close_cb);
   ASSERT(1 == uv_is_closing((uv_handle_t*) req->handle));
@@ -71,14 +71,14 @@ TEST_IMPL(shutdown_close_tcp) {
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(connect_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);
@@ -94,10 +94,10 @@ TEST_IMPL(shutdown_close_pipe) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_cb);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(connect_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -37,7 +37,7 @@ static int close_cb_called = 0;
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_EQ(req, &shutdown_req);
   ASSERT(status == 0 || status == UV_ECANCELED);
   shutdown_cb_called++;
 }
@@ -51,7 +51,7 @@ static void close_cb(uv_handle_t* handle) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -76,16 +76,16 @@ static void shutdown_cb(uv_shutdown_t *req, int status) {
 
   ASSERT(called_connect_cb == 1);
   ASSERT(!got_eof);
-  ASSERT(called_tcp_close_cb == 0);
-  ASSERT(called_timer_close_cb == 0);
-  ASSERT(called_timer_cb == 0);
+  ASSERT_EQ(called_tcp_close_cb, 0);
+  ASSERT_EQ(called_timer_close_cb, 0);
+  ASSERT_EQ(called_timer_cb, 0);
 
   called_shutdown_cb++;
 }
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(req == &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
@@ -101,7 +101,7 @@ static void connect_cb(uv_connect_t *req, int status) {
   uv_shutdown(&shutdown_req, (uv_stream_t*) &tcp, shutdown_cb);
 
   called_connect_cb++;
-  ASSERT(called_shutdown_cb == 0);
+  ASSERT_EQ(called_shutdown_cb, 0);
 }
 
 
@@ -131,7 +131,7 @@ static void timer_cb(uv_timer_t* handle) {
    * The most important assert of the test: we have not received
    * tcp_close_cb yet.
    */
-  ASSERT(called_tcp_close_cb == 0);
+  ASSERT_EQ(called_tcp_close_cb, 0);
   uv_close((uv_handle_t*) &tcp, tcp_close_cb);
 
   called_timer_cb++;
@@ -152,7 +152,7 @@ TEST_IMPL(shutdown_eof) {
   qbuf.len = 1;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -54,7 +54,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (!got_q) {
-    ASSERT(nread == 1);
+    ASSERT_EQ(nread, 1);
     ASSERT(!got_eof);
     ASSERT(buf->base[0] == 'Q');
     free(buf->base);
@@ -74,7 +74,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 static void shutdown_cb(uv_shutdown_t *req, int status) {
   ASSERT(req == &shutdown_req);
 
-  ASSERT(called_connect_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
   ASSERT(!got_eof);
   ASSERT_EQ(called_tcp_close_cb, 0);
   ASSERT_EQ(called_timer_close_cb, 0);
@@ -108,10 +108,10 @@ static void connect_cb(uv_connect_t *req, int status) {
 static void tcp_close_cb(uv_handle_t* handle) {
   ASSERT(handle == (uv_handle_t*) &tcp);
 
-  ASSERT(called_connect_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
   ASSERT(got_q);
   ASSERT(got_eof);
-  ASSERT(called_timer_cb == 1);
+  ASSERT_EQ(called_timer_cb, 1);
 
   called_tcp_close_cb++;
 }
@@ -168,13 +168,13 @@ TEST_IMPL(shutdown_eof) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(called_connect_cb == 1);
-  ASSERT(called_shutdown_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
+  ASSERT_EQ(called_shutdown_cb, 1);
   ASSERT(got_eof);
   ASSERT(got_q);
-  ASSERT(called_tcp_close_cb == 1);
-  ASSERT(called_timer_close_cb == 1);
-  ASSERT(called_timer_cb == 1);
+  ASSERT_EQ(called_tcp_close_cb, 1);
+  ASSERT_EQ(called_timer_close_cb, 1);
+  ASSERT_EQ(called_timer_cb, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -72,7 +72,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void shutdown_cb(uv_shutdown_t *req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_EQ(req, &shutdown_req);
 
   ASSERT_EQ(called_connect_cb, 1);
   ASSERT(!got_eof);
@@ -86,7 +86,7 @@ static void shutdown_cb(uv_shutdown_t *req, int status) {
 
 static void connect_cb(uv_connect_t *req, int status) {
   ASSERT_EQ(status, 0);
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
   uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb);
@@ -124,7 +124,7 @@ static void timer_close_cb(uv_handle_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_EQ(handle, &timer);
   uv_close((uv_handle_t*) handle, timer_close_cb);
 
   /*

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -56,7 +56,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   if (!got_q) {
     ASSERT_EQ(nread, 1);
     ASSERT(!got_eof);
-    ASSERT(buf->base[0] == 'Q');
+    ASSERT_EQ(buf->base[0], 'Q');
     free(buf->base);
     got_q = 1;
     puts("got Q");

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -46,7 +46,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 
 static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)t == &tcp);
+  ASSERT_EQ((uv_tcp_t*)t, &tcp);
 
   if (nread == 0) {
     free(buf->base);
@@ -106,7 +106,7 @@ static void connect_cb(uv_connect_t *req, int status) {
 
 
 static void tcp_close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &tcp);
+  ASSERT_EQ(handle, (uv_handle_t*) &tcp);
 
   ASSERT_EQ(called_connect_cb, 1);
   ASSERT(got_q);
@@ -118,7 +118,7 @@ static void tcp_close_cb(uv_handle_t* handle) {
 
 
 static void timer_close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &timer);
+  ASSERT_EQ(handle, (uv_handle_t*) &timer);
   called_timer_close_cb++;
 }
 

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -61,7 +61,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
     got_q = 1;
     puts("got Q");
   } else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     if (buf->base) {
       free(buf->base);
     }

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT(req == &req1);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   shutdown_cb_called++;
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
@@ -46,10 +46,10 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&req1, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_shutdown(&req2, req->handle, shutdown_cb);
   ASSERT(r != 0);
 
@@ -67,16 +67,16 @@ TEST_IMPL(shutdown_twice) {
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(shutdown_cb_called == 1);
 

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -78,7 +78,7 @@ TEST_IMPL(shutdown_twice) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -37,7 +37,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &req1);
+  ASSERT_EQ(req, &req1);
   ASSERT_EQ(status, 0);
   shutdown_cb_called++;
   uv_close((uv_handle_t*) req->handle, close_cb);

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -94,20 +94,20 @@ static void signal_handling_worker(void* context) {
   /* Setup the signal watchers and start them. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_init(&loop, &signal1a);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1a, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_init(&loop, &signal1b);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1b, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   if (action == ONLY_SIGUSR2 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_init(&loop, &signal2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal2, signal2_cb, SIGUSR2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Signal watchers are now set up. */
@@ -117,26 +117,26 @@ static void signal_handling_worker(void* context) {
    * will return when all signal watchers caught a signal.
    */
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Restart the signal watchers. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_start(&signal1a, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1b, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   if (action == ONLY_SIGUSR2 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_start(&signal2, signal2_cb, SIGUSR2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Wait for signals once more. */
   uv_sem_post(&sem);
 
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Close the watchers. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
@@ -150,7 +150,7 @@ static void signal_handling_worker(void* context) {
 
   /* Wait for the signal watchers to close. */
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_loop_close(&loop);
 }
@@ -174,15 +174,15 @@ static void loop_creating_worker(void* context) {
     ASSERT(0 == uv_loop_init(loop));
 
     r = uv_signal_init(loop, &signal);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_signal_start(&signal, signal_unexpected_cb, SIGTERM);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_close((uv_handle_t*) &signal, NULL);
 
     r = uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_loop_close(loop);
     free(loop);
@@ -213,17 +213,17 @@ TEST_IMPL(signal_multiple_loops) {
   int r;
 
   r = uv_sem_init(&sem, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_mutex_init(&counter_lock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Create a couple of threads that create a destroy loops continuously. */
   for (i = 0; i < NUM_LOOP_CREATING_THREADS; i++) {
     r = uv_thread_create(&loop_creating_threads[i],
                          loop_creating_worker,
                          NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Create a couple of threads that actually handle signals. */
@@ -237,7 +237,7 @@ TEST_IMPL(signal_multiple_loops) {
     r = uv_thread_create(&signal_handling_threads[i],
                          signal_handling_worker,
                          (void*) (uintptr_t) action);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Wait until all threads have started and set up their signal watchers. */
@@ -245,9 +245,9 @@ TEST_IMPL(signal_multiple_loops) {
     uv_sem_wait(&sem);
 
   r = kill(getpid(), SIGUSR1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = kill(getpid(), SIGUSR2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Wait for all threads to handle these signals. */
   for (i = 0; i < NUM_SIGNAL_HANDLING_THREADS; i++)
@@ -261,14 +261,14 @@ TEST_IMPL(signal_multiple_loops) {
   pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
   r = kill(getpid(), SIGUSR1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = kill(getpid(), SIGUSR2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Wait for all signal handling threads to exit. */
   for (i = 0; i < NUM_SIGNAL_HANDLING_THREADS; i++) {
     r = uv_thread_join(&signal_handling_threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Tell all loop creating threads to stop. */
@@ -277,7 +277,7 @@ TEST_IMPL(signal_multiple_loops) {
   /* Wait for all loop creating threads to exit. */
   for (i = 0; i < NUM_LOOP_CREATING_THREADS; i++) {
     r = uv_thread_join(&loop_creating_threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_sem_destroy(&sem);

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -288,8 +288,8 @@ TEST_IMPL(signal_multiple_loops) {
   /* The division by three reflects the fact that we spawn three different
    * thread groups of (NUM_SIGNAL_HANDLING_THREADS / 3) threads each.
    */
-  ASSERT(signal1_cb_counter == 8 * (NUM_SIGNAL_HANDLING_THREADS / 3));
-  ASSERT(signal2_cb_counter == 4 * (NUM_SIGNAL_HANDLING_THREADS / 3));
+  ASSERT_EQ(signal1_cb_counter, 8 * (NUM_SIGNAL_HANDLING_THREADS / 3));
+  ASSERT_EQ(signal2_cb_counter, 4 * (NUM_SIGNAL_HANDLING_THREADS / 3));
 
   /* We don't know exactly how much loops will be created and destroyed, but at
    * least there should be 1 for every loop creating thread.

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -66,14 +66,14 @@ static void increment_counter(volatile int* counter) {
 
 
 static void signal1_cb(uv_signal_t* handle, int signum) {
-  ASSERT(signum == SIGUSR1);
+  ASSERT_EQ(signum, SIGUSR1);
   increment_counter(&signal1_cb_counter);
   uv_signal_stop(handle);
 }
 
 
 static void signal2_cb(uv_signal_t* handle, int signum) {
-  ASSERT(signum == SIGUSR2);
+  ASSERT_EQ(signum, SIGUSR2);
   increment_counter(&signal2_cb_counter);
   uv_signal_stop(handle);
 }

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -35,7 +35,7 @@ static int close_cb_called;
 
 
 static void stop_loop_cb(uv_signal_t* signal, int signum) {
-  ASSERT(signum == SIGPIPE);
+  ASSERT_EQ(signum, SIGPIPE);
   uv_stop(signal->loop);
 }
 
@@ -50,7 +50,7 @@ static void close_cb(uv_handle_t *handle) {
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == UV_EPIPE);
+  ASSERT_EQ(status, UV_EPIPE);
   free(buf);
   uv_close((uv_handle_t *) &pipe_hdl, close_cb);
   uv_close((uv_handle_t *) &signal_hdl, close_cb);

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -81,7 +81,7 @@ TEST_IMPL(signal_pending_on_close) {
   buffer = uv_buf_init(buf, 1<<24);
 
   r = uv_write(&write_req, (uv_stream_t *) &pipe_hdl, &buffer, 1, write_cb);
-  ASSERT(0 == r);
+  ASSERT_EQ(r, 0);
 
   /* cause a SIGPIPE on write in next iteration */
   close(pipefds[0]);
@@ -90,7 +90,7 @@ TEST_IMPL(signal_pending_on_close) {
 
   ASSERT(0 == uv_loop_close(&loop));
 
-  ASSERT(2 == close_cb_called);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -110,7 +110,7 @@ TEST_IMPL(signal_close_loop_alive) {
 
   ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
   ASSERT(0 == uv_loop_close(&loop));
-  ASSERT(1 == close_cb_called);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -104,7 +104,7 @@ struct signal_ctx {
 
 static void signal_cb(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
-  ASSERT(signum == ctx->signum);
+  ASSERT_EQ(signum, ctx->signum);
   if (++ctx->ncalls == NSIGNALS) {
     if (ctx->stop_or_close == STOP)
       uv_signal_stop(handle);
@@ -117,7 +117,7 @@ static void signal_cb(uv_signal_t* handle, int signum) {
 
 static void signal_cb_one_shot(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
-  ASSERT(signum == ctx->signum);
+  ASSERT_EQ(signum, ctx->signum);
   ASSERT(++ctx->ncalls == 1);
   if (ctx->stop_or_close == CLOSE)
     uv_close((uv_handle_t*)handle, NULL);

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -225,11 +225,11 @@ TEST_IMPL(we_get_signal_one_shot) {
   sc.stop_or_close = NOOP;
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(sc.ncalls, 1);
 
   start_timer(loop, SIGCHLD, &tc);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(sc.ncalls, 1);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
@@ -237,7 +237,7 @@ TEST_IMPL(we_get_signal_one_shot) {
   start_timer(loop, SIGCHLD, &tc);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(sc.ncalls, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -118,7 +118,8 @@ static void signal_cb(uv_signal_t* handle, int signum) {
 static void signal_cb_one_shot(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
   ASSERT_EQ(signum, ctx->signum);
-  ASSERT(++ctx->ncalls == 1);
+  ++ctx->ncalls;
+  ASSERT_EQ(ctx->ncalls, 1);
   if (ctx->stop_or_close == CLOSE)
     uv_close((uv_handle_t*)handle, NULL);
 }

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -167,13 +167,13 @@ TEST_IMPL(we_get_signal) {
   start_watcher(loop, SIGCHLD, &sc, 0);
   sc.stop_or_close = STOP; /* stop, don't close the signal handle */
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   start_timer(loop, SIGCHLD, &tc);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
@@ -181,8 +181,8 @@ TEST_IMPL(we_get_signal) {
 
   start_timer(loop, SIGCHLD, &tc);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -205,10 +205,10 @@ TEST_IMPL(we_get_signals) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
   for (i = 0; i < ARRAY_SIZE(sc); i++)
-    ASSERT(sc[i].ncalls == NSIGNALS);
+    ASSERT_EQ(sc[i].ncalls, NSIGNALS);
 
   for (i = 0; i < ARRAY_SIZE(tc); i++)
-    ASSERT(tc[i].ncalls == NSIGNALS);
+    ASSERT_EQ(tc[i].ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -224,7 +224,7 @@ TEST_IMPL(we_get_signal_one_shot) {
   start_watcher(loop, SIGCHLD, &sc, 1);
   sc.stop_or_close = NOOP;
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, 1);
 
   start_timer(loop, SIGCHLD, &tc);
@@ -236,7 +236,7 @@ TEST_IMPL(we_get_signal_one_shot) {
   uv_signal_start_oneshot(&sc.handle, signal_cb_one_shot, SIGCHLD);
   start_timer(loop, SIGCHLD, &tc);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, 1);
 
   MAKE_VALGRIND_HAPPY();
@@ -257,7 +257,7 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[0].stop_or_close = CLOSE;
   sc[1].stop_or_close = CLOSE;
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 1);
   ASSERT_EQ(sc[1].ncalls, 1);
 
@@ -270,7 +270,7 @@ TEST_IMPL(we_get_signals_mixed) {
   start_watcher(loop, SIGCHLD, sc + 2, 0);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 1);
   ASSERT_EQ(sc[1].ncalls, 1);
   ASSERT_EQ(sc[2].ncalls, 0);
@@ -284,9 +284,9 @@ TEST_IMPL(we_get_signals_mixed) {
   start_watcher(loop, SIGCHLD, sc + 2, 1);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == NSIGNALS);
-  ASSERT(sc[1].ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, NSIGNALS);
+  ASSERT_EQ(sc[1].ncalls, NSIGNALS);
   ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 2 one-shot then remove 2 normal */
@@ -300,7 +300,7 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[1]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 0);
   ASSERT_EQ(sc[1].ncalls, 0);
   ASSERT_EQ(sc[2].ncalls, 1);
@@ -316,11 +316,11 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 0);
   ASSERT_EQ(sc[1].ncalls, 1);
   ASSERT_EQ(sc[2].ncalls, 0);
-  ASSERT(sc[3].ncalls == NSIGNALS);
+  ASSERT_EQ(sc[3].ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -258,8 +258,8 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 1);
-  ASSERT(sc[1].ncalls == 1);
+  ASSERT_EQ(sc[0].ncalls, 1);
+  ASSERT_EQ(sc[1].ncalls, 1);
 
   /* 2 one-shot, 1 normal then remove normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -271,8 +271,8 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 1);
-  ASSERT(sc[1].ncalls == 1);
+  ASSERT_EQ(sc[0].ncalls, 1);
+  ASSERT_EQ(sc[1].ncalls, 1);
   ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 1 one-shot then remove one-shot */
@@ -303,8 +303,8 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 0);
   ASSERT_EQ(sc[1].ncalls, 0);
-  ASSERT(sc[2].ncalls == 1);
-  ASSERT(sc[2].ncalls == 1);
+  ASSERT_EQ(sc[2].ncalls, 1);
+  ASSERT_EQ(sc[2].ncalls, 1);
 
   /* 1 normal, 1 one-shot, 2 normal then remove 1st normal, 2nd normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -318,7 +318,7 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 0);
-  ASSERT(sc[1].ncalls == 1);
+  ASSERT_EQ(sc[1].ncalls, 1);
   ASSERT_EQ(sc[2].ncalls, 0);
   ASSERT(sc[3].ncalls == NSIGNALS);
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -273,7 +273,7 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT(sc[0].ncalls == 1);
   ASSERT(sc[1].ncalls == 1);
-  ASSERT(sc[2].ncalls == 0);
+  ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 1 one-shot then remove one-shot */
   start_timer(loop, SIGCHLD, &tc);
@@ -287,7 +287,7 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT(sc[0].ncalls == NSIGNALS);
   ASSERT(sc[1].ncalls == NSIGNALS);
-  ASSERT(sc[2].ncalls == 0);
+  ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 2 one-shot then remove 2 normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -301,8 +301,8 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[1]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 0);
-  ASSERT(sc[1].ncalls == 0);
+  ASSERT_EQ(sc[0].ncalls, 0);
+  ASSERT_EQ(sc[1].ncalls, 0);
   ASSERT(sc[2].ncalls == 1);
   ASSERT(sc[2].ncalls == 1);
 
@@ -317,9 +317,9 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 0);
+  ASSERT_EQ(sc[0].ncalls, 0);
   ASSERT(sc[1].ncalls == 1);
-  ASSERT(sc[2].ncalls == 0);
+  ASSERT_EQ(sc[2].ncalls, 0);
   ASSERT(sc[3].ncalls == NSIGNALS);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -70,7 +70,7 @@ TEST_IMPL(socket_buffer_size) {
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -75,7 +75,7 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT(exit_status == 1);
+  ASSERT_EQ(exit_status, 1);
   ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*) process, close_cb);
 }
@@ -96,7 +96,7 @@ static void kill_cb(uv_process_t* process,
   printf("exit_cb\n");
   exit_cb_called++;
 #ifdef _WIN32
-  ASSERT(exit_status == 1);
+  ASSERT_EQ(exit_status, 1);
 #else
   ASSERT_EQ(exit_status, 0);
 #endif
@@ -259,8 +259,8 @@ TEST_IMPL(spawn_empty_env) {
   ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -278,8 +278,8 @@ TEST_IMPL(spawn_exit_code) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -309,8 +309,8 @@ TEST_IMPL(spawn_stdout) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output is: %s", output);
   ASSERT(strcmp("hello world\n", output) == 0);
 
@@ -349,12 +349,12 @@ TEST_IMPL(spawn_stdout_to_file) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 12);
+  ASSERT_EQ(r, 12);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -404,12 +404,12 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 27);
+  ASSERT_EQ(r, 27);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -467,12 +467,12 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 27);
+  ASSERT_EQ(r, 27);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -546,8 +546,8 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
 
@@ -621,8 +621,8 @@ TEST_IMPL(spawn_stdin) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3); /* Once for process twice for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3); /* Once for process twice for the pipe. */
   ASSERT(strcmp(buffer, output) == 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -655,8 +655,8 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output from stdio[3] is: %s", output);
   ASSERT(strcmp("fourth stdio!\n", output) == 0);
 
@@ -725,8 +725,8 @@ TEST_IMPL(spawn_tcp_server) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -747,8 +747,8 @@ TEST_IMPL(spawn_ignored_stdio) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -772,8 +772,8 @@ TEST_IMPL(spawn_and_kill) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process and once for timer. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process and once for timer. */
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -809,8 +809,8 @@ TEST_IMPL(spawn_preserve_env) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   printf("output is: %s", output);
   ASSERT(strcmp("testval", output) == 0);
@@ -900,8 +900,8 @@ TEST_IMPL(spawn_and_kill_with_std) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 5); /* process x 1, timer x 1, stdio x 3. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 5); /* process x 1, timer x 1, stdio x 3. */
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -947,7 +947,7 @@ TEST_IMPL(spawn_and_ping) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
   ASSERT(strcmp(output, "TEST") == 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -994,7 +994,7 @@ TEST_IMPL(spawn_same_stdout_stderr) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
   ASSERT(strcmp(output, "TEST") == 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -1026,8 +1026,8 @@ TEST_IMPL(spawn_closed_process_io) {
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* process, child stdin */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* process, child stdin */
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1080,8 +1080,8 @@ TEST_IMPL(kill) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1130,8 +1130,8 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output is: %s", output);
   ASSERT(strcmp("hello world\n", output) == 0);
 
@@ -1401,8 +1401,8 @@ TEST_IMPL(spawn_setuid_setgid) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1573,8 +1573,8 @@ TEST_IMPL(spawn_affinity) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   free(newmask);
 
@@ -1707,8 +1707,8 @@ TEST_IMPL(spawn_fs_open) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(0 == uv_fs_close(NULL, &fs_req, fd, NULL));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2);  /* One for `in`, one for process */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);  /* One for `in`, one for process */
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1749,7 +1749,7 @@ TEST_IMPL(closed_fd_events) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
 
   /* should have received just one byte */
-  ASSERT(output_used == 1);
+  ASSERT_EQ(output_used, 1);
 
   /* close the pipe and see if we still get events */
   uv_close((uv_handle_t*) &pipe_handle, close_cb);
@@ -1764,7 +1764,7 @@ TEST_IMPL(closed_fd_events) {
     /* have to run again to really trigger the timer */
     ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
 
-  ASSERT(timer_counter == 1);
+  ASSERT_EQ(timer_counter, 1);
 
   /* cleanup */
   ASSERT(0 == uv_process_kill(&process, /* SIGTERM */ 15));
@@ -1837,8 +1837,8 @@ TEST_IMPL(spawn_reads_child_path) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1942,8 +1942,8 @@ TEST_IMPL(spawn_inherit_streams) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   r = memcmp(ubuf, output, sizeof ubuf);
   ASSERT_EQ(r, 0);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -76,7 +76,7 @@ static void exit_cb(uv_process_t* process,
   printf("exit_cb\n");
   exit_cb_called++;
   ASSERT(exit_status == 1);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*) process, close_cb);
 }
 
@@ -98,7 +98,7 @@ static void kill_cb(uv_process_t* process,
 #ifdef _WIN32
   ASSERT(exit_status == 1);
 #else
-  ASSERT(exit_status == 0);
+  ASSERT_EQ(exit_status, 0);
 #endif
 #if defined(__APPLE__) || defined(__MVS__)
   /*
@@ -155,7 +155,7 @@ static void on_read_once(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
 
@@ -163,7 +163,7 @@ static void write_cb(uv_write_t* req, int status) {
 static void init_process_options(char* test, uv_exit_cb exit_cb) {
   /* Note spawn_helper1 defined in test/run-tests.c */
   int r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
   args[0] = exepath;
   args[1] = test;
@@ -273,10 +273,10 @@ TEST_IMPL(spawn_exit_code) {
   init_process_options("spawn_helper1", exit_cb);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -301,13 +301,13 @@ TEST_IMPL(spawn_stdout) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
@@ -333,7 +333,7 @@ TEST_IMPL(spawn_stdout_to_file) {
 
   r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
 
@@ -344,10 +344,10 @@ TEST_IMPL(spawn_stdout_to_file) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -358,7 +358,7 @@ TEST_IMPL(spawn_stdout_to_file) {
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
@@ -386,7 +386,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
 
   r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
 
@@ -399,10 +399,10 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -413,7 +413,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
@@ -447,7 +447,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
                  O_CREAT | O_RDWR,
                  S_IRUSR | S_IWUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   file = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
   file = dup2(file, STDERR_FILENO);
@@ -462,10 +462,10 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -476,7 +476,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
@@ -515,7 +515,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
                  O_CREAT | O_RDWR,
                  S_IRUSR | S_IWUSR,
                  NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   stdout_file = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
   stdout_file = dup2(stdout_file, STDOUT_FILENO);
@@ -524,7 +524,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   /* open 'stderr_file' and replace STDERR_FILENO with it */
   r = uv_fs_open(NULL, &fs_req, "stderr_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   stderr_file = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
   stderr_file = dup2(stderr_file, STDERR_FILENO);
@@ -541,10 +541,10 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -557,7 +557,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, stdout_file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
@@ -569,7 +569,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, stderr_file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
@@ -608,18 +608,18 @@ TEST_IMPL(spawn_stdin) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = buffer;
   buf.len = sizeof(buffer);
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 3); /* Once for process twice for the pipe. */
@@ -647,13 +647,13 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   options.stdio_count = 4;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &pipe, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
@@ -671,7 +671,7 @@ int spawn_tcp_server_helper(void) {
   int r;
 
   r = uv_tcp_init(uv_default_loop(), &tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifdef _WIN32
   handle = _get_osfhandle(3);
@@ -679,13 +679,13 @@ int spawn_tcp_server_helper(void) {
   handle = 3;
 #endif
   r = uv_tcp_open(&tcp, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Make sure that we can listen on a socket that was
    * passed down from the parent process
    */
   r = uv_listen((uv_stream_t*) &tcp, SOMAXCONN, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return 1;
 }
@@ -702,11 +702,11 @@ TEST_IMPL(spawn_tcp_server) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &tcp_server, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp_server, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_INHERIT_FD;
@@ -720,10 +720,10 @@ TEST_IMPL(spawn_tcp_server) {
   options.stdio_count = 4;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -742,10 +742,10 @@ TEST_IMPL(spawn_ignored_stdio) {
   options.stdio_count = 0;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -761,16 +761,16 @@ TEST_IMPL(spawn_and_kill) {
   init_process_options("spawn_helper4", kill_cb);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* Once for process and once for timer. */
@@ -795,19 +795,19 @@ TEST_IMPL(spawn_preserve_env) {
   options.stdio_count = 2;
 
   r = putenv("ENV_TEST=testval");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Explicitly set options.env to NULL to test for env clobbering. */
   options.env = NULL;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2);
@@ -828,22 +828,22 @@ TEST_IMPL(spawn_detached) {
   options.flags |= UV_PROCESS_DETACHED;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*) &process);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   ASSERT(process.pid == uv_process_get_pid(&process));
 
   r = uv_kill(process.pid, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_kill(process.pid, SIGTERM);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -861,13 +861,13 @@ TEST_IMPL(spawn_and_kill_with_std) {
   init_process_options("spawn_helper4", kill_cb);
 
   r = uv_pipe_init(uv_default_loop(), &in, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &out, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &err, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
@@ -879,26 +879,26 @@ TEST_IMPL(spawn_and_kill_with_std) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(message, sizeof message);
   r = uv_write(&write, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &err, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 5); /* process x 1, timer x 1, stdio x 3. */
@@ -928,24 +928,24 @@ TEST_IMPL(spawn_and_ping) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.
    */
   r = uv_process_kill(&process, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(strcmp(output, "TEST") == 0);
@@ -975,24 +975,24 @@ TEST_IMPL(spawn_same_stdout_stderr) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.
    */
   r = uv_process_kill(&process, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(strcmp(output, "TEST") == 0);
@@ -1055,7 +1055,7 @@ TEST_IMPL(kill) {
 #endif
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
@@ -1071,14 +1071,14 @@ TEST_IMPL(kill) {
    * child process is still alive, not kill it.
    */
   r = uv_kill(process.pid, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Kill the process. */
   r = uv_kill(process.pid, SIGTERM);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -1122,13 +1122,13 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   ASSERT(pipe_handle != INVALID_HANDLE_VALUE);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
@@ -1207,9 +1207,9 @@ TEST_IMPL(argument_escaping) {
   free(test_output);
 
   result = make_program_args(verbatim, 1, &verbatim_output);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
   result = make_program_args(verbatim, 0, &non_verbatim_output);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
 
   wprintf(L"    verbatim_output: %s\n", verbatim_output);
   wprintf(L"non_verbatim_output: %s\n", non_verbatim_output);
@@ -1303,7 +1303,7 @@ TEST_IMPL(environment_creation) {
   }
 
   result = make_program_env(environment, &env);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
 
   for (str = env, prev = NULL; *str; prev = str, str += wcslen(str) + 1) {
     int found = 0;
@@ -1396,10 +1396,10 @@ TEST_IMPL(spawn_setuid_setgid) {
   if (r == UV_EACCES)
     RETURN_SKIP("user 'nobody' cannot access the test runner");
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -1453,9 +1453,9 @@ TEST_IMPL(spawn_setuid_fails) {
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1498,9 +1498,9 @@ TEST_IMPL(spawn_setgid_fails) {
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1543,7 +1543,7 @@ TEST_IMPL(spawn_affinity) {
 #else
   CPU_ZERO(&cpuset);
   r = pthread_getaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   for (i = 0; i < cpumask_size; ++i) {
     if (CPU_ISSET(i, &cpuset)) {
       cpu = i;
@@ -1568,10 +1568,10 @@ TEST_IMPL(spawn_affinity) {
   options.args[3] = "dummy"; /* need 4 args for test/run-tests.c dispatch */
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -1604,7 +1604,7 @@ TEST_IMPL(spawn_affinity_invalid_mask) {
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == UV_EINVAL);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1632,9 +1632,9 @@ TEST_IMPL(spawn_setuid_fails) {
   ASSERT(r == UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1653,9 +1653,9 @@ TEST_IMPL(spawn_setgid_fails) {
   ASSERT(r == UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -1686,7 +1686,7 @@ TEST_IMPL(spawn_fs_open) {
   uv_stdio_container_t stdio[1];
 
   r = uv_fs_open(NULL, &fs_req, "/dev/null", O_RDWR, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   fd = (uv_os_fd_t)fs_req.result;
   uv_fs_req_cleanup(&fs_req);
 
@@ -1832,10 +1832,10 @@ TEST_IMPL(spawn_reads_child_path) {
   options.env = env;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
@@ -1934,19 +1934,19 @@ TEST_IMPL(spawn_inherit_streams) {
                &buf,
                1,
                write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &pipe_stdout_parent, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 3);
 
   r = memcmp(ubuf, output, sizeof ubuf);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -226,7 +226,7 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
     err = waitpid(process.pid, &status, 0);
   while (err == -1 && errno == EINTR);
 
-  ASSERT(err == -1);
+  ASSERT_EQ(err, -1);
   ASSERT_EQ(errno, ECHILD);
 
   uv_close((uv_handle_t*) &process, NULL);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -118,7 +118,7 @@ static void kill_cb(uv_process_t* process,
    * This process should be dead.
    */
   err = uv_kill(process->pid, 0);
-  ASSERT(err == UV_ESRCH);
+  ASSERT_EQ(err, UV_ESRCH);
 }
 
 static void detach_failure_cb(uv_process_t* process,
@@ -140,7 +140,7 @@ static void on_read(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
     output_used += nread;
   } else if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*) tcp, close_cb);
   }
 }
@@ -227,7 +227,7 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
   while (err == -1 && errno == EINTR);
 
   ASSERT(err == -1);
-  ASSERT(errno == ECHILD);
+  ASSERT_EQ(errno, ECHILD);
 
   uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
@@ -1447,9 +1447,9 @@ TEST_IMPL(spawn_setuid_fails) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
 #if defined(__CYGWIN__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EPERM);
+  ASSERT_EQ(r, UV_EPERM);
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -1492,9 +1492,9 @@ TEST_IMPL(spawn_setgid_fails) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
 #if defined(__CYGWIN__) || defined(__MVS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EPERM);
+  ASSERT_EQ(r, UV_EPERM);
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -1602,7 +1602,7 @@ TEST_IMPL(spawn_affinity_invalid_mask) {
   options.cpumask = newmask;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   ASSERT_EQ(exit_cb_called, 0);
 
@@ -1629,7 +1629,7 @@ TEST_IMPL(spawn_setuid_fails) {
   options.uid = (uv_uid_t) -42424242;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == UV_ENOTSUP);
+  ASSERT_EQ(r, UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
@@ -1650,7 +1650,7 @@ TEST_IMPL(spawn_setgid_fails) {
   options.gid = (uv_gid_t) -42424242;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == UV_ENOTSUP);
+  ASSERT_EQ(r, UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -267,7 +267,7 @@ int stdio_over_pipes_helper(void) {
     uv_run(loop, UV_RUN_DEFAULT);
 
     ASSERT(after_write_called == 7 * (j + 1));
-    ASSERT(on_pipe_read_called == j);
+    ASSERT_EQ(on_pipe_read_called, j);
     ASSERT_EQ(close_cb_called, 0);
 
     uv_ref((uv_handle_t*) &stdout_pipe1);

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -266,7 +266,7 @@ int stdio_over_pipes_helper(void) {
     notify_parent_process();
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(after_write_called == 7 * (j + 1));
+    ASSERT_EQ(after_write_called, 7 * (j + 1));
     ASSERT_EQ(on_pipe_read_called, j);
     ASSERT_EQ(close_cb_called, 0);
 

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -149,11 +149,11 @@ static void test_stdio_over_pipes(int overlapped) {
   ASSERT_EQ(r, 0);
 
   ASSERT(on_read_cb_called > 1);
-  ASSERT(after_write_cb_called == 2);
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(after_write_cb_called, 2);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
   ASSERT(memcmp("hello world\nhello world\n", output, 24) == 0);
-  ASSERT(output_used == 24);
+  ASSERT_EQ(output_used, 24);
 
   MAKE_VALGRIND_HAPPY();
 }
@@ -294,9 +294,9 @@ int stdio_over_pipes_helper(void) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(after_write_called == 14);
-  ASSERT(on_pipe_read_called == 2);
-  ASSERT(close_cb_called == 4);
+  ASSERT_EQ(after_write_called, 14);
+  ASSERT_EQ(on_pipe_read_called, 2);
+  ASSERT_EQ(close_cb_called, 4);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -282,8 +282,8 @@ int stdio_over_pipes_helper(void) {
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(after_write_called == 7 * (j + 1));
-    ASSERT(on_pipe_read_called == j + 1);
+    ASSERT_EQ(after_write_called, 7 * (j + 1));
+    ASSERT_EQ(on_pipe_read_called, j + 1);
     ASSERT_EQ(close_cb_called, 0);
   }
 

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -52,8 +52,8 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT(exit_status == 0);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(exit_status, 0);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*)process, close_cb);
   uv_close((uv_handle_t*)&in, close_cb);
   uv_close((uv_handle_t*)&out, close_cb);
@@ -62,7 +62,7 @@ static void exit_cb(uv_process_t* process,
 
 static void init_process_options(char* test, uv_exit_cb exit_cb) {
   int r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
   args[0] = exepath;
   args[1] = test;
@@ -108,7 +108,7 @@ static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* rdbuf) {
       wrbuf = uv_buf_init(output, 12);
       req = malloc(sizeof(*req));
       r = uv_write(req, (uv_stream_t*) &in, &wrbuf, 1, after_write);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
   }
 
@@ -140,13 +140,13 @@ static void test_stdio_over_pipes(int overlapped) {
   options.stdio_count = 3;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(on_read_cb_called > 1);
   ASSERT(after_write_cb_called == 2);
@@ -190,7 +190,7 @@ static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) 
 
 
 static void after_pipe_write(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   after_write_called++;
 }
 
@@ -226,22 +226,22 @@ int stdio_over_pipes_helper(void) {
   ASSERT(UV_NAMED_PIPE == uv_guess_handle(UV_STDOUT_FD));
 
   r = uv_pipe_init(loop, &stdin_pipe1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdout_pipe1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdin_pipe2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdout_pipe2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_open(&stdin_pipe1, UV_STDIN_FD);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&stdout_pipe1, UV_STDOUT_FD);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&stdin_pipe2, UV_STDIN_FD);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&stdout_pipe2, UV_STDOUT_FD);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (j = 0; j < 2; j++) {
     /* Unref both stdio handles to make sure that all writes complete. */
@@ -260,7 +260,7 @@ int stdio_over_pipes_helper(void) {
                    &buf[i],
                    1,
                    after_pipe_write);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
 
     notify_parent_process();
@@ -268,7 +268,7 @@ int stdio_over_pipes_helper(void) {
 
     ASSERT(after_write_called == 7 * (j + 1));
     ASSERT(on_pipe_read_called == j);
-    ASSERT(close_cb_called == 0);
+    ASSERT_EQ(close_cb_called, 0);
 
     uv_ref((uv_handle_t*) &stdout_pipe1);
     uv_ref((uv_handle_t*) &stdin_pipe1);
@@ -278,13 +278,13 @@ int stdio_over_pipes_helper(void) {
     r = uv_read_start((uv_stream_t*) (j == 0 ? &stdin_pipe1 : &stdin_pipe2),
                       on_read_alloc,
                       on_pipe_read);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_run(loop, UV_RUN_DEFAULT);
 
     ASSERT(after_write_called == 7 * (j + 1));
     ASSERT(on_pipe_read_called == j + 1);
-    ASSERT(close_cb_called == 0);
+    ASSERT_EQ(close_cb_called, 0);
   }
 
   uv_close((uv_handle_t*)&stdin_pipe1, close_cb);

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -54,7 +54,7 @@ static void conn_read_cb(uv_stream_t* stream,
                          const uv_buf_t* buf) {
   ASSERT(nread == UV_ENOBUFS);
   ASSERT(buf->base == NULL);
-  ASSERT(buf->len == 0);
+  ASSERT_EQ(buf->len, 0);
 
   uv_close((uv_handle_t*) &incoming, close_cb);
   uv_close((uv_handle_t*) &client, close_cb);

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -114,9 +114,9 @@ TEST_IMPL(tcp_alloc_cb_fail) {
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(connection_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -52,8 +52,8 @@ static void conn_alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void conn_read_cb(uv_stream_t* stream,
                          ssize_t nread,
                          const uv_buf_t* buf) {
-  ASSERT(nread == UV_ENOBUFS);
-  ASSERT(buf->base == NULL);
+  ASSERT_EQ(nread, UV_ENOBUFS);
+  ASSERT_EQ(buf->base, NULL);
   ASSERT_EQ(buf->len, 0);
 
   uv_close((uv_handle_t*) &incoming, close_cb);

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -42,7 +42,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 static void conn_alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
@@ -65,17 +65,17 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   buf = uv_buf_init(hello, sizeof(hello));
   r = uv_write(&write_req, req->handle, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
   ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -53,7 +53,7 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
   ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
@@ -102,7 +102,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRNOTAVAIL);
+  ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -127,7 +127,7 @@ TEST_IMPL(tcp_bind_error_fault) {
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -155,7 +155,7 @@ TEST_IMPL(tcp_bind_error_inval) {
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -195,7 +195,7 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, UV_TCP_IPV6ONLY);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -237,11 +237,11 @@ TEST_IMPL(tcp_bind_writable_flags) {
 
   buf = uv_buf_init("PING", 4);
   r = uv_write(&write_req, (uv_stream_t*) &server, &buf, 1, NULL);
-  ASSERT(r == UV_EPIPE);
+  ASSERT_EQ(r, UV_EPIPE);
   r = uv_shutdown(&shutdown_req, (uv_stream_t*) &server, NULL);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
   r = uv_read_start((uv_stream_t*) &server, NULL, NULL);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   uv_close((uv_handle_t*)&server, close_cb);
 

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -60,7 +60,7 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -85,7 +85,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -108,7 +108,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -133,7 +133,7 @@ TEST_IMPL(tcp_bind_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -161,7 +161,7 @@ TEST_IMPL(tcp_bind_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -247,7 +247,7 @@ TEST_IMPL(tcp_bind_writable_flags) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -41,17 +41,17 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT(r == UV_EADDRINUSE);
 
@@ -75,7 +75,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
   ASSERT(0 == uv_ip4_addr("127.255.255.255", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* It seems that Linux is broken here - bind succeeds. */
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
@@ -100,7 +100,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
   ASSERT(0 == uv_ip4_addr("4.4.4.4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT(r == UV_EADDRNOTAVAIL);
 
@@ -125,7 +125,7 @@ TEST_IMPL(tcp_bind_error_fault) {
   garbage_addr = (struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
   ASSERT(r == UV_EINVAL);
 
@@ -151,9 +151,9 @@ TEST_IMPL(tcp_bind_error_inval) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
   ASSERT(r == UV_EINVAL);
 
@@ -176,9 +176,9 @@ TEST_IMPL(tcp_bind_localhost_ok) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -193,7 +193,7 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, UV_TCP_IPV6ONLY);
   ASSERT(r == UV_EINVAL);
 
@@ -207,9 +207,9 @@ TEST_IMPL(tcp_listen_without_bind) {
   uv_tcp_t server;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -226,11 +226,11 @@ TEST_IMPL(tcp_bind_writable_flags) {
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_is_writable((uv_stream_t*) &server));
   ASSERT(0 == uv_is_readable((uv_stream_t*) &server));

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -64,7 +64,7 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -90,7 +90,7 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -118,7 +118,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -149,7 +149,7 @@ TEST_IMPL(tcp_bind6_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -45,17 +45,17 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT(r == UV_EADDRINUSE);
 
@@ -82,7 +82,7 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
   ASSERT(0 == uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT(r == UV_EADDRNOTAVAIL);
 
@@ -110,7 +110,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
   garbage_addr = (struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
   ASSERT(r == UV_EINVAL);
 
@@ -139,9 +139,9 @@ TEST_IMPL(tcp_bind6_error_inval) {
   ASSERT(0 == uv_ip6_addr("::", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
   ASSERT(r == UV_EINVAL);
 
@@ -167,9 +167,9 @@ TEST_IMPL(tcp_bind6_localhost_ok) {
   ASSERT(0 == uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -57,7 +57,7 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
   ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
@@ -84,7 +84,7 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRNOTAVAIL);
+  ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -112,7 +112,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
   r = uv_tcp_init(uv_default_loop(), &server);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
@@ -143,7 +143,7 @@ TEST_IMPL(tcp_bind6_error_inval) {
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
   ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -47,7 +47,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
@@ -68,7 +68,7 @@ static void connect_cb(uv_connect_t* req, int status) {
     return;
   }
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(connect_reqs <= req);
   ASSERT(req <= connect_reqs + ARRAY_SIZE(connect_reqs));
   i = req - connect_reqs;

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -118,7 +118,7 @@ static void connection_cb(uv_stream_t* server, int status) {
   unsigned int i;
   uv_tcp_t* incoming;
 
-  ASSERT(server == (uv_stream_t*) &tcp_server);
+  ASSERT_EQ(server, (uv_stream_t*) &tcp_server);
 
   /* Ignore tcp_check connection */
   if (got_connections == ARRAY_SIZE(tcp_incoming))

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -91,7 +91,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   pending_incoming = (uv_tcp_t*) stream - &tcp_incoming[0];
   ASSERT(pending_incoming < got_connections);
   ASSERT(0 == uv_read_stop(stream));
-  ASSERT(1 == nread);
+  ASSERT_EQ(nread, 1);
 
   loop = stream->loop;
   read_cb_called++;
@@ -185,7 +185,7 @@ TEST_IMPL(tcp_close_accept) {
   ASSERT(ARRAY_SIZE(tcp_outgoing) == got_connections);
   ASSERT((ARRAY_SIZE(tcp_outgoing) + 2) == close_cb_called);
   ASSERT(ARRAY_SIZE(tcp_outgoing) == write_cb_called);
-  ASSERT(1 == read_cb_called);
+  ASSERT_EQ(read_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -182,9 +182,9 @@ TEST_IMPL(tcp_close_accept) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(ARRAY_SIZE(tcp_outgoing) == got_connections);
-  ASSERT((ARRAY_SIZE(tcp_outgoing) + 2) == close_cb_called);
-  ASSERT(ARRAY_SIZE(tcp_outgoing) == write_cb_called);
+  ASSERT_EQ(got_connections, ARRAY_SIZE(tcp_outgoing));
+  ASSERT_EQ(close_cb_called, ARRAY_SIZE(tcp_outgoing) + 2);
+  ASSERT_EQ(write_cb_called, ARRAY_SIZE(tcp_outgoing));
   ASSERT_EQ(read_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -56,7 +56,7 @@ static void do_write(uv_tcp_t* handle) {
   buf = uv_buf_init("PING", 4);
   for (i = 0; i < ARRAY_SIZE(write_reqs); i++) {
     r = uv_write(&write_reqs[i], (uv_stream_t*) handle, &buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -97,7 +97,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   ASSERT(req->handle == (uv_stream_t*)&tcp_client);
   write_cb_called++;
 }
@@ -135,7 +135,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connection_cb(uv_stream_t* server, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(loop, &tcp_accepted));
   ASSERT(0 == uv_accept(server, (uv_stream_t*) &tcp_accepted));
@@ -151,13 +151,13 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -168,13 +168,13 @@ static void do_connect(uv_loop_t* loop, uv_tcp_t* tcp_client) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -193,16 +193,16 @@ TEST_IMPL(tcp_close_reset_client) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(write_cb_called == 4);
   ASSERT(close_cb_called == 1);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -220,15 +220,15 @@ TEST_IMPL(tcp_close_reset_client_after_shutdown) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   ASSERT(shutdown_cb_called == 1);
 
   MAKE_VALGRIND_HAPPY();
@@ -247,16 +247,16 @@ TEST_IMPL(tcp_close_reset_accepted) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(write_cb_called == 4);
   ASSERT(close_cb_called == 1);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -274,15 +274,15 @@ TEST_IMPL(tcp_close_reset_accepted_after_shutdown) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   ASSERT(shutdown_cb_called == 1);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -87,7 +87,7 @@ static void read_cb2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* conn_req, int status) {
-  ASSERT(conn_req == &connect_req);
+  ASSERT_EQ(conn_req, &connect_req);
   uv_read_start((uv_stream_t*) &tcp_client, alloc_cb, read_cb2);
   do_write(&tcp_client);
   if (client_close)

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -200,8 +200,8 @@ TEST_IMPL(tcp_close_reset_client) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 1);
   ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -227,9 +227,9 @@ TEST_IMPL(tcp_close_reset_client_after_shutdown) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
+  ASSERT_EQ(write_cb_called, 4);
   ASSERT_EQ(close_cb_called, 0);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -254,8 +254,8 @@ TEST_IMPL(tcp_close_reset_accepted) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 1);
   ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY();
@@ -281,9 +281,9 @@ TEST_IMPL(tcp_close_reset_accepted_after_shutdown) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
+  ASSERT_EQ(write_cb_called, 4);
   ASSERT_EQ(close_cb_called, 0);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -80,7 +80,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 }
 
 static void read_cb2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)stream == &tcp_client);
+  ASSERT_EQ((uv_tcp_t*)stream, &tcp_client);
   if (nread == UV_EOF)
     uv_close((uv_handle_t*) stream, NULL);
 }
@@ -98,32 +98,32 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
   ASSERT_EQ(close_cb_called, 0);
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
+  ASSERT_EQ(req->handle, (uv_stream_t*)&tcp_client);
   write_cb_called++;
 }
 
 
 static void close_cb(uv_handle_t* handle) {
   if (client_close)
-    ASSERT(handle == (uv_handle_t*) &tcp_client);
+    ASSERT_EQ(handle, (uv_handle_t*) &tcp_client);
   else
-    ASSERT(handle == (uv_handle_t*) &tcp_accepted);
+    ASSERT_EQ(handle, (uv_handle_t*) &tcp_accepted);
 
   close_cb_called++;
 }
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   if (client_close)
-    ASSERT(req->handle == (uv_stream_t*) &tcp_client);
+    ASSERT_EQ(req->handle, (uv_stream_t*) &tcp_client);
   else
-    ASSERT(req->handle == (uv_stream_t*) &tcp_accepted);
+    ASSERT_EQ(req->handle, (uv_stream_t*) &tcp_accepted);
 
   shutdown_cb_called++;
 }
 
 
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)stream == &tcp_accepted);
+  ASSERT_EQ((uv_tcp_t*)stream, &tcp_accepted);
   if (nread < 0) {
     uv_close((uv_handle_t*) stream, NULL);
   } else {

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -77,7 +77,7 @@ TEST_IMPL(tcp_close_while_connecting) {
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(0 == uv_timer_init(loop, &timer1_handle));
   ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
   ASSERT(0 == uv_timer_init(loop, &timer2_handle));

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -84,9 +84,9 @@ TEST_IMPL(tcp_close_while_connecting) {
   ASSERT(0 == uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(timer1_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(timer1_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
 

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -128,7 +128,7 @@ TEST_IMPL(tcp_close) {
 
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 
-  ASSERT(write_cb_called == NUM_WRITE_REQS);
+  ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
   ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -129,7 +129,7 @@ TEST_IMPL(tcp_close) {
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 
   ASSERT(write_cb_called == NUM_WRITE_REQS);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -49,7 +49,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
     ASSERT(req != NULL);
 
     r = uv_write(req, (uv_stream_t*)&tcp_handle, &buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_close((uv_handle_t*)&tcp_handle, close_cb);
@@ -58,7 +58,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   ASSERT(req->handle == (uv_stream_t*)&tcp_handle);
   write_cb_called++;
   free(req);
@@ -72,7 +72,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connection_cb(uv_stream_t* server, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -83,13 +83,13 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)handle);
 }
@@ -112,19 +112,19 @@ TEST_IMPL(tcp_close) {
   start_server(loop, &tcp_server);
 
   r = uv_tcp_init(loop, &tcp_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_handle,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -59,14 +59,14 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
   ASSERT_EQ(close_cb_called, 0);
-  ASSERT(req->handle == (uv_stream_t*)&tcp_handle);
+  ASSERT_EQ(req->handle, (uv_stream_t*)&tcp_handle);
   write_cb_called++;
   free(req);
 }
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*)&tcp_handle);
+  ASSERT_EQ(handle, (uv_handle_t*)&tcp_handle);
   close_cb_called++;
 }
 

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -75,7 +75,7 @@ TEST_IMPL(tcp_connect_error_after_write) {
   ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -72,7 +72,7 @@ TEST_IMPL(tcp_connect_error_after_write) {
   buf = uv_buf_init("TEST", 4);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
   ASSERT(r == UV_EBADF);
@@ -81,13 +81,13 @@ TEST_IMPL(tcp_connect_error_after_write) {
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(connect_cb_called == 1);
   ASSERT(write_cb_called == 1);

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -89,9 +89,9 @@ TEST_IMPL(tcp_connect_error_after_write) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -66,7 +66,7 @@ TEST_IMPL(tcp_connect_error_fault) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(connect_cb_called, 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -54,7 +54,7 @@ TEST_IMPL(tcp_connect_error_fault) {
   garbage_addr = (const struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
@@ -65,7 +65,7 @@ TEST_IMPL(tcp_connect_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 0);
+  ASSERT_EQ(connect_cb_called, 0);
   ASSERT(close_cb_called == 1);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -59,7 +59,7 @@ TEST_IMPL(tcp_connect_error_fault) {
                      &server,
                      (const struct sockaddr*) garbage_addr,
                      connect_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -67,13 +67,13 @@ TEST_IMPL(tcp_connect_timeout) {
   ASSERT(0 == uv_ip4_addr("8.8.8.8", 9999, &addr));
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 50, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -81,10 +81,10 @@ TEST_IMPL(tcp_connect_timeout) {
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -151,7 +151,7 @@ TEST_IMPL(tcp_local_connect_timeout) {
   ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -39,7 +39,7 @@ static void close_cb(uv_handle_t* handle);
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(req == &connect_req);
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   connect_cb_called++;
 }
 

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -38,14 +38,14 @@ static void close_cb(uv_handle_t* handle);
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, UV_ECANCELED);
   connect_cb_called++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_EQ(handle, &timer);
   uv_close((uv_handle_t*)&conn, close_cb);
   uv_close((uv_handle_t*)&timer, close_cb);
 }

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -52,7 +52,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
   garbage_addr = (const struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
@@ -63,7 +63,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 0);
+  ASSERT_EQ(connect_cb_called, 0);
   ASSERT(close_cb_called == 1);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -57,7 +57,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
                      &server,
                      (const struct sockaddr*) garbage_addr,
                      connect_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -64,7 +64,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(connect_cb_called, 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -50,7 +50,7 @@ static void on_connection(uv_stream_t* server, int status) {
   ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)handle);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
 
   uv_close((uv_handle_t*) server, NULL);
   uv_close((uv_handle_t*) handle, (uv_close_cb)free);
@@ -112,7 +112,7 @@ TEST_IMPL(tcp_create_early) {
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
   ASSERT_EQ(r, 0);
-  ASSERT(sockname.sin_family == AF_INET);
+  ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
@@ -165,9 +165,9 @@ TEST_IMPL(tcp_create_early_bad_bind) {
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
 #if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MSYS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EFAULT);
+  ASSERT_EQ(r, UV_EFAULT);
 #endif
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -183,10 +183,10 @@ TEST_IMPL(tcp_create_early_bad_domain) {
   int r;
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, 47);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, 1024);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -159,7 +159,7 @@ TEST_IMPL(tcp_create_early_bad_bind) {
     namelen = sizeof sockname;
     r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
     ASSERT_EQ(r, 0);
-    ASSERT(sockname.sin6_family == AF_INET6);
+    ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif
 

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -32,7 +32,7 @@
 
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
@@ -41,13 +41,13 @@ static void on_connection(uv_stream_t* server, int status) {
   uv_tcp_t* handle;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   handle = malloc(sizeof(*handle));
   ASSERT(handle != NULL);
 
   r = uv_tcp_init_ex(server->loop, handle, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)handle);
   ASSERT(r == UV_EBUSY);
@@ -64,13 +64,13 @@ static void tcp_listener(uv_loop_t* loop, uv_tcp_t* server) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*) server, 128, on_connection);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -81,13 +81,13 @@ static void tcp_connector(uv_loop_t* loop, uv_tcp_t* client, uv_connect_t* req) 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
 
   r = uv_tcp_init(loop, client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(req,
                      client,
                      (const struct sockaddr*) &server_addr,
                      on_connect);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -101,26 +101,26 @@ TEST_IMPL(tcp_create_early) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(fd != INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(sockname.sin_family == AF_INET);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(memcmp(&addr.sin_addr,
                 &sockname.sin_addr,
                 sizeof(addr.sin_addr)) == 0);
@@ -145,10 +145,10 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(fd != INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
@@ -158,7 +158,7 @@ TEST_IMPL(tcp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(sockname.sin6_family == AF_INET6);
   }
 #endif

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -34,18 +34,18 @@ TEST_IMPL(tcp_flags) {
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_nodelay(&handle, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_keepalive(&handle, 1, 60);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -76,7 +76,7 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(req->handle == (uv_stream_t*) &client_handle);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -84,7 +84,7 @@ static void connection_cb(uv_stream_t* handle, int status) {
   int r;
   uv_os_fd_t fd;
 
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
   ASSERT(0 == uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
 
@@ -99,12 +99,12 @@ static void connection_cb(uv_stream_t* handle, int status) {
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   ASSERT(0 == uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
 }

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -133,7 +133,7 @@ TEST_IMPL(tcp_oob) {
                              connect_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(ticks == kMaxTicks);
+  ASSERT_EQ(ticks, kMaxTicks);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -75,7 +75,7 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &client_handle);
+  ASSERT_EQ(req->handle, (uv_stream_t*) &client_handle);
   ASSERT_EQ(status, 0);
 }
 

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -102,7 +102,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_EQ(req, &shutdown_req);
   ASSERT_EQ(status, 0);
 
   /* Now we wait for the EOF */
@@ -187,7 +187,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   stream = req->handle;
@@ -211,7 +211,7 @@ static void connect1_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   stream = req->handle;

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -130,7 +130,7 @@ static void read1_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
   if (nread >= 0) {
     for (i = 0; i < nread; ++i)
-      ASSERT(buf->base[i] == 'P');
+      ASSERT_EQ(buf->base[i], 'P');
   } else {
     ASSERT_EQ(nread, UV_EOF);
     printf("GOT EOF\n");

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -118,7 +118,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     ASSERT(memcmp("PING", buf->base, nread) == 0);
   }
   else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*)tcp, close_cb);
   }
 }
@@ -132,7 +132,7 @@ static void read1_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     for (i = 0; i < nread; ++i)
       ASSERT(buf->base[i] == 'P');
   } else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     printf("GOT EOF\n");
     uv_close((uv_handle_t*)tcp, close_cb);
   }
@@ -263,7 +263,7 @@ TEST_IMPL(tcp_open) {
     ASSERT_EQ(r, 0);
 
     r = uv_tcp_open(&client2, sock);
-    ASSERT(r == UV_EEXIST);
+    ASSERT_EQ(r, UV_EEXIST);
 
     uv_close((uv_handle_t*) &client2, NULL);
   }
@@ -297,7 +297,7 @@ TEST_IMPL(tcp_open_twice) {
   ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock2);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
   close_socket(sock2);
 
   uv_close((uv_handle_t*) &client, NULL);

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -46,7 +46,7 @@ static void startup(void) {
 #ifdef _WIN32
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 }
 
@@ -66,7 +66,7 @@ static uv_os_sock_t create_tcp_socket(void) {
     /* Allow reuse of the port. */
     int yes = 1;
     int r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -81,7 +81,7 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -103,7 +103,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT(req == &shutdown_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* Now we wait for the EOF */
   shutdown_cb_called++;
@@ -166,7 +166,7 @@ static void write1_cb(uv_write_t* req, int status) {
 
   buf = uv_buf_init("P", 1);
   r = uv_write(&write_req, req->handle, &buf, 1, write1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   write_cb_called++;
 }
@@ -177,7 +177,7 @@ static void timer_cb(uv_timer_t* handle) {
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, (uv_stream_t*) &client, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   shutdown_requested++;
 }
 
@@ -188,21 +188,21 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
 
   r = uv_write(&write_req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -212,24 +212,24 @@ static void connect1_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
 
   r = uv_timer_init(uv_default_loop(), &tm);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&tm, timer_cb, 2000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("P", 1);
   r = uv_write(&write_req, stream, &buf, 1, write1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -244,23 +244,23 @@ TEST_IMPL(tcp_open) {
   sock = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
     uv_tcp_t client2;
 
     r = uv_tcp_init(uv_default_loop(), &client2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_tcp_open(&client2, sock);
     ASSERT(r == UV_EEXIST);
@@ -291,10 +291,10 @@ TEST_IMPL(tcp_open_twice) {
   sock2 = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock2);
   ASSERT(r == UV_EBUSY);
@@ -376,16 +376,16 @@ TEST_IMPL(tcp_write_ready) {
   sock = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -114,7 +114,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   ASSERT(tcp != NULL);
 
   if (nread >= 0) {
-    ASSERT(nread == 4);
+    ASSERT_EQ(nread, 4);
     ASSERT(memcmp("PING", buf->base, nread) == 0);
   }
   else {
@@ -271,10 +271,10 @@ TEST_IMPL(tcp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -356,9 +356,9 @@ TEST_IMPL(tcp_open_connected) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -389,11 +389,11 @@ TEST_IMPL(tcp_write_ready) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(shutdown_requested == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(shutdown_requested, 1);
+  ASSERT_EQ(connect_cb_called, 1);
   ASSERT(write_cb_called > 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-read-stop-start.c
+++ b/test/test-tcp-read-stop-start.c
@@ -33,14 +33,14 @@ static uv_connect_t connect_req;
 static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
 
 static void on_write_close_immediately(uv_write_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   uv_close((uv_handle_t*)req->handle, NULL); /* Close immediately */
   free(req);
 }
 
 static void on_write(uv_write_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   free(req);
 }
@@ -86,7 +86,7 @@ static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 }
 
 static void on_connection(uv_stream_t* server, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(server->loop, &connection));
 
@@ -96,7 +96,7 @@ static void on_connection(uv_stream_t* server, int status) {
 }
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   do_write((uv_stream_t*)&client, on_write_close_immediately);
 }

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -50,7 +50,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
   ASSERT(0 == uv_read_start((uv_stream_t*) &tcp_handle,
                             (uv_alloc_cb) fail_cb,

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -66,10 +66,10 @@ static void timer_cb(uv_timer_t* handle) {
 
   buf = uv_buf_init("TEST", 4);
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_shutdown(&shutdown_req, (uv_stream_t*)&conn, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -80,22 +80,22 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   r = uv_read_start((uv_stream_t*)&conn, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   shutdown_cb_called++;
   uv_close((uv_handle_t*)&conn, close_cb);
 }
@@ -110,22 +110,22 @@ TEST_IMPL(tcp_shutdown_after_write) {
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 125, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(loop, &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(connect_cb_called == 1);
   ASSERT(write_cb_called == 1);

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -127,11 +127,11 @@ TEST_IMPL(tcp_shutdown_after_write) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(conn_close_cb_called == 1);
-  ASSERT(timer_close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(conn_close_cb_called, 1);
+  ASSERT_EQ(timer_close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -49,7 +49,7 @@ static void incoming_close_cb(uv_handle_t* handle) {
     r = uv_try_write((uv_stream_t*) &client, &buf, 1);
   fprintf(stderr, "uv_try_write error: %d %s\n", r, uv_strerror(r));
   ASSERT(r == UV_EPIPE || r == UV_ECONNABORTED || r == UV_ECONNRESET);
-  ASSERT(client.write_queue_size == 0);
+  ASSERT_EQ(client.write_queue_size, 0);
 }
 
 

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -54,13 +54,13 @@ static void incoming_close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
   ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -100,9 +100,9 @@ TEST_IMPL(tcp_try_write_error) {
   uv_close((uv_handle_t*) &client, close_cb);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(connection_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(connection_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -46,7 +46,7 @@ static void close_cb(uv_handle_t* handle) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   do {
@@ -87,7 +87,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
   ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -127,7 +127,7 @@ TEST_IMPL(tcp_try_write) {
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(close_cb_called, 3);
   ASSERT_EQ(connection_cb_called, 1);
-  ASSERT(bytes_read == bytes_written);
+  ASSERT_EQ(bytes_read, bytes_written);
   ASSERT(bytes_written > 0);
 
   MAKE_VALGRIND_HAPPY();

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -124,9 +124,9 @@ TEST_IMPL(tcp_try_write) {
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(connection_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(connection_cb_called, 1);
   ASSERT(bytes_read == bytes_written);
   ASSERT(bytes_written > 0);
 

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -60,13 +60,13 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &client_handle);
+  ASSERT_EQ(req->handle, (uv_stream_t*) &client_handle);
   ASSERT_EQ(status, 0);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &peer_handle);
+  ASSERT_EQ(req->handle, (uv_stream_t*) &peer_handle);
   ASSERT_EQ(status, 0);
 }
 

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -61,13 +61,13 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(req->handle == (uv_stream_t*) &client_handle);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT(req->handle == (uv_stream_t*) &peer_handle);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -76,7 +76,7 @@ static void connection_cb(uv_stream_t* handle, int status) {
 
   buf = uv_buf_init("PING", 4);
 
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
   ASSERT(0 == uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
   ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &peer_handle,

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -32,13 +32,13 @@ uv_buf_t buf = { "HELLO", 4 };
 
 
 static void write_cb(uv_write_t *req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT(status == UV_ECONNREFUSED);
+  ASSERT_EQ(status, UV_ECONNREFUSED);
 }
 
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -106,9 +106,9 @@ TEST_IMPL(tcp_write_fail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -41,13 +41,13 @@ static void close_socket(uv_tcp_t* sock) {
   int r;
 
   r = uv_fileno((uv_handle_t*)sock, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   r = closesocket((uv_os_sock_t)fd);
 #else
   r = close(fd);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -74,7 +74,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
@@ -84,7 +84,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   buf = uv_buf_init("hello\n", 6);
   r = uv_write(&write_req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -96,13 +96,13 @@ TEST_IMPL(tcp_write_fail) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -73,7 +73,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   stream = req->handle;

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -67,7 +67,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i;
   uv_buf_t buf;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   buf = uv_buf_init(base, sizeof(base));
@@ -78,13 +78,13 @@ static void connect_cb(uv_connect_t* req, int status) {
                  &buf,
                  1,
                  write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
   ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -125,14 +125,14 @@ TEST_IMPL(tcp_write_queue_order) {
 
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(connection_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(connection_cb_called, 1);
   ASSERT(write_callbacks > 0);
   ASSERT(write_cancelled_callbacks > 0);
   ASSERT(write_callbacks +
          write_error_callbacks +
          write_cancelled_callbacks == REQ_COUNT);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -45,7 +45,7 @@ static void connection_cb(uv_stream_t* server, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(server == (uv_stream_t*)&tcp_server);
+  ASSERT_EQ(server, (uv_stream_t*)&tcp_server);
   ASSERT_EQ(status, 0);
 
   r = uv_tcp_init(server->loop, &tcp_peer);

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -46,22 +46,22 @@ static void connection_cb(uv_stream_t* server, int status) {
   uv_buf_t buf;
 
   ASSERT(server == (uv_stream_t*)&tcp_server);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_tcp_init(server->loop, &tcp_peer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)&tcp_peer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&tcp_peer, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = "hello\n";
   buf.len = 6;
 
   r = uv_write(&write_req, (uv_stream_t*)&tcp_peer, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -89,7 +89,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* Close the client. */
   uv_close((uv_handle_t*)&tcp_client, NULL);
@@ -97,7 +97,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
@@ -113,25 +113,25 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   ASSERT(loop != NULL);
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 1, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(write_cb_called > 0);
   ASSERT(read_cb_called > 0);

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -88,7 +88,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   /* Close the client. */

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -66,7 +66,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
   uv_tcp_t* tcp;
 
   ASSERT(req == &shutdown_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   tcp = (uv_tcp_t*)(req->handle);
 
@@ -116,7 +116,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i, j, r;
 
   ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
@@ -131,16 +131,16 @@ static void connect_cb(uv_connect_t* req, int status) {
     }
 
     r = uv_write(write_req, stream, send_bufs, CHUNKS_PER_WRITE, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -155,13 +155,13 @@ TEST_IMPL(tcp_writealot) {
   ASSERT(send_buffer != NULL);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -165,10 +165,10 @@ TEST_IMPL(tcp_writealot) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
   ASSERT(write_cb_called == WRITES);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
   ASSERT(bytes_sent == TOTAL_BYTES);
   ASSERT(bytes_sent_done == TOTAL_BYTES);
   ASSERT(bytes_received_done == TOTAL_BYTES);

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -77,7 +77,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
   shutdown_cb_called++;
 
   /* We should have had all the writes called already. */
-  ASSERT(write_cb_called == WRITES);
+  ASSERT_EQ(write_cb_called, WRITES);
 }
 
 
@@ -88,7 +88,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     bytes_received_done += nread;
   }
   else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     printf("GOT EOF\n");
     uv_close((uv_handle_t*)tcp, close_cb);
   }
@@ -167,11 +167,11 @@ TEST_IMPL(tcp_writealot) {
 
   ASSERT_EQ(shutdown_cb_called, 1);
   ASSERT_EQ(connect_cb_called, 1);
-  ASSERT(write_cb_called == WRITES);
+  ASSERT_EQ(write_cb_called, WRITES);
   ASSERT_EQ(close_cb_called, 1);
-  ASSERT(bytes_sent == TOTAL_BYTES);
-  ASSERT(bytes_sent_done == TOTAL_BYTES);
-  ASSERT(bytes_received_done == TOTAL_BYTES);
+  ASSERT_EQ(bytes_sent, TOTAL_BYTES);
+  ASSERT_EQ(bytes_sent_done, TOTAL_BYTES);
+  ASSERT_EQ(bytes_received_done, TOTAL_BYTES);
 
   free(send_buffer);
 

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -71,7 +71,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
   tcp = (uv_tcp_t*)(req->handle);
 
   /* The write buffer should be empty by now. */
-  ASSERT(tcp->write_queue_size == 0);
+  ASSERT_EQ(tcp->write_queue_size, 0);
 
   /* Now we wait for the EOF */
   shutdown_cb_called++;

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -65,7 +65,7 @@ static void close_cb(uv_handle_t* handle) {
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   uv_tcp_t* tcp;
 
-  ASSERT(req == &shutdown_req);
+  ASSERT_EQ(req, &shutdown_req);
   ASSERT_EQ(status, 0);
 
   tcp = (uv_tcp_t*)(req->handle);
@@ -115,7 +115,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int i, j, r;
 
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(req, &connect_req);
   ASSERT_EQ(status, 0);
 
   stream = req->handle;

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -91,13 +91,13 @@ TEST_IMPL(thread_affinity) {
 
   ASSERT(cpumask[t1first + 0] == (ncpus == 1));
   ASSERT(cpumask[t1first + 1] == (ncpus >= 2));
-  ASSERT(cpumask[t1first + 2] == 0);
+  ASSERT_EQ(cpumask[t1first + 2], 0);
   ASSERT(cpumask[t1first + 3] == (ncpus >= 4));
 
   ASSERT(cpumask[t2first + 0] == 1);
-  ASSERT(cpumask[t2first + 1] == 0);
+  ASSERT_EQ(cpumask[t2first + 1], 0);
   ASSERT(cpumask[t2first + 2] == (ncpus >= 3));
-  ASSERT(cpumask[t2first + 3] == 0);
+  ASSERT_EQ(cpumask[t2first + 3], 0);
 
   free(cpumask);
 

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -109,7 +109,7 @@ TEST_IMPL(thread_affinity) {
 TEST_IMPL(thread_affinity) {
   int cpumasksize;
   cpumasksize = uv_cpumask_size();
-  ASSERT(cpumasksize == UV_ENOTSUP);
+  ASSERT_EQ(cpumasksize, UV_ENOTSUP);
   return 0;
 }
 

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -94,7 +94,7 @@ TEST_IMPL(thread_affinity) {
   ASSERT_EQ(cpumask[t1first + 2], 0);
   ASSERT(cpumask[t1first + 3] == (ncpus >= 4));
 
-  ASSERT(cpumask[t2first + 0] == 1);
+  ASSERT_EQ(cpumask[t2first + 0], 1);
   ASSERT_EQ(cpumask[t2first + 1], 0);
   ASSERT(cpumask[t2first + 2] == (ncpus >= 3));
   ASSERT_EQ(cpumask[t2first + 3], 0);

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -19,9 +19,9 @@ static void check_affinity(void* arg) {
   ASSERT(cpumasksize > 0);
   tid = uv_thread_self();
   r = uv_thread_setaffinity(&tid, cpumask, NULL, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_thread_setaffinity(&tid, cpumask + cpumasksize, cpumask, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -49,7 +49,7 @@ TEST_IMPL(thread_affinity) {
   ASSERT(cpumask);
 
   r = uv_thread_getaffinity(&threads[0], cpumask, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(cpumask[0] && "test must be run with cpu 0 affinity");
   ncpus = 0;
   while (cpumask[++ncpus]) { }

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -71,7 +71,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
                      "localhost",
                      NULL,
                      NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -84,7 +84,7 @@ static void getaddrinfo_cb(uv_getaddrinfo_t* handle,
 #endif
   struct getaddrinfo_req* req;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   req = container_of(handle, struct getaddrinfo_req, handle);
   uv_freeaddrinfo(res);
@@ -98,7 +98,7 @@ static void fs_do(struct fs_req* req) {
   int r;
 
   r = uv_fs_stat(req->loop, &req->handle, ".", fs_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -152,10 +152,10 @@ TEST_IMPL(thread_create) {
   int r;
 
   r = uv_thread_create(&tid, thread_entry, (void *) 42);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_thread_join(&tid);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(thread_called == 1);
 
@@ -180,12 +180,12 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_create(&threads[i].thread_id, do_work, &threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_join(&threads[i].thread_id);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(threads[i].thread_called == 1);
   }
 

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -186,7 +186,7 @@ TEST_IMPL(threadpool_multiple_event_loops) {
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_join(&threads[i].thread_id);
     ASSERT_EQ(r, 0);
-    ASSERT(threads[i].thread_called == 1);
+    ASSERT_EQ(threads[i].thread_called, 1);
   }
 
   return 0;

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -142,7 +142,7 @@ static void do_work(void* arg) {
 
 
 static void thread_entry(void* arg) {
-  ASSERT(arg == (void *) 42);
+  ASSERT_EQ(arg, (void *) 42);
   thread_called++;
 }
 

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -157,7 +157,7 @@ TEST_IMPL(thread_create) {
   r = uv_thread_join(&tid);
   ASSERT_EQ(r, 0);
 
-  ASSERT(thread_called == 1);
+  ASSERT_EQ(thread_called, 1);
 
   return 0;
 }

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -270,7 +270,7 @@ TEST_IMPL(threadpool_cancel_work) {
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(timer_cb_called, 1);
-  ASSERT(ARRAY_SIZE(reqs) == done2_cb_called);
+  ASSERT_EQ(done2_cb_called, ARRAY_SIZE(reqs));
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -317,7 +317,7 @@ TEST_IMPL(threadpool_cancel_fs) {
   ASSERT(0 == uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
   ASSERT(0 == uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
   ASSERT(0 == uv_fs_write(loop, reqs + n++, 0, &iov, 1, 0, fs_cb));
-  ASSERT(n == ARRAY_SIZE(reqs));
+  ASSERT_EQ(n, ARRAY_SIZE(reqs));
 
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -155,7 +155,7 @@ static void nop_random_cb(uv_random_t* req, int status, void* buf, size_t len) {
 
   ASSERT_EQ(status, UV_ECANCELED);
   ASSERT_EQ(buf, (void *) ri->buf);
-  ASSERT(len == sizeof(ri->buf));
+  ASSERT_EQ(len, sizeof(ri->buf));
 
   done_cb_called++;
 }

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -154,7 +154,7 @@ static void nop_random_cb(uv_random_t* req, int status, void* buf, size_t len) {
   ri = container_of(req, struct random_info, random_req);
 
   ASSERT_EQ(status, UV_ECANCELED);
-  ASSERT(buf == (void*) ri->buf);
+  ASSERT_EQ(buf, (void *) ri->buf);
   ASSERT(len == sizeof(ri->buf));
 
   done_cb_called++;

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -187,7 +187,7 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -223,7 +223,7 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -243,10 +243,10 @@ TEST_IMPL(threadpool_cancel_random) {
                         0,
                         nop_random_cb));
   ASSERT(0 == uv_cancel((uv_req_t*) &req));
-  ASSERT(0 == done_cb_called);
+  ASSERT_EQ(done_cb_called, 0);
   unblock_threadpool();
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == done_cb_called);
+  ASSERT_EQ(done_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -269,7 +269,7 @@ TEST_IMPL(threadpool_cancel_work) {
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
   ASSERT(ARRAY_SIZE(reqs) == done2_cb_called);
 
   MAKE_VALGRIND_HAPPY();
@@ -323,7 +323,7 @@ TEST_IMPL(threadpool_cancel_fs) {
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(n == fs_cb_called);
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(timer_cb_called, 1);
 
 
   MAKE_VALGRIND_HAPPY();
@@ -339,10 +339,10 @@ TEST_IMPL(threadpool_cancel_single) {
   loop = uv_default_loop();
   ASSERT(0 == uv_queue_work(loop, &req, (uv_work_cb) abort, nop_done_cb));
   ASSERT(0 == uv_cancel((uv_req_t*) &req));
-  ASSERT(0 == done_cb_called);
+  ASSERT_EQ(done_cb_called, 0);
   unblock_threadpool();
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == done_cb_called);
+  ASSERT_EQ(done_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -88,7 +88,7 @@ static void unblock_threadpool(void) {
 
 
 static void fs_cb(uv_fs_t* req) {
-  ASSERT(req->result == UV_ECANCELED);
+  ASSERT_EQ(req->result, UV_ECANCELED);
   uv_fs_req_cleanup(req);
   fs_cb_called++;
 }
@@ -97,8 +97,8 @@ static void fs_cb(uv_fs_t* req) {
 static void getaddrinfo_cb(uv_getaddrinfo_t* req,
                            int status,
                            struct addrinfo* res) {
-  ASSERT(status == UV_EAI_CANCELED);
-  ASSERT(res == NULL);
+  ASSERT_EQ(status, UV_EAI_CANCELED);
+  ASSERT_EQ(res, NULL);
   uv_freeaddrinfo(res);  /* Should not crash. */
 }
 
@@ -107,9 +107,9 @@ static void getnameinfo_cb(uv_getnameinfo_t* handle,
                            int status,
                            const char* hostname,
                            const char* service) {
-  ASSERT(status == UV_EAI_CANCELED);
-  ASSERT(hostname == NULL);
-  ASSERT(service == NULL);
+  ASSERT_EQ(status, UV_EAI_CANCELED);
+  ASSERT_EQ(hostname, NULL);
+  ASSERT_EQ(service, NULL);
 }
 
 
@@ -119,7 +119,7 @@ static void work2_cb(uv_work_t* req) {
 
 
 static void done2_cb(uv_work_t* req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   done2_cb_called++;
 }
 
@@ -143,7 +143,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void nop_done_cb(uv_work_t* req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   done_cb_called++;
 }
 
@@ -153,7 +153,7 @@ static void nop_random_cb(uv_random_t* req, int status, void* buf, size_t len) {
 
   ri = container_of(req, struct random_info, random_req);
 
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   ASSERT(buf == (void*) ri->buf);
   ASSERT(len == sizeof(ri->buf));
 

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -322,7 +322,7 @@ TEST_IMPL(threadpool_cancel_fs) {
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(n == fs_cb_called);
+  ASSERT_EQ(n, fs_cb_called);
   ASSERT_EQ(timer_cb_called, 1);
 
 

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -173,16 +173,16 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   saturate_threadpool();
 
   r = uv_getaddrinfo(loop, reqs + 0, getaddrinfo_cb, "fail", NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 1, getaddrinfo_cb, NULL, "fail", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 2, getaddrinfo_cb, "fail", "fail", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 3, getaddrinfo_cb, "fail", NULL, &hints);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
@@ -202,23 +202,23 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   int r;
 
   r = uv_ip4_addr("127.0.0.1", 80, &addr4);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   INIT_CANCEL_INFO(&ci, reqs);
   loop = uv_default_loop();
   saturate_threadpool();
 
   r = uv_getnameinfo(loop, reqs + 0, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 1, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 2, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 3, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
   ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -64,7 +64,7 @@ TEST_IMPL(threadpool_queue_work_einval) {
 
   work_req.data = &data;
   r = uv_queue_work(uv_default_loop(), &work_req, NULL, after_work_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -51,8 +51,8 @@ TEST_IMPL(threadpool_queue_work_simple) {
   ASSERT_EQ(r, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 1);
-  ASSERT(after_work_cb_count == 1);
+  ASSERT_EQ(work_cb_count, 1);
+  ASSERT_EQ(after_work_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -29,7 +29,7 @@ static char data;
 
 
 static void work_cb(uv_work_t* req) {
-  ASSERT(req == &work_req);
+  ASSERT_EQ(req, &work_req);
   ASSERT(req->data == &data);
   work_cb_count++;
 }
@@ -37,7 +37,7 @@ static void work_cb(uv_work_t* req) {
 
 static void after_work_cb(uv_work_t* req, int status) {
   ASSERT_EQ(status, 0);
-  ASSERT(req == &work_req);
+  ASSERT_EQ(req, &work_req);
   ASSERT(req->data == &data);
   after_work_cb_count++;
 }

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -36,7 +36,7 @@ static void work_cb(uv_work_t* req) {
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(req == &work_req);
   ASSERT(req->data == &data);
   after_work_cb_count++;
@@ -48,7 +48,7 @@ TEST_IMPL(threadpool_queue_work_simple) {
 
   work_req.data = &data;
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT(work_cb_count == 1);
@@ -68,8 +68,8 @@ TEST_IMPL(threadpool_queue_work_einval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 0);
-  ASSERT(after_work_cb_count == 0);
+  ASSERT_EQ(work_cb_count, 0);
+  ASSERT_EQ(after_work_cb_count, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -132,9 +132,9 @@ TEST_IMPL(timer_again) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(repeat_1_cb_called == 10);
-  ASSERT(repeat_2_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(repeat_1_cb_called, 10);
+  ASSERT_EQ(repeat_2_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   fprintf(stderr, "Test took %ld ms (expected ~700 ms)\n",
           (long int)(uv_now(uv_default_loop()) - start_time));

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 static void repeat_1_cb(uv_timer_t* handle) {
   int r;
 
-  ASSERT(handle == &repeat_1);
+  ASSERT_EQ(handle, &repeat_1);
   ASSERT(uv_timer_get_repeat((uv_timer_t*)handle) == 50);
 
   fprintf(stderr, "repeat_1_cb called after %ld ms\n",
@@ -67,7 +67,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
 
 
 static void repeat_2_cb(uv_timer_t* handle) {
-  ASSERT(handle == &repeat_2);
+  ASSERT_EQ(handle, &repeat_2);
   ASSERT(repeat_2_cb_allowed);
 
   fprintf(stderr, "repeat_2_cb called after %ld ms\n",

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -102,7 +102,7 @@ TEST_IMPL(timer_again) {
   r = uv_timer_init(uv_default_loop(), &dummy);
   ASSERT_EQ(r, 0);
   r = uv_timer_again(&dummy);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_unref((uv_handle_t*)&dummy);
 
   /* Start timer repeat_1. */
@@ -114,7 +114,7 @@ TEST_IMPL(timer_again) {
 
   /* Verify that it is not possible to uv_timer_again a non-repeating timer. */
   r = uv_timer_again(&repeat_1);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -54,7 +54,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
   repeat_1_cb_called++;
 
   r = uv_timer_again(&repeat_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (repeat_1_cb_called == 10) {
     uv_close((uv_handle_t*)handle, close_cb);
@@ -100,16 +100,16 @@ TEST_IMPL(timer_again) {
 
   /* Verify that it is not possible to uv_timer_again a never-started timer. */
   r = uv_timer_init(uv_default_loop(), &dummy);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_again(&dummy);
   ASSERT(r == UV_EINVAL);
   uv_unref((uv_handle_t*)&dummy);
 
   /* Start timer repeat_1. */
   r = uv_timer_init(uv_default_loop(), &repeat_1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat_1, repeat_1_cb, 50, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_timer_get_repeat(&repeat_1) == 0);
 
   /* Verify that it is not possible to uv_timer_again a non-repeating timer. */
@@ -125,9 +125,9 @@ TEST_IMPL(timer_again) {
    * it should not time out until repeat_1 stops.
    */
   r = uv_timer_init(uv_default_loop(), &repeat_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat_2, repeat_2_cb, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_timer_get_repeat(&repeat_2) == 100);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -33,18 +33,18 @@ static int timer_cb_called;
 
 static void prepare_cb(uv_prepare_t* handle) {
   ASSERT(0 == uv_prepare_stop(&prepare_handle));
-  ASSERT(0 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(prepare_cb_called, 0);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 0);
   prepare_cb_called++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
   ASSERT(0 == uv_timer_stop(&timer_handle));
-  ASSERT(1 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(prepare_cb_called, 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 0);
   timer_cb_called++;
 }
 
@@ -54,9 +54,9 @@ static void check_cb(uv_check_t* handle) {
   ASSERT(0 == uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
   ASSERT(0 == uv_prepare_start(&prepare_handle, prepare_cb));
-  ASSERT(0 == prepare_cb_called);
-  ASSERT(0 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(prepare_cb_called, 0);
+  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
   check_cb_called++;
 }
 
@@ -68,9 +68,9 @@ TEST_IMPL(timer_from_check) {
   ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(prepare_cb_called, 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 1);
   uv_close((uv_handle_t*) &prepare_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -218,7 +218,7 @@ TEST_IMPL(timer_order) {
 
 
 static void tiny_timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &tiny_timer);
+  ASSERT_EQ(handle, &tiny_timer);
   uv_close((uv_handle_t*) &tiny_timer, NULL);
   uv_close((uv_handle_t*) &huge_timer1, NULL);
   uv_close((uv_handle_t*) &huge_timer2, NULL);
@@ -242,9 +242,9 @@ static void huge_repeat_cb(uv_timer_t* handle) {
   static int ncalls;
 
   if (ncalls == 0)
-    ASSERT(handle == &huge_timer1);
+    ASSERT_EQ(handle, &huge_timer1);
   else
-    ASSERT(handle == &tiny_timer);
+    ASSERT_EQ(handle, &tiny_timer);
 
   if (++ncalls == 10) {
     uv_close((uv_handle_t*) &tiny_timer, NULL);

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -101,24 +101,24 @@ TEST_IMPL(timer) {
   for (i = 0; i < ARRAY_SIZE(once_timers); i++) {
     once = once_timers + i;
     r = uv_timer_init(uv_default_loop(), once);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_timer_start(once, once_cb, i * 50, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* The 11th timer is a repeating timer that runs 4 times */
   r = uv_timer_init(uv_default_loop(), &repeat);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat, repeat_cb, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* The 12th timer should not do anything. */
   r = uv_timer_init(uv_default_loop(), &never);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&never, never_cb, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_stop(&never);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_unref((uv_handle_t*)&never);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -141,13 +141,13 @@ TEST_IMPL(timer_start_twice) {
   int r;
 
   r = uv_timer_init(uv_default_loop(), &once);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&once, never_cb, 86400 * 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&once, once_cb, 10, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(once_cb_called == 1);
 

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -123,11 +123,11 @@ TEST_IMPL(timer) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(once_cb_called == 10);
-  ASSERT(once_close_cb_called == 10);
+  ASSERT_EQ(once_cb_called, 10);
+  ASSERT_EQ(once_close_cb_called, 10);
   printf("repeat_cb_called %d\n", repeat_cb_called);
-  ASSERT(repeat_cb_called == 5);
-  ASSERT(repeat_close_cb_called == 1);
+  ASSERT_EQ(repeat_cb_called, 5);
+  ASSERT_EQ(repeat_close_cb_called, 1);
 
   ASSERT(500 <= uv_now(uv_default_loop()) - start_time);
 
@@ -149,7 +149,7 @@ TEST_IMPL(timer_start_twice) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  ASSERT(once_cb_called == 1);
+  ASSERT_EQ(once_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -196,7 +196,7 @@ TEST_IMPL(timer_order) {
   ASSERT(0 == uv_timer_start(&handle_b, order_cb_b, 0, 0));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(order_cb_called == 2);
+  ASSERT_EQ(order_cb_called, 2);
 
   ASSERT(0 == uv_timer_stop(&handle_a));
   ASSERT(0 == uv_timer_stop(&handle_b));
@@ -210,7 +210,7 @@ TEST_IMPL(timer_order) {
   ASSERT(0 == uv_timer_start(&handle_a, order_cb_a, 0, 0));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(order_cb_called == 2);
+  ASSERT_EQ(order_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -169,12 +169,14 @@ TEST_IMPL(timer_init) {
 
 
 static void order_cb_a(uv_timer_t *handle) {
-  ASSERT(order_cb_called++ == *(int*)handle->data);
+  ASSERT_EQ(order_cb_called, *(int*)handle->data);
+  order_cb_called++;
 }
 
 
 static void order_cb_b(uv_timer_t *handle) {
-  ASSERT(order_cb_called++ == *(int*)handle->data);
+  ASSERT_EQ(order_cb_called, *(int*)handle->data);
+  order_cb_called++;
 }
 
 

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -278,11 +278,11 @@ TEST_IMPL(timer_run_once) {
   ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(1 == timer_run_once_timer_cb_called);
+  ASSERT_EQ(timer_run_once_timer_cb_called, 1);
 
   ASSERT(0 == uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(2 == timer_run_once_timer_cb_called);
+  ASSERT_EQ(timer_run_once_timer_cb_called, 2);
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -38,7 +38,7 @@ TEST_IMPL(tmpdir) {
 
   ASSERT(strlen(tmpdir) == 0);
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(strlen(tmpdir) == len);
   ASSERT(len > 0);
   ASSERT(tmpdir[len] == '\0');
@@ -71,11 +71,11 @@ TEST_IMPL(tmpdir) {
   const char *name = "TMP";
   char tmpdir_win[] = "C:\\xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   r = uv_os_setenv(name, tmpdir_win);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   char tmpdirx[PATHMAX];
   size_t lenx = sizeof tmpdirx;
   r = uv_os_tmpdir(tmpdirx, &lenx);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   return 0;

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -55,17 +55,17 @@ TEST_IMPL(tmpdir) {
   /* Test the case where the buffer is too small */
   len = SMALLPATH;
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == UV_ENOBUFS);
+  ASSERT_EQ(r, UV_ENOBUFS);
   ASSERT(len > SMALLPATH);
 
   /* Test invalid inputs */
   r = uv_os_tmpdir(NULL, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_tmpdir(tmpdir, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   len = 0;
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
 #ifdef _WIN32
   const char *name = "TMP";

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -41,7 +41,7 @@ TEST_IMPL(tmpdir) {
   ASSERT_EQ(r, 0);
   ASSERT(strlen(tmpdir) == len);
   ASSERT(len > 0);
-  ASSERT(tmpdir[len] == '\0');
+  ASSERT_EQ(tmpdir[len], '\0');
 
   if (len > 1) {
     last = tmpdir[len - 1];

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -221,22 +221,22 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
   /* Emulate transmission of M-a at normal console */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(ttyin_fd, &alt_records[0], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == 2);
+  ASSERT_EQ(written, 2);
   WriteConsoleInputW(ttyin_fd, &alt_records[1], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
 
   /* Emulate transmission of M-a at WSL(#2111) */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(ttyin_fd, &alt_records[0], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, TRUE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == 2);
+  ASSERT_EQ(written, 2);
   WriteConsoleInputW(ttyin_fd, &alt_records[1], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -173,7 +173,7 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
    */
   make_key_event_records(VK_F1, 0, TRUE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -287,16 +287,16 @@ TEST_IMPL(tty_composing_character) {
   WriteConsoleInputW(ttyin_fd, &alt_records[0], 1, &written);
   make_key_event_records(VK_NUMPAD0, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD1, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD2, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD8, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(ttyin_fd, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   WriteConsoleInputW(ttyin_fd, &alt_records[1], 1, &written);
 
   uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -73,7 +73,7 @@ static void tty_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
     }
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   }
 }
 
@@ -153,19 +153,19 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = ESC"[[A";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /*
    * Send F1 keystrokes. Test of issue cause by #2114 that vt100 fn key
@@ -204,19 +204,19 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = ESC"a"ESC"a";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate transmission of M-a at normal console */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
@@ -267,19 +267,19 @@ TEST_IMPL(tty_composing_character) {
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = EUR_UTF8;
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate EUR inputs by LEFT ALT+NUMPAD ASCII KeyComos */
   make_key_event_records(VK_MENU, 0, FALSE, alt_records);

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -1324,7 +1324,7 @@ TEST_IMPL(tty_full_reset) {
   ASSERT(compare_screen(&tty_out, &actual, &expect));
   ASSERT(get_cursor_size(&tty_out) == saved_cursor_size);
   ASSERT(get_cursor_visibility(&tty_out) == saved_cursor_visibility);
-  ASSERT(actual.si.csbi.srWindow.Top == 0);
+  ASSERT_EQ(actual.si.csbi.srWindow.Top, 0);
 
   terminate_tty(&tty_out);
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -179,7 +179,7 @@ static void setup_screen(uv_tty_t* tty_out) {
   origin.Y = info.srWindow.Top;
   ASSERT(FillConsoleOutputCharacter(
       tty_out->handle, '.', length, origin, &number_of_written));
-  ASSERT(length == number_of_written);
+  ASSERT_EQ(length, number_of_written);
 }
 
 static void clear_screen(uv_tty_t* tty_out, struct screen_info* si) {
@@ -192,10 +192,10 @@ static void clear_screen(uv_tty_t* tty_out, struct screen_info* si) {
   origin.Y = info.srWindow.Top;
   FillConsoleOutputCharacterA(
       tty_out->handle, ' ', length, origin, &number_of_written);
-  ASSERT(length == number_of_written);
+  ASSERT_EQ(length, number_of_written);
   FillConsoleOutputAttribute(
       tty_out->handle, si->default_attr, length, origin, &number_of_written);
-  ASSERT(length == number_of_written);
+  ASSERT_EQ(length, number_of_written);
 }
 
 static void free_screen(struct captured_screen* cs) {
@@ -391,7 +391,7 @@ TEST_IMPL(tty_cursor_up) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up nth times */
   cursor_pos_old = cursor_pos;
@@ -399,7 +399,7 @@ TEST_IMPL(tty_cursor_up) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up from Window top does nothing */
   cursor_pos_old.X = 1;
@@ -408,8 +408,8 @@ TEST_IMPL(tty_cursor_up) {
   snprintf(buffer, sizeof(buffer), "%sA", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -442,7 +442,7 @@ TEST_IMPL(tty_cursor_down) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down nth times */
   cursor_pos_old = cursor_pos;
@@ -450,7 +450,7 @@ TEST_IMPL(tty_cursor_down) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down from bottom line does nothing */
   cursor_pos_old.X = si.width / 2;
@@ -459,8 +459,8 @@ TEST_IMPL(tty_cursor_down) {
   snprintf(buffer, sizeof(buffer), "%sB", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -492,7 +492,7 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
   ASSERT(cursor_pos_old.X + 1 == cursor_pos.X);
 
   /* cursor forward nth times */
@@ -500,7 +500,7 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%s%dC", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
   ASSERT(cursor_pos_old.X + si.width / 4 == cursor_pos.X);
 
   /* cursor forward from end of line does nothing*/
@@ -510,8 +510,8 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor forward from end of screen does nothing */
   cursor_pos_old.X = si.width;
@@ -520,8 +520,8 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -553,7 +553,7 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
   ASSERT(cursor_pos_old.X - 1 == cursor_pos.X);
 
   /* cursor back nth times */
@@ -561,7 +561,7 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%s%dD", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
   ASSERT(cursor_pos_old.X - si.width / 4 == cursor_pos.X);
 
   /* cursor back from beginning of line does nothing */
@@ -571,8 +571,8 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor back from top of screen does nothing */
   cursor_pos_old.X = 1;
@@ -632,7 +632,7 @@ TEST_IMPL(tty_cursor_next_line) {
   snprintf(buffer, sizeof(buffer), "%sE", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
   ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
@@ -717,21 +717,21 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos.X, 1);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Move cursor to nth character */
   snprintf(buffer, sizeof(buffer), "%s%dG", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(si.width / 4 == cursor_pos.X);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Moving out of screen will fit within screen */
   snprintf(buffer, sizeof(buffer), "%s%dG", CSI, si.width + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width == cursor_pos.X);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(si.width, cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   terminate_tty(&tty_out);
 
@@ -778,7 +778,7 @@ TEST_IMPL(tty_cursor_move_absolute) {
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height / 2, si.width + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width == cursor_pos.X);
+  ASSERT_EQ(si.width, cursor_pos.X);
   ASSERT(si.height / 2 == cursor_pos.Y);
 
   snprintf(
@@ -786,7 +786,7 @@ TEST_IMPL(tty_cursor_move_absolute) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(si.width / 2 == cursor_pos.X);
-  ASSERT(si.height == cursor_pos.Y);
+  ASSERT_EQ(si.height, cursor_pos.Y);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -1261,8 +1261,8 @@ TEST_IMPL(tty_save_restore_cursor_position) {
   snprintf(buffer, sizeof(buffer), "%su", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == cursor_pos_old.X);
-  ASSERT(cursor_pos.Y == cursor_pos_old.Y);
+  ASSERT_EQ(cursor_pos.X, cursor_pos_old.X);
+  ASSERT_EQ(cursor_pos.Y, cursor_pos_old.Y);
 
   cursor_pos_old.X = si.width / 2;
   cursor_pos_old.Y = si.height / 2;
@@ -1280,8 +1280,8 @@ TEST_IMPL(tty_save_restore_cursor_position) {
   snprintf(buffer, sizeof(buffer), "%s8", ESC);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == cursor_pos_old.X);
-  ASSERT(cursor_pos.Y == cursor_pos_old.Y);
+  ASSERT_EQ(cursor_pos.X, cursor_pos_old.X);
+  ASSERT_EQ(cursor_pos.Y, cursor_pos_old.Y);
 
   terminate_tty(&tty_out);
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -581,8 +581,8 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -615,7 +615,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line nth times */
   cursor_pos_old = cursor_pos;
@@ -623,7 +623,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line from buttom row moves beginning of line */
   cursor_pos_old.X = si.width / 2;
@@ -633,7 +633,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -666,7 +666,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line nth times */
   cursor_pos_old = cursor_pos;
@@ -674,7 +674,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line from top of screen does nothing */
   cursor_pos_old.X = 1;
@@ -683,8 +683,8 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -716,7 +716,7 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sG", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(cursor_pos_old.Y == cursor_pos.Y);
 
   /* Move cursor to nth character */
@@ -762,8 +762,8 @@ TEST_IMPL(tty_cursor_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sH", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.X);
-  ASSERT(1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Move the cursor to the middle of the screen */
   snprintf(

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -166,7 +166,7 @@ static void write_console(uv_tty_t* tty_out, char* src) {
 
   r = uv_try_write((uv_stream_t*) tty_out, &buf, 1);
   ASSERT(r >= 0);
-  ASSERT((unsigned int) r == buf.len);
+  ASSERT_EQ((unsigned int) r, buf.len);
 }
 
 static void setup_screen(uv_tty_t* tty_out) {
@@ -217,10 +217,10 @@ static void capture_screen(uv_tty_t* tty_out, struct captured_screen* cs) {
   ASSERT(cs->attributes != NULL);
   ASSERT(ReadConsoleOutputCharacter(
       tty_out->handle, cs->text, cs->si.length, origin, &length));
-  ASSERT((unsigned int) cs->si.length == length);
+  ASSERT_EQ((unsigned int) cs->si.length, length);
   ASSERT(ReadConsoleOutputAttribute(
       tty_out->handle, cs->attributes, cs->si.length, origin, &length));
-  ASSERT((unsigned int) cs->si.length == length);
+  ASSERT_EQ((unsigned int) cs->si.length, length);
 }
 
 static void make_expect_screen_erase(struct captured_screen* cs,

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -1506,8 +1506,8 @@ TEST_IMPL(tty_escape_sequence_processing) {
   snprintf(buffer, sizeof(buffer), "%s1;%dH", CSI, UINT16_MAX + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == 1);
-  ASSERT(cursor_pos.Y == 1);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Too many argument are ignored */
   cursor_pos.X = 1;
@@ -1540,8 +1540,8 @@ TEST_IMPL(tty_escape_sequence_processing) {
            expect.si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == 1);
-  ASSERT(cursor_pos.Y == 1);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Invalid sequence are ignored */
   saved_cursor_size = get_cursor_size(&tty_out);

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -390,7 +390,7 @@ TEST_IMPL(tty_cursor_up) {
   snprintf(buffer, sizeof(buffer), "%sA", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y - 1, cursor_pos.Y);
   ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up nth times */
@@ -398,7 +398,7 @@ TEST_IMPL(tty_cursor_up) {
   snprintf(buffer, sizeof(buffer), "%s%dA", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y - si.height / 4, cursor_pos.Y);
   ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up from Window top does nothing */
@@ -441,7 +441,7 @@ TEST_IMPL(tty_cursor_down) {
   snprintf(buffer, sizeof(buffer), "%sB", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y + 1, cursor_pos.Y);
   ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down nth times */
@@ -449,7 +449,7 @@ TEST_IMPL(tty_cursor_down) {
   snprintf(buffer, sizeof(buffer), "%s%dB", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y + si.height / 4, cursor_pos.Y);
   ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down from bottom line does nothing */
@@ -493,7 +493,7 @@ TEST_IMPL(tty_cursor_forward) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
-  ASSERT(cursor_pos_old.X + 1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X + 1, cursor_pos.X);
 
   /* cursor forward nth times */
   cursor_pos_old = cursor_pos;
@@ -501,7 +501,7 @@ TEST_IMPL(tty_cursor_forward) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
-  ASSERT(cursor_pos_old.X + si.width / 4 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X + si.width / 4, cursor_pos.X);
 
   /* cursor forward from end of line does nothing*/
   cursor_pos_old.X = si.width;
@@ -554,7 +554,7 @@ TEST_IMPL(tty_cursor_back) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
-  ASSERT(cursor_pos_old.X - 1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X - 1, cursor_pos.X);
 
   /* cursor back nth times */
   cursor_pos_old = cursor_pos;
@@ -562,7 +562,7 @@ TEST_IMPL(tty_cursor_back) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
-  ASSERT(cursor_pos_old.X - si.width / 4 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.X - si.width / 4, cursor_pos.X);
 
   /* cursor back from beginning of line does nothing */
   cursor_pos_old.X = 1;
@@ -614,7 +614,7 @@ TEST_IMPL(tty_cursor_next_line) {
   snprintf(buffer, sizeof(buffer), "%sE", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y + 1, cursor_pos.Y);
   ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line nth times */
@@ -622,7 +622,7 @@ TEST_IMPL(tty_cursor_next_line) {
   snprintf(buffer, sizeof(buffer), "%s%dE", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y + si.height / 4, cursor_pos.Y);
   ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line from buttom row moves beginning of line */
@@ -665,7 +665,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%sF", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y - 1, cursor_pos.Y);
   ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line nth times */
@@ -673,7 +673,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%s%dF", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.Y - si.height / 4, cursor_pos.Y);
   ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line from top of screen does nothing */
@@ -723,7 +723,7 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%s%dG", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 4 == cursor_pos.X);
+  ASSERT_EQ(si.width / 4, cursor_pos.X);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Moving out of screen will fit within screen */
@@ -770,8 +770,8 @@ TEST_IMPL(tty_cursor_move_absolute) {
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height / 2, si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 2 == cursor_pos.X);
-  ASSERT(si.height / 2 == cursor_pos.Y);
+  ASSERT_EQ(si.width / 2, cursor_pos.X);
+  ASSERT_EQ(si.height / 2, cursor_pos.Y);
 
   /* Moving out of screen will fit within screen */
   snprintf(
@@ -779,13 +779,13 @@ TEST_IMPL(tty_cursor_move_absolute) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(si.width, cursor_pos.X);
-  ASSERT(si.height / 2 == cursor_pos.Y);
+  ASSERT_EQ(si.height / 2, cursor_pos.Y);
 
   snprintf(
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height + 1, si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 2 == cursor_pos.X);
+  ASSERT_EQ(si.width / 2, cursor_pos.X);
   ASSERT_EQ(si.height, cursor_pos.Y);
   ASSERT(!is_scrolling(&tty_out, si));
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -362,7 +362,7 @@ static void initialize_tty(uv_tty_t* tty_out) {
   ASSERT(ttyout != INVALID_HANDLE_VALUE);
   ASSERT(UV_TTY == uv_guess_handle(ttyout));
   r = uv_tty_init(uv_default_loop(), tty_out, ttyout, 0); /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void terminate_tty(uv_tty_t* tty_out) {

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -1113,7 +1113,7 @@ TEST_IMPL(tty_set_style) {
   }
 
   /* Set foregroud and background color */
-  ASSERT(ARRAY_SIZE(fg_attrs) == ARRAY_SIZE(bg_attrs));
+  ASSERT_EQ(ARRAY_SIZE(fg_attrs), ARRAY_SIZE(bg_attrs));
   length = ARRAY_SIZE(bg_attrs);
   for (i = 0; i < length; i++) {
     capture_screen(&tty_out, &expect);

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -155,7 +155,7 @@ static void tty_raw_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT(nread  == 1);
+    ASSERT_EQ(nread, 1);
     ASSERT(buf->base[0] == ' ');
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -92,17 +92,17 @@ TEST_IMPL(tty) {
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
 
   r = uv_tty_get_winsize(&tty_out, &width, &height);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   printf("width=%d height=%d\n", width, height);
 
@@ -122,11 +122,11 @@ TEST_IMPL(tty) {
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Turn off raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_NORMAL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Calling uv_tty_reset_mode() repeatedly should not clobber errno. */
   errno = 0;
@@ -159,7 +159,7 @@ static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf
     ASSERT(buf->base[0] == ' ');
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   }
 }
 
@@ -183,19 +183,19 @@ TEST_IMPL(tty_raw) {
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_raw_alloc, tty_raw_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Give uv_tty_line_read_thread time to block on ReadConsoleW */
   Sleep(100);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Write ' ' that should be read in raw mode */
   record.EventType = KEY_EVENT;
@@ -236,7 +236,7 @@ TEST_IMPL(tty_empty_write) {
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
 
@@ -244,7 +244,7 @@ TEST_IMPL(tty_empty_write) {
   bufs[0].base = &dummy[0];
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &tty_out, NULL);
 
@@ -277,7 +277,7 @@ TEST_IMPL(tty_large_write) {
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   memset(dummy, '.', sizeof(dummy) - 1);
   dummy[sizeof(dummy) - 1] = '\n';
@@ -312,14 +312,14 @@ TEST_IMPL(tty_raw_cancel) {
   ASSERT(UV_TTY == uv_guess_handle(handle));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, handle, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_read_start((uv_stream_t*)&tty_in, tty_raw_alloc, tty_raw_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_stop((uv_stream_t*) &tty_in);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -133,7 +133,7 @@ TEST_IMPL(tty) {
   ASSERT(0 == uv_tty_reset_mode());
   ASSERT(0 == uv_tty_reset_mode());
   ASSERT(0 == uv_tty_reset_mode());
-  ASSERT(0 == errno);
+  ASSERT_EQ(errno, 0);
 
   /* TODO check the actual mode! */
 

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -285,7 +285,7 @@ TEST_IMPL(tty_large_write) {
   bufs[0] = uv_buf_init(dummy, sizeof(dummy));
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
-  ASSERT(r == 10000);
+  ASSERT_EQ(r, 10000);
 
   uv_close((uv_handle_t*) &tty_out, NULL);
 

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -156,7 +156,7 @@ static void tty_raw_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
     ASSERT_EQ(nread, 1);
-    ASSERT(buf->base[0] == ' ');
+    ASSERT_EQ(buf->base[0], ' ');
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
     ASSERT_EQ(nread, 0);

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -129,7 +129,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   r = uv_udp_recv_stop(handle);
@@ -185,11 +185,11 @@ TEST_IMPL(udp_alloc_cb_fail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 1);
-  ASSERT(cl_recv_cb_called == 1);
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(sv_recv_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 1);
+  ASSERT_EQ(cl_recv_cb_called, 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(sv_recv_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -71,7 +71,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
   ASSERT(nread == UV_ENOBUFS);
 
   cl_recv_cb_called++;
@@ -84,11 +84,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, cl_alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   cl_send_cb_called++;
 }
@@ -96,7 +96,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -126,21 +126,21 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   req = malloc(sizeof *req);
   ASSERT(req != NULL);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sv_recv_cb_called++;
 }
@@ -155,18 +155,18 @@ TEST_IMPL(udp_alloc_cb_fail) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, sv_alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PING", 4);
   r = uv_udp_send(&req,
@@ -175,13 +175,13 @@ TEST_IMPL(udp_alloc_cb_fail) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_send_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
-  ASSERT(sv_recv_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_send_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_EQ(sv_recv_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -72,7 +72,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        unsigned flags) {
   CHECK_HANDLE(handle);
   ASSERT_EQ(flags, 0);
-  ASSERT(nread == UV_ENOBUFS);
+  ASSERT_EQ(nread, UV_ENOBUFS);
 
   cl_recv_cb_called++;
 
@@ -121,7 +121,7 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 

--- a/test/test-udp-bind.c
+++ b/test/test-udp-bind.c
@@ -47,7 +47,7 @@ TEST_IMPL(udp_bind) {
   ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*) &h1, NULL);
   uv_close((uv_handle_t*) &h2, NULL);

--- a/test/test-udp-bind.c
+++ b/test/test-udp-bind.c
@@ -38,13 +38,13 @@ TEST_IMPL(udp_bind) {
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, 0);
   ASSERT(r == UV_EADDRINUSE);
@@ -53,7 +53,7 @@ TEST_IMPL(udp_bind) {
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -71,22 +71,22 @@ TEST_IMPL(udp_bind_reuseaddr) {
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &h1, NULL);
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -62,7 +62,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
   if (++cl_send_cb_called == 1) {
     uv_udp_connect(&client, NULL);
@@ -74,7 +74,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
                     1,
                     (const struct sockaddr*) &lo_addr,
                     cl_send_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
 }
@@ -111,16 +111,16 @@ TEST_IMPL(udp_connect) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &lo_addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &lo_addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("EXIT", 4);
 
@@ -128,13 +128,13 @@ TEST_IMPL(udp_connect) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
   ASSERT(r == UV_EISCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* To send messages in connected UDP sockets addr must be NULL */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
@@ -145,7 +145,7 @@ TEST_IMPL(udp_connect) {
   ASSERT(r == UV_EISCONN);
 
   r = uv_udp_connect(&client, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, NULL);
   ASSERT(r == UV_ENOTCONN);
 
@@ -161,7 +161,7 @@ TEST_IMPL(udp_connect) {
 
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_send(&req,
                   &client,
                   &buf,
@@ -170,7 +170,7 @@ TEST_IMPL(udp_connect) {
                   cl_send_cb);
   ASSERT(r == UV_EISCONN);
   r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -86,7 +86,7 @@ static void sv_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   if (nread > 0) {
-    ASSERT(nread == 4);
+    ASSERT_EQ(nread, 4);
     ASSERT(addr != NULL);
     ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
     if (++sv_recv_cb_called == 4) {
@@ -140,7 +140,7 @@ TEST_IMPL(udp_connect) {
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
   ASSERT(r == UV_EISCONN);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
   ASSERT(r == UV_EISCONN);
 
@@ -155,7 +155,7 @@ TEST_IMPL(udp_connect) {
 
   /* To send messages in disconnected UDP sockets addr must be set */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
   ASSERT(r == UV_EDESTADDRREQ);
 
@@ -174,9 +174,9 @@ TEST_IMPL(udp_connect) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 4);
-  ASSERT(cl_send_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 4);
+  ASSERT_EQ(cl_send_cb_called, 2);
 
   ASSERT_EQ(client.send_queue_size, 0);
   ASSERT_EQ(server.send_queue_size, 0);

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -178,8 +178,8 @@ TEST_IMPL(udp_connect) {
   ASSERT(sv_recv_cb_called == 4);
   ASSERT(cl_send_cb_called == 2);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -67,7 +67,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   if (++cl_send_cb_called == 1) {
     uv_udp_connect(&client, NULL);
     r = uv_udp_send(req, &client, &buf, 1, NULL, cl_send_cb);
-    ASSERT(r == UV_EDESTADDRREQ);
+    ASSERT_EQ(r, UV_EDESTADDRREQ);
     r = uv_udp_send(req,
                     &client,
                     &buf,
@@ -130,7 +130,7 @@ TEST_IMPL(udp_connect) {
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
   ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
@@ -138,26 +138,26 @@ TEST_IMPL(udp_connect) {
 
   /* To send messages in connected UDP sockets addr must be NULL */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
   ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
 
   r = uv_udp_connect(&client, NULL);
   ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, NULL);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   /* To send messages in disconnected UDP sockets addr must be set */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
   ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT(r == UV_EDESTADDRREQ);
+  ASSERT_EQ(r, UV_EDESTADDRREQ);
 
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
@@ -168,7 +168,7 @@ TEST_IMPL(udp_connect) {
                   1,
                   (const struct sockaddr*) &lo_addr,
                   cl_send_cb);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
   ASSERT_EQ(r, 0);
 

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -99,7 +99,7 @@ TEST_IMPL(udp_create_early_bad_bind) {
     namelen = sizeof sockname;
     r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
     ASSERT_EQ(r, 0);
-    ASSERT(sockname.sin6_family == AF_INET6);
+    ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif
 

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -41,26 +41,26 @@ TEST_IMPL(udp_create_early) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(fd != INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(sockname.sin_family == AF_INET);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(memcmp(&addr.sin_addr,
                 &sockname.sin_addr,
                 sizeof(addr.sin_addr)) == 0);
@@ -85,10 +85,10 @@ TEST_IMPL(udp_create_early_bad_bind) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(fd != INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
@@ -98,7 +98,7 @@ TEST_IMPL(udp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(sockname.sin6_family == AF_INET6);
   }
 #endif

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -52,7 +52,7 @@ TEST_IMPL(udp_create_early) {
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
   ASSERT_EQ(r, 0);
-  ASSERT(sockname.sin_family == AF_INET);
+  ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
@@ -105,9 +105,9 @@ TEST_IMPL(udp_create_early_bad_bind) {
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
 #if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MSYS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EFAULT);
+  ASSERT_EQ(r, UV_EFAULT);
 #endif
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -123,10 +123,10 @@ TEST_IMPL(udp_create_early_bad_domain) {
   int r;
 
   r = uv_udp_init_ex(uv_default_loop(), &client, 47);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_udp_init_ex(uv_default_loop(), &client, 1024);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -83,8 +83,8 @@ TEST_IMPL(udp_dgram_too_big) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -65,7 +65,7 @@ TEST_IMPL(udp_dgram_too_big) {
   memset(dgram, 42, sizeof dgram); /* silence valgrind */
 
   r = uv_udp_init(uv_default_loop(), &handle_);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(dgram, sizeof dgram);
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
@@ -76,10 +76,10 @@ TEST_IMPL(udp_dgram_too_big) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(send_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -49,7 +49,7 @@ static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_REQ(req);
   CHECK_HANDLE(req->handle);
 
-  ASSERT(status == UV_EMSGSIZE);
+  ASSERT_EQ(status, UV_EMSGSIZE);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
   send_cb_called++;

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -92,7 +92,7 @@ static int is_from_client(const struct sockaddr* addr) {
 
   /* Debugging output, and filter out unwanted network traffic */
   if (addr != NULL) {
-    ASSERT(addr->sa_family == AF_INET6);
+    ASSERT_EQ(addr->sa_family, AF_INET6);
     addr6 = (struct sockaddr_in6*) addr;
     r = uv_inet_ntop(addr->sa_family, &addr6->sin6_addr, dst, sizeof(dst));
     if (r == 0)

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -81,7 +81,7 @@ static void close_cb(uv_handle_t* handle) {
 static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_REQ(req);
   CHECK_HANDLE(req->handle);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   send_cb_called++;
 }
 
@@ -154,10 +154,10 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
   ASSERT(0 == uv_ip6_addr("::0", TEST_PORT, &addr6));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr6, bind_flags);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   addr6_len = sizeof(addr6);
   ASSERT(uv_udp_getsockname(&server, (struct sockaddr*) &addr6, &addr6_len) == 0);
@@ -165,10 +165,10 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
   printf("on [%.*s]:%d\n", (int) sizeof(dst), dst, addr6.sin6_port);
 
   r = uv_udp_recv_start(&server, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   ASSERT(uv_inet_ntop(addr.sin_family, &addr.sin_addr, dst, sizeof(dst)) == 0);
@@ -185,7 +185,7 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   addr_len = sizeof(addr);
   ASSERT(uv_udp_getsockname(&client, (struct sockaddr*) &addr, &addr_len) == 0);
@@ -194,14 +194,14 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
   client_port = addr.sin_port;
 
   r = uv_timer_init(uv_default_loop(), &timeout);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timeout, timeout_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(send_cb_called == 0);
-  ASSERT(recv_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(send_cb_called, 0);
+  ASSERT_EQ(recv_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -244,7 +244,7 @@ TEST_IMPL(udp_ipv6_only) {
 
   do_test(ipv6_recv_fail, UV_UDP_IPV6ONLY);
 
-  ASSERT(recv_cb_called == 0);
+  ASSERT_EQ(recv_cb_called, 0);
   ASSERT(send_cb_called == 1);
 
   return 0;

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -129,7 +129,7 @@ static void ipv6_recv_ok(uv_udp_t* handle,
   if (!is_from_client(addr) || (nread == 0 && addr == NULL))
     return;
 
-  ASSERT(nread == 9);
+  ASSERT_EQ(nread, 9);
   ASSERT(!memcmp(buf->base, data, 9));
   recv_cb_called++;
 }
@@ -205,7 +205,7 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY();
 }
@@ -231,8 +231,8 @@ TEST_IMPL(udp_dual_stack) {
 
   printf("recv_cb_called %d\n", recv_cb_called);
   printf("send_cb_called %d\n", send_cb_called);
-  ASSERT(recv_cb_called == 1);
-  ASSERT(send_cb_called == 1);
+  ASSERT_EQ(recv_cb_called, 1);
+  ASSERT_EQ(send_cb_called, 1);
 
   return 0;
 }
@@ -245,7 +245,7 @@ TEST_IMPL(udp_ipv6_only) {
   do_test(ipv6_recv_fail, UV_UDP_IPV6ONLY);
 
   ASSERT_EQ(recv_cb_called, 0);
-  ASSERT(send_cb_called == 1);
+  ASSERT_EQ(send_cb_called, 1);
 
   return 0;
 }

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -96,8 +96,8 @@ TEST_IMPL(udp_multicast_interface) {
   ASSERT(sv_send_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -68,14 +68,14 @@ TEST_IMPL(udp_multicast_interface) {
   ASSERT(0 == uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_multicast_interface(&server, "0.0.0.0");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -85,10 +85,10 @@ TEST_IMPL(udp_multicast_interface) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -93,8 +93,8 @@ TEST_IMPL(udp_multicast_interface) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT_EQ(client.send_queue_size, 0);
   ASSERT_EQ(server.send_queue_size, 0);

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -71,11 +71,11 @@ TEST_IMPL(udp_multicast_interface6) {
   ASSERT(0 == uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip6_addr("::", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   r = uv_udp_set_multicast_interface(&server, "::1%lo0");
@@ -92,7 +92,7 @@ TEST_IMPL(udp_multicast_interface6) {
   }
 #endif
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -102,10 +102,10 @@ TEST_IMPL(udp_multicast_interface6) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -110,8 +110,8 @@ TEST_IMPL(udp_multicast_interface6) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -103,7 +103,7 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -61,7 +61,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -95,7 +95,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -121,18 +121,18 @@ static void cl_recv_cb(uv_udp_t* handle,
     char source_addr[64];
 
     r = uv_ip4_name((const struct sockaddr_in*)addr, source_addr, sizeof(source_addr));
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_LEAVE_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
 #if !defined(__OpenBSD__) && !defined(__NetBSD__)
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, NULL, source_addr, UV_JOIN_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 
     r = do_send(&req_ss);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -144,30 +144,30 @@ TEST_IMPL(udp_multicast_join) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* bind to the desired port */
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* join the multicast channel */
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_JOIN_GROUP);
   if (r == UV_ENODEV)
     RETURN_SKIP("No multicast support.");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = do_send(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -108,7 +108,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -172,9 +172,9 @@ TEST_IMPL(udp_multicast_join) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_recv_cb_called == 2);
-  ASSERT(sv_send_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_recv_cb_called, 2);
+  ASSERT_EQ(sv_send_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -75,7 +75,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -109,7 +109,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -135,16 +135,16 @@ static void cl_recv_cb(uv_udp_t* handle,
     char source_addr[64];
 
     r = uv_ip6_name((const struct sockaddr_in6*)addr, source_addr, sizeof(source_addr));
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, UV_LEAVE_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, source_addr, UV_JOIN_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = do_send(&req_ss);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -178,14 +178,14 @@ TEST_IMPL(udp_multicast_join6) {
   ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* bind to the desired port */
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, UV_JOIN_GROUP);
 
@@ -198,21 +198,21 @@ TEST_IMPL(udp_multicast_join6) {
     RETURN_SKIP("No ipv6 multicast route");
   }
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 /* TODO(gengjiawen): Fix test on QEMU. */
 #if defined(__QEMU__)
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   
   r = do_send(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -117,7 +117,7 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -122,7 +122,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -217,9 +217,9 @@ TEST_IMPL(udp_multicast_join6) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_recv_cb_called == 2);
-  ASSERT(sv_send_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_recv_cb_called, 2);
+  ASSERT_EQ(sv_send_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -60,14 +60,14 @@ TEST_IMPL(udp_multicast_ttl) {
   struct sockaddr_in addr;
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &addr));
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_multicast_ttl(&server, 32);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -78,10 +78,10 @@ TEST_IMPL(udp_multicast_ttl) {
                   1,
                   (const struct sockaddr*) &addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -86,8 +86,8 @@ TEST_IMPL(udp_multicast_ttl) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -109,7 +109,7 @@ static void recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 
@@ -175,7 +175,7 @@ TEST_IMPL(udp_open) {
     ASSERT_EQ(r, 0);
 
     r = uv_udp_open(&client2, sock);
-    ASSERT(r == UV_EEXIST);
+    ASSERT_EQ(r, UV_EEXIST);
 
     uv_close((uv_handle_t*) &client2, NULL);
   }
@@ -209,7 +209,7 @@ TEST_IMPL(udp_open_twice) {
   ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock2);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
   close_socket(sock2);
 
   uv_close((uv_handle_t*) &client, NULL);

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -41,7 +41,7 @@ static void startup(void) {
 #ifdef _WIN32
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 }
 
@@ -61,7 +61,7 @@ static uv_os_sock_t create_udp_socket(void) {
     /* Allow reuse of the port. */
     int yes = 1;
     int r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -76,7 +76,7 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -113,14 +113,14 @@ static void recv_cb(uv_udp_t* handle,
     return;
   }
 
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
   ASSERT(nread == 4);
   ASSERT(memcmp("PING", buf->base, nread) == 0);
 
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) handle, close_cb);
 }
@@ -128,7 +128,7 @@ static void recv_cb(uv_udp_t* handle,
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   send_cb_called++;
   uv_close((uv_handle_t*)req->handle, close_cb);
@@ -148,16 +148,16 @@ TEST_IMPL(udp_open) {
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -165,14 +165,14 @@ TEST_IMPL(udp_open) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
     uv_udp_t client2;
 
     r = uv_udp_init(uv_default_loop(), &client2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_open(&client2, sock);
     ASSERT(r == UV_EEXIST);
@@ -203,10 +203,10 @@ TEST_IMPL(udp_open_twice) {
   sock2 = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock2);
   ASSERT(r == UV_EBUSY);
@@ -231,16 +231,16 @@ TEST_IMPL(udp_open_bound) {
   sock = create_udp_socket();
 
   r = bind(sock, (struct sockaddr*) &addr, sizeof(addr));
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -263,22 +263,22 @@ TEST_IMPL(udp_open_connect) {
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof(addr));
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -286,7 +286,7 @@ TEST_IMPL(udp_open_connect) {
                   1,
                   NULL,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -327,9 +327,9 @@ TEST_IMPL(udp_send_unix) {
   ASSERT(0 == listen(fd, 1));
 
   r = uv_udp_init(loop, &handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_open(&handle, fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_udp_send(&req,
@@ -338,7 +338,7 @@ TEST_IMPL(udp_send_unix) {
                   1,
                   (const struct sockaddr*) &addr,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&handle, NULL);
   uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -116,7 +116,7 @@ static void recv_cb(uv_udp_t* handle,
   ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(memcmp("PING", buf->base, nread) == 0);
 
   r = uv_udp_recv_stop(handle);
@@ -183,8 +183,8 @@ TEST_IMPL(udp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   ASSERT_EQ(client.send_queue_size, 0);
 
@@ -290,8 +290,8 @@ TEST_IMPL(udp_open_connect) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   ASSERT_EQ(client.send_queue_size, 0);
 

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -186,7 +186,7 @@ TEST_IMPL(udp_open) {
   ASSERT(send_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(client.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -293,7 +293,7 @@ TEST_IMPL(udp_open_connect) {
   ASSERT(send_cb_called == 1);
   ASSERT(close_cb_called == 2);
 
-  ASSERT(client.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -56,7 +56,7 @@ static int udp_options_test(const struct sockaddr* addr) {
     if (addr->sa_family == AF_INET6)
       ASSERT_EQ(r, 0);
     else
-      ASSERT(r == UV_ENOTSUP);
+      ASSERT_EQ(r, UV_ENOTSUP);
 #else
     ASSERT_EQ(r, 0);
 #endif
@@ -64,7 +64,7 @@ static int udp_options_test(const struct sockaddr* addr) {
 
   for (i = 0; i < (int) ARRAY_SIZE(invalid_ttls); i++) {
     r = uv_udp_set_ttl(&h, invalid_ttls[i]);
-    ASSERT(r == UV_EINVAL);
+    ASSERT_EQ(r, UV_EINVAL);
   }
 
   r = uv_udp_set_multicast_loop(&h, 1);
@@ -81,7 +81,7 @@ static int udp_options_test(const struct sockaddr* addr) {
 
   /* anything >255 should fail */
   r = uv_udp_set_multicast_ttl(&h, 256);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   /* don't test ttl=-1, it's a valid value on some platforms */
 
   r = uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -36,29 +36,29 @@ static int udp_options_test(const struct sockaddr* addr) {
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)&h); /* don't keep the loop alive */
 
   r = uv_udp_bind(&h, addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 0);
   r |= uv_udp_set_broadcast(&h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* values 1-255 should work */
   for (i = 1; i <= 255; i++) {
     r = uv_udp_set_ttl(&h, i);
 #if defined(__MVS__)
     if (addr->sa_family == AF_INET6)
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     else
       ASSERT(r == UV_ENOTSUP);
 #else
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
   }
 
@@ -71,12 +71,12 @@ static int udp_options_test(const struct sockaddr* addr) {
   r |= uv_udp_set_multicast_loop(&h, 1);
   r |= uv_udp_set_multicast_loop(&h, 0);
   r |= uv_udp_set_multicast_loop(&h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* values 0-255 should work */
   for (i = 0; i <= 255; i++) {
     r = uv_udp_set_multicast_ttl(&h, i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* anything >255 should fail */
@@ -85,7 +85,7 @@ static int udp_options_test(const struct sockaddr* addr) {
   /* don't test ttl=-1, it's a valid value on some platforms */
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -78,7 +78,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PONG", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -136,7 +136,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   /* FIXME? `uv_udp_recv_stop` does what it says: recv_cb is not called
@@ -198,11 +198,11 @@ TEST_IMPL(udp_send_and_recv) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 1);
-  ASSERT(cl_recv_cb_called == 1);
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(sv_recv_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 1);
+  ASSERT_EQ(cl_recv_cb_called, 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(sv_recv_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   ASSERT_EQ(client.send_queue_size, 0);
   ASSERT_EQ(server.send_queue_size, 0);

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -73,7 +73,7 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 
@@ -128,7 +128,7 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -65,7 +65,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -91,11 +91,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   cl_send_cb_called++;
 }
@@ -103,7 +103,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -133,7 +133,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
   ASSERT(nread == 4);
@@ -144,14 +144,14 @@ static void sv_recv_cb(uv_udp_t* handle,
     * either... Not sure I like that but it's consistent with `uv_read_stop`.
     */
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   req = malloc(sizeof *req);
   ASSERT(req != NULL);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sv_recv_cb_called++;
 }
@@ -166,18 +166,18 @@ TEST_IMPL(udp_send_and_recv) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", expects "PONG" */
   buf = uv_buf_init("PING", 4);
@@ -188,13 +188,13 @@ TEST_IMPL(udp_send_and_recv) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_send_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
-  ASSERT(sv_recv_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_send_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_EQ(sv_recv_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -204,8 +204,8 @@ TEST_IMPL(udp_send_and_recv) {
   ASSERT(sv_recv_cb_called == 1);
   ASSERT(close_cb_called == 2);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -44,7 +44,7 @@ static void send_cb(uv_udp_send_t* req, int status);
 static void idle_cb(uv_idle_t* handle) {
   int r;
 
-  ASSERT(send_req.handle == NULL);
+  ASSERT_EQ(send_req.handle, NULL);
   CHECK_OBJECT(handle, uv_idle_t, idle_handle);
   ASSERT(0 == uv_idle_stop(handle));
 

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -61,7 +61,7 @@ static void idle_cb(uv_idle_t* handle) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -57,7 +57,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   cl_send_cb_called++;
@@ -80,7 +80,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
   ASSERT(nread == 4);
@@ -103,18 +103,18 @@ TEST_IMPL(udp_send_immediate) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -125,7 +125,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -135,7 +135,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -83,7 +83,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_EQ(flags, 0);
 
   ASSERT(addr != NULL);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(memcmp("PING", rcvbuf->base, nread) == 0 ||
          memcmp("PANG", rcvbuf->base, nread) == 0);
 
@@ -139,9 +139,9 @@ TEST_IMPL(udp_send_immediate) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -75,7 +75,7 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -140,10 +140,10 @@ TEST_IMPL(udp_send_unreachable) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 2);
+  ASSERT_EQ(send_cb_called, 2);
   ASSERT(recv_cb_called == alloc_cb_called);
-  ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -77,7 +77,7 @@ static void recv_cb(uv_udp_t* handle,
     ASSERT(0 && "unexpected error");
   } else if (nread == 0) {
     /* Returning unused buffer */
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
   } else {
     ASSERT(addr != NULL);
   }

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -85,7 +85,7 @@ static void recv_cb(uv_udp_t* handle,
 
 
 static void timer_cb(uv_timer_t* h) {
-  ASSERT(h == &timer);
+  ASSERT_EQ(h, &timer);
   timer_cb_called++;
   uv_close((uv_handle_t*) &client, close_cb);
   uv_close((uv_handle_t*) h, close_cb);

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -59,7 +59,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT(req != NULL);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
   send_cb_called++;
 }
@@ -103,19 +103,19 @@ TEST_IMPL(udp_send_unreachable) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
 
   r = uv_timer_init( uv_default_loop(), &timer );
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start( &timer, timer_cb, 1000, 0 );
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -126,7 +126,7 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -136,7 +136,7 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -141,7 +141,7 @@ TEST_IMPL(udp_send_unreachable) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(send_cb_called, 2);
-  ASSERT(recv_cb_called == alloc_cb_called);
+  ASSERT_EQ(recv_cb_called, alloc_cb_called);
   ASSERT_EQ(timer_cb_called, 1);
   ASSERT_EQ(close_cb_called, 2);
 

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -67,7 +67,7 @@ static void sv_recv_cb(uv_udp_t* handle,
     return;
   }
 
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(addr != NULL);
 
   ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
@@ -106,12 +106,12 @@ TEST_IMPL(udp_try_send) {
 
   buf = uv_buf_init("EXIT", 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 1);
 
   ASSERT_EQ(client.send_queue_size, 0);
   ASSERT_EQ(server.send_queue_size, 0);

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -87,18 +87,18 @@ TEST_IMPL(udp_try_send) {
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(buffer, sizeof(buffer));
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -63,7 +63,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT(nread > 0);
 
   if (nread == 0) {
-    ASSERT(addr == NULL);
+    ASSERT_EQ(addr, NULL);
     return;
   }
 
@@ -102,7 +102,7 @@ TEST_IMPL(udp_try_send) {
 
   buf = uv_buf_init(buffer, sizeof(buffer));
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
-  ASSERT(r == UV_EMSGSIZE);
+  ASSERT_EQ(r, UV_EMSGSIZE);
 
   buf = uv_buf_init("EXIT", 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -113,8 +113,8 @@ TEST_IMPL(udp_try_send) {
   ASSERT(close_cb_called == 2);
   ASSERT(sv_recv_cb_called == 1);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-uname.c
+++ b/test/test-uname.c
@@ -39,7 +39,7 @@ TEST_IMPL(uname) {
 
   /* Verify that NULL is handled properly. */
   r = uv_os_uname(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Verify the happy path. */
   r = uv_os_uname(&buffer);

--- a/test/test-uname.c
+++ b/test/test-uname.c
@@ -43,7 +43,7 @@ TEST_IMPL(uname) {
 
   /* Verify the happy path. */
   r = uv_os_uname(&buffer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   ASSERT(uname(&buf) != -1);

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -31,7 +31,7 @@ static uv_timer_t timer;
 
 
 static void walk_cb(uv_handle_t* handle, void* arg) {
-  ASSERT(arg == (void*)magic_cookie);
+  ASSERT_EQ(arg, (void*)magic_cookie);
 
   if (handle == (uv_handle_t*)&timer) {
     seen_timer_handle++;

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -65,7 +65,7 @@ TEST_IMPL(walk_handles) {
   ASSERT_EQ(seen_timer_handle, 0);
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
-  ASSERT(seen_timer_handle == 1);
+  ASSERT_EQ(seen_timer_handle, 1);
 
   /* Loop is finished, walk_cb should not see our timer handle. */
   seen_timer_handle = 0;

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -56,21 +56,21 @@ TEST_IMPL(walk_handles) {
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start event loop, expect to see the timer handle in walk_cb. */
-  ASSERT(seen_timer_handle == 0);
+  ASSERT_EQ(seen_timer_handle, 0);
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(seen_timer_handle == 1);
 
   /* Loop is finished, walk_cb should not see our timer handle. */
   seen_timer_handle = 0;
   uv_walk(loop, walk_cb, magic_cookie);
-  ASSERT(seen_timer_handle == 0);
+  ASSERT_EQ(seen_timer_handle, 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -42,7 +42,7 @@ static void walk_cb(uv_handle_t* handle, void* arg) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_EQ(handle, &timer);
 
   uv_walk(handle->loop, walk_cb, magic_cookie);
   uv_close((uv_handle_t*)handle, NULL);

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -104,8 +104,8 @@ TEST_IMPL(watcher_cross_stop) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(ARRAY_SIZE(sockets) == send_cb_called);
-  ASSERT(ARRAY_SIZE(sockets) == close_cb_called);
+  ASSERT_EQ(send_cb_called, ARRAY_SIZE(sockets));
+  ASSERT_EQ(close_cb_called, ARRAY_SIZE(sockets));
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
**Overall**: Turn cases of `ASSERT(A == B)` into `ASSERT_EQ(A, B)`. This is only done where both `A` and `B` are side-effect free; neither may be a function call.

This change makes debugging easier, as the `ASSERT_EQ()` macro will print the LHS and RHS expressions if it fails, which often helps find what the problem is.

Performed with:

```
$ find test/ -name \*.c | \
  xargs sed -i "s/ASSERT(\([a-zA-Z0-9_.]\+\) == \([0-9]\+\))/ASSERT_EQ(\1, 2)/"
$ find test/ -name \*.c | \
  xargs sed -i "s/ASSERT(\([a-z0-9_.]\+->[a-z_.]\+\) == \([0-9]\+\))/ASSERT_EQ(\1, \2)/"
$ find test/ -name \*.c | \
  xargs sed -i "s/ASSERT(\([0-9]\+\) == \([a-zA-Z_.]\+\))/ASSERT_EQ(\2, \1)/"
$ find test/ -name \*.c | \
  xargs sed -i "s/ASSERT(\([a-zA-Z0-9._]\+\) == \(\&\?[a-zA-Z0-9._]\+\))/ASSERT_EQ(\1, \2)/"
```

Then some manual editing on a few more cases found by various grep expressions.

If accepted, I plan to follow up with a variety more neatenings of the test expressions, perhaps leading to a `ASSERT_NO_ERR(r)` macro which, if fails, prints both the numerical value and stringified name of the error value in `r`.