### PR TITLE
DVS filesystem uses EOPNOTSUPP as errno

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1420,8 +1420,9 @@ static int uv__fs_statx(int fd,
   case -1:
     /* EPERM happens when a seccomp filter rejects the system call.
      * Has been observed with libseccomp < 2.3.3 and docker < 18.04.
+     * EOPNOTSUPP is used on DVS exported filesystems
      */
-    if (errno != EINVAL && errno != EPERM && errno != ENOSYS)
+    if (errno != EINVAL && errno != EPERM && errno != ENOSYS && errno != EOPNOTSUPP)
       return -1;
     /* Fall through. */
   default:


### PR DESCRIPTION
Hello,

We were getting failures on a new system being brought up on a remote filesystem being exported over DVS. It doesn't support statx, and is returning the errno: EOPNOTSUPP. This fixes the problem.

Cheers,
Mark