### PR TITLE
Revert "build: fix android autotools build"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -385,10 +385,6 @@ if ANDROID
 uvinclude_HEADERS += include/uv/android-ifaddrs.h
 libuv_la_CFLAGS += -D_GNU_SOURCE
 libuv_la_SOURCES += src/unix/android-ifaddrs.c \
-                    src/unix/linux-core.c \
-                    src/unix/linux-inotify.c \
-                    src/unix/linux-syscalls.c \
-                    src/unix/procfs-exepath.c \
                     src/unix/pthread-fixes.c \
                     src/unix/random-getrandom.c \
                     src/unix/random-sysctl-linux.c


### PR DESCRIPTION
This reverts commit f9618443920fd0cbd3ab11c9d37c1f24a7aa1067.

Also fixes #2768 and #3048