### PR TITLE
unix: fixed st_rdev output of uv_fs_stat when using statx

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -58,6 +58,7 @@
 
 #if defined(__linux__) || defined(__sun)
 # include <sys/sendfile.h>
+# include <sys/sysmacros.h>
 #endif
 
 #if defined(__APPLE__)
@@ -1434,12 +1435,12 @@ static int uv__fs_statx(int fd,
     return UV_ENOSYS;
   }
 
-  buf->st_dev = 256 * statxbuf.stx_dev_major + statxbuf.stx_dev_minor;
+  buf->st_dev = makedev(statxbuf.stx_dev_major, statxbuf.stx_dev_minor);
   buf->st_mode = statxbuf.stx_mode;
   buf->st_nlink = statxbuf.stx_nlink;
   buf->st_uid = statxbuf.stx_uid;
   buf->st_gid = statxbuf.stx_gid;
-  buf->st_rdev = statxbuf.stx_rdev_major;
+  buf->st_rdev = makedev(statxbuf.stx_rdev_major, statxbuf.stx_rdev_minor);
   buf->st_ino = statxbuf.stx_ino;
   buf->st_size = statxbuf.stx_size;
   buf->st_blksize = statxbuf.stx_blksize;


### PR DESCRIPTION
Fixed wrong output value of `st_rdev` when using statx. The `stx_rdev_minor` part was missing.
We now generate `st_rdev` from `struct statx` like glibc in `sysdeps/unix/sysv/linux/statx_cp.c`.

Issue: #3051