### PR TITLE
unix: re-allow WRONLY fd in uv_read_start

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -169,6 +169,8 @@ int uv_pipe_open(uv_pipe_t* handle, uv_os_fd_t fd) {
   mode &= O_ACCMODE;
   if (mode != O_WRONLY)
     flags |= UV_HANDLE_READABLE;
+  else
+    flags |= UV_HANDLE_READABLE_CLOSED;
   if (mode != O_RDONLY)
     flags |= UV_HANDLE_WRITABLE;
 

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -242,7 +242,7 @@ static int uv__process_open_stream(uv_stdio_container_t* container,
   if (container->flags & UV_WRITABLE_PIPE)
     flags |= UV_HANDLE_READABLE;
   if (container->flags & UV_READABLE_PIPE)
-    flags |= UV_HANDLE_WRITABLE;
+    flags |= UV_HANDLE_WRITABLE | UV_HANDLE_READABLE_CLOSED;
 
   return uv__stream_open(container->data.stream, pipefds[0], flags);
 }

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1561,7 +1561,7 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 
-  if (!(stream->flags & UV_HANDLE_READABLE))
+  if (!(stream->flags & (UV_HANDLE_READABLE | UV_HANDLE_READABLE_CLOSED)))
     return UV_ENOTCONN;
 
   /* The UV_HANDLE_READING flag is irrelevant of the state of the tcp - it just
@@ -1658,7 +1658,10 @@ void uv__stream_close(uv_stream_t* handle) {
   uv__io_close(handle->loop, &handle->io_watcher);
   uv_read_stop(handle);
   uv__handle_stop(handle);
-  handle->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
+  handle->flags &= ~(
+          UV_HANDLE_READABLE |
+          UV_HANDLE_WRITABLE |
+          UV_HANDLE_READABLE_CLOSED);
 
   if (handle->io_watcher.fd != -1) {
     /* Don't close stdio file descriptors.  Nothing good comes from it. */

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -219,6 +219,8 @@ skip:
 
   if (mode != O_WRONLY)
     flags |= UV_HANDLE_READABLE;
+  else
+    flags |= UV_HANDLE_READABLE_CLOSED;
   if (mode != O_RDONLY)
     flags |= UV_HANDLE_WRITABLE;
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -92,6 +92,11 @@ enum {
   /* Used by uv_tcp_t and uv_udp_t handles */
   UV_HANDLE_IPV6                        = 0x00400000,
 
+  /* Used on write-only streams to enable polling to
+     detect a closed connection without having to write
+     anything to the stream. */
+  UV_HANDLE_READABLE_CLOSED             = 0x00800000,
+
   /* Only used by uv_tcp_t handles. */
   UV_HANDLE_TCP_NODELAY                 = 0x01000000,
   UV_HANDLE_TCP_KEEPALIVE               = 0x02000000,

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -489,6 +489,7 @@ TEST_DECLARE   (win32_signum_number)
 #else
 TEST_DECLARE   (emfile)
 TEST_DECLARE   (close_fd)
+TEST_DECLARE   (close_rx_fd)
 TEST_DECLARE   (spawn_fs_open)
 TEST_DECLARE   (spawn_setuid_setgid)
 TEST_DECLARE   (we_get_signal)
@@ -980,6 +981,7 @@ TASK_LIST_START
 #else
   TEST_ENTRY  (emfile)
   TEST_ENTRY  (close_fd)
+  TEST_ENTRY  (close_rx_fd)
   TEST_ENTRY  (spawn_fs_open)
   TEST_ENTRY  (spawn_setuid_setgid)
   TEST_ENTRY  (we_get_signal)


### PR DESCRIPTION
For the writing end (`O_WRONLY`) of a `pipe(2)`, we should also allow polling for read, so that the user could listen for a broken pipe on the writing end using `uv_read_start()` without having to try to write anything to the pipe, or wait until the next write to find out.

Fixes: https://github.com/libuv/libuv/issues/2058