### PR TITLE
unix: re-allow WRONLY fd in uv_read_start

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -163,6 +163,8 @@ int uv_pipe_open(uv_pipe_t* handle, uv_file fd) {
   mode &= O_ACCMODE;
   if (mode != O_WRONLY)
     flags |= UV_HANDLE_READABLE;
+  else
+    flags |= UV_HANDLE_READABLE_CLOSED;
   if (mode != O_RDONLY)
     flags |= UV_HANDLE_WRITABLE;
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1652,7 +1652,10 @@ void uv__stream_close(uv_stream_t* handle) {
   uv__io_close(handle->loop, &handle->io_watcher);
   uv_read_stop(handle);
   uv__handle_stop(handle);
-  handle->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
+  handle->flags &= ~(
+          UV_HANDLE_READABLE |
+          UV_HANDLE_WRITABLE |
+          UV_HANDLE_READABLE_CLOSED);
 
   if (handle->io_watcher.fd != -1) {
     /* Don't close stdio file descriptors.  Nothing good comes from it. */

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1186,6 +1186,11 @@ static void uv__read(uv_stream_t* stream) {
         uv__stream_eof(stream, &buf);
         return;
 #endif
+#if !defined(__FreeBSD__) && !defined(__sun)
+      } else if (errno == EBADF && stream->flags & UV_HANDLE_READABLE_CLOSED) {
+        uv__stream_eof(stream, &buf);
+        return;
+#endif
       } else {
         /* Error. User should call uv_close(). */
         stream->read_cb(stream, UV__ERR(errno), &buf);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -844,7 +844,7 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_READING)
     return UV_EALREADY;
 
-  if (!(stream->flags & UV_HANDLE_READABLE))
+  if (!(stream->flags & (UV_HANDLE_READABLE | UV_HANDLE_READABLE_CLOSED)))
     return UV_ENOTCONN;
 
   return uv__read_start(stream, alloc_cb, read_cb);

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -101,6 +101,13 @@ enum {
   /* Used by uv_tcp_t and uv_udp_t handles */
   UV_HANDLE_IPV6                        = 0x00400000,
 
+  /*
+   * Used on write-only streams to enable polling to
+   * detect a closed connection without having to write
+   * anything to the stream.
+   */
+  UV_HANDLE_READABLE_CLOSED             = 0x00800000,
+
   /* Only used by uv_tcp_t handles. */
   UV_HANDLE_TCP_NODELAY                 = 0x01000000,
   UV_HANDLE_TCP_KEEPALIVE               = 0x02000000,

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #endif
 
+static unsigned int close_rx_read_cb_called;
 static unsigned int read_cb_called;
 
 static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
@@ -36,15 +37,32 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   switch (++read_cb_called) {
   case 1:
-    ASSERT(nread == 1);
+    ASSERT_EQ(nread, 1);
     uv_read_stop(handle);
     break;
   case 2:
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t *) handle, NULL);
     break;
   default:
-    ASSERT(!"read_cb_called > 2");
+    FATAL("read_cb_called > 2");
+  }
+}
+
+static void close_rx_read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
+  switch (++close_rx_read_cb_called) {
+  case 1:
+    ASSERT_EQ(nread, 1);
+    uv_read_stop(handle);
+    uv_close((uv_handle_t *) handle, NULL);
+    break;
+  case 2:
+    ASSERT_EQ(nread, UV_EBADF);
+    uv_read_stop(handle);
+    uv_close((uv_handle_t *) handle, NULL);
+    break;
+  default:
+    FATAL("close_rx_read_cb_called > 2");
   }
 }
 
@@ -55,29 +73,53 @@ TEST_IMPL(close_fd) {
   uv_file fd[2];
   bufs[0] = uv_buf_init("", 1);
 
-  ASSERT(0 == uv_pipe(fd, 0, 0));
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT(0 == uv_pipe_open(&pipe_handle, fd[0]));
+  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[0]));
   /* uv_pipe_open() takes ownership of the file descriptor. */
   fd[0] = -1;
 
-  ASSERT(1 == uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT(1 == req.result);
+  ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
+  ASSERT_EQ(1, req.result);
   uv_fs_req_cleanup(&req);
 #ifdef _WIN32
-  ASSERT(0 == _close(fd[1]));
+  ASSERT_EQ(0, _close(fd[1]));
 #else
-  ASSERT(0 == close(fd[1]));
+  ASSERT_EQ(0, close(fd[1]));
 #endif
   fd[1] = -1;
-  ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == read_cb_called);
-  ASSERT(0 == uv_is_active((const uv_handle_t *) &pipe_handle));
-  ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(2 == read_cb_called);
-  ASSERT(0 != uv_is_closing((const uv_handle_t *) &pipe_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(0, uv_is_active((const uv_handle_t *) &pipe_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(2, read_cb_called);
+  ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &pipe_handle));
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+TEST_IMPL(close_rx_fd) {
+  uv_pipe_t rx_handle;
+  uv_pipe_t tx_handle;
+  int fd[2];
+
+  ASSERT_EQ(0, pipe(fd));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &rx_handle, 0));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &tx_handle, 0));
+  ASSERT_EQ(0, uv_pipe_open(&rx_handle, fd[0]));
+  fd[0] = -1;  /* uv_pipe_open() takes ownership of the file descriptor. */
+  ASSERT_EQ(1, write(fd[1], "", 1));
+  ASSERT_EQ(0, uv_pipe_open(&tx_handle, fd[1]));
+  fd[1] = -1;  /* uv_pipe_open() takes ownership of the file descriptor. */
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &rx_handle, alloc_cb, close_rx_read_cb));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &tx_handle, alloc_cb, close_rx_read_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(2, close_rx_read_cb_called);
+  ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &tx_handle));
+  ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &rx_handle));
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -57,7 +57,7 @@ static void close_rx_read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t*
     uv_close((uv_handle_t *) handle, NULL);
     break;
   case 2:
-    ASSERT_EQ(nread, UV_EBADF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_read_stop(handle);
     uv_close((uv_handle_t *) handle, NULL);
     break;
@@ -101,6 +101,7 @@ TEST_IMPL(close_fd) {
   return 0;
 }
 
+#ifndef _WIN32
 TEST_IMPL(close_rx_fd) {
   uv_pipe_t rx_handle;
   uv_pipe_t tx_handle;
@@ -124,3 +125,4 @@ TEST_IMPL(close_rx_fd) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+#endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -461,6 +461,7 @@ TEST_DECLARE   (ip6_addr_link_local)
 TEST_DECLARE   (poll_close_doesnt_corrupt_stack)
 TEST_DECLARE   (poll_closesocket)
 TEST_DECLARE   (close_fd)
+TEST_DECLARE   (close_rx_fd)
 TEST_DECLARE   (closed_fd_events)
 TEST_DECLARE   (spawn_fs_open)
 #ifdef _WIN32
@@ -947,6 +948,7 @@ TASK_LIST_START
   TEST_ENTRY  (poll_close_doesnt_corrupt_stack)
   TEST_ENTRY  (poll_closesocket)
   TEST_ENTRY  (close_fd)
+  TEST_ENTRY  (close_rx_fd)
   TEST_ENTRY  (closed_fd_events)
   TEST_ENTRY  (spawn_fs_open)
 #ifdef _WIN32

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -461,7 +461,6 @@ TEST_DECLARE   (ip6_addr_link_local)
 TEST_DECLARE   (poll_close_doesnt_corrupt_stack)
 TEST_DECLARE   (poll_closesocket)
 TEST_DECLARE   (close_fd)
-TEST_DECLARE   (close_rx_fd)
 TEST_DECLARE   (closed_fd_events)
 TEST_DECLARE   (spawn_fs_open)
 #ifdef _WIN32
@@ -486,6 +485,7 @@ TEST_DECLARE   (we_get_signals_mixed)
 TEST_DECLARE   (signal_multiple_loops)
 TEST_DECLARE   (signal_pending_on_close)
 TEST_DECLARE   (signal_close_loop_alive)
+TEST_DECLARE   (close_rx_fd)
 #endif
 #ifdef __APPLE__
 TEST_DECLARE   (osx_select)
@@ -948,7 +948,6 @@ TASK_LIST_START
   TEST_ENTRY  (poll_close_doesnt_corrupt_stack)
   TEST_ENTRY  (poll_closesocket)
   TEST_ENTRY  (close_fd)
-  TEST_ENTRY  (close_rx_fd)
   TEST_ENTRY  (closed_fd_events)
   TEST_ENTRY  (spawn_fs_open)
 #ifdef _WIN32
@@ -973,6 +972,7 @@ TASK_LIST_START
   TEST_ENTRY  (signal_multiple_loops)
   TEST_ENTRY  (signal_pending_on_close)
   TEST_ENTRY  (signal_close_loop_alive)
+  TEST_ENTRY  (close_rx_fd)
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
For the writing end (`O_WRONLY`) of a `pipe(2)`, we should also allow polling for read, so that the user could listen for a broken pipe on the writing end using `uv_read_start()` without having to try to write anything to the pipe, or wait until the next write to find out.

Fixes: https://github.com/libuv/libuv/issues/2058