### PR TITLE
unix,process: replace uv__write_int with uv__write_errno

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -201,6 +201,12 @@ static void uv__write_int(int fd, int val) {
 }
 
 
+static void uv__write_errno(int error_fd) {
+  uv__write_int(error_fd, UV__ERR(errno));
+  _exit(127);
+}
+
+
 #if !(defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH))
 /* execvp is marked __WATCHOS_PROHIBITED __TVOS_PROHIBITED, so must be
  * avoided. Since this isn't called on those targets, the function
@@ -229,10 +235,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (use_fd < 0 || use_fd >= fd)
       continue;
     pipes[fd][1] = fcntl(use_fd, F_DUPFD, stdio_count);
-    if (pipes[fd][1] == -1) {
-      uv__write_int(error_fd, UV__ERR(errno));
-      _exit(127);
-    }
+    if (pipes[fd][1] == -1)
+      uv__write_errno(error_fd);
   }
 
   for (fd = 0; fd < stdio_count; fd++) {
@@ -249,10 +253,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
         use_fd = open("/dev/null", fd == 0 ? O_RDONLY : O_RDWR);
         close_fd = use_fd;
 
-        if (use_fd < 0) {
-          uv__write_int(error_fd, UV__ERR(errno));
-          _exit(127);
-        }
+        if (use_fd < 0)
+          uv__write_errno(error_fd);
       }
     }
 
@@ -261,10 +263,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
     else
       fd = dup2(use_fd, fd);
 
-    if (fd == -1) {
-      uv__write_int(error_fd, UV__ERR(errno));
-      _exit(127);
-    }
+    if (fd == -1)
+      uv__write_errno(error_fd);
 
     if (fd <= 2)
       uv__nonblock_fcntl(fd, 0);
@@ -280,10 +280,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
       uv__close(use_fd);
   }
 
-  if (options->cwd != NULL && chdir(options->cwd)) {
-    uv__write_int(error_fd, UV__ERR(errno));
-    _exit(127);
-  }
+  if (options->cwd != NULL && chdir(options->cwd))
+    uv__write_errno(error_fd);
 
   if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
     /* When dropping privileges from root, the `setgroups` call will
@@ -296,15 +294,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
     SAVE_ERRNO(setgroups(0, NULL));
   }
 
-  if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid)) {
-    uv__write_int(error_fd, UV__ERR(errno));
-    _exit(127);
-  }
+  if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid))
+    uv__write_errno(error_fd);
 
-  if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid)) {
-    uv__write_int(error_fd, UV__ERR(errno));
-    _exit(127);
-  }
+  if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid))
+    uv__write_errno(error_fd);
 
   if (options->env != NULL) {
     environ = options->env;
@@ -327,26 +321,23 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (SIG_ERR != signal(n, SIG_DFL))
       continue;
 
-    uv__write_int(error_fd, UV__ERR(errno));
-    _exit(127);
+    uv__write_errno(error_fd);
   }
 
   /* Reset signal mask. */
   sigemptyset(&set);
   err = pthread_sigmask(SIG_SETMASK, &set, NULL);
 
-  if (err != 0) {
-    uv__write_int(error_fd, UV__ERR(err));
-    _exit(127);
-  }
+  if (err != 0)
+    uv__write_errno(error_fd);
 
 #ifdef __MVS__
   execvpe(options->file, options->args, environ);
 #else
   execvp(options->file, options->args);
 #endif
-  uv__write_int(error_fd, UV__ERR(errno));
-  _exit(127);
+
+  uv__write_errno(error_fd);
 }
 #endif
 


### PR DESCRIPTION
Reading the code reveals a lot of repetition, here the logic is simplified using `uv__write_errno`.