### PR TITLE
zos: build in ASCII code page and introduce zoslib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,9 +266,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
-  list(APPEND uv_defines PATH_MAX=255)
+  list(APPEND uv_defines PATH_MAX=1024)
   list(APPEND uv_defines _AE_BIMODAL)
   list(APPEND uv_defines _ALL_SOURCE)
+  list(APPEND uv_defines _ENHANCED_ASCII_EXT=0xFFFFFFFF)
   list(APPEND uv_defines _ISOC99_SOURCE)
   list(APPEND uv_defines _LARGE_TIME_API)
   list(APPEND uv_defines _OPEN_MSGQ_EXT)
@@ -279,14 +280,24 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
   list(APPEND uv_defines _UNIX03_SOURCE)
   list(APPEND uv_defines _UNIX03_THREADS)
   list(APPEND uv_defines _UNIX03_WITHDRAWN)
+  list(APPEND uv_defines _XOPEN_SOURCE=600)
   list(APPEND uv_defines _XOPEN_SOURCE_EXTENDED)
   list(APPEND uv_sources
        src/unix/pthread-fixes.c
        src/unix/os390.c
        src/unix/os390-syscalls.c)
-  list(APPEND uv_cflags -Wc,DLL -Wc,exportall -Wc,xplink)
-  list(APPEND uv_libraries -Wl,xplink)
-  list(APPEND uv_test_libraries -Wl,xplink)
+  list(APPEND uv_cflags
+       -q64
+       -qascii
+       -qexportall
+       -qgonumber
+       -qlongname
+       -qlibansi
+       -qfloat=IEEE
+       -qtune=10
+       -qarch=10
+       -qasm
+       -qasmlib=sys1.maclib:sys1.modgen)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OS400")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
        src/unix/random-sysctl-linux.c)
 endif()
 
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux|OS390")
+if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Android|Linux")
   list(APPEND uv_sources src/unix/proctitle.c)
 endif()
 
@@ -286,7 +286,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
   list(APPEND uv_sources
        src/unix/pthread-fixes.c
        src/unix/os390.c
-       src/unix/os390-syscalls.c)
+       src/unix/os390-syscalls.c
+       src/unix/os390-proctitle.c)
   list(APPEND uv_cflags
        -q64
        -qascii

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
+  enable_language(CXX)
   list(APPEND uv_defines PATH_MAX=1024)
   list(APPEND uv_defines _AE_BIMODAL)
   list(APPEND uv_defines _ALL_SOURCE)
@@ -298,6 +299,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
        -qarch=10
        -qasm
        -qasmlib=sys1.maclib:sys1.modgen)
+  find_library(ZOSLIB
+    NAMES zoslib
+    PATHS ${ZOSLIB_DIR}
+    PATH_SUFFIXES lib
+  )
+  list(APPEND uv_libraries ${ZOSLIB})
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
@@ -360,6 +367,10 @@ target_include_directories(uv
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
+  target_include_directories(uv PUBLIC $<BUILD_INTERFACE:${ZOSLIB_DIR}/include>)
+  set_target_properties(uv PROPERTIES LINKER_LANGUAGE CXX)
+endif()
 target_link_libraries(uv ${uv_libraries})
 
 add_library(uv_a STATIC ${uv_sources})
@@ -371,6 +382,10 @@ target_include_directories(uv_a
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
+  target_include_directories(uv_a PUBLIC $<BUILD_INTERFACE:${ZOSLIB_DIR}/include>)
+  set_target_properties(uv_a PROPERTIES LINKER_LANGUAGE CXX)
+endif()
 target_link_libraries(uv_a ${uv_libraries})
 
 if(LIBUV_BUILD_TESTS)
@@ -593,6 +608,11 @@ if(LIBUV_BUILD_TESTS)
   add_test(NAME uv_test_a
            COMMAND uv_run_tests_a
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
+    set_target_properties(uv_run_benchmarks_a PROPERTIES LINKER_LANGUAGE CXX)
+    set_target_properties(uv_run_tests PROPERTIES LINKER_LANGUAGE CXX)
+    set_target_properties(uv_run_tests_a PROPERTIES LINKER_LANGUAGE CXX)
+  endif()
 endif()
 
 if(UNIX OR MINGW)

--- a/README.md
+++ b/README.md
@@ -308,6 +308,13 @@ describes the package in more detail.
 
 ### z/OS Notes
 
+z/OS compilation requires [ZOSLIB](https://github.com/ibmruntimes/zoslib) to be installed. When building with [CMake][], use the flag `-DZOSLIB_DIR` to specify the path to [ZOSLIB](https://github.com/ibmruntimes/zoslib):
+
+```bash
+$ (cd build && cmake .. -DBUILD_TESTING=ON -DZOSLIB_DIR=/path/to/zoslib)
+$ cmake --build build
+```
+
 z/OS creates System V semaphores and message queues. These persist on the system
 after the process terminates unless the event loop is closed.
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1357,7 +1357,8 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_birthtim.tv_nsec = src->st_ctimensec;
   dst->st_flags = 0;
   dst->st_gen = 0;
-#elif !defined(_AIX) && (       \
+#elif !defined(_AIX) &&         \
+    !defined(__MVS__) && (      \
     defined(__DragonFly__)   || \
     defined(__FreeBSD__)     || \
     defined(__OpenBSD__)     || \

--- a/src/unix/os390-proctitle.c
+++ b/src/unix/os390-proctitle.c
@@ -1,4 +1,5 @@
-/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+/* Copyright libuv project contributors. All rights reserved.
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
  * deal in the Software without restriction, including without limitation the
@@ -24,18 +25,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct uv__process_title {
-  char* str;
-  size_t len;  /* Length of the current process title. */
-  size_t cap;  /* Maximum capacity. Computed once in uv_setup_args(). */
-};
-
-extern void uv__set_process_title(const char* title);
-
 static uv_mutex_t process_title_mutex;
 static uv_once_t process_title_mutex_once = UV_ONCE_INIT;
-static struct uv__process_title process_title;
-static void* args_mem;
+static char* process_title = NULL;
+static void* args_mem = NULL;
 
 
 static void init_process_title_mutex_once(void) {
@@ -44,7 +37,6 @@ static void init_process_title_mutex_once(void) {
 
 
 char** uv_setup_args(int argc, char** argv) {
-  struct uv__process_title pt;
   char** new_argv;
   size_t size;
   char* s;
@@ -53,13 +45,9 @@ char** uv_setup_args(int argc, char** argv) {
   if (argc <= 0)
     return argv;
 
-  pt.str = argv[0];
-  pt.len = strlen(argv[0]);
-  pt.cap = pt.len + 1;
-
   /* Calculate how much memory we need for the argv strings. */
-  size = pt.cap;
-  for (i = 1; i < argc; i++)
+  size = 0;
+  for (i = 0; i < argc; i++)
     size += strlen(argv[i]) + 1;
 
   /* Add space for the argv pointers. */
@@ -70,53 +58,43 @@ char** uv_setup_args(int argc, char** argv) {
     return argv;
 
   /* Copy over the strings and set up the pointer table. */
-  i = 0;
   s = (char*) &new_argv[argc + 1];
-  size = pt.cap;
-  goto loop;
-
-  for (/* empty */; i < argc; i++) {
+  for (i = 0; i < argc; i++) {
     size = strlen(argv[i]) + 1;
-  loop:
     memcpy(s, argv[i], size);
     new_argv[i] = s;
     s += size;
   }
   new_argv[i] = NULL;
 
-  pt.cap = argv[i - 1] + size - argv[0];
-
   args_mem = new_argv;
-  process_title = pt;
+  process_title = uv__strdup(argv[0]);
 
   return new_argv;
 }
 
 
 int uv_set_process_title(const char* title) {
-  struct uv__process_title* pt;
-  size_t len;
+  char* new_title;
 
   /* If uv_setup_args wasn't called or failed, we can't continue. */
   if (args_mem == NULL)
     return UV_ENOBUFS;
 
-  pt = &process_title;
-  len = strlen(title);
+  /* We cannot free this pointer when libuv shuts down,
+   * the process may still be using it.
+   */
+  new_title = uv__strdup(title);
+  if (new_title == NULL)
+    return UV_ENOMEM;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
 
-  if (len >= pt->cap) {
-    len = 0;
-    if (pt->cap > 0)
-      len = pt->cap - 1;
-  }
+  if (process_title != NULL)
+    uv__free(process_title);
 
-  memcpy(pt->str, title, len);
-  memset(pt->str + len, '\0', pt->cap - len);
-  pt->len = len;
-  uv__set_process_title(pt->str);
+  process_title = new_title;
 
   uv_mutex_unlock(&process_title_mutex);
 
@@ -125,25 +103,26 @@ int uv_set_process_title(const char* title) {
 
 
 int uv_get_process_title(char* buffer, size_t size) {
+  size_t len;
+
   if (buffer == NULL || size == 0)
     return UV_EINVAL;
 
   /* If uv_setup_args wasn't called or failed, we can't continue. */
-  if (args_mem == NULL)
+  if (args_mem == NULL || process_title == NULL)
     return UV_ENOBUFS;
 
   uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_lock(&process_title_mutex);
 
-  if (size <= process_title.len) {
+  len = strlen(process_title);
+
+  if (size <= len) {
     uv_mutex_unlock(&process_title_mutex);
     return UV_ENOBUFS;
   }
 
-  if (process_title.len != 0)
-    memcpy(buffer, process_title.str, process_title.len + 1);
-
-  buffer[process_title.len] = '\0';
+  strcpy(buffer, process_title);
 
   uv_mutex_unlock(&process_title_mutex);
 

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -550,15 +550,6 @@ ssize_t os390_readlink(const char* path, char* buf, size_t len) {
 }
 
 
-size_t strnlen(const char* str, size_t maxlen) {
-  char* p = memchr(str, 0, maxlen);
-  if (p == NULL)
-    return maxlen;
-  else
-    return p - str;
-}
-
-
 int sem_init(UV_PLATFORM_SEM_T* semid, int pshared, unsigned int value) {
   UNREACHABLE();
 }

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -28,6 +28,7 @@
 #include <dirent.h>
 #include <poll.h>
 #include <pthread.h>
+#include "zos-base.h"
 
 #define EPOLL_CTL_ADD             1
 #define EPOLL_CTL_DEL             2
@@ -57,7 +58,6 @@ int epoll_wait(uv__os390_epoll* ep, struct epoll_event *events, int maxevents, i
 int epoll_file_close(int fd);
 
 /* utility functions */
-int nanosleep(const struct timespec* req, struct timespec* rem);
 int scandir(const char* maindir, struct dirent*** namelist,
             int (*filter)(const struct dirent *),
             int (*compar)(const struct dirent **,

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -639,6 +639,10 @@ static int os390_message_queue_handler(uv__os390_epoll* ep) {
     /* Some event that we are not interested in. */
     return 0;
 
+  /* `__rfim_utok` is treated as text when it should be treated as binary while
+   * running in ASCII mode, resulting in an unwanted autoconversion.
+   */
+  __a2e_l(msg.__rfim_utok, sizeof(msg.__rfim_utok));
   handle = *(uv_fs_event_t**)(msg.__rfim_utok);
   handle->cb(handle, uv__basename_r(handle->path), events, 0);
   return 1;

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -869,9 +869,6 @@ update_timeout:
   }
 }
 
-void uv__set_process_title(const char* title) {
-  /* do nothing */
-}
 
 int uv__io_fork(uv_loop_t* loop) {
   /*

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -28,6 +28,7 @@
 #include <builtins.h>
 #include <termios.h>
 #include <sys/msg.h>
+#include "zos-base.h"
 #if defined(__clang__)
 #include "csrsic.h"
 #else
@@ -144,102 +145,8 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
 }
 
 
-/*
-    Get the exe path using the thread entry information
-    in the address space.
-*/
-static int getexe(const int pid, char* buf, size_t len) {
-  struct {
-    int pid;
-    int thid[2];
-    char accesspid;
-    char accessthid;
-    char asid[2];
-    char loginname[8];
-    char flag;
-    char len;
-  } Input_data;
-
-  union {
-    struct {
-      char gthb[4];
-      int pid;
-      int thid[2];
-      char accesspid;
-      char accessthid[3];
-      int lenused;
-      int offsetProcess;
-      int offsetConTTY;
-      int offsetPath;
-      int offsetCommand;
-      int offsetFileData;
-      int offsetThread;
-    } Output_data;
-    char buf[2048];
-  } Output_buf;
-
-  struct Output_path_type {
-    char gthe[4];
-    short int len;
-    char path[1024];
-  };
-
-  int Input_length;
-  int Output_length;
-  void* Input_address;
-  void* Output_address;
-  struct Output_path_type* Output_path;
-  int rv;
-  int rc;
-  int rsn;
-
-  Input_length = PGTH_LEN;
-  Output_length = sizeof(Output_buf);
-  Output_address = &Output_buf;
-  Input_address = &Input_data;
-  memset(&Input_data, 0, sizeof Input_data);
-  Input_data.flag |= PGTHAPATH;
-  Input_data.pid = pid;
-  Input_data.accesspid = PGTH_CURRENT;
-
-#ifdef _LP64
-  BPX4GTH(&Input_length,
-          &Input_address,
-          &Output_length,
-          &Output_address,
-          &rv,
-          &rc,
-          &rsn);
-#else
-  BPX1GTH(&Input_length,
-          &Input_address,
-          &Output_length,
-          &Output_address,
-          &rv,
-          &rc,
-          &rsn);
-#endif
-
-  if (rv == -1) {
-    errno = rc;
-    return -1;
-  }
-
-  /* Check highest byte to ensure data availability */
-  assert(((Output_buf.Output_data.offsetPath >>24) & 0xFF) == 'A');
-
-  /* Get the offset from the lowest 3 bytes */
-  Output_path = (struct Output_path_type*) ((char*) (&Output_buf) +
-      (Output_buf.Output_data.offsetPath & 0x00FFFFFF));
-
-  if (Output_path->len >= len) {
-    errno = ENOBUFS;
-    return -1;
-  }
-
-  uv__strscpy(buf, Output_path->path, len);
-
-  return 0;
+static int getexe(char* buf, size_t len) {
+  return uv__strscpy(buf, __getargv()[0], len);
 }
 
 
@@ -259,8 +166,7 @@ int uv_exepath(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  pid = getpid();
-  res = getexe(pid, args, sizeof(args));
+  res = getexe(args, sizeof(args));
   if (res < 0)
     return UV_EINVAL;
 

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -44,6 +44,10 @@ extern char **environ;
 # include <grp.h>
 #endif
 
+#if defined(__MVS__)
+# include "zos-base.h"
+#endif
+
 
 static void uv__chld(uv_signal_t* handle, int signum) {
   uv_process_t* process;
@@ -336,7 +340,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
     _exit(127);
   }
 
+#ifdef __MVS__
+  execvpe(options->file, options->args, environ);
+#else
   execvp(options->file, options->args);
+#endif
   uv__write_int(error_fd, UV__ERR(errno));
   _exit(127);
 }

--- a/test/run-benchmarks.c
+++ b/test/run-benchmarks.c
@@ -28,6 +28,16 @@
 /* Actual benchmarks and helpers are defined in benchmark-list.h */
 #include "benchmark-list.h"
 
+#ifdef __MVS__
+#include "zos-base.h"
+/* Initialize environment and zoslib */
+__attribute__((constructor)) void init() {
+  zoslib_config_t config;
+  init_zoslib_config(&config);
+  init_zoslib(config);
+}
+#endif
+
 
 static int maybe_run_test(int argc, char **argv);
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -36,6 +36,16 @@
 /* Actual tests and helpers are defined in test-list.h */
 #include "test-list.h"
 
+#ifdef __MVS__
+#include "zos-base.h"
+/* Initialize environment and zoslib */
+__attribute__((constructor)) void init() {
+  zoslib_config_t config;
+  init_zoslib_config(&config);
+  init_zoslib(config);
+}
+#endif
+
 int ipc_helper(int listen_after_write);
 int ipc_helper_heavy_traffic_deadlock_bug(void);
 int ipc_helper_tcp_connection(void);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1453,7 +1453,8 @@ TEST_IMPL(fs_fstat) {
   ASSERT(s->st_mtim.tv_nsec == t.st_mtimespec.tv_nsec);
   ASSERT(s->st_ctim.tv_sec == t.st_ctimespec.tv_sec);
   ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
-#elif defined(_AIX)
+#elif defined(_AIX)    || \
+      defined(__MVS__)
   ASSERT(s->st_atim.tv_sec == t.st_atime);
   ASSERT(s->st_atim.tv_nsec == 0);
   ASSERT(s->st_mtim.tv_sec == t.st_mtime);


### PR DESCRIPTION
This PR is for building libuv on z/OS systems. The PR make changes to build libuv in ASCII code page, and introduce a dependency on [ZOSLIB](https://github.com/ibmruntimes/zoslib) to enable this transition.

[ZOSLIB](https://github.com/ibmruntimes/zoslib) is a z/OS C/C++ library which implements additional POSIX APIs that are not available in the LE C Runtime Library, and provides API for EBCDIC <-> ASCII conversion. ZOSLIB can be installed separately on the system, and then linked to libuv using the `-DZOSLIB_DIR` option introduced by this PR.