### PR TITLE
test-getaddrinfo: use example.invalid

### DIFF
--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -100,7 +100,7 @@ TEST_IMPL(getaddrinfo_fail) {
   ASSERT(0 == uv_getaddrinfo(uv_default_loop(),
                              &req,
                              getaddrinfo_fail_cb,
-                             "xyzzy.xyzzy.xyzzy.",
+                             "example.invalid.",
                              NULL,
                              NULL));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
@@ -122,7 +122,7 @@ TEST_IMPL(getaddrinfo_fail_sync) {
   ASSERT(0 > uv_getaddrinfo(uv_default_loop(),
                             &req,
                             NULL,
-                            "xyzzy.xyzzy.xyzzy.",
+                            "example.invalid.",
                             NULL,
                             NULL));
   uv_freeaddrinfo(req.addrinfo);


### PR DESCRIPTION
RFC 2606 reserves the .invalid top-level domain for this purpose.