### PR TITLE
Fixed _FILE_OFFSET_BITS on 32-bit systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,9 +155,13 @@ if(WIN32)
   list(APPEND uv_test_libraries ws2_32)
   list(APPEND uv_test_sources src/win/snprintf.c test/runner-win.c)
 else()
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+  try_compile(WITH_FILE_OFFSET_BITS_64 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/check-file-offset-bits.c COMPILE_DEFINITIONS -D_FILE_OFFSET_BITS=64)
+
+  if(WITH_FILE_OFFSET_BITS_64)
     list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
   endif()
+
   if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390|QNX")
     # TODO: This should be replaced with find_package(Threads) if possible
     # Android has pthread as part of its c library, not as a separate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,9 @@ if(WIN32)
   list(APPEND uv_test_libraries ws2_32)
   list(APPEND uv_test_sources src/win/snprintf.c test/runner-win.c)
 else()
-  list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+  endif()
   if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390|QNX")
     # TODO: This should be replaced with find_package(Threads) if possible
     # Android has pthread as part of its c library, not as a separate

--- a/test/check-file-offset-bits.c
+++ b/test/check-file-offset-bits.c
@@ -1,0 +1,6 @@
+#include <fcntl.h>
+
+int main()
+{
+  	return fcntl64(0, 0);
+}


### PR DESCRIPTION
UV doesn't link on the 32-bit Unix system.
```
lib/libuv_a.a(process.c.o): In function `uv_spawn':
process.c:(.text+0x368): undefined reference to `fcntl64'
lib/libuv_a.a(core.c.o): In function `uv__nonblock_fcntl':
core.c:(.text+0x6ec): undefined reference to `fcntl64'
core.c:(.text+0x744): undefined reference to `fcntl64'
lib/libuv_a.a(core.c.o): In function `uv__cloexec_fcntl':
core.c:(.text+0x798): undefined reference to `fcntl64'
core.c:(.text+0x7ec): undefined reference to `fcntl64'
lib/libuv_a.a(pipe.c.o):pipe.c:(.text+0x2a0): more undefined references to `fcntl64' follow
collect2: error: ld returned 1 exit status
```