### PR TITLE
Fix declaration after statement and comment syntax

### DIFF
--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -209,6 +209,7 @@ static void on_recv(uv_udp_t* handle,
                     const struct sockaddr* addr,
                     unsigned flags) {
   uv_buf_t sndbuf;
+  uv_udp_send_t* req;
 
   if (nread == 0) {
     /* Everything OK, but nothing read. */
@@ -218,7 +219,7 @@ static void on_recv(uv_udp_t* handle,
   ASSERT(nread > 0);
   ASSERT(addr->sa_family == AF_INET);
 
-  uv_udp_send_t* req = send_alloc();
+  req = send_alloc();
   ASSERT(req != NULL);
   sndbuf = uv_buf_init(rcvbuf->base, nread);
   ASSERT(0 <= uv_udp_send(req, handle, &sndbuf, 1, addr, on_send));

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -111,7 +111,7 @@ static int is_supported_system(void) {
     if (cnt != 3) {
       return 0;
     }
-    // relase >= 10.0.16299
+    /* relase >= 10.0.16299 */
     for (cnt = 0; cnt < 3; ++cnt) {
       if (semver[cnt] > min_semver[cnt])
         return 1;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -124,7 +124,7 @@ TEST_IMPL(udp_connect) {
 
   buf = uv_buf_init("EXIT", 4);
 
-  // connect() to INADDR_ANY fails on Windows wih WSAEADDRNOTAVAIL
+  /* connect() to INADDR_ANY fails on Windows wih WSAEADDRNOTAVAIL */
   ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &tmp_addr));
   r = uv_udp_connect(&client, (const struct sockaddr*) &tmp_addr);
 #ifdef _WIN32


### PR DESCRIPTION
The last thing remaining is:
```
../src/unix/udp.c:929:3: warning: ISO C90 forbids mixing declarations and code [-Wdeclaration-after-statement]
  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
  ^
../src/uv-common.h:61:8: note: expanded from macro 'STATIC_ASSERT'
  void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
```