### PR TITLE
unix: fix uv_uptime() regression

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -636,7 +636,7 @@ int uv_uptime(double* uptime) {
   /* Try /proc/uptime first, then fallback to clock_gettime(). */
   
   if (0 == uv__slurp("/proc/uptime", buf, sizeof(buf)))
-    if (1 == sscanf(buf, "%f", uptime))
+    if (1 == sscanf(buf, "%lf", uptime))
       return 0;
 
   /* Try CLOCK_BOOTTIME first, fall back to CLOCK_MONOTONIC if not available


### PR DESCRIPTION
As it was in the original version of
https://github.com/libuv/libuv/pull/3072, `%lf` must be used in
`sscanf()` as the value is being stored in a `double` and not a `float`.

From the `fscanf()` section of the `C99` standard:

> l(ell)           Specifies that a following d,i,o,u,x,X, or n conversion specifier applies to  an  argument  with  type  pointer  to long  int or unsigned  long int;that a following a,A,e,E,f,F,g, or G conversion specifier applies to an  argument  with  type  pointer  to double; or that  a  following c,s,or [ conversion specifier applies to an argument with type pointer to wchar_t.