### PR TITLE
Moving to ASSERT_NULL and ASSERT_NOT_NULL macros.

### DIFF
--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -68,7 +68,7 @@ static int test_async_pummel(int nthreads) {
   int i;
 
   tids = calloc(nthreads, sizeof(tids[0]));
-  ASSERT(tids != NULL);
+  ASSERT_NOT_NULL(tids);
 
   ASSERT(0 == uv_async_init(uv_default_loop(), &handle, async_cb));
   ACCESS_ONCE(const char*, handle.data) = running;

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -79,7 +79,7 @@ static int test_async(int nthreads) {
   int i;
 
   threads = calloc(nthreads, sizeof(threads[0]));
-  ASSERT(threads != NULL);
+  ASSERT_NOT_NULL(threads);
 
   for (i = 0; i < nthreads; i++) {
     ctx = threads + i;

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -86,7 +86,7 @@ BENCHMARK_IMPL(million_async) {
   timeout = 5000;
 
   container = malloc(sizeof(*container));
-  ASSERT(container != NULL);
+  ASSERT_NOT_NULL(container);
   container->async_events = 0;
   container->handles_seen = 0;
 

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -49,7 +49,7 @@ BENCHMARK_IMPL(million_timers) {
   int i;
 
   timers = malloc(NUM_TIMERS * sizeof(timers[0]));
-  ASSERT(timers != NULL);
+  ASSERT_NOT_NULL(timers);
 
   loop = uv_default_loop();
   timeout = 0;

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -114,7 +114,7 @@ static void ipc_connection_cb(uv_stream_t* ipc_pipe, int status) {
   buf = uv_buf_init("PING", 4);
   sc = container_of(ipc_pipe, struct ipc_server_ctx, ipc_pipe);
   pc = calloc(1, sizeof(*pc));
-  ASSERT(pc != NULL);
+  ASSERT_NOT_NULL(pc);
 
   if (ipc_pipe->type == UV_TCP)
     ASSERT(0 == uv_tcp_init(loop, (uv_tcp_t*) &pc->peer_handle));
@@ -295,7 +295,7 @@ static void sv_connection_cb(uv_stream_t* server_handle, int status) {
   ASSERT(status == 0);
 
   storage = malloc(sizeof(*storage));
-  ASSERT(storage != NULL);
+  ASSERT_NOT_NULL(storage);
 
   if (server_handle->type == UV_TCP)
     ASSERT(0 == uv_tcp_init(server_handle->loop, (uv_tcp_t*) storage));
@@ -372,8 +372,8 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
 
   servers = calloc(num_servers, sizeof(servers[0]));
   clients = calloc(num_clients, sizeof(clients[0]));
-  ASSERT(servers != NULL);
-  ASSERT(clients != NULL);
+  ASSERT_NOT_NULL(servers);
+  ASSERT_NOT_NULL(clients);
 
   /* We're making the assumption here that from the perspective of the
    * OS scheduler, threads are functionally equivalent to and interchangeable

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -114,11 +114,11 @@ static void connect_cb(uv_connect_t* req, int status) {
     return;
   }
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
 
   conn = (conn_rec*)req->data;
-  ASSERT(conn != NULL);
+  ASSERT_NOT_NULL(conn);
 
 #if DEBUG
   printf("connect_cb %d\n", conn->i);
@@ -137,7 +137,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
-  ASSERT(stream != NULL);
+  ASSERT_NOT_NULL(stream);
 
 #if DEBUG
   printf("read_cb %d\n", p->i);
@@ -161,7 +161,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 static void close_cb(uv_handle_t* handle) {
   conn_rec* p = (conn_rec*)handle->data;
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   closed_streams++;
 
 #if DEBUG

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -71,7 +71,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   write_cb_called++;
 }
@@ -103,7 +103,7 @@ BENCHMARK_IMPL(tcp_write_batch) {
   int r;
 
   write_reqs = malloc(sizeof(*write_reqs) * NUM_WRITE_REQS);
-  ASSERT(write_reqs != NULL);
+  ASSERT_NOT_NULL(write_reqs);
 
   /* Prepare the data to write out. */
   for (i = 0; i < NUM_WRITE_REQS; i++) {

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -72,7 +72,7 @@ static void alloc_cb(uv_handle_t* handle,
 static void send_cb(uv_udp_send_t* req, int status) {
   struct sender_state* s;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   if (status != 0) {
     ASSERT(status == UV_ECANCELED);
@@ -127,7 +127,7 @@ static void recv_cb(uv_udp_t* handle,
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -47,7 +47,7 @@ static void connection_cb(uv_stream_t* stream, int status) {
   ASSERT(stream == (uv_stream_t*)&tcp_server);
 
   conn = malloc(sizeof *conn);
-  ASSERT(conn != NULL);
+  ASSERT_NOT_NULL(conn);
 
   r = uv_tcp_init(stream->loop, &conn->handle);
   ASSERT(r == 0);

--- a/test/dns-server.c
+++ b/test/dns-server.c
@@ -280,7 +280,7 @@ static void on_connection(uv_stream_t* server, int status) {
   ASSERT(status == 0);
 
   handle = (dnshandle*) malloc(sizeof *handle);
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   /* initialize read buffer state */
   handle->state.prevbuf_ptr = 0;

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -113,7 +113,7 @@ static void after_read(uv_stream_t* handle,
   }
 
   wr = (write_req_t*) malloc(sizeof *wr);
-  ASSERT(wr != NULL);
+  ASSERT_NOT_NULL(wr);
   wr->buf = uv_buf_init(buf->base, nread);
 
   if (uv_write(&wr->req, handle, &wr->buf, 1, after_write)) {
@@ -155,14 +155,14 @@ static void on_connection(uv_stream_t* server, int status) {
   switch (serverType) {
   case TCP:
     stream = malloc(sizeof(uv_tcp_t));
-    ASSERT(stream != NULL);
+    ASSERT_NOT_NULL(stream);
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
     ASSERT(r == 0);
     break;
 
   case PIPE:
     stream = malloc(sizeof(uv_pipe_t));
-    ASSERT(stream != NULL);
+    ASSERT_NOT_NULL(stream);
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
     ASSERT(r == 0);
     break;
@@ -197,7 +197,7 @@ static uv_udp_send_t* send_alloc(void) {
 }
 
 static void on_send(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   req->data = send_freelist;
   send_freelist = req;
@@ -219,7 +219,7 @@ static void on_recv(uv_udp_t* handle,
   ASSERT(addr->sa_family == AF_INET);
 
   uv_udp_send_t* req = send_alloc();
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   sndbuf = uv_buf_init(rcvbuf->base, nread);
   ASSERT(0 <= uv_udp_send(req, handle, &sndbuf, 1, addr, on_send));
 }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -198,7 +198,7 @@ static int maybe_run_test(int argc, char **argv) {
 
     /* Test if the test value from the parent is still set */
     test = getenv("ENV_TEST");
-    ASSERT(test != NULL);
+    ASSERT_NOT_NULL(test);
 
     r = fprintf(stdout, "%s", test);
     ASSERT(r > 0);

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -30,7 +30,7 @@ static int close_cb_called = 0;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -70,7 +70,7 @@ static void thread_cb(void *arg) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -48,7 +48,7 @@ static int shutdown_cb_called = 0;
 static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
   buf->len = size;
   buf->base = malloc(size);
-  ASSERT(buf->base != NULL);
+  ASSERT_NOT_NULL(buf->base);
 }
 
 

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -32,7 +32,7 @@ static uv_timer_t timer_handle2;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -37,7 +37,7 @@ TEST_IMPL(default_loop_close) {
   uv_timer_t timer_handle;
 
   loop = uv_default_loop();
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
 
   ASSERT(0 == uv_timer_init(loop, &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
@@ -46,7 +46,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT(0 == uv_loop_close(loop));
 
   loop = uv_default_loop();
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
 
   ASSERT(0 == uv_timer_init(loop, &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -37,7 +37,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   free(handle);
 
@@ -50,8 +50,8 @@ static void do_accept(uv_timer_t* timer_handle) {
   uv_tcp_t* accepted_handle = (uv_tcp_t*)malloc(sizeof *accepted_handle);
   int r;
 
-  ASSERT(timer_handle != NULL);
-  ASSERT(accepted_handle != NULL);
+  ASSERT_NOT_NULL(timer_handle);
+  ASSERT_NOT_NULL(accepted_handle);
 
   r = uv_tcp_init(uv_default_loop(), accepted_handle);
   ASSERT(r == 0);
@@ -82,7 +82,7 @@ static void connection_cb(uv_stream_t* tcp, int status) {
   ASSERT(status == 0);
 
   timer_handle = (uv_timer_t*)malloc(sizeof *timer_handle);
-  ASSERT(timer_handle != NULL);
+  ASSERT_NOT_NULL(timer_handle);
 
   /* Accept the client after 1 second */
   r = uv_timer_init(uv_default_loop(), timer_handle);
@@ -103,7 +103,7 @@ static void start_server(void) {
   int r;
 
   ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
-  ASSERT(server != NULL);
+  ASSERT_NOT_NULL(server);
 
   r = uv_tcp_init(uv_default_loop(), server);
   ASSERT(r == 0);
@@ -125,7 +125,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   if (nread >= 0) {
     ASSERT(nread == 0);
   } else {
-    ASSERT(tcp != NULL);
+    ASSERT_NOT_NULL(tcp);
     ASSERT(nread == UV_EOF);
     uv_close((uv_handle_t*)tcp, close_cb);
   }
@@ -135,7 +135,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
 
   /* Not that the server will send anything, but otherwise we'll never know
@@ -156,8 +156,8 @@ static void client_connect(void) {
   int r;
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(client != NULL);
-  ASSERT(connect_req != NULL);
+  ASSERT_NOT_NULL(client);
+  ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), client);
   ASSERT(r == 0);

--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -34,26 +34,26 @@ TEST_IMPL(dlerror) {
   lib.errmsg = NULL;
   lib.handle = NULL;
   msg = uv_dlerror(&lib);
-  ASSERT(msg != NULL);
-  ASSERT(strstr(msg, dlerror_no_error) != NULL);
+  ASSERT_NOT_NULL(msg);
+  ASSERT_NOT_NULL(strstr(msg, dlerror_no_error));
 
   r = uv_dlopen(path, &lib);
   ASSERT(r == -1);
 
   msg = uv_dlerror(&lib);
-  ASSERT(msg != NULL);
+  ASSERT_NOT_NULL(msg);
 #if !defined(__OpenBSD__) && !defined(__QNX__)
-  ASSERT(strstr(msg, path) != NULL);
+  ASSERT_NOT_NULL(strstr(msg, path));
 #endif
-  ASSERT(strstr(msg, dlerror_no_error) == NULL);
+  ASSERT_NULL(strstr(msg, dlerror_no_error));
 
   /* Should return the same error twice in a row. */
   msg = uv_dlerror(&lib);
-  ASSERT(msg != NULL);
+  ASSERT_NOT_NULL(msg);
 #if !defined(__OpenBSD__) && !defined(__QNX__)
-  ASSERT(strstr(msg, path) != NULL);
+  ASSERT_NOT_NULL(strstr(msg, path));
 #endif
-  ASSERT(strstr(msg, dlerror_no_error) == NULL);
+  ASSERT_NULL(strstr(msg, dlerror_no_error));
 
   uv_dlclose(&lib);
 

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -50,13 +50,13 @@ TEST_IMPL(error_message) {
     return 0;
   }
 
-  ASSERT(strstr(uv_strerror(UV_EINVAL), "Success") == NULL);
+  ASSERT_NULL(strstr(uv_strerror(UV_EINVAL), "Success"));
   ASSERT(strcmp(uv_strerror(1337), "Unknown error") == 0);
   ASSERT(strcmp(uv_strerror(-1337), "Unknown error") == 0);
 
-  ASSERT(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success") == NULL);
-  ASSERT(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337") != NULL);
-  ASSERT(strstr(uv_strerror_r(-1337, buf, sizeof(buf)), "-1337") != NULL);
+  ASSERT_NULL(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success"));
+  ASSERT_NOT_NULL(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337"));
+  ASSERT_NOT_NULL(strstr(uv_strerror_r(-1337, buf, sizeof(buf)), "-1337"));
 
   return 0;
 }

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -118,7 +118,7 @@ static void touch_file(const char* name) {
 }
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
@@ -337,7 +337,7 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
 static void timer_cb_close_handle(uv_timer_t* timer) {
   uv_handle_t* handle;
 
-  ASSERT(timer != NULL);
+  ASSERT_NOT_NULL(timer);
   handle = timer->data;
 
   uv_close((uv_handle_t*)timer, NULL);
@@ -758,7 +758,7 @@ TEST_IMPL(fs_event_watch_file_root_dir) {
   const char* sys_drive = getenv("SystemDrive");
   char path[] = "\\\\?\\X:\\bootsect.bak";
 
-  ASSERT(sys_drive != NULL);
+  ASSERT_NOT_NULL(sys_drive);
   strncpy(path + sizeof("\\\\?\\") - 1, sys_drive, 1);
 
   loop = uv_default_loop();
@@ -1072,7 +1072,7 @@ static void timer_cb_nop(uv_timer_t* handle) {
 }
 
 static void fs_event_error_report_close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 
   /* handle is allocated on-stack, no need to free it */

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -105,8 +105,8 @@ static void poll_cb(uv_fs_poll_t* handle,
 
   ASSERT(handle == &poll_handle);
   ASSERT(1 == uv_is_active((uv_handle_t*) handle));
-  ASSERT(prev != NULL);
-  ASSERT(curr != NULL);
+  ASSERT_NOT_NULL(prev);
+  ASSERT_NOT_NULL(curr);
 
   switch (poll_cb_called++) {
   case 0:

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -118,7 +118,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
   ASSERT(r == 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == 0);
-  ASSERT(opendir_req.ptr != NULL);
+  ASSERT_NOT_NULL(opendir_req.ptr);
   dir = opendir_req.ptr;
   uv_fs_req_cleanup(&opendir_req);
 
@@ -191,7 +191,7 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
   ASSERT(r == UV_ENOENT);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == UV_ENOENT);
-  ASSERT(opendir_req.ptr == NULL);
+  ASSERT_NULL(opendir_req.ptr);
   uv_fs_req_cleanup(&opendir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -247,7 +247,7 @@ TEST_IMPL(fs_readdir_file) {
   ASSERT(r == UV_ENOTDIR);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == UV_ENOTDIR);
-  ASSERT(opendir_req.ptr == NULL);
+  ASSERT_NULL(opendir_req.ptr);
 
   uv_fs_req_cleanup(&opendir_req);
 
@@ -403,7 +403,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   ASSERT(r == 0);
   ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
   ASSERT(opendir_req.result == 0);
-  ASSERT(opendir_req.ptr != NULL);
+  ASSERT_NOT_NULL(opendir_req.ptr);
 
   entries_count = 0;
   dir = opendir_req.ptr;

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -77,7 +77,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
   ASSERT(req->result == 0);
-  ASSERT(req->ptr != NULL);
+  ASSERT_NOT_NULL(req->ptr);
   dir = req->ptr;
   dir->dirents = dirents;
   dir->nentries = ARRAY_SIZE(dirents);
@@ -171,7 +171,7 @@ static void non_existing_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
   ASSERT(req->result == UV_ENOENT);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
 
   uv_fs_req_cleanup(req);
   ++non_existing_opendir_cb_count;
@@ -223,7 +223,7 @@ static void file_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
   ASSERT(req->result == UV_ENOTDIR);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
 
   uv_fs_req_cleanup(req);
   ++file_opendir_cb_count;
@@ -329,7 +329,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
   ASSERT(req == &opendir_req);
   ASSERT(req->fs_type == UV_FS_OPENDIR);
   ASSERT(req->result == 0);
-  ASSERT(req->ptr != NULL);
+  ASSERT_NOT_NULL(req->ptr);
 
   dir = req->ptr;
   dir->dirents = dirents;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -343,7 +343,7 @@ static void statfs_cb(uv_fs_t* req) {
 
   ASSERT(req->fs_type == UV_FS_STATFS);
   ASSERT(req->result == 0);
-  ASSERT(req->ptr != NULL);
+  ASSERT_NOT_NULL(req->ptr);
   stats = req->ptr;
 
 #if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
@@ -366,7 +366,7 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT(stats->f_ffree <= stats->f_files);
 #endif
   uv_fs_req_cleanup(req);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
   statfs_cb_count++;
 }
 
@@ -630,7 +630,7 @@ static void empty_scandir_cb(uv_fs_t* req) {
   ASSERT(req == &scandir_req);
   ASSERT(req->fs_type == UV_FS_SCANDIR);
   ASSERT(req->result == 0);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
   ASSERT(UV_EOF == uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
@@ -642,7 +642,7 @@ static void non_existent_scandir_cb(uv_fs_t* req) {
   ASSERT(req == &scandir_req);
   ASSERT(req->fs_type == UV_FS_SCANDIR);
   ASSERT(req->result == UV_ENOENT);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
   ASSERT(UV_ENOENT == uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
@@ -653,7 +653,7 @@ static void file_scandir_cb(uv_fs_t* req) {
   ASSERT(req == &scandir_req);
   ASSERT(req->fs_type == UV_FS_SCANDIR);
   ASSERT(req->result == UV_ENOTDIR);
-  ASSERT(req->ptr == NULL);
+  ASSERT_NULL(req->ptr);
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
 }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2011,12 +2011,12 @@ TEST_IMPL(fs_readlink) {
   ASSERT(0 == uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(dummy_cb_count == 1);
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   ASSERT(UV_ENOENT == uv_fs_readlink(NULL, &req, "no_such_file", NULL));
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
@@ -2032,7 +2032,7 @@ TEST_IMPL(fs_realpath) {
   ASSERT(0 == uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(dummy_cb_count == 1);
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
 #ifdef _WIN32
   /*
    * Windows XP and Server 2003 don't support GetFinalPathNameByHandleW()
@@ -2046,7 +2046,7 @@ TEST_IMPL(fs_realpath) {
   uv_fs_req_cleanup(&req);
 
   ASSERT(UV_ENOENT == uv_fs_realpath(NULL, &req, "no_such_file", NULL));
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
@@ -2843,7 +2843,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
   ASSERT(r == 0);
   ASSERT(req.result == 0);
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   ASSERT(UV_EOF == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
@@ -2880,7 +2880,7 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
   ASSERT(r == UV_ENOENT);
   ASSERT(req.result == UV_ENOENT);
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   ASSERT(UV_ENOENT == uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
@@ -2932,7 +2932,7 @@ TEST_IMPL(fs_open_dir) {
   r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
   ASSERT(r >= 0);
   ASSERT(req.result >= 0);
-  ASSERT(req.ptr == NULL);
+  ASSERT_NULL(req.ptr);
   file = r;
   uv_fs_req_cleanup(&req);
 
@@ -3332,7 +3332,7 @@ static void fs_write_alotof_bufs(int add_flags) {
   loop = uv_default_loop();
 
   iovs = malloc(sizeof(*iovs) * iovcount);
-  ASSERT(iovs != NULL);
+  ASSERT_NOT_NULL(iovs);
   iovmax = uv_test_getiovmax();
 
   r = uv_fs_open(NULL,
@@ -3361,7 +3361,7 @@ static void fs_write_alotof_bufs(int add_flags) {
 
   /* Read the strings back to separate buffers. */
   buffer = malloc(sizeof(test_buf) * iovcount);
-  ASSERT(buffer != NULL);
+  ASSERT_NOT_NULL(buffer);
 
   for (index = 0; index < iovcount; ++index)
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
@@ -3444,7 +3444,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
   loop = uv_default_loop();
 
   iovs = malloc(sizeof(*iovs) * iovcount);
-  ASSERT(iovs != NULL);
+  ASSERT_NOT_NULL(iovs);
   iovmax = uv_test_getiovmax();
 
   r = uv_fs_open(NULL,
@@ -3480,7 +3480,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
 
   /* Read the strings back to separate buffers. */
   buffer = malloc(sizeof(test_buf) * iovcount);
-  ASSERT(buffer != NULL);
+  ASSERT_NOT_NULL(buffer);
 
   for (index = 0; index < iovcount; ++index)
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf),
@@ -3676,16 +3676,16 @@ static void test_fs_partial(int doread) {
   iovcount = 54321;
 
   iovs = malloc(sizeof(*iovs) * iovcount);
-  ASSERT(iovs != NULL);
+  ASSERT_NOT_NULL(iovs);
 
   ctx.pid = pthread_self();
   ctx.doread = doread;
   ctx.interval = 1000;
   ctx.size = sizeof(test_buf) * iovcount;
   ctx.data = malloc(ctx.size);
-  ASSERT(ctx.data != NULL);
+  ASSERT_NOT_NULL(ctx.data);
   buffer = malloc(ctx.size);
-  ASSERT(buffer != NULL);
+  ASSERT_NOT_NULL(buffer);
 
   for (index = 0; index < iovcount; ++index)
     iovs[index] = uv_buf_init(buffer + index * sizeof(test_buf), sizeof(test_buf));
@@ -3773,15 +3773,15 @@ TEST_IMPL(fs_read_write_null_arguments) {
   /* Validate some memory management on failed input validation before sending
      fs work to the thread pool. */
   ASSERT(r == UV_EINVAL);
-  ASSERT(write_req.path == NULL);
-  ASSERT(write_req.ptr == NULL);
+  ASSERT_NULL(write_req.path);
+  ASSERT_NULL(write_req.ptr);
 #ifdef _WIN32
-  ASSERT(write_req.file.pathw == NULL);
-  ASSERT(write_req.fs.info.new_pathw == NULL);
-  ASSERT(write_req.fs.info.bufs == NULL);
+  ASSERT_NULL(write_req.file.pathw);
+  ASSERT_NULL(write_req.fs.info.new_pathw);
+  ASSERT_NULL(write_req.fs.info.bufs);
 #else
-  ASSERT(write_req.new_path == NULL);
-  ASSERT(write_req.bufs == NULL);
+  ASSERT_NULL(write_req.new_path);
+  ASSERT_NULL(write_req.bufs);
 #endif
   uv_fs_req_cleanup(&write_req);
 

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -49,7 +49,7 @@ TEST_IMPL(get_currentexe) {
 #ifdef _WIN32
   snprintf(path, sizeof(path), "%s", executable_path);
 #else
-  ASSERT(NULL != realpath(executable_path, path));
+  ASSERT_NOT_NULL(realpath(executable_path, path));
 #endif
 
   match = strstr(buffer, path);

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -40,7 +40,7 @@ TEST_IMPL(get_passwd) {
   ASSERT(len > 0);
 
 #ifdef _WIN32
-  ASSERT(pwd.shell == NULL);
+  ASSERT_NULL(pwd.shell);
 #else
   len = strlen(pwd.shell);
 # ifndef __PASE__
@@ -74,16 +74,16 @@ TEST_IMPL(get_passwd) {
   /* Test uv_os_free_passwd() */
   uv_os_free_passwd(&pwd);
 
-  ASSERT(pwd.username == NULL);
-  ASSERT(pwd.shell == NULL);
-  ASSERT(pwd.homedir == NULL);
+  ASSERT_NULL(pwd.username);
+  ASSERT_NULL(pwd.shell);
+  ASSERT_NULL(pwd.homedir);
 
   /* Test a double free */
   uv_os_free_passwd(&pwd);
 
-  ASSERT(pwd.username == NULL);
-  ASSERT(pwd.shell == NULL);
-  ASSERT(pwd.homedir == NULL);
+  ASSERT_NULL(pwd.username);
+  ASSERT_NULL(pwd.shell);
+  ASSERT_NULL(pwd.homedir);
 
   /* Test invalid input */
   r = uv_os_get_passwd(NULL);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -42,7 +42,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
 
   ASSERT(fail_cb_called == 0);
   ASSERT(status < 0);
-  ASSERT(res == NULL);
+  ASSERT_NULL(res);
   uv_freeaddrinfo(res);  /* Should not crash. */
   fail_cb_called++;
 }
@@ -191,7 +191,7 @@ TEST_IMPL(getaddrinfo_concurrent) {
     callback_counts[i] = 0;
 
     data = (int*)malloc(sizeof(int));
-    ASSERT(data != NULL);
+    ASSERT_NOT_NULL(data);
     *data = i;
     getaddrinfo_handles[i].data = data;
 

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -38,10 +38,10 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
                             int status,
                             const char* hostname,
                             const char* service) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(status == 0);
-  ASSERT(hostname != NULL);
-  ASSERT(service != NULL);
+  ASSERT_NOT_NULL(hostname);
+  ASSERT_NOT_NULL(service);
 }
 
 

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -116,7 +116,7 @@ static void on_connection(uv_stream_t* server, int status) {
   ASSERT(status == 0);
 
   handle = malloc(sizeof(*handle));
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   r = uv_tcp_init(loop, handle);
   ASSERT(r == 0);

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -34,7 +34,7 @@ TEST_IMPL(handle_type_name) {
   ASSERT(strcmp(uv_handle_type_name(UV_UDP), "udp") == 0);
   ASSERT(strcmp(uv_handle_type_name(UV_FILE), "file") == 0);
   ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX));
-  ASSERT(uv_handle_type_name(UV_HANDLE_TYPE_MAX + 1) == NULL);
+  ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX + 1));
   ASSERT_NULL(uv_handle_type_name(UV_UNKNOWN_HANDLE));
   return 0;
 }
@@ -45,7 +45,7 @@ TEST_IMPL(req_type_name) {
   ASSERT(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send") == 0);
   ASSERT(strcmp(uv_req_type_name(UV_WORK), "work") == 0);
   ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX));
-  ASSERT(uv_req_type_name(UV_REQ_TYPE_MAX + 1) == NULL);
+  ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX + 1));
   ASSERT_NULL(uv_req_type_name(UV_UNKNOWN_REQ));
   return 0;
 }

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -33,9 +33,9 @@ TEST_IMPL(handle_type_name) {
   ASSERT(strcmp(uv_handle_type_name(UV_NAMED_PIPE), "pipe") == 0);
   ASSERT(strcmp(uv_handle_type_name(UV_UDP), "udp") == 0);
   ASSERT(strcmp(uv_handle_type_name(UV_FILE), "file") == 0);
-  ASSERT(uv_handle_type_name(UV_HANDLE_TYPE_MAX) == NULL);
+  ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX));
   ASSERT(uv_handle_type_name(UV_HANDLE_TYPE_MAX + 1) == NULL);
-  ASSERT(uv_handle_type_name(UV_UNKNOWN_HANDLE) == NULL);
+  ASSERT_NULL(uv_handle_type_name(UV_UNKNOWN_HANDLE));
   return 0;
 }
 
@@ -44,9 +44,9 @@ TEST_IMPL(req_type_name) {
   ASSERT(strcmp(uv_req_type_name(UV_REQ), "req") == 0);
   ASSERT(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send") == 0);
   ASSERT(strcmp(uv_req_type_name(UV_WORK), "work") == 0);
-  ASSERT(uv_req_type_name(UV_REQ_TYPE_MAX) == NULL);
+  ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX));
   ASSERT(uv_req_type_name(UV_REQ_TYPE_MAX + 1) == NULL);
-  ASSERT(uv_req_type_name(UV_UNKNOWN_REQ) == NULL);
+  ASSERT_NULL(uv_req_type_name(UV_UNKNOWN_REQ));
   return 0;
 }
 
@@ -58,7 +58,7 @@ TEST_IMPL(getters_setters) {
   int r;
 
   loop = malloc(uv_loop_size());
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
   r = uv_loop_init(loop);
   ASSERT(r == 0);
 

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -66,7 +66,7 @@ static void do_write(uv_stream_t* handle) {
   int r;
 
   write_info = malloc(sizeof *write_info);
-  ASSERT(write_info != NULL);
+  ASSERT_NOT_NULL(write_info);
 
   for (i = 0; i < BUFFERS_PER_WRITE; i++) {
     memset(&write_info->buffers[i], BUFFER_CONTENT, BUFFER_SIZE);

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -143,7 +143,7 @@ static void idle_1_cb(uv_idle_t* handle) {
   fprintf(stderr, "%s", "IDLE_1_CB\n");
   fflush(stderr);
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(idles_1_active > 0);
 
   /* Init idle_2 and make it active */
@@ -170,7 +170,7 @@ static void idle_1_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "IDLE_1_CLOSE_CB\n");
   fflush(stderr);
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   idle_1_close_cb_called++;
 }

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -32,7 +32,7 @@ static uv_tcp_t client;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
@@ -65,7 +65,7 @@ static void start_server(void) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   free(req);
   uv_close((uv_handle_t*)&client, close_cb);
@@ -79,7 +79,7 @@ static void client_connect(void) {
   int r;
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(connect_req != NULL);
+  ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -36,7 +36,7 @@ static int close_cb_called = 0;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -37,7 +37,7 @@ static int connect_cb_called = 0;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -42,7 +42,7 @@ static uv_connect_t conn_req;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -96,7 +96,7 @@ TEST_IMPL(pipe_getsockname) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
   ASSERT(r == 0);

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -68,7 +68,7 @@ TEST_IMPL(pipe_server_close) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
   ASSERT(r == 0);

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -105,10 +105,10 @@ TEST_IMPL(pipe_set_non_blocking) {
 #ifdef _WIN32
     ASSERT(n == UV_EAGAIN); /* E_NOTIMPL */
     ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &pipe_handle, &buf, 1, write_cb));
-    ASSERT(write_req.handle != NULL);
+    ASSERT_NOT_NULL(write_req.handle);
     ASSERT(1 == uv_run(uv_default_loop(), UV_RUN_ONCE)); /* queue write_cb */
     ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE)); /* process write_cb */
-    ASSERT(write_req.handle == NULL); /* check for signaled completion of write_cb */
+    ASSERT_NULL(write_req.handle); /* check for signaled completion of write_cb */
     n = buf.len;
 #endif
     ASSERT(n == sizeof(data));

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -147,7 +147,7 @@ static connection_context_t* create_connection_context(
   connection_context_t* context;
 
   context = (connection_context_t*) malloc(sizeof *context);
-  ASSERT(context != NULL);
+  ASSERT_NOT_NULL(context);
 
   context->sock = sock;
   context->is_server_connection = is_server_connection;
@@ -464,7 +464,7 @@ static server_context_t* create_server_context(
   server_context_t* context;
 
   context = (server_context_t*) malloc(sizeof *context);
-  ASSERT(context != NULL);
+  ASSERT_NOT_NULL(context);
 
   context->sock = sock;
   context->connections = 0;

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -154,7 +154,7 @@ TEST_IMPL(check_ref) {
 
 
 static void prepare_cb(uv_prepare_t* h) {
-  ASSERT(h != NULL);
+  ASSERT_NOT_NULL(h);
   uv_unref((uv_handle_t*)h);
 }
 

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -170,7 +170,7 @@ static void loop_creating_worker(void* context) {
     int r;
 
     loop = malloc(sizeof(*loop));
-    ASSERT(loop != NULL);
+    ASSERT_NOT_NULL(loop);
     ASSERT(0 == uv_loop_init(loop));
 
     r = uv_signal_init(loop, &signal);

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -49,7 +49,7 @@ static void close_cb(uv_handle_t *handle) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == UV_EPIPE);
   free(buf);
   uv_close((uv_handle_t *) &pipe_hdl, close_cb);
@@ -76,7 +76,7 @@ TEST_IMPL(signal_pending_on_close) {
 
   /* Write data large enough so it needs loop iteration */
   buf = malloc(1<<24);
-  ASSERT(buf != NULL);
+  ASSERT_NOT_NULL(buf);
   memset(buf, '.', 1<<24);
   buffer = uv_buf_init(buf, 1<<24);
 

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1176,7 +1176,7 @@ TEST_IMPL(argument_escaping) {
   WCHAR* non_verbatim_output;
 
   test_output = calloc(count, sizeof(WCHAR*));
-  ASSERT(test_output != NULL);
+  ASSERT_NOT_NULL(test_output);
   for (i = 0; i < count; ++i) {
     test_output[i] = calloc(2 * (wcslen(test_str[i]) + 2), sizeof(WCHAR));
     quote_cmd_arg(test_str[i], test_output[i]);
@@ -1185,7 +1185,7 @@ TEST_IMPL(argument_escaping) {
     total_size += wcslen(test_output[i]) + 1;
   }
   command_line = calloc(total_size + 1, sizeof(WCHAR));
-  ASSERT(command_line != NULL);
+  ASSERT_NOT_NULL(command_line);
   for (i = 0; i < count; ++i) {
     wcscat(command_line, test_output[i]);
     wcscat(command_line, L" ");
@@ -1351,7 +1351,7 @@ TEST_IMPL(spawn_with_an_odd_path) {
 
   char newpath[2048];
   char *path = getenv("PATH");
-  ASSERT(path != NULL);
+  ASSERT_NOT_NULL(path);
   snprintf(newpath, 2048, ";.;%s", path);
   SetEnvironmentVariable("PATH", newpath);
 
@@ -1385,7 +1385,7 @@ TEST_IMPL(spawn_setuid_setgid) {
 
   /* become the "nobody" user. */
   pw = getpwnam("nobody");
-  ASSERT(pw != NULL);
+  ASSERT_NOT_NULL(pw);
   options.uid = pw->pw_uid;
   options.gid = pw->pw_gid;
   snprintf(uidstr, sizeof(uidstr), "%d", pw->pw_uid);
@@ -1423,7 +1423,7 @@ TEST_IMPL(spawn_setuid_fails) {
   if (uid == 0) {
     struct passwd* pw;
     pw = getpwnam("nobody");
-    ASSERT(pw != NULL);
+    ASSERT_NOT_NULL(pw);
     ASSERT(0 == setgid(pw->pw_gid));
     ASSERT(0 == setuid(pw->pw_uid));
   }
@@ -1474,7 +1474,7 @@ TEST_IMPL(spawn_setgid_fails) {
   if (uid == 0) {
     struct passwd* pw;
     pw = getpwnam("nobody");
-    ASSERT(pw != NULL);
+    ASSERT_NOT_NULL(pw);
     ASSERT(0 == setgid(pw->pw_gid));
     ASSERT(0 == setuid(pw->pw_uid));
   }

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -53,7 +53,7 @@ static void conn_read_cb(uv_stream_t* stream,
                          ssize_t nread,
                          const uv_buf_t* buf) {
   ASSERT(nread == UV_ENOBUFS);
-  ASSERT(buf->base == NULL);
+  ASSERT_NULL(buf->base);
   ASSERT(buf->len == 0);
 
   uv_close((uv_handle_t*) &incoming, close_cb);

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -30,7 +30,7 @@ static int close_cb_called = 0;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -29,7 +29,7 @@ static int close_cb_called = 0;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -46,7 +46,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
   buf = uv_buf_init("PING", 4);
   for (i = 0; i < NUM_WRITE_REQS; i++) {
     req = malloc(sizeof *req);
-    ASSERT(req != NULL);
+    ASSERT_NOT_NULL(req);
 
     r = uv_write(req, (uv_stream_t*)&tcp_handle, &buf, 1, write_cb);
     ASSERT(r == 0);

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -31,14 +31,14 @@ static int close_cb_called = 0;
 
 
 static void connect_cb(uv_connect_t* handle, int status) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   connect_cb_called++;
 }
 
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -30,13 +30,13 @@ static int close_cb_called = 0;
 
 
 static void connect_cb(uv_connect_t* handle, int status) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   connect_cb_called++;
 }
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -44,7 +44,7 @@ static void on_connection(uv_stream_t* server, int status) {
   ASSERT(status == 0);
 
   handle = malloc(sizeof(*handle));
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   r = uv_tcp_init_ex(server->loop, handle, AF_INET);
   ASSERT(r == 0);

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -96,7 +96,7 @@ static void alloc_cb(uv_handle_t* handle,
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
@@ -111,7 +111,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 
 static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT(tcp != NULL);
+  ASSERT_NOT_NULL(tcp);
 
   if (nread >= 0) {
     ASSERT(nread == 4);
@@ -126,7 +126,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 static void read1_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   int i;
-  ASSERT(tcp != NULL);
+  ASSERT_NOT_NULL(tcp);
 
   if (nread >= 0) {
     for (i = 0; i < nread; ++i)
@@ -140,7 +140,7 @@ static void read1_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   if (status) {
     fprintf(stderr, "uv_write error: %s\n", uv_strerror(status));
@@ -155,7 +155,7 @@ static void write1_cb(uv_write_t* req, int status) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   if (status) {
     ASSERT(shutdown_cb_called);
     return;

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -52,13 +52,13 @@ static void close_socket(uv_tcp_t* sock) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   ASSERT(status != 0);
   fprintf(stderr, "uv_write error: %s\n", uv_strerror(status));

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -110,7 +110,7 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
-  ASSERT(loop != NULL);
+  ASSERT_NOT_NULL(loop);
 
   r = uv_tcp_init(loop, &tcp_server);
   ASSERT(r == 0);

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -57,7 +57,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
@@ -82,7 +82,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 
 static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT(tcp != NULL);
+  ASSERT_NOT_NULL(tcp);
 
   if (nread >= 0) {
     bytes_received_done += nread;
@@ -98,7 +98,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   if (status) {
     fprintf(stderr, "uv_write error: %s\n", uv_strerror(status));
@@ -152,7 +152,7 @@ TEST_IMPL(tcp_writealot) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   send_buffer = calloc(1, TOTAL_BYTES);
-  ASSERT(send_buffer != NULL);
+  ASSERT_NOT_NULL(send_buffer);
 
   r = uv_tcp_init(uv_default_loop(), &client);
   ASSERT(r == 0);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -194,11 +194,11 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 
 
 static void tls_thread(void* arg) {
-  ASSERT(NULL == uv_key_get(&tls_key));
+  ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, arg);
   ASSERT(arg == uv_key_get(&tls_key));
   uv_key_set(&tls_key, NULL);
-  ASSERT(NULL == uv_key_get(&tls_key));
+  ASSERT_NULL(uv_key_get(&tls_key));
 }
 
 
@@ -206,7 +206,7 @@ TEST_IMPL(thread_local_storage) {
   char name[] = "main";
   uv_thread_t threads[2];
   ASSERT(0 == uv_key_create(&tls_key));
-  ASSERT(NULL == uv_key_get(&tls_key));
+  ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, name);
   ASSERT(name == uv_key_get(&tls_key));
   ASSERT(0 == uv_thread_create(threads + 0, tls_thread, threads + 0));

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -98,7 +98,7 @@ static void getaddrinfo_cb(uv_getaddrinfo_t* req,
                            int status,
                            struct addrinfo* res) {
   ASSERT(status == UV_EAI_CANCELED);
-  ASSERT(res == NULL);
+  ASSERT_NULL(res);
   uv_freeaddrinfo(res);  /* Should not crash. */
 }
 
@@ -108,8 +108,8 @@ static void getnameinfo_cb(uv_getnameinfo_t* handle,
                            const char* hostname,
                            const char* service) {
   ASSERT(status == UV_EAI_CANCELED);
-  ASSERT(hostname == NULL);
-  ASSERT(service == NULL);
+  ASSERT_NULL(hostname);
+  ASSERT_NULL(service);
 }
 
 

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -35,7 +35,7 @@ static uint64_t start_time;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   close_cb_called++;
 }

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -37,7 +37,7 @@ static uv_timer_t huge_timer2;
 static void once_close_cb(uv_handle_t* handle) {
   printf("ONCE_CLOSE_CB\n");
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(0 == uv_is_active(handle));
 
   once_close_cb_called++;
@@ -47,7 +47,7 @@ static void once_close_cb(uv_handle_t* handle) {
 static void once_cb(uv_timer_t* handle) {
   printf("ONCE_CB %d\n", once_cb_called);
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(0 == uv_is_active((uv_handle_t*) handle));
 
   once_cb_called++;
@@ -62,7 +62,7 @@ static void once_cb(uv_timer_t* handle) {
 static void repeat_close_cb(uv_handle_t* handle) {
   printf("REPEAT_CLOSE_CB\n");
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
 
   repeat_close_cb_called++;
 }
@@ -71,7 +71,7 @@ static void repeat_close_cb(uv_handle_t* handle) {
 static void repeat_cb(uv_timer_t* handle) {
   printf("REPEAT_CB\n");
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(1 == uv_is_active((uv_handle_t*) handle));
 
   repeat_cb_called++;

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -55,7 +55,7 @@ static void print_err_msg(const char* expect, ssize_t expect_len,
 
 static void tty_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
   buf->base = malloc(size);
-  ASSERT(buf->base != NULL);
+  ASSERT_NOT_NULL(buf->base);
   buf->len = size;
 }
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -212,9 +212,9 @@ static void capture_screen(uv_tty_t* tty_out, struct captured_screen* cs) {
   origin.X = 0;
   origin.Y = cs->si.csbi.srWindow.Top;
   cs->text = malloc(cs->si.length * sizeof(*cs->text));
-  ASSERT(cs->text != NULL);
+  ASSERT_NOT_NULL(cs->text);
   cs->attributes = (WORD*) malloc(cs->si.length * sizeof(*cs->attributes));
-  ASSERT(cs->attributes != NULL);
+  ASSERT_NOT_NULL(cs->attributes);
   ASSERT(ReadConsoleOutputCharacter(
       tty_out->handle, cs->text, cs->si.length, origin, &length));
   ASSERT((unsigned int) cs->si.length == length);

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -83,7 +83,7 @@ static void cl_recv_cb(uv_udp_t* handle,
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -95,7 +95,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -121,14 +121,14 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
   CHECK_HANDLE(handle);
   ASSERT(flags == 0);
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
@@ -136,7 +136,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT(r == 0);
 
   req = malloc(sizeof *req);
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -61,7 +61,7 @@ static void close_cb(uv_handle_t* handle) {
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
   if (++cl_send_cb_called == 1) {
@@ -87,7 +87,7 @@ static void sv_recv_cb(uv_udp_t* handle,
                        unsigned flags) {
   if (nread > 0) {
     ASSERT(nread == 4);
-    ASSERT(addr != NULL);
+    ASSERT_NOT_NULL(addr);
     ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
     if (++sv_recv_cb_called == 4) {
       uv_close((uv_handle_t*) &server, close_cb);

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -77,13 +77,13 @@ static void recv_cb(uv_udp_t* handle,
   /* free and return if this is a mmsg free-only callback invocation */
   if (flags & UV_UDP_MMSG_FREE) {
     ASSERT_EQ(nread, 0);
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     free(rcvbuf->base);
     return;
   }
 
   ASSERT_EQ(nread, 4);
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT_MEM_EQ("PING", rcvbuf->base, nread);
 
   recv_cb_called++;

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -54,7 +54,7 @@ static void alloc_cb(uv_handle_t* handle,
 
   /* Actually malloc to exercise free'ing the buffer later */
   buf->base = malloc(buffer_size);
-  ASSERT(buf->base != NULL);
+  ASSERT_NOT_NULL(buf->base);
   buf->len = buffer_size;
   alloc_cb_called++;
 }

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -43,7 +43,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0 || status == UV_ENETUNREACH || status == UV_EPERM);
   CHECK_HANDLE(req->handle);
 

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -43,7 +43,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -60,7 +60,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -103,11 +103,11 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -72,7 +72,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -115,11 +115,11 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -43,7 +43,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0 || status == UV_ENETUNREACH || status == UV_EPERM);
   CHECK_HANDLE(req->handle);
 

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -91,7 +91,7 @@ static void alloc_cb(uv_handle_t* handle,
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   close_cb_called++;
 }
 
@@ -109,13 +109,13 @@ static void recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
   ASSERT(flags == 0);
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(memcmp("PING", buf->base, nread) == 0);
 
@@ -127,7 +127,7 @@ static void recv_cb(uv_udp_t* handle,
 
 
 static void send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
 
   send_cb_called++;

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -73,11 +73,11 @@ static void cl_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards cl_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PONG", buf->base, nread));
 
@@ -90,7 +90,7 @@ static void cl_recv_cb(uv_udp_t* handle,
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -102,7 +102,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -128,14 +128,14 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
   CHECK_HANDLE(handle);
   ASSERT(flags == 0);
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
@@ -147,7 +147,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT(r == 0);
 
   req = malloc(sizeof *req);
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -44,7 +44,7 @@ static void send_cb(uv_udp_send_t* req, int status);
 static void idle_cb(uv_idle_t* handle) {
   int r;
 
-  ASSERT(send_req.handle == NULL);
+  ASSERT_NULL(send_req.handle);
   CHECK_OBJECT(handle, uv_idle_t, idle_handle);
   ASSERT(0 == uv_idle_stop(handle));
 
@@ -66,7 +66,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 
 static void send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0 || status == UV_ENETUNREACH);
   CHECK_OBJECT(req->handle, uv_udp_t, client);
   CHECK_OBJECT(req, uv_udp_send_t, send_req);

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -56,7 +56,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void cl_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
 
@@ -75,14 +75,14 @@ static void sv_recv_cb(uv_udp_t* handle,
 
   if (nread == 0) {
     /* Returning unused buffer. Don't count towards sv_recv_cb_called */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
   CHECK_HANDLE(handle);
   ASSERT(flags == 0);
 
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
   ASSERT(nread == 4);
   ASSERT(memcmp("PING", rcvbuf->base, nread) == 0 ||
          memcmp("PANG", rcvbuf->base, nread) == 0);

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -58,7 +58,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void send_cb(uv_udp_send_t* req, int status) {
-  ASSERT(req != NULL);
+  ASSERT_NOT_NULL(req);
   ASSERT(status == 0);
   CHECK_HANDLE(req->handle);
   send_cb_called++;
@@ -77,9 +77,9 @@ static void recv_cb(uv_udp_t* handle,
     ASSERT(0 && "unexpected error");
   } else if (nread == 0) {
     /* Returning unused buffer */
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
   } else {
-    ASSERT(addr != NULL);
+    ASSERT_NOT_NULL(addr);
   }
 }
 

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -63,12 +63,12 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT(nread > 0);
 
   if (nread == 0) {
-    ASSERT(addr == NULL);
+    ASSERT_NULL(addr);
     return;
   }
 
   ASSERT(nread == 4);
-  ASSERT(addr != NULL);
+  ASSERT_NOT_NULL(addr);
 
   ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
   uv_close((uv_handle_t*) handle, close_cb);


### PR DESCRIPTION
This partially solves #2974, since the existing PR (#3042) for ASSERT macro replacement has been marked stale and hasn't made any commits related to ASSERT_NULL macros.
Most of the replacements are done with `sed` command as mentioned in the original PR. Considering the number of lines changed, this would be relatively easier to review.