### PR TITLE
win,fsevent: optionally ignore change to last access time

### DIFF
--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -83,7 +83,12 @@ Data types
             * (is ignoring) changes in its subdirectories.
             * This flag will override this behaviour on platforms that support it.
             */
-            UV_FS_EVENT_RECURSIVE = 4
+            UV_FS_EVENT_RECURSIVE = 4,
+            /*
+            * By default, changes to the last access timestamp are reported.
+            * This flag makes fs_event ignore such changes.
+            */
+            UV_FS_EVENT_IGNORE_LAST_ACCESS = 8,
         };
 
 

--- a/docs/src/guide/filesystem.rst
+++ b/docs/src/guide/filesystem.rst
@@ -297,12 +297,14 @@ argument, ``flags``, can be:
     enum uv_fs_event_flags {
         UV_FS_EVENT_WATCH_ENTRY = 1,
         UV_FS_EVENT_STAT = 2,
-        UV_FS_EVENT_RECURSIVE = 4
+        UV_FS_EVENT_RECURSIVE = 4,
+        UV_FS_EVENT_IGNORE_LAST_ACCESS = 8,
     };
 
 ``UV_FS_EVENT_WATCH_ENTRY`` and ``UV_FS_EVENT_STAT`` don't do anything (yet).
 ``UV_FS_EVENT_RECURSIVE`` will start watching subdirectories as well on
-supported platforms.
+supported platforms. ``UV_FS_EVENT_IGNORE_LAST_ACCESS`` ignores changes to the
+last access timestamp.
 
 The callback will receive the following arguments:
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1626,7 +1626,13 @@ enum uv_fs_event_flags {
    * (is ignoring) changes in it's subdirectories.
    * This flag will override this behaviour on platforms that support it.
    */
-  UV_FS_EVENT_RECURSIVE = 4
+  UV_FS_EVENT_RECURSIVE = 4,
+
+  /*
+   * By default, changes to the last access timestamp are reported.
+   * This flag makes fs_event ignore such changes.
+   */
+  UV_FS_EVENT_IGNORE_LAST_ACCESS = 8,
 };
 
 

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -49,7 +49,7 @@ static void uv_fs_event_queue_readdirchanges(uv_loop_t* loop,
                                FILE_NOTIFY_CHANGE_ATTRIBUTES   |
                                FILE_NOTIFY_CHANGE_SIZE         |
                                FILE_NOTIFY_CHANGE_LAST_WRITE   |
-                               FILE_NOTIFY_CHANGE_LAST_ACCESS  |
+                               ((handle->flags & UV_FS_EVENT_IGNORE_LAST_ACCESS) ? 0 : FILE_NOTIFY_CHANGE_LAST_ACCESS) |
                                FILE_NOTIFY_CHANGE_CREATION     |
                                FILE_NOTIFY_CHANGE_SECURITY,
                              NULL,
@@ -317,7 +317,7 @@ short_path_done:
                                FILE_NOTIFY_CHANGE_ATTRIBUTES   |
                                FILE_NOTIFY_CHANGE_SIZE         |
                                FILE_NOTIFY_CHANGE_LAST_WRITE   |
-                               FILE_NOTIFY_CHANGE_LAST_ACCESS  |
+                               ((handle->flags & UV_FS_EVENT_IGNORE_LAST_ACCESS) ? 0 : FILE_NOTIFY_CHANGE_LAST_ACCESS) |
                                FILE_NOTIFY_CHANGE_CREATION     |
                                FILE_NOTIFY_CHANGE_SECURITY,
                              NULL,

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -389,6 +389,9 @@ TEST_DECLARE   (fs_event_close_in_callback)
 TEST_DECLARE   (fs_event_start_and_close)
 TEST_DECLARE   (fs_event_error_reporting)
 TEST_DECLARE   (fs_event_getpath)
+#ifdef _WIN32
+TEST_DECLARE   (fs_event_ignore_last_access)
+#endif
 TEST_DECLARE   (fs_scandir_empty_dir)
 TEST_DECLARE   (fs_scandir_non_existent_dir)
 TEST_DECLARE   (fs_scandir_file)
@@ -1041,6 +1044,9 @@ TASK_LIST_START
   TEST_ENTRY  (fs_event_start_and_close)
   TEST_ENTRY_CUSTOM (fs_event_error_reporting, 0, 0, 60000)
   TEST_ENTRY  (fs_event_getpath)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_event_ignore_last_access)
+#endif
   TEST_ENTRY  (fs_scandir_empty_dir)
   TEST_ENTRY  (fs_scandir_non_existent_dir)
   TEST_ENTRY  (fs_scandir_file)


### PR DESCRIPTION
On Windows, fs_event reports changes to file metadata, which includes
the last access time. Some applications are interested only in write
operations. Getting notified of read-only access events may create
significant overhead, especially if the application has to double-check
if the event constitutes a write access. The event metadata itself does
not contain this information.

As an optimization for such applications, add an option to ignore
changes to the last access time.