### PR TITLE
doc: fix versionadded metadata

### DIFF
--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -135,4 +135,4 @@ API
 
     Equivalent to :man:`pipe(2)` with the `O_CLOEXEC` flag set.
 
-    .. versionadded:: 1.x.0
+    .. versionadded:: 1.41.0

--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -143,4 +143,4 @@ API
 
     Equivalent to :man:`socketpair(2)` with a domain of AF_UNIX.
 
-    .. versionadded:: 1.x.0
+    .. versionadded:: 1.41.0


### PR DESCRIPTION
This commit adds the `versionadded` metadata for `uv_pipe()` and `uv_socketpair()`.

Refs: https://github.com/libuv/libuv/pull/2953