### PR TITLE
fix memleaks in uv__get_cpu_speed for darwin

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -305,6 +305,11 @@ static int uv__get_cpu_speed(uint64_t* speed) {
 
   err = 0;
 out:
+  if (device_type_str != NULL)
+    pCFRelease(device_type_str);
+  if (clock_frequency_str != NULL)
+    pCFRelease(clock_frequency_str);
+
   if (core_foundation_handle != NULL)
     dlclose(core_foundation_handle);
 


### PR DESCRIPTION
ERROR: LeakSanitizer: detected memory leaks

```
Direct leak of 432 byte(s) in 9 object(s) allocated from:
    #0 0x1062eedc2 in __sanitizer_mz_calloc+0x92 (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x46dc2)
    #1 0x7fff20171eb6 in _malloc_zone_calloc+0x3a (libsystem_malloc.dylib:x86_64+0x1beb6)
    #2 0x7fff203ac180 in _CFRuntimeCreateInstance+0x124 (CoreFoundation:x86_64h+0x4180)
    #3 0x7fff203ab906 in __CFStringCreateImmutableFunnel3+0x84d (CoreFoundation:x86_64h+0x3906)
    #4 0x7fff203ab0a1 in CFStringCreateWithCString+0x48 (CoreFoundation:x86_64h+0x30a1)
    #5 0x1056f63e1 in uv__get_cpu_speed darwin.c:267
    #6 0x1056f491e in uv_cpu_info darwin.c:338
```

I just CFRelease that.