### PR TITLE
Disable SYS_close syscall when Thread Sanitizer is active

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -88,6 +88,10 @@ extern char** environ;
 # define uv__accept4 accept4
 #endif
 
+#if defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
+# include <sanitizer/linux_syscall_hooks.h>
+#endif
+
 static int uv__run_pending(uv_loop_t* loop);
 
 /* Verify that uv_buf_t is ABI-compatible with struct iovec. */
@@ -539,7 +543,13 @@ int uv__close_nocancel(int fd) {
   return close$NOCANCEL$UNIX2003(fd);
 #endif
 #pragma GCC diagnostic pop
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
+  long rc;
+  __sanitizer_syscall_pre_close(fd);
+  rc = syscall(SYS_close, fd);
+  __sanitizer_syscall_post_close(rc, fd);
+  return rc;
+#elif defined(__linux__) && !defined(__SANITIZE_THREAD__)
   return syscall(SYS_close, fd);
 #else
   return close(fd);
@@ -1570,7 +1580,7 @@ int uv__search_path(const char* prog, char* buf, size_t* buflen) {
     buf[*buflen] = '\0';
 
     return 0;
-  } 
+  }
 
   /* Case iii). Search PATH environment variable */
   cloned_path = NULL;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -62,6 +62,17 @@
 # include <AvailabilityMacros.h>
 #endif
 
+/*
+ * Define common detection for active Thread Sanitizer
+ * - clang uses __has_feature(thread_sanitizer)
+ * - gcc-7+ uses __SANITIZE_THREAD__
+ */
+#if defined(__has_feature)
+# if __has_feature(thread_sanitizer)
+#  define __SANITIZE_THREAD__ 1
+# endif
+#endif
+
 #if defined(PATH_MAX)
 # define UV__PATH_MAX PATH_MAX
 #else


### PR DESCRIPTION
Thread Sanitizer doesn't intercept syscall(SYS_close, fd) that's used
instead of close(fd); on Linux.  That leads to false positives as Thread
Sanitizer thinks the descriptor is still being used by the thread.

Disabling the usage of SYS_close won't help in common case where the
libuv is not instrumented, but at least it gives the developers an
option to prepare a Thread Sanitizer compatible build by compiling an
instrumented version.

Some extra notes:
* Is there a place where to document this?
* Is the performance benefit (for streams) that high that it justifies the use of `SYS_close`? I understand the need of `syscalls()` for interfaces that might not be in libc, but is that really necessary for `close()`?