### PR TITLE
Some systems provide dlopen() in libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AX_PTHREAD([
     LIBS="$LIBS $PTHREAD_LIBS"
     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 ])
-AC_CHECK_LIB([dl], [dlopen])
+AC_SEARCH_LIBS([dlopen], [dl])
 AC_SEARCH_LIBS([kstat_lookup], [kstat])
 AC_SEARCH_LIBS([gethostbyname], [nsl])
 AC_SEARCH_LIBS([perfstat_cpu], [perfstat])


### PR DESCRIPTION
libuv is packaged for OmniOS, an illumos distribution (OpenSolaris fork), and on that platform `libdl.so` is just a legacy stub library that does not need to be linked; `dlopen()` and friends are present in libc.

Changing to using `AC_SEARCH_LIBS()` instead of `AC_CHECK_LIB()` stops the unnecessary linking of libdl.