### PR TITLE
linux: work around copy_file_range() cephfs bug

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -907,10 +907,16 @@ out:
 
 #ifdef __linux__
 static unsigned uv__kernel_version(void) {
+  static unsigned cached_version;
   struct utsname u;
+  unsigned version;
   unsigned major;
   unsigned minor;
   unsigned patch;
+
+  version = uv__load_relaxed(&cached_version);
+  if (version != 0)
+    return version;
 
   if (-1 == uname(&u))
     return 0;
@@ -918,7 +924,10 @@ static unsigned uv__kernel_version(void) {
   if (3 != sscanf(u.release, "%u.%u.%u", &major, &minor, &patch))
     return 0;
 
-  return major * 65536 + minor * 256 + patch;
+  version = major * 65536 + minor * 256 + patch;
+  uv__store_relaxed(&cached_version, version);
+
+  return version;
 }
 
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -56,6 +56,10 @@
 # define HAVE_PREADV 0
 #endif
 
+#if defined(__linux__)
+# include "sys/utsname.h"
+#endif
+
 #if defined(__linux__) || defined(__sun)
 # include <sys/sendfile.h>
 # include <sys/sysmacros.h>
@@ -901,6 +905,41 @@ out:
 }
 
 
+#ifdef __linux__
+static unsigned uv__kernel_version(void) {
+  struct utsname u;
+  unsigned major;
+  unsigned minor;
+  unsigned patch;
+
+  if (-1 == uname(&u))
+    return 0;
+
+  if (3 != sscanf(u.release, "%u.%u.%u", &major, &minor, &patch))
+    return 0;
+
+  return major * 65536 + minor * 256 + patch;
+}
+
+
+/* Pre-4.20 kernels have a bug where CephFS uses the RADOS copy-from command
+ * in copy_file_range() when it shouldn't. There is no workaround except to
+ * fall back to a regular copy.
+ */
+static int uv__is_buggy_cephfs(int fd) {
+  struct statfs s;
+
+  if (-1 == fstatfs(fd, &s))
+    return 0;
+
+  if (s.f_type != /* CephFS */ 0xC36400)
+    return 0;
+
+  return uv__kernel_version() < /* 4.20.0 */ 0x041400;
+}
+#endif  /* __linux__ */
+
+
 static ssize_t uv__fs_sendfile(uv_fs_t* req) {
   int in_fd;
   int out_fd;
@@ -924,6 +963,9 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
 
         if (r == -1 && errno == ENOSYS) {
           /* ENOSYS - it will never work */
+          errno = 0;
+          copy_file_range_support = 0;
+        } else if (r == -1 && errno == EACCES && uv__is_buggy_cephfs(in_fd)) {
           errno = 0;
           copy_file_range_support = 0;
         } else if (r == -1 && (errno == ENOTSUP || errno == EXDEV)) {


### PR DESCRIPTION
Pre-4.20 kernels have a bug where CephFS uses the RADOS copy-from
command when it shouldn't. Fall back to a regular file copy.

Fixes: https://github.com/libuv/libuv/issues/3117
Refs: https://github.com/torvalds/linux/commit/6f9718fe41c3a47e4362bddf145e2db6ad7d8e87

cc @kakaroto - can you confirm that it fixes the issue you're seeing?