### PR TITLE
Add option to not export symbols on GNUC platforms

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -31,6 +31,11 @@ extern "C" {
 #error "Define either BUILDING_UV_SHARED or USING_UV_SHARED, not both."
 #endif
 
+#if defined(BUILDING_UV_SHARED)
+/* Always expose symbols when building as a shared library */
+#undef UV_HIDE_SYMBOLS
+#endif
+
 #ifdef _WIN32
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
@@ -43,7 +48,7 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
-#elif __GNUC__ >= 4
+#elif __GNUC__ >= 4 && !defined(UV_HIDE_SYMBOLS)
 # define UV_EXTERN __attribute__((visibility("default")))
 #else
 # define UV_EXTERN /* nothing */


### PR DESCRIPTION
Publishing symbols in static builds means that when another object,
say libexample.so, links in libuv_a.a then libexample.so will expose
all the libuv symbols. This is generally undesirable, as the main
usage of static libraries I see today is to hide dependencies.
At least, when linked into another library; symbol visibility is mostly
irrelevant when linking into an executable.

I am not convinced this is the correct approach, but the need to
disable symbol exporting is important to me. Maybe the CMake
file can have a setting for whether to export symbols, defaulting
to true for backwards compatibility?

Edit: reworked approach is to add a define `UV_HIDE_SYMBOLS`.
If set, then on GNUC platforms it will not export symbols. If
`BUILD_UV_SHARED` is set then `UV_HIDE_SYMBOLS` will be
`#undef`'d because that's pathological.