### PR TITLE
darwin: use default stack size for fsevents pthread to fix SIGBUS errors

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -595,8 +595,7 @@ out:
 static int uv__fsevents_loop_init(uv_loop_t* loop) {
   CFRunLoopSourceContext ctx;
   uv__cf_loop_state_t* state;
-  pthread_attr_t attr_storage;
-  pthread_attr_t* attr;
+  pthread_attr_t attr;
   int err;
 
   if (loop->cf_state != NULL)
@@ -641,25 +640,19 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
     goto fail_signal_source_create;
   }
 
-  /* In the unlikely event that pthread_attr_init() fails, create the thread
-   * with the default stack size. We'll likely use less address space but that
-   * in itself is not a fatal error.
-   */
-  attr = &attr_storage;
-  if (pthread_attr_init(attr))
-    attr = NULL;
+  if (pthread_attr_init(&attr))
+    abort();
 
-  if (attr != NULL)
-    if (pthread_attr_setstacksize(attr, uv__thread_stack_size()))
-      abort();
+  if (pthread_attr_setstacksize(&attr, uv__thread_stack_size()))
+    abort();
 
   loop->cf_state = state;
 
   /* uv_thread_t is an alias for pthread_t. */
-  err = UV__ERR(pthread_create(&loop->cf_thread, attr, uv__cf_loop_runner, loop));
+  err = UV__ERR(pthread_create(&loop->cf_thread, &attr, uv__cf_loop_runner, loop));
 
-  if (attr != NULL)
-    pthread_attr_destroy(attr);
+  if (pthread_attr_destroy(&attr))
+    abort();
 
   if (err)
     goto fail_thread_create;

--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -642,15 +642,15 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   }
 
   /* In the unlikely event that pthread_attr_init() fails, create the thread
-   * with the default stack size. We'll use a little more address space but
-   * that in itself is not a fatal error.
+   * with the default stack size. We'll likely use less address space but that
+   * in itself is not a fatal error.
    */
   attr = &attr_storage;
   if (pthread_attr_init(attr))
     attr = NULL;
 
   if (attr != NULL)
-    if (pthread_attr_setstacksize(attr, 4 * PTHREAD_STACK_MIN))
+    if (pthread_attr_setstacksize(attr, uv__thread_stack_size()))
       abort();
 
   loop->cf_state = state;

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -261,6 +261,7 @@ void uv__prepare_close(uv_prepare_t* handle);
 void uv__process_close(uv_process_t* handle);
 void uv__stream_close(uv_stream_t* handle);
 void uv__tcp_close(uv_tcp_t* handle);
+size_t uv__thread_stack_size(void);
 void uv__udp_close(uv_udp_t* handle);
 void uv__udp_finish_close(uv_udp_t* handle);
 uv_handle_type uv__handle_type(int fd);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -168,7 +168,7 @@ void uv_barrier_destroy(uv_barrier_t* barrier) {
  * On Linux, threads created by musl have a much smaller stack than threads
  * created by glibc (80 vs. 2048 or 4096 kB.)  Follow glibc for consistency.
  */
-static size_t thread_stack_size(void) {
+size_t uv__thread_stack_size(void) {
 #if defined(__APPLE__) || defined(__linux__)
   struct rlimit lim;
 
@@ -234,7 +234,7 @@ int uv_thread_create_ex(uv_thread_t* tid,
 
   attr = NULL;
   if (stack_size == 0) {
-    stack_size = thread_stack_size();
+    stack_size = uv__thread_stack_size();
   } else {
     pagesize = (size_t)getpagesize();
     /* Round up to the nearest page boundary. */


### PR DESCRIPTION
This fixes `SIGBUS` crashes on macOS 10.15 due to FSEvents code attempting to allocate large arrays on the stack.

The existing size (`4 * PTHREAD_STACK_MIN` or 32KB) causes a stack overflow when more than ~1000 events are received at once. Removing the manual `pthread_attr_setstacksize` call here defaults to a stack size of 512KB.

Fixes: https://github.com/nodejs/node/issues/37697
Refs: https://github.com/joyent/libuv/pull/964