### PR TITLE
zos: correctly get free memory and total memory

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -181,7 +181,7 @@ uint64_t uv_get_free_memory(void) {
   data_area_ptr rcep = {0};
   cvt.assign = *(data_area_ptr_assign_type*)(CVT_PTR);
   rcep.assign = *(data_area_ptr_assign_type*)(cvt.deref + CVTRCEP_OFFSET);
-  freeram = *((uint64_t*)(rcep.deref + RCEAFC_OFFSET)) * 4;
+  freeram = (uint64_t)*((uint32_t*)(rcep.deref + RCEAFC_OFFSET)) * 4096;
   return freeram;
 }
 

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -62,12 +62,6 @@
 /* Address of the rsm control and enumeration area. */
 #define CVTRCEP_OFFSET    0x490
 
-/*
-    Number of frames currently available to system.
-    Excluded are frames backing perm storage, frames offline, and bad frames.
-*/
-#define RCEPOOL_OFFSET    0x004
-
 /* Total number of frames currently on all available frame queues. */
 #define RCEAFC_OFFSET     0x088
 
@@ -187,14 +181,8 @@ uint64_t uv_get_free_memory(void) {
 
 
 uint64_t uv_get_total_memory(void) {
-  uint64_t totalram;
-
-  data_area_ptr cvt = {0};
-  data_area_ptr rcep = {0};
-  cvt.assign = *(data_area_ptr_assign_type*)(CVT_PTR);
-  rcep.assign = *(data_area_ptr_assign_type*)(cvt.deref + CVTRCEP_OFFSET);
-  totalram = *((uint64_t*)(rcep.deref + RCEPOOL_OFFSET)) * 4;
-  return totalram;
+  /* Use CVTRLSTG to get the size of actual real storage online at IPL in K. */
+  return (uint64_t)((int)((char *__ptr32 *__ptr32 *)0)[4][214]) * 1024;
 }
 
 


### PR DESCRIPTION
The `uv_get_free_memory()` and `uv_get_total_memory()` implementation on z/OS are currently returning incorrect results. e.g. on a system with 98304M of total memory:

```
free_mem=277491291464401044, total_mem=424748866592587768, constrained_mem=0
```

This is because the rcepool field being dereferenced for the memory values needs to be treated as unsigned ints. This PR fixes `uv_get_free_memory()` to return the correct memory value, and use CVTRLSTG to implement `uv_get_total_memory()` which is more accurate than rcepool.

CVTRLSTG under CVT Mapping is size of actual real storage online at IPL in K. Its offset is decimal 856 bytes. To access it, address 0 is PSA. Under PSA Mapping, there is FLCCVT at decimal offset 16, which is address of CVT after IPL. So at 856 bytes offset, with the 32-bit pointer casts, CVTRLSTG is `0[16/4][856/4]` or `0[4][214]`. For more information on CVTRLSTG, see MVS Data Areas [Volume 1](https://www-01.ibm.com/servers/resourcelink/svc00100.nsf/pages/zOSV2R3ga320935/$file/iead100_v2r3.pdf) and [Volume 3](https://www-01.ibm.com/servers/resourcelink/svc00100.nsf/pages/zosv2r3ga320938/$file/iead300_v2r3.pdf).

