### PR TITLE
win,fs: fix C4090 warning with MSVC

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1238,7 +1238,7 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func func) {
   uint64_t v;
   char* path;
   
-  path = req->path;
+  path = (char*)req->path;
   len = wcslen(req->file.pathw);
   ep = req->file.pathw + len;
   if (len < num_x || wcsncmp(ep - num_x, L"XXXXXX", num_x)) {


### PR DESCRIPTION
When compiling the current code MSVC prints this warning:

    warning C4090: '=': different 'const' qualifiers

This warning was introduced with dc6fdcd where the `(char*)` cast for
the call to `wcstombs` was removed.

Readding this cast to silence the warning.