### PR TITLE
unix: strnlen is not available on Solaris 10

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -348,7 +348,7 @@ int uv__sendmmsg(int fd, struct uv__mmsghdr* mmsg, unsigned int vlen);
 
 #if defined(__sun)
 #if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
-size_t strnlen(const char *s, size_t maxlen);
+size_t strnlen(const char* s, size_t maxlen);
 #endif
 #endif
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -346,5 +346,11 @@ int uv__sendmmsg(int fd, struct uv__mmsghdr* mmsg, unsigned int vlen);
 #define HAVE_MMSG 0
 #endif
 
+#if defined(__sun)
+#if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
+size_t strnlen(const char *s, size_t maxlen);
+#endif
+#endif
+
 
 #endif /* UV_UNIX_INTERNAL_H_ */

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -865,3 +865,14 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
 
   uv__free(addresses);
 }
+
+#if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
+size_t strnlen(const char *s, size_t maxlen) {
+  const char *end;
+  end = memchr(s, '\0', maxlen);
+  if (! end) {
+    return maxlen;
+  }
+  return end - s;
+}
+#endif

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -866,6 +866,7 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
   uv__free(addresses);
 }
 
+
 #if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
 size_t strnlen(const char* s, size_t maxlen) {
   const char* end;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -867,12 +867,11 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
 }
 
 #if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
-size_t strnlen(const char *s, size_t maxlen) {
-  const char *end;
+size_t strnlen(const char* s, size_t maxlen) {
+  const char* end;
   end = memchr(s, '\0', maxlen);
-  if (! end) {
+  if (end == NULL)
     return maxlen;
-  }
   return end - s;
 }
 #endif


### PR DESCRIPTION
strnlen is not available, fall back to using memchr instead of adding compatibility code as this is the only use of strnlen in the tree