### PR TITLE
test: log to stdout to conform TAP spec

### DIFF
--- a/test/runner.c
+++ b/test/runner.c
@@ -98,8 +98,8 @@ int run_tests(int benchmark_output) {
   skip = (actual > 0 && 0 == strcmp(TASKS[0].task_name, "platform_output"));
   qsort(TASKS + skip, actual - skip, sizeof(TASKS[0]), compare_task);
 
-  fprintf(stderr, "1..%d\n", total);
-  fflush(stderr);
+  fprintf(stdout, "1..%d\n", total);
+  fflush(stdout);
 
   /* Run all tests. */
   passed = 0;
@@ -156,8 +156,8 @@ void log_tap_result(int test_count,
     reason[0] = '\0';
   }
 
-  fprintf(stderr, "%s %d - %s%s%s\n", result, test_count, test, directive, reason);
-  fflush(stderr);
+  fprintf(stdout, "%s %d - %s%s%s\n", result, test_count, test, directive, reason);
+  fflush(stdout);
 }
 
 
@@ -307,28 +307,28 @@ out:
   /* Show error and output from processes if the test failed. */
   if ((status != TEST_OK && status != TEST_SKIP) || task->show_output) {
     if (strlen(errmsg) > 0)
-      fprintf(stderr, "# %s\n", errmsg);
-    fprintf(stderr, "# ");
-    fflush(stderr);
+      fprintf(stdout, "# %s\n", errmsg);
+    fprintf(stdout, "# ");
+    fflush(stdout);
 
     for (i = 0; i < process_count; i++) {
       switch (process_output_size(&processes[i])) {
        case -1:
-        fprintf(stderr, "Output from process `%s`: (unavailable)\n",
+        fprintf(stdout, "Output from process `%s`: (unavailable)\n",
                 process_get_name(&processes[i]));
-        fflush(stderr);
+        fflush(stdout);
         break;
 
        case 0:
-        fprintf(stderr, "Output from process `%s`: (no output)\n",
+        fprintf(stdout, "Output from process `%s`: (no output)\n",
                 process_get_name(&processes[i]));
-        fflush(stderr);
+        fflush(stdout);
         break;
 
        default:
-        fprintf(stderr, "Output from process `%s`:\n", process_get_name(&processes[i]));
-        fflush(stderr);
-        process_copy_output(&processes[i], stderr);
+        fprintf(stdout, "Output from process `%s`:\n", process_get_name(&processes[i]));
+        fflush(stdout);
+        process_copy_output(&processes[i], stdout);
         break;
       }
     }
@@ -337,18 +337,18 @@ out:
   } else if (benchmark_output) {
     switch (process_output_size(main_proc)) {
      case -1:
-      fprintf(stderr, "%s: (unavailable)\n", test);
-      fflush(stderr);
+      fprintf(stdout, "%s: (unavailable)\n", test);
+      fflush(stdout);
       break;
 
      case 0:
-      fprintf(stderr, "%s: (no output)\n", test);
-      fflush(stderr);
+      fprintf(stdout, "%s: (no output)\n", test);
+      fflush(stdout);
       break;
 
      default:
       for (i = 0; i < process_count; i++) {
-        process_copy_output(&processes[i], stderr);
+        process_copy_output(&processes[i], stdout);
       }
       break;
     }
@@ -378,8 +378,8 @@ int run_test_part(const char* test, const char* part) {
     }
   }
 
-  fprintf(stderr, "No test part with that name: %s:%s\n", test, part);
-  fflush(stderr);
+  fprintf(stdout, "No test part with that name: %s:%s\n", test, part);
+  fflush(stdout);
   return 255;
 }
 


### PR DESCRIPTION
Hi!

I replaced the stderrs in the test runner with stdouts, since the TAP specification [1] explicitely states:
`A harness must only read TAP output from standard output and not from standard error.`

Best regards
bb

[1] https://testanything.org/tap-specification.html