### PR TITLE
Fix for ENOTTY error in uv_pipe_open

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -150,9 +150,13 @@ int uv_pipe_open(uv_pipe_t* handle, uv_file fd) {
   if (mode == -1)
     return UV__ERR(errno); /* according to docs, must be EBADF */
 
+  /* If ioctl(FIONBIO) reports ENOTTY, try fcntl(F_GETFL) + fcntl(F_SETFL).
+   * Workaround for e.g. kqueue fds not supporting ioctls.
+   */
   err = uv__nonblock(fd, 1);
-  if (err)
-    return err;
+  if (err == UV_ENOTTY)
+    if (uv__nonblock == uv__nonblock_ioctl)
+      err = uv__nonblock_fcntl(fd, 1);
 
 #if defined(__APPLE__)
   err = uv__stream_try_select((uv_stream_t*) handle, &fd);


### PR DESCRIPTION
I have an issue similar to bug https://github.com/libuv/libuv/pull/885 with an electron app (signal-desktop):

```
{"name":"log","hostname":"XXX","pid":45794,"level":50,"time":"2021-04-03T14:20:17.802Z","msg":"Top-level unhandled
error: Error: ENOTTY: inappropriate ioctl for device, uv_pipe_open
   at new Socket (net.js:329:26)
   at createWritableStdioStream (internal/bootstrap/switches/is_main_thread.js:67:18)
   at process.getStdout [as stdout] (internal/bootstrap/switches/is_main_thread.js:122:12)
   at IncomingMessage.Readable.pipe (_stream_readable.js:659:32)
   at ClientRequest.<anonymous> ([REDACTED]/Signal-Desktop-1.40.1/node_modules/node-fetch/lib/index.js:1553:19)
   at ClientRequest.emit (events.js:315:20)
   at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:596:27)
   at HTTPParser.parserOnHeadersComplete (_http_common.js:119:17)
   at TLSSocket.socketOnData (_http_client.js:469:22)
   at TLSSocket.emit (events.js:315:20)","v":0}
```

It seems to be caused by an attempt to use an ioctl on a kqueue fds:
```
40603: kevent(1,{ },0,{ 49,EVFILT_READ,0x0,0,0x120,0x0 },1024,{ 0.000000000 }) = 1 (0x1)
40603: read(49,"\^W\^C\^C\^A\^[l\M^]\M-\\M^L.\^A"...,65536) = 288 (0x120)
40603: ioctl(1,TIOCGETA,0x7ffffffe04b0)          ERR#25 'Inappropriate ioctl for device'
40603: fstat(1,{ mode=p--------- ,inode=0,size=0,blksize=0 }) = 0 (0x0)
40603: ioctl(1,TIOCGETA,0x7ffffffe0300)          ERR#25 'Inappropriate ioctl for device'
40603: fstat(1,{ mode=p--------- ,inode=0,size=0,blksize=0 }) = 0 (0x0)
40603: fcntl(1,F_GETFL,)                         = 2 (0x2)
40603: ioctl(1,FIONBIO,0x7ffffffe048c)           ERR#25 'Inappropriate ioctl for device'
```

I'm not sure the fix is right but the error is fixed with the patch in the pull request.

Thanks.
