### PR TITLE
darwin: fix compilation errors with -Wall -Wextra

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -210,6 +210,7 @@ static int uv__get_cpu_speed(uint64_t* speed) {
   void* core_foundation_handle;
   void* iokit_handle;
   int err;
+  CFMutableDictionaryRef classes_to_match;
 
   kern_return_t kr;
   mach_port_t mach_port;
@@ -257,8 +258,7 @@ static int uv__get_cpu_speed(uint64_t* speed) {
 
   kr = pIOMasterPort(MACH_PORT_NULL, &mach_port);
   assert(kr == KERN_SUCCESS);
-  CFMutableDictionaryRef classes_to_match
-      = pIOServiceMatching("IOPlatformDevice");
+  classes_to_match = pIOServiceMatching("IOPlatformDevice");
   kr = pIOServiceGetMatchingServices(mach_port, classes_to_match, &it);
   assert(kr == KERN_SUCCESS);
   service = pIOIteratorNext(it);

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -215,6 +215,8 @@ static int uv__get_cpu_speed(uint64_t* speed) {
   mach_port_t mach_port;
   io_iterator_t it;
   io_object_t service;
+  CFStringRef device_type_str = NULL;
+  CFStringRef clock_frequency_str = NULL;
 
   mach_port = 0;
 
@@ -261,8 +263,8 @@ static int uv__get_cpu_speed(uint64_t* speed) {
   assert(kr == KERN_SUCCESS);
   service = pIOIteratorNext(it);
 
-  CFStringRef device_type_str = S("device_type");
-  CFStringRef clock_frequency_str = S("clock-frequency");
+  device_type_str = S("device_type");
+  clock_frequency_str = S("clock-frequency");
 
   while (service != 0) {
     CFDataRef data;

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -954,8 +954,8 @@ static int uv__udp_set_source_membership6(uv_udp_t* handle,
     mreq.gsr_interface = 0;
   }
 
-  STATIC_ASSERT(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
-  STATIC_ASSERT(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
+  assert(sizeof(mreq.gsr_group) >= sizeof(*multicast_addr));
+  assert(sizeof(mreq.gsr_source) >= sizeof(*source_addr));
   memcpy(&mreq.gsr_group, multicast_addr, sizeof(*multicast_addr));
   memcpy(&mreq.gsr_source, source_addr, sizeof(*source_addr));
 


### PR DESCRIPTION
This commit fixes a bunch of compilation errors
that are caused by the device_type_str and
clock_frequency_str not being initialized.
The problems will arise in case the initialization
performed by the V macro fails and the goto
code is executed.

Closes #3160