### PR TITLE
core: Correct the conditionals for {cloexec,nonblock}_ioctl

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -584,7 +584,7 @@ int uv__close(int fd) {
   return uv__close_nocheckstdio(fd);
 }
 
-
+#if UV__NONBLOCK_IS_IOCTL
 int uv__nonblock_ioctl(int fd, int set) {
   int r;
 
@@ -599,7 +599,6 @@ int uv__nonblock_ioctl(int fd, int set) {
 }
 
 
-#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__HAIKU__)
 int uv__cloexec_ioctl(int fd, int set) {
   int r;
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -176,9 +176,11 @@ struct uv__stream_queued_fds_s {
     defined(__NetBSD__)
 #define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
+#define UV__NONBLOCK_IS_IOCTL 1
 #else
 #define uv__cloexec uv__cloexec_fcntl
 #define uv__nonblock uv__nonblock_fcntl
+#define UV__NONBLOCK_IS_IOCTL 0
 #endif
 
 /* On Linux, uv__nonblock_fcntl() and uv__nonblock_ioctl() do not commute

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -79,9 +79,10 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    * Workaround for e.g. kqueue fds not supporting ioctls.
    */
   err = uv__nonblock(fd, 1);
+#if UV__NONBLOCK_IS_IOCTL
   if (err == UV_ENOTTY)
-    if (uv__nonblock == uv__nonblock_ioctl)
-      err = uv__nonblock_fcntl(fd, 1);
+    err = uv__nonblock_fcntl(fd, 1);
+#endif
 
   if (err)
     return err;


### PR DESCRIPTION
These functions are declared with one set of conditionals in the
header, and defined with another set of conditionals in the c file.
This commit picks the more specific set of conditions and switches
the conditions in the c file to those.

(the aforementioned conditions in the header: https://github.com/libuv/libuv/blob/v1.x/src/unix/internal.h#L169-L182)