### PR TITLE
include: define _GNU_SOURCE

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -21,10 +21,6 @@
 
 /* See https://github.com/libuv/libuv#documentation for documentation. */
 
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE
-#endif
-
 #ifndef UV_H
 #define UV_H
 #ifdef __cplusplus

--- a/include/uv.h
+++ b/include/uv.h
@@ -21,6 +21,10 @@
 
 /* See https://github.com/libuv/libuv#documentation for documentation. */
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #ifndef UV_H
 #define UV_H
 #ifdef __cplusplus

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -17,6 +17,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 
 #include "uv.h"
 #include "internal.h"

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -18,6 +18,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 
 #include "uv.h"
 #include "internal.h"


### PR DESCRIPTION
_GNU_SOURCE needs to be defined before including the other header files.

Fixes: https://github.com/libuv/libuv/issues/3164