### PR TITLE
Add proper divide by zero protection

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -855,9 +855,9 @@ static int read_times(FILE* statfile_fp,
   char buf[1024];
 
   ticks = (unsigned int)sysconf(_SC_CLK_TCK);
-  multiplier = ((uint64_t)1000L / ticks);
   assert(ticks != (unsigned int) -1);
   assert(ticks != 0);
+  multiplier = ((uint64_t)1000L / ticks);
 
   rewind(statfile_fp);
 


### PR DESCRIPTION
Apparently, we should assert the non-existence of dividing by zero before performing the actual division. This eliminates any undefined behavior.