### PR TITLE
win: Allow UNC path with forward slash

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -170,8 +170,8 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   WCHAR *result, *result_pos;
   DWORD attrs;
   if (dir_len > 2 && (
-	(dir[0] == L'\\' && dir[1] == L'\\') ||
-	(dir[0] == L'/' && dir[1] == L'/') 
+	(dir[0] == L'\\' || dir[0] == L'/') &&
+	(dir[1] == L'\\' || dir[1] == L'/') 
 	 ) {
     /* It's a UNC path so ignore cwd */
     cwd_len = 0;

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -169,7 +169,10 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t cwd_len) {
   WCHAR *result, *result_pos;
   DWORD attrs;
-  if (dir_len > 2 && dir[0] == L'\\' && dir[1] == L'\\') {
+  if (dir_len > 2 && (
+	(dir[0] == L'\\' && dir[1] == L'\\') ||
+	(dir[0] == L'/' && dir[1] == L'/') 
+	 ) {
     /* It's a UNC path so ignore cwd */
     cwd_len = 0;
   } else if (dir_len >= 1 && (dir[0] == L'/' || dir[0] == L'\\')) {

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -171,7 +171,7 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   DWORD attrs;
   if (dir_len > 2 &&
       ((dir[0] == L'\\' || dir[0] == L'/') &&
-       (dir[1] == L'\\' || dir[1] == L'/')) {
+       (dir[1] == L'\\' || dir[1] == L'/'))) {
     /* It's a UNC path so ignore cwd */
     cwd_len = 0;
   } else if (dir_len >= 1 && (dir[0] == L'/' || dir[0] == L'\\')) {

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -169,10 +169,9 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t cwd_len) {
   WCHAR *result, *result_pos;
   DWORD attrs;
-  if (dir_len > 2 && (
-	(dir[0] == L'\\' || dir[0] == L'/') &&
-	(dir[1] == L'\\' || dir[1] == L'/') 
-	 ) {
+  if (dir_len > 2 &&
+      ((dir[0] == L'\\' || dir[0] == L'/') &&
+       (dir[1] == L'\\' || dir[1] == L'/')) {
     /* It's a UNC path so ignore cwd */
     cwd_len = 0;
   } else if (dir_len >= 1 && (dir[0] == L'/' || dir[0] == L'\\')) {


### PR DESCRIPTION
PR to fix the issue #3159.
The origin [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/22141) is on CMake side: **CTest cannot run executable from network path**.