### PR TITLE
misc: remove unnecessary `_GNU_SOURCE` macros

### DIFF
--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -21,9 +21,6 @@
 /* Expose glibc-specific EAI_* error codes. Needs to be defined before we
  * include any headers.
  */
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE
-#endif
 
 #include "uv.h"
 #include "internal.h"

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -22,9 +22,6 @@
 #ifndef UV_LINUX_SYSCALL_H_
 #define UV_LINUX_SYSCALL_H_
 
-#undef  _GNU_SOURCE
-#define _GNU_SOURCE
-
 #include <stdint.h>
 #include <signal.h>
 #include <sys/types.h>


### PR DESCRIPTION
Since we are building with the `-D_GNU_SOURCE` option turned on, the macro
definitions are not needed anymore.

Refs: https://github.com/libuv/libuv/pull/3165#issuecomment-835747442