### PR TITLE
unix: check handle type instead of only comparing fd number

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -577,7 +577,7 @@ int uv__close_nocheckstdio(int fd) {
 
 
 int uv__close(int fd) {
-  assert(fd > STDERR_FILENO);  /* Catch stdio close bugs. */
+  assert(fd > STDERR_FILENO || !isatty(fd));  /* Catch stdio close bugs. */
 #if defined(__MVS__)
   SAVE_ERRNO(epoll_file_close(fd));
 #endif

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1640,7 +1640,7 @@ void uv__stream_close(uv_stream_t* handle) {
 
   if (handle->io_watcher.fd != -1) {
     /* Don't close stdio file descriptors.  Nothing good comes from it. */
-    if (handle->io_watcher.fd > STDERR_FILENO)
+    if (handle->io_watcher.fd > STDERR_FILENO || !isatty(handle->io_watcher.fd))
       uv__close(handle->io_watcher.fd);
     handle->io_watcher.fd = -1;
   }


### PR DESCRIPTION
If the user closed STDIO fds, they will be reused, it causes assertion failed or fd leak in uv.