### PR TITLE
win,fs: correct error code in uv_fs_read and uv_fs_write

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -758,7 +758,7 @@ void fs__read_filemap(uv_fs_t* req, struct uv__fd_info_s* fd_info) {
   void* view;
 
   if (rw_flags == UV_FS_O_WRONLY) {
-    SET_REQ_WIN32_ERROR(req, ERROR_ACCESS_DENIED);
+    SET_REQ_WIN32_ERROR(req, ERROR_INVALID_FLAGS);
     return;
   }
   if (fd_info->is_directory) {
@@ -936,7 +936,7 @@ void fs__write_filemap(uv_fs_t* req, HANDLE file,
   FILETIME ft;
 
   if (rw_flags == UV_FS_O_RDONLY) {
-    SET_REQ_WIN32_ERROR(req, ERROR_ACCESS_DENIED);
+    SET_REQ_WIN32_ERROR(req, ERROR_INVALID_FLAGS);
     return;
   }
   if (fd_info->is_directory) {

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -276,21 +276,21 @@ static void fs_open_flags(int add_flags) {
   /* r */
   flags = add_flags | UV_FS_O_RDONLY;
   openFail(absent_file, UV_ENOENT);
-  writeFail(empty_file, UV_EPERM);
+  writeFail(empty_file, UV_EBADF);
   readExpect(empty_file, "", 0);
-  writeFail(dummy_file, UV_EPERM);
+  writeFail(dummy_file, UV_EBADF);
   readExpect(dummy_file, "a", 1);
-  writeFail(empty_dir, UV_EPERM);
+  writeFail(empty_dir, UV_EBADF);
   readFail(empty_dir, UV_EISDIR);
 
   /* rs */
   flags = add_flags | UV_FS_O_RDONLY | UV_FS_O_SYNC;
   openFail(absent_file, UV_ENOENT);
-  writeFail(empty_file, UV_EPERM);
+  writeFail(empty_file, UV_EBADF);
   readExpect(empty_file, "", 0);
-  writeFail(dummy_file, UV_EPERM);
+  writeFail(dummy_file, UV_EBADF);
   readExpect(dummy_file, "a", 1);
-  writeFail(empty_dir, UV_EPERM);
+  writeFail(empty_dir, UV_EBADF);
   readFail(empty_dir, UV_EISDIR);
 
   /* r+ */
@@ -316,18 +316,18 @@ static void fs_open_flags(int add_flags) {
   /* w */
   flags = add_flags | UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY;
   writeExpect(absent_file, "bc", 2);
-  readFail(absent_file, UV_EPERM);
+  readFail(absent_file, UV_EBADF);
   writeExpect(empty_file, "bc", 2);
-  readFail(empty_file, UV_EPERM);
+  readFail(empty_file, UV_EBADF);
   writeExpect(dummy_file, "bc", 2);
-  readFail(dummy_file, UV_EPERM);
+  readFail(dummy_file, UV_EBADF);
   openFail(empty_dir, UV_EISDIR);
 
   /* wx */
   flags = add_flags | UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY |
     UV_FS_O_EXCL;
   writeExpect(absent_file, "bc", 2);
-  readFail(absent_file, UV_EPERM);
+  readFail(absent_file, UV_EBADF);
   openFail(empty_file, UV_EEXIST);
   openFail(dummy_file, UV_EEXIST);
   openFail(empty_dir, UV_EEXIST);
@@ -354,19 +354,19 @@ static void fs_open_flags(int add_flags) {
   /* a */
   flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY;
   writeExpect(absent_file, "bc", 2);
-  readFail(absent_file, UV_EPERM);
+  readFail(absent_file, UV_EBADF);
   writeExpect(empty_file, "bc", 2);
-  readFail(empty_file, UV_EPERM);
+  readFail(empty_file, UV_EBADF);
   writeExpect(dummy_file, "abc", 3);
-  readFail(dummy_file, UV_EPERM);
+  readFail(dummy_file, UV_EBADF);
   writeFail(empty_dir, UV_EISDIR);
-  readFail(empty_dir, UV_EPERM);
+  readFail(empty_dir, UV_EBADF);
 
   /* ax */
   flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
     UV_FS_O_EXCL;
   writeExpect(absent_file, "bc", 2);
-  readFail(absent_file, UV_EPERM);
+  readFail(absent_file, UV_EBADF);
   openFail(empty_file, UV_EEXIST);
   openFail(dummy_file, UV_EEXIST);
   openFail(empty_dir, UV_EEXIST);
@@ -375,13 +375,13 @@ static void fs_open_flags(int add_flags) {
   flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_WRONLY |
     UV_FS_O_SYNC;
   writeExpect(absent_file, "bc", 2);
-  readFail(absent_file, UV_EPERM);
+  readFail(absent_file, UV_EBADF);
   writeExpect(empty_file, "bc", 2);
-  readFail(empty_file, UV_EPERM);
+  readFail(empty_file, UV_EBADF);
   writeExpect(dummy_file, "abc", 3);
-  readFail(dummy_file, UV_EPERM);
+  readFail(dummy_file, UV_EBADF);
   writeFail(empty_dir, UV_EISDIR);
-  readFail(empty_dir, UV_EPERM);
+  readFail(empty_dir, UV_EBADF);
 
   /* a+ */
   flags = add_flags | UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR;


### PR DESCRIPTION
Just like the unix counterpart, `uv_fs_read` and `uv_fs_write` should
throw an `EBADF` instead of manually throwing an `EPERM` when the passed
`fd` has not been opened with the right flags.

Signed-off-by: Darshan Sen <raisinten@gmail.com>
