### PR TITLE
inet: fix inconsistent return value of inet_ntop6

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -141,8 +141,9 @@ static int inet_ntop6(const unsigned char *src, char *dst, size_t size) {
   if (best.base != -1 && (best.base + best.len) == ARRAY_SIZE(words))
     *tp++ = ':';
   *tp++ = '\0';
-  if (UV_E2BIG == uv__strscpy(dst, tmp, size))
+  if ((size_t) (tp - tmp) > size)
     return UV_ENOSPC;
+  uv__strscpy(dst, tmp, size);
   return 0;
 }
 


### PR DESCRIPTION
inet_ntop6 return value is inconsistent with  inet_ntop4 when size is 0.
It seems more reasonable to return UV_ENOSPC in this case.

```C
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <arpa/inet.h>

int main()
{
    struct sockaddr_in6 src = {};
    const char* p = inet_ntop(AF_INET6, &src.sin6_addr, NULL, 0);
    printf("p=%p, error=%s\n", p, strerror(errno));

    return 0;
}
```

output:
```
p=0x0, error=No space left on device
```

