### PR TITLE
stream: introduce uv_try_write2(...)

### DIFF
--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -202,6 +202,14 @@ API
     * < 0: negative error code (``UV_EAGAIN`` is returned if no data can be sent
       immediately).
 
+.. c:function:: int uv_try_write2(uv_stream_t* handle, const uv_buf_t bufs[], unsigned int nbufs, uv_stream_t* send_handle)
+
+    Same as :c:func:`uv_try_write` and extended write function for sending
+    handles over a pipe like c:func:`uv_write2`.
+
+    Try to send a handle is not supported on Windows,
+    where it returns ``UV_EAGAIN``.
+
 .. c:function:: int uv_is_readable(const uv_stream_t* handle)
 
     Returns 1 if the stream is readable, 0 otherwise.

--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -210,6 +210,8 @@ API
     Try to send a handle is not supported on Windows,
     where it returns ``UV_EAGAIN``.
 
+    .. versionadded:: 1.42.0
+    
 .. c:function:: int uv_is_readable(const uv_stream_t* handle)
 
     Returns 1 if the stream is readable, 0 otherwise.

--- a/include/uv.h
+++ b/include/uv.h
@@ -527,6 +527,10 @@ UV_EXTERN int uv_write2(uv_write_t* req,
 UV_EXTERN int uv_try_write(uv_stream_t* handle,
                            const uv_buf_t bufs[],
                            unsigned int nbufs);
+UV_EXTERN int uv_try_write2(uv_stream_t* handle,
+                           const uv_buf_t bufs[],
+                           unsigned int nbufs,
+                           uv_stream_t* send_handle);
 
 /* uv_write_t is a subclass of uv_req_t. */
 struct uv_write_s {

--- a/include/uv.h
+++ b/include/uv.h
@@ -528,9 +528,9 @@ UV_EXTERN int uv_try_write(uv_stream_t* handle,
                            const uv_buf_t bufs[],
                            unsigned int nbufs);
 UV_EXTERN int uv_try_write2(uv_stream_t* handle,
-                           const uv_buf_t bufs[],
-                           unsigned int nbufs,
-                           uv_stream_t* send_handle);
+                            const uv_buf_t bufs[],
+                            unsigned int nbufs,
+                            uv_stream_t* send_handle);
 
 /* uv_write_t is a subclass of uv_req_t. */
 struct uv_write_s {

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1522,6 +1522,14 @@ int uv_write(uv_write_t* req,
 int uv_try_write(uv_stream_t* stream,
                  const uv_buf_t bufs[],
                  unsigned int nbufs) {
+    return uv_try_write2(stream, bufs, nbufs, NULL);
+}
+
+
+int uv_try_write2(uv_stream_t* stream,
+                 const uv_buf_t bufs[],
+                 unsigned int nbufs,
+                 uv_stream_t* send_handle) {
   int err;
 
   /* Connecting or already writing some data */
@@ -1532,7 +1540,7 @@ int uv_try_write(uv_stream_t* stream,
   if (err < 0)
     return err;
 
-  return uv__try_write(stream, bufs, nbufs, NULL);
+  return uv__try_write(stream, bufs, nbufs, send_handle);
 }
 
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1522,14 +1522,14 @@ int uv_write(uv_write_t* req,
 int uv_try_write(uv_stream_t* stream,
                  const uv_buf_t bufs[],
                  unsigned int nbufs) {
-    return uv_try_write2(stream, bufs, nbufs, NULL);
+  return uv_try_write2(stream, bufs, nbufs, NULL);
 }
 
 
 int uv_try_write2(uv_stream_t* stream,
-                 const uv_buf_t bufs[],
-                 unsigned int nbufs,
-                 uv_stream_t* send_handle) {
+                  const uv_buf_t bufs[],
+                  unsigned int nbufs,
+                  uv_stream_t* send_handle) {
   int err;
 
   /* Connecting or already writing some data */

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -189,12 +189,12 @@ int uv_try_write(uv_stream_t* stream,
 
 
 int uv_try_write2(uv_stream_t* stream,
-                 const uv_buf_t bufs[],
-                 unsigned int nbufs,
-                 uv_stream_t* send_handle) {
+                  const uv_buf_t bufs[],
+                  unsigned int nbufs,
+                  uv_stream_t* send_handle) {
   if (send_handle != NULL)
     return UV_EAGAIN;
-  return uv_try_write(stream, bufs, nbufs, NULL);
+  return uv_try_write(stream, bufs, nbufs);
 }
 
 

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -188,6 +188,16 @@ int uv_try_write(uv_stream_t* stream,
 }
 
 
+int uv_try_write2(uv_stream_t* stream,
+                 const uv_buf_t bufs[],
+                 unsigned int nbufs,
+                 uv_stream_t* send_handle) {
+  if (send_handle != NULL)
+    return UV_EAGAIN;
+  return uv_try_write(stream, bufs, nbufs, NULL);
+}
+
+
 int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
   uv_loop_t* loop = handle->loop;
 


### PR DESCRIPTION
it is reasonable for me to keep the `uv_try_write*` methods and `uv_write*` functions aligned. And things seem clearer after we refactored `uv_try_write`.
`uv_try_write2(stream, bufs, nbufs, send_handle)` acts like `uv_try_write()` and extended write function for sending handles over a pipe like `uv_write2`.
it always returns `UV_EAGAIN` instead of `UV_ENOSYS` on Windows so we can easily write cross-platform code without special treatment.
