### PR TITLE
unix: update loop time after fork()

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -158,6 +158,8 @@ int uv_loop_fork(uv_loop_t* loop) {
     }
   }
 
+  uv__update_time(loop);
+
   return 0;
 }
 


### PR DESCRIPTION
The fork system call may take milliseconds, so we could treat it as a blocking syscall.
This may cause some timers in the child process to expire immediately, especially when the main process forks the child processes continuously.
It’s also ok to let the user decide when to call `uv_update_time()`, but it would make me feel more satisfied if `uv_loop_fork()` did this :)