### PR TITLE
enhance STATIC_ASSERT macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 include(CMakePackageConfigHelpers)
 include(CMakeDependentOption)
+include(CheckCSourceCompiles)
 include(CheckCCompilerFlag)
 include(GNUInstallDirs)
 include(CTest)
@@ -94,6 +95,13 @@ list(APPEND uv_cflags ${lint-no-hides-global-msvc})
 list(APPEND uv_cflags ${lint-no-conditional-assignment-msvc})
 list(APPEND uv_cflags ${lint-no-unsafe-msvc})
 list(APPEND uv_cflags ${lint-utf8-msvc} )
+
+check_c_source_compiles("
+  #include <assert.h>
+  int main() { static_assert(1>0, \"true\"); return 0; }" 
+  STATIC_ASSERT_FOUND)
+set(have-static-assert $<$<BOOL:${STATIC_ASSERT_FOUND}>:-DHAVE_STATIC_ASSERT>)
+list(APPEND uv_cflags ${have-static-assert})
 
 set(uv_sources
     src/fs-poll.c

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -48,8 +48,15 @@
 #define container_of(ptr, type, member) \
   ((type *) ((char *) (ptr) - offsetof(type, member)))
 
-#define STATIC_ASSERT(expr)                                                   \
-  void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
+#if !defined(STATIC_ASSERT)
+# if defined(HAVE_STATIC_ASSERT)
+#  include <assert.h>
+#  define STATIC_ASSERT(expr) static_assert((expr), #expr)
+# else
+#  define STATIC_ASSERT(expr)                                                   \
+    void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
+# endif
+#endif
 
 #if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 7)
 #define uv__load_relaxed(p) __atomic_load_n(p, __ATOMIC_RELAXED)


### PR DESCRIPTION
- allow overriding `STATIC_ASSERT` macro by injecting `STATIC_ASSERT` define to the build
- use toolchain's implementation for `static_assert` if available at build time

Rationale:
fixes #3131 on modern toolchains where custom `STATIC_ASSERT` implementation emits compilation warnings.