### PR TITLE
darwin: fix -Wsometimes-uninitialized warning

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -302,12 +302,13 @@ static int uv__get_cpu_speed(uint64_t* speed) {
   pIOObjectRelease(it);
 
   err = 0;
-out:
+
   if (device_type_str != NULL)
     pCFRelease(device_type_str);
   if (clock_frequency_str != NULL)
     pCFRelease(clock_frequency_str);
 
+out:
   if (core_foundation_handle != NULL)
     dlclose(core_foundation_handle);
 


### PR DESCRIPTION
See https://github.com/swow/swow/runs/2671186547?check_suite_focus=true#step:5:439

```
warning: variable 'device_type_str' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
  V(core_foundation_handle, CFDataGetBytes);
warning: variable 'clock_frequency_str' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
  V(core_foundation_handle, CFRelease);
```
