### PR TITLE
win,errors: remap `ERROR_ACCESS_DENIED` to `UV_EACCES`

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -73,6 +73,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
     case ERROR_CANT_ACCESS_FILE:            return UV_EACCES;
+    case ERROR_ACCESS_DENIED:               return UV_EACCES;
     case ERROR_ADDRESS_ALREADY_ASSOCIATED:  return UV_EADDRINUSE;
     case WSAEADDRINUSE:                     return UV_EADDRINUSE;
     case WSAEADDRNOTAVAIL:                  return UV_EADDRNOTAVAIL;
@@ -154,7 +155,6 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENOTSOCK:                       return UV_ENOTSOCK;
     case ERROR_NOT_SUPPORTED:               return UV_ENOTSUP;
     case ERROR_BROKEN_PIPE:                 return UV_EOF;
-    case ERROR_ACCESS_DENIED:               return UV_EPERM;
     case ERROR_PRIVILEGE_NOT_HELD:          return UV_EPERM;
     case ERROR_BAD_PIPE:                    return UV_EPIPE;
     case ERROR_NO_DATA:                     return UV_EPIPE;


### PR DESCRIPTION
If we try to use `uv_fs_rmdir` on a read-only directory on Windows, it
internally calls `_wrmdir`, which sets `_doserrno` to `ERROR_ACCESS_DENIED`
and `errno` to `EACCES`. However, `ERROR_ACCESS_DENIED` is mapped to `UV_EPERM`,
so I believe it should be remapped to `UV_EACCES`.

Signed-off-by: Darshan Sen <raisinten@gmail.com>