### PR TITLE
subsystem: net tcp 

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -617,7 +617,8 @@ UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
 
 enum uv_tcp_flags {
   /* Used with uv_tcp_bind, when an IPv6 address is used. */
-  UV_TCP_IPV6ONLY = 1
+  UV_TCP_IPV6ONLY = 1,
+  UV_TCP_REUSEPORT = 2,
 };
 
 UV_EXTERN int uv_tcp_bind(uv_tcp_t* handle,

--- a/include/uv.h
+++ b/include/uv.h
@@ -618,7 +618,7 @@ UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
 enum uv_tcp_flags {
   /* Used with uv_tcp_bind, when an IPv6 address is used. */
   UV_TCP_IPV6ONLY = 1,
-  UV_TCP_REUSEPORT = 2,
+  UV_TCP_REUSEPORT = 2
 };
 
 UV_EXTERN int uv_tcp_bind(uv_tcp_t* handle,

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -163,8 +163,9 @@ int uv__tcp_bind(uv_tcp_t* tcp,
   on = 1;
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
     return UV__ERR(errno);
-  on = 1;  
+  
 #if defined(SO_REUSEPORT) && defined(__linux__) 
+  on = 1;  
   if ((flags & UV_TCP_REUSEPORT) && setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
     return UV__ERR(errno);
 #endif

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -166,7 +166,9 @@ int uv__tcp_bind(uv_tcp_t* tcp,
   
   on = 1;
 #if defined(SO_REUSEPORT) && defined(__linux__)
-  if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
+  const char* val = getenv("SO_REUSEPORT");
+  int enable = (val != NULL && atoi(val) == 1); 
+  if (enable && setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
     return UV__ERR(errno);
 #endif
 

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -163,6 +163,12 @@ int uv__tcp_bind(uv_tcp_t* tcp,
   on = 1;
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
     return UV__ERR(errno);
+  
+  on = 1;
+#if defined(SO_REUSEPORT) && defined(__linux__)
+  if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
+    return UV__ERR(errno);
+#endif
 
 #ifndef __OpenBSD__
 #ifdef IPV6_V6ONLY

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -163,12 +163,9 @@ int uv__tcp_bind(uv_tcp_t* tcp,
   on = 1;
   if (setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
     return UV__ERR(errno);
-  
-  on = 1;
-#if defined(SO_REUSEPORT) && defined(__linux__)
-  const char* val = getenv("SO_REUSEPORT");
-  int enable = (val != NULL && atoi(val) == 1); 
-  if (enable && setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
+  on = 1;  
+#if defined(SO_REUSEPORT) && defined(__linux__) 
+  if ((flags & UV_TCP_REUSEPORT) && setsockopt(tcp->io_watcher.fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)))
     return UV__ERR(errno);
 #endif
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -464,6 +464,10 @@ TEST_DECLARE   (poll_close)
 TEST_DECLARE   (poll_bad_fdtype)
 #ifdef __linux__
 TEST_DECLARE   (poll_nested_epoll)
+  #if defined(SO_REUSEPORT)
+    TEST_DECLARE  (tcp_bind_reuseport_ok)
+    TEST_DECLARE  (tcp_bind6_reuseport_ok)
+  #endif
 #endif
 #ifdef UV_HAVE_KQUEUE
 TEST_DECLARE   (poll_nested_kqueue)
@@ -918,6 +922,10 @@ TASK_LIST_START
 
 #ifdef __linux__
   TEST_ENTRY  (poll_nested_epoll)
+  #if defined(SO_REUSEPORT)
+    TEST_ENTRY  (tcp_bind_reuseport_ok)
+    TEST_ENTRY  (tcp_bind6_reuseport_ok)
+  #endif
 #endif
 #ifdef UV_HAVE_KQUEUE
   TEST_ENTRY  (poll_nested_kqueue)

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -48,6 +48,10 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   r = uv_tcp_init(uv_default_loop(), &server2);
   ASSERT(r == 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
+  /*
+    when bind is get EADDRINUSE error, it will set delayed_error = EADDRINUSE, 
+    and return by listen call, so here is 0
+  */
   ASSERT(r == 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -53,7 +53,12 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  #if defined(SO_REUSEPORT) && defined(__linux__)
+    ASSERT(r == 0);
+  #else 
+    ASSERT(r == UV_EADDRINUSE);
+  #endif
+
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -58,7 +58,9 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   #if defined(SO_REUSEPORT) && defined(__linux__)
-    ASSERT(r == 0);
+    const char* val = getenv("SO_REUSEPORT");
+    int enable = (val != NULL && atoi(val) == 1); 
+    ASSERT(enable ? r == 0 : r == UV_EADDRINUSE);
   #else 
     ASSERT(r == UV_EADDRINUSE);
   #endif

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -48,22 +48,12 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   r = uv_tcp_init(uv_default_loop(), &server2);
   ASSERT(r == 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  /*
-    when bind is get EADDRINUSE error, it will set delayed_error = EADDRINUSE, 
-    and return by listen call, so here is 0
-  */
   ASSERT(r == 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  #if defined(SO_REUSEPORT) && defined(__linux__)
-    const char* val = getenv("SO_REUSEPORT");
-    int enable = (val != NULL && atoi(val) == 1); 
-    ASSERT(enable ? r == 0 : r == UV_EADDRINUSE);
-  #else 
-    ASSERT(r == UV_EADDRINUSE);
-  #endif
+  ASSERT(r == UV_EADDRINUSE);
 
 
   uv_close((uv_handle_t*)&server1, close_cb);
@@ -77,6 +67,42 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   return 0;
 }
 
+TEST_IMPL(tcp_bind_reuseport_ok) {
+  struct sockaddr_in addr;
+  uv_tcp_t server1, server2;
+  int r;
+
+  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  r = uv_tcp_init(uv_default_loop(), &server1);
+  ASSERT(r == 0);
+  r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, UV_TCP_REUSEPORT);
+  ASSERT(r == 0);
+
+  r = uv_tcp_init(uv_default_loop(), &server2);
+  ASSERT(r == 0);
+  r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, UV_TCP_REUSEPORT);
+  /*
+    when bind is get EADDRINUSE error, it will set delayed_error = EADDRINUSE, 
+    and return by listen call, so here is 0
+  */
+  ASSERT(r == 0);
+
+  r = uv_listen((uv_stream_t*)&server1, 128, NULL);
+  ASSERT(r == 0);
+  r = uv_listen((uv_stream_t*)&server2, 128, NULL);
+  ASSERT(r == 0);
+
+
+  uv_close((uv_handle_t*)&server1, close_cb);
+  uv_close((uv_handle_t*)&server2, close_cb);
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(close_cb_called == 2);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
 
 TEST_IMPL(tcp_bind_error_addrnotavail_1) {
   struct sockaddr_in addr;

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -55,7 +55,6 @@ TEST_IMPL(tcp_bind_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT(r == UV_EADDRINUSE);
 
-
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
 
@@ -81,10 +80,6 @@ TEST_IMPL(tcp_bind_reuseport_ok) {
   r = uv_tcp_init(uv_default_loop(), &server2);
   ASSERT(r == 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, UV_TCP_REUSEPORT);
-  /*
-    when bind is get EADDRINUSE error, it will set delayed_error = EADDRINUSE, 
-    and return by listen call, so here is 0
-  */
   ASSERT(r == 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -59,7 +59,6 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT(r == UV_EADDRINUSE);
 
-
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
 
@@ -95,7 +94,6 @@ TEST_IMPL(tcp_bind6_reuseport_ok) {
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT(r == 0);
-
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -57,7 +57,12 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  #if defined(SO_REUSEPORT) && defined(__linux__)
+    ASSERT(r == 0);
+  #else 
+    ASSERT(r == UV_EADDRINUSE);
+  #endif
+
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -58,7 +58,9 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   ASSERT(r == 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   #if defined(SO_REUSEPORT) && defined(__linux__)
-    ASSERT(r == 0);
+    const char* val = getenv("SO_REUSEPORT");
+    int enable = (val != NULL && atoi(val) == 1); 
+    ASSERT(enable ? r == 0 : r == UV_EADDRINUSE);
   #else 
     ASSERT(r == UV_EADDRINUSE);
   #endif


### PR DESCRIPTION
support reuserport flag for tcp socket, improve performance and load balancing 

reuserport flag in linux will make process accept and handle the connection better