### PR TITLE
Reap all processes if getpid() == 1

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -48,12 +48,42 @@ extern char **environ;
 # include "zos-base.h"
 #endif
 
-
-static void uv__chld(uv_signal_t* handle, int signum) {
+static void uv__finalize_processes(QUEUE* pending)
   uv_process_t* process;
-  uv_loop_t* loop;
+  QUEUE* q;
+  QUEUE* h;
   int exit_status;
   int term_signal;
+
+  h = pending;
+  q = QUEUE_HEAD(h);
+  while (q != h) {
+    process = QUEUE_DATA(q, uv_process_t, queue);
+    q = QUEUE_NEXT(q);
+
+    QUEUE_REMOVE(&process->queue);
+    QUEUE_INIT(&process->queue);
+    uv__handle_stop(process);
+
+    if (process->exit_cb == NULL)
+      continue;
+
+    exit_status = 0;
+    if (WIFEXITED(process->status))
+      exit_status = WEXITSTATUS(process->status);
+
+    term_signal = 0;
+    if (WIFSIGNALED(process->status))
+      term_signal = WTERMSIG(process->status);
+
+    process->exit_cb(process, exit_status, term_signal);
+  }
+  assert(QUEUE_EMPTY(pending));
+}
+
+static void uv__chld_normal(uv_signal_t* handle, int signum) {
+  uv_process_t* process;
+  uv_loop_t* loop;
   int status;
   pid_t pid;
   QUEUE pending;
@@ -89,30 +119,59 @@ static void uv__chld(uv_signal_t* handle, int signum) {
     QUEUE_INSERT_TAIL(&pending, &process->queue);
   }
 
-  h = &pending;
-  q = QUEUE_HEAD(h);
-  while (q != h) {
-    process = QUEUE_DATA(q, uv_process_t, queue);
-    q = QUEUE_NEXT(q);
+  uv__finalize_processes(&pending);
+}
 
-    QUEUE_REMOVE(&process->queue);
-    QUEUE_INIT(&process->queue);
-    uv__handle_stop(process);
+static void uv__chld_init(uv_signal_t* handle, int signum) {
+  uv_process_t* process;
+  uv_loop_t* loop;
+  pid_t pid;
+  int status;
+  QUEUE pending;
+  QUEUE* q;
+  QUEUE* h;
 
-    if (process->exit_cb == NULL)
-      continue;
+  assert(signum == SIGCHLD);
 
-    exit_status = 0;
-    if (WIFEXITED(process->status))
-      exit_status = WEXITSTATUS(process->status);
+  QUEUE_INIT(&pending);
+  loop = handle->loop;
 
-    term_signal = 0;
-    if (WIFSIGNALED(process->status))
-      term_signal = WTERMSIG(process->status);
+  for (;;) {
+    do
+      pid = waitpid(-1, &status, WNOHANG);
+    while (pid == -1 && errno == EINTR);
 
-    process->exit_cb(process, exit_status, term_signal);
+    if (pid == 0)
+      break;
+
+    if (pid == -1) {
+      if (errno != ECHILD)
+        abort();
+      break;
+    }
+
+    h = &loop->process_handles;
+    q = QUEUE_HEAD(h);
+
+    while (q != h) {
+      process = QUEUE_DATA(q, uv_process_t, queue);
+      if (process->pid == pid) {
+        QUEUE_REMOVE(&process->queue);
+        QUEUE_INSERT_TAIL(&pending, &process->queue);
+        break;
+      }
+      q = QUEUE_NEXT(q);
+    }
   }
-  assert(QUEUE_EMPTY(&pending));
+
+  uv__finalize_processes(&pending);
+}
+
+static void uv__chld(uv_signal_t* handle, int signum) {
+  if (getpid() == 1)
+    uv__chld_init(handle, signum);
+  else
+    uv__chld_normal(handle, signum);
 }
 
 /*


### PR DESCRIPTION
This is useful to allow libuv users to run in containers or as init systems (effectively the same thing).