### PR TITLE
unix: Use arc4random_buf to get randomness on OpenBSD

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -733,7 +733,8 @@ API
     - FreeBSD: `getrandom(2) <https://www.freebsd.org/cgi/man.cgi?query=getrandom&sektion=2>_`,
       or `/dev/urandom` after reading from `/dev/random` once.
     - NetBSD: `KERN_ARND` `sysctl(3) <https://netbsd.gw.com/cgi-bin/man-cgi?sysctl+3+NetBSD-current>_`
-    - macOS, OpenBSD: `getentropy(2) <https://man.openbsd.org/getentropy.2>_`
+    - OpenBSD: `arc4random_buf(3) <https://man.openbsd.org/arc4random_buf.3>_`
+    - macOS: `getentropy(2) <https://man.openbsd.org/getentropy.2>_`
       if available, or `/dev/urandom` after reading from `/dev/random` once.
     - AIX: `/dev/random`.
     - IBM i: `/dev/urandom`.

--- a/src/random.c
+++ b/src/random.c
@@ -35,13 +35,14 @@ static int uv__random(void* buf, size_t buflen) {
   rc = uv__random_readpath("/dev/urandom", buf, buflen);
 #elif defined(_AIX) || defined(__QNX__)
   rc = uv__random_readpath("/dev/random", buf, buflen);
-#elif defined(__APPLE__) || defined(__OpenBSD__) || \
-     (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
+#elif defined(__APPLE__) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
   rc = uv__random_getentropy(buf, buflen);
   if (rc == UV_ENOSYS)
     rc = uv__random_devurandom(buf, buflen);
 #elif defined(__NetBSD__)
   rc = uv__random_sysctl(buf, buflen);
+#elif defined(__OpenBSD__)
+  rc = uv__random_arc4random(buf, buflen);
 #elif defined(__FreeBSD__) || defined(__linux__)
   rc = uv__random_getrandom(buf, buflen);
   if (rc == UV_ENOSYS)

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -288,6 +288,7 @@ int uv__random_getrandom(void* buf, size_t buflen);
 int uv__random_getentropy(void* buf, size_t buflen);
 int uv__random_readpath(const char* path, void* buf, size_t buflen);
 int uv__random_sysctl(void* buf, size_t buflen);
+int uv__random_arc4random(void* buf, size_t buflen);
 
 #if defined(__APPLE__)
 int uv___stream_fd(const uv_stream_t* handle);

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -238,3 +238,8 @@ error:
   *cpu_infos = NULL;
   return UV__ERR(errno);
 }
+
+int uv__random_arc4random(void* buf, size_t buflen) {
+  arc4random_buf(buf, buflen);
+  return 0;
+}


### PR DESCRIPTION
Hello. The OpenBSD documentation recommends using arc4random over getentropy: https://man.openbsd.org/getentropy.2


I've written a small benchmark to test getentropy versus arc4random:
```
#include <err.h>
#include <stdio.h>
#include <stdlib.h>
#include <time.h>
#include <sys/time.h>
#include <unistd.h>

void random_getentropy(void *, size_t);

int
main(void)
{
	void *buf;
	size_t buflen = 32768;
	size_t total = 1024 * 1024 * 1024;
	struct timespec elapsed, start, stop;
	int i;

	if ((buf = malloc(buflen)) == 0)
		err(1, "malloc");

	clock_gettime(CLOCK_MONOTONIC, &start);
	for (i = 0; i < total / buflen; i++)
		random_getentropy(buf, buflen);
	clock_gettime(CLOCK_MONOTONIC,&stop);
	timespecsub(&stop, &start, &elapsed);
	printf("random_getentropy: %lld.%09lds elapsed\n",
			(long long)elapsed.tv_sec, elapsed.tv_nsec);

	clock_gettime(CLOCK_MONOTONIC, &start);
	for (i = 0; i < total / buflen; i++)
		arc4random_buf(buf, buflen);
	clock_gettime(CLOCK_MONOTONIC,&stop);
	timespecsub(&stop, &start, &elapsed);
	printf("arc4random_buf: %lld.%09lds elapsed\n",
			(long long)elapsed.tv_sec, elapsed.tv_nsec);
}

void
random_getentropy(void *_buf, size_t buflen)
{
	unsigned char *buf = _buf;
	size_t pos;
	size_t stride;

	for (pos = 0, stride = 256; pos + stride < buflen; pos += stride)
		if (getentropy(buf + pos, stride))
			err(1, "getentropy");
	if (getentropy(buf + pos, buflen - pos))
		err(1, "getentropy");
}
```

Here's the output on my OpenBSD computer:
$ cc -O2 main.c
$ ./a.out
random_getentropy: 10.235908013s elapsed
arc4random_buf: 3.543738920s elapsed

I see there's some discussion about arc4random on #2528 , maybe it would be a good idea to benchmark arc4random versus the current methods on the other platforms that provide it.