### PR TITLE
doc: switch discussion forum to github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 If you want to report a bug, you are in the right place!
 
 If you need help or have a question, go here:
-https://github.com/libuv/help/issues/new
+https://github.com/libuv/libuv/discussions
 
 If you are reporting a libuv test failure, please ensure that you are not
 running the test as root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ The stable branch is effectively frozen; patches that change the libuv
 API/ABI or affect the run-time behavior of applications get rejected.
 
 In case of doubt, open an issue in the [issue tracker][], post your question
-to the [libuv mailing list], or contact one of [project maintainers][] on [IRC][].
+to the [libuv discussions forum], or message the [libuv mailing list].
 
-Especially do so if you plan to work on something big.  Nothing is more
-frustrating than seeing your hard work go to waste because your vision
-does not align with that of a project maintainers.
+Especially do so if you plan to work on something big. Nothing is more
+frustrating than seeing your hard work go to waste because your vision does not
+align with that of the [project maintainers].
 
 
 ### BRANCH
@@ -166,6 +166,6 @@ not send out notifications when you add commits.
 
 [issue tracker]: https://github.com/libuv/libuv/issues
 [libuv mailing list]: http://groups.google.com/group/libuv
-[IRC]: http://webchat.freenode.net/?channels=libuv
+[libuv discussions forum]: https://github.com/libuv/libuv/discussions
 [Google C/C++ style guide]: https://google.github.io/styleguide/cppguide.html
 [project maintainers]: https://github.com/libuv/libuv/blob/master/MAINTAINERS.md

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ The documentation is licensed under the CC BY 4.0 license. Check the [LICENSE-do
 
 ## Community
 
- * [Support](https://github.com/libuv/help)
+ * [Support](https://github.com/libuv/libuv/discussions)
  * [Mailing list](http://groups.google.com/group/libuv)
- * [IRC chatroom (#libuv@irc.freenode.org)](http://webchat.freenode.net?channels=libuv&uio=d4)
 
 ## Documentation
 

--- a/docs/code/dns/main.c
+++ b/docs/code/dns/main.c
@@ -69,8 +69,8 @@ int main() {
     hints.ai_flags = 0;
 
     uv_getaddrinfo_t resolver;
-    fprintf(stderr, "irc.freenode.net is... ");
-    int r = uv_getaddrinfo(loop, &resolver, on_resolved, "irc.freenode.net", "6667", &hints);
+    fprintf(stderr, "irc.libera.chat is... ");
+    int r = uv_getaddrinfo(loop, &resolver, on_resolved, "irc.libera.chat", "6667", &hints);
 
     if (r) {
         fprintf(stderr, "getaddrinfo call error %s\n", uv_err_name(r));

--- a/docs/src/guide/networking.rst
+++ b/docs/src/guide/networking.rst
@@ -193,7 +193,7 @@ Querying DNS
 libuv provides asynchronous DNS resolution. For this it provides its own
 ``getaddrinfo`` replacement [#]_. In the callback you can
 perform normal socket operations on the retrieved addresses. Let's connect to
-Freenode to see an example of DNS resolution.
+Libera.chat to see an example of DNS resolution.
 
 .. rubric:: dns/main.c
 .. literalinclude:: ../../code/dns/main.c


### PR DESCRIPTION
Freenode is gone (replaced by Libera.chat), but IRC was unused anyways.

Fixes: https://github.com/libuv/libuv/issues/3157
Fixes: https://github.com/libuv/libuv/issues/3208