### PR TITLE
core: uv_backend_timeout should return 0 when has pending watchers

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -334,7 +334,7 @@ int uv_backend_fd(const uv_loop_t* loop) {
 }
 
 
-int uv_backend_timeout(const uv_loop_t* loop) {
+int uv__io_poll_timeout(const uv_loop_t* loop) {
   if (loop->stop_flag != 0)
     return 0;
 
@@ -351,6 +351,14 @@ int uv_backend_timeout(const uv_loop_t* loop) {
     return 0;
 
   return uv__next_timeout(loop);
+}
+
+
+int uv_backend_timeout(const uv_loop_t* loop) {
+  if (!QUEUE_EMPTY(&loop->watcher_queue))
+    return 0;
+
+  return uv__io_poll_timeout(loop);
 }
 
 
@@ -384,7 +392,7 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
     timeout = 0;
     if ((mode == UV_RUN_ONCE && !ran_pending) || mode == UV_RUN_DEFAULT)
-      timeout = uv_backend_timeout(loop);
+      timeout = uv__io_poll_timeout(loop);
 
     uv__io_poll(loop, timeout);
 

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -51,6 +51,9 @@ TEST_IMPL(loop_backend_timeout) {
 
   r = uv_timer_start(&timer, cb, 1000, 0); /* 1 sec */
   ASSERT(r == 0);
+  while (uv_backend_timeout(loop) == 0) {
+    uv_run(loop, UV_RUN_NOWAIT);
+  }
   ASSERT(uv_backend_timeout(loop) > 100); /* 0.1 sec */
   ASSERT(uv_backend_timeout(loop) <= 1000); /* 1 sec */
 


### PR DESCRIPTION
Looks like when a new FD is going to be `EPOLL_CTL_ADD`ed, it is first pushed to `watcher_queue`; a later call to `uv__io_poll` would actually register them to kernel.  But with `UV_RUN_NOWAIT` the iteration stops at an unfortunate point where we may have "runnable task" before blocking, and `uv_backend_timeout` failed to report this kind of work.

Some context: I'm embedding libuv into python's asyncio loop, to integrate existing codebase into python.  (Not really performance-sensitive, so not using https://github.com/MagicStack/uvloop/; this project is not really ready for such kind of loop sharing yet)  My approach is to write a custom `Selector` (implements python `selectors.BaseSelector`) that simply calls `uv_run(UV_RUN_NOWAIT)` right before calling calling `epoll_wait(epfd_of_python_asyncio)`, using combined timeout from libuv and python.  Before this patch `uv_backend_timeout` may return -1 even when there are work in `watcher_queue`, and the relevant FDs are not registered to kernel, causing an infinite fruitless wait.

Draft because I'm not sure whether this is the best approach; with this patch downstream caller would just go back and call another `uv_run(UV_RUN_NOWAIT)`, but this may incur an unnecessary call to `epoll_wait`.  Maybe we could modify the execution order and split up `uv__io_poll` so that we check for stop right before calling `epoll_wait`, but that can be a massive change.

Dear maintainers if you decide this approach is good enough I can take a little time to add tests for it.