### PR TITLE
kqueue: ignore write-end closed notifications

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -359,7 +359,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (ev->flags & EV_ERROR)
         revents |= POLLERR;
 
-      if ((ev->flags & EV_EOF) && (w->pevents & UV__POLLRDHUP))
+      if ((ev->filter == EVFILT_READ || ev->filter == EVFILT_EXCEPT) &&
+          (ev->flags & EV_EOF) && (w->pevents & UV__POLLRDHUP))
         revents |= UV__POLLRDHUP;
 
       if (revents == 0)

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -326,6 +326,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
             if (errno != ENOENT)
               abort();
         }
+        if ((ev->flags & EV_EOF) && (w->pevents & UV__POLLRDHUP))
+          revents |= UV__POLLRDHUP;
       }
 
       if (ev->filter == EV_OOBAND) {
@@ -358,11 +360,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
       if (ev->flags & EV_ERROR)
         revents |= POLLERR;
-
-      if (ev->filter == EVFILT_READ || ev->filter == EVFILT_EXCEPT)
-        if (ev->flags & EV_EOF)
-          if (w->pevents & UV__POLLRDHUP)
-            revents |= UV__POLLRDHUP;
 
       if (revents == 0)
         continue;

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -359,9 +359,10 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (ev->flags & EV_ERROR)
         revents |= POLLERR;
 
-      if ((ev->filter == EVFILT_READ || ev->filter == EVFILT_EXCEPT) &&
-          (ev->flags & EV_EOF) && (w->pevents & UV__POLLRDHUP))
-        revents |= UV__POLLRDHUP;
+      if (ev->filter == EVFILT_READ || ev->filter == EVFILT_EXCEPT)
+        if (ev->flags & EV_EOF)
+          if (w->pevents & UV__POLLRDHUP)
+            revents |= UV__POLLRDHUP;
 
       if (revents == 0)
         continue;


### PR DESCRIPTION
The combination EVFILT_WRITE+EV_EOF is valid and indicates that the
reader has disconnected (called `shutdown(SHUT_RD)`). Probably very rare
in practice, but this seems more correct.

Issue noticed (for UV_DISCONNECT clients of uv_poll), while doing
research for https://github.com/libuv/libuv/pull/3250.