### PR TITLE
Don't need API cast to uv_handle_t*, C++ checks

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -229,6 +229,61 @@ typedef struct uv_fs_event_s uv_fs_event_t;
 typedef struct uv_fs_poll_s uv_fs_poll_t;
 typedef struct uv_signal_s uv_signal_t;
 
+/* Handle pointer alias; avoid casting in C, type checks in C++. */
+#if !defined(__cplusplus)
+  typedef void* uv_handle_ptr;
+  typedef const void* const_uv_handle_ptr;
+#else
+  struct uv_handle_ptr {  /* standard layout, same as lone void* */
+    void *p;
+    /* Allow construction from any handle pointer subclass */
+    uv_handle_ptr (uv_loop_t* p) : p (p) {}
+    uv_handle_ptr (uv_handle_t* p) : p (p) {}
+    uv_handle_ptr (uv_dir_t* p) : p (p) {}
+    uv_handle_ptr (uv_stream_t* p) : p (p) {}
+    uv_handle_ptr (uv_tcp_t* p) : p (p) {}
+    uv_handle_ptr (uv_udp_t* p) : p (p) {}
+    uv_handle_ptr (uv_pipe_t* p) : p (p) {}
+    uv_handle_ptr (uv_tty_t* p) : p (p) {}
+    uv_handle_ptr (uv_poll_t* p) : p (p) {}
+    uv_handle_ptr (uv_timer_t* p) : p (p) {}
+    uv_handle_ptr (uv_prepare_t* p) : p (p) {}
+    uv_handle_ptr (uv_check_t* p) : p (p) {}
+    uv_handle_ptr (uv_idle_t* p) : p (p) {}
+    uv_handle_ptr (uv_async_t* p) : p (p) {}
+    uv_handle_ptr (uv_process_t* p) : p (p) {}
+    uv_handle_ptr (uv_fs_event_t* p) : p (p) {}
+    uv_handle_ptr (uv_fs_poll_t* p) : p (p) {}
+    uv_handle_ptr (uv_signal_t* p) : p (p) {}
+    /* Allow cast to handle_t* to mimic cast of plain C void* */
+    operator uv_handle_t*() { return (uv_handle_t*)p; }
+  };
+  struct const_uv_handle_ptr {  /* standard layout, same as lone void* */
+    const void *p;
+    /* Allow construction from any const handle pointer subclass */
+    const_uv_handle_ptr (const uv_loop_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_handle_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_dir_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_stream_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_tcp_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_udp_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_pipe_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_tty_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_poll_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_timer_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_prepare_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_check_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_idle_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_async_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_process_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_fs_event_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_fs_poll_t* p) : p (p) {}
+    const_uv_handle_ptr (const uv_signal_t* p) : p (p) {}
+    /* Allow cast to const handle_t* to mimic cast of plain C void* */
+    operator const uv_handle_t*() const { return (const uv_handle_t*)p; }
+  };
+#endif
+
 /* Request types. */
 typedef struct uv_req_s uv_req_t;
 typedef struct uv_getaddrinfo_s uv_getaddrinfo_t;
@@ -300,9 +355,9 @@ UV_EXTERN int uv_loop_fork(uv_loop_t* loop);
 UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
 UV_EXTERN void uv_stop(uv_loop_t*);
 
-UV_EXTERN void uv_ref(uv_handle_t*);
-UV_EXTERN void uv_unref(uv_handle_t*);
-UV_EXTERN int uv_has_ref(const uv_handle_t*);
+UV_EXTERN void uv_ref(uv_handle_ptr);
+UV_EXTERN void uv_unref(uv_handle_ptr);
+UV_EXTERN int uv_has_ref(const_uv_handle_ptr);
 
 UV_EXTERN void uv_update_time(uv_loop_t*);
 UV_EXTERN uint64_t uv_now(const uv_loop_t*);
@@ -450,11 +505,11 @@ struct uv_handle_s {
 };
 
 UV_EXTERN size_t uv_handle_size(uv_handle_type type);
-UV_EXTERN uv_handle_type uv_handle_get_type(const uv_handle_t* handle);
+UV_EXTERN uv_handle_type uv_handle_get_type(const_uv_handle_ptr handle);
 UV_EXTERN const char* uv_handle_type_name(uv_handle_type type);
-UV_EXTERN void* uv_handle_get_data(const uv_handle_t* handle);
-UV_EXTERN uv_loop_t* uv_handle_get_loop(const uv_handle_t* handle);
-UV_EXTERN void uv_handle_set_data(uv_handle_t* handle, void* data);
+UV_EXTERN void* uv_handle_get_data(const_uv_handle_ptr handle);
+UV_EXTERN uv_loop_t* uv_handle_get_loop(const_uv_handle_ptr handle);
+UV_EXTERN void uv_handle_set_data(uv_handle_ptr handle, void* data);
 
 UV_EXTERN size_t uv_req_size(uv_req_type type);
 UV_EXTERN void* uv_req_get_data(const uv_req_t* req);
@@ -462,7 +517,7 @@ UV_EXTERN void uv_req_set_data(uv_req_t* req, void* data);
 UV_EXTERN uv_req_type uv_req_get_type(const uv_req_t* req);
 UV_EXTERN const char* uv_req_type_name(uv_req_type type);
 
-UV_EXTERN int uv_is_active(const uv_handle_t* handle);
+UV_EXTERN int uv_is_active(const_uv_handle_ptr handle);
 
 UV_EXTERN void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg);
 
@@ -470,12 +525,12 @@ UV_EXTERN void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg);
 UV_EXTERN void uv_print_all_handles(uv_loop_t* loop, FILE* stream);
 UV_EXTERN void uv_print_active_handles(uv_loop_t* loop, FILE* stream);
 
-UV_EXTERN void uv_close(uv_handle_t* handle, uv_close_cb close_cb);
+UV_EXTERN void uv_close(uv_handle_ptr handle, uv_close_cb close_cb);
 
-UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value);
-UV_EXTERN int uv_recv_buffer_size(uv_handle_t* handle, int* value);
+UV_EXTERN int uv_send_buffer_size(uv_handle_ptr handle, int* value);
+UV_EXTERN int uv_recv_buffer_size(uv_handle_ptr handle, int* value);
 
-UV_EXTERN int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd);
+UV_EXTERN int uv_fileno(const_uv_handle_ptr handle, uv_os_fd_t* fd);
 
 UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
 
@@ -550,7 +605,7 @@ UV_EXTERN int uv_is_writable(const uv_stream_t* handle);
 
 UV_EXTERN int uv_stream_set_blocking(uv_stream_t* handle, int blocking);
 
-UV_EXTERN int uv_is_closing(const uv_handle_t* handle);
+UV_EXTERN int uv_is_closing(const_uv_handle_ptr handle);
 
 
 /*

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -111,7 +111,8 @@ uint64_t uv_hrtime(void) {
 }
 
 
-void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+void uv_close(uv_handle_ptr handleptr, uv_close_cb close_cb) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   assert(!uv__is_closing(handle));
 
   handle->flags |= UV_HANDLE_CLOSING;
@@ -335,7 +336,8 @@ static void uv__run_closing_handles(uv_loop_t* loop) {
 }
 
 
-int uv_is_closing(const uv_handle_t* handle) {
+int uv_is_closing(const_uv_handle_ptr handleptr) {
+  const uv_handle_t* handle = (const uv_handle_t*) handleptr;
   return uv__is_closing(handle);
 }
 
@@ -447,7 +449,8 @@ void uv_update_time(uv_loop_t* loop) {
 }
 
 
-int uv_is_active(const uv_handle_t* handle) {
+int uv_is_active(const_uv_handle_ptr handleptr) {
+  const uv_handle_t *handle = (const uv_handle_t*) handleptr;
   return uv__is_active(handle);
 }
 
@@ -759,7 +762,8 @@ void uv_disable_stdio_inheritance(void) {
 }
 
 
-int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
+int uv_fileno(const_uv_handle_ptr handleptr, uv_os_fd_t* fd) {
+  const uv_handle_t *handle = (const uv_handle_t*) handleptr;
   int fd_out;
 
   switch (handle->type) {

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -558,17 +558,20 @@ void uv_print_active_handles(uv_loop_t* loop, FILE* stream) {
 }
 
 
-void uv_ref(uv_handle_t* handle) {
+void uv_ref(uv_handle_ptr handleptr) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   uv__handle_ref(handle);
 }
 
 
-void uv_unref(uv_handle_t* handle) {
+void uv_unref(uv_handle_ptr handleptr) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   uv__handle_unref(handle);
 }
 
 
-int uv_has_ref(const uv_handle_t* handle) {
+int uv_has_ref(const_uv_handle_ptr handleptr) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   return uv__has_ref(handle);
 }
 
@@ -595,11 +598,13 @@ size_t uv__count_bufs(const uv_buf_t bufs[], unsigned int nbufs) {
   return bytes;
 }
 
-int uv_recv_buffer_size(uv_handle_t* handle, int* value) {
+int uv_recv_buffer_size(uv_handle_ptr handleptr, int* value) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   return uv__socket_sockopt(handle, SO_RCVBUF, value);
 }
 
-int uv_send_buffer_size(uv_handle_t* handle, int *value) {
+int uv_send_buffer_size(uv_handle_ptr handleptr, int *value) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   return uv__socket_sockopt(handle, SO_SNDBUF, value);
 }
 

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -33,19 +33,23 @@ const char* uv_handle_type_name(uv_handle_type type) {
   return NULL;
 }
 
-uv_handle_type uv_handle_get_type(const uv_handle_t* handle) {
+uv_handle_type uv_handle_get_type(const_uv_handle_ptr handleptr) {
+  const uv_handle_t* handle = (const uv_handle_t*) handleptr;
   return handle->type;
 }
 
-void* uv_handle_get_data(const uv_handle_t* handle) {
+void* uv_handle_get_data(const_uv_handle_ptr handleptr) {
+  const uv_handle_t* handle = (const uv_handle_t*) handleptr;
   return handle->data;
 }
 
-uv_loop_t* uv_handle_get_loop(const uv_handle_t* handle) {
+uv_loop_t* uv_handle_get_loop(const_uv_handle_ptr handleptr) {
+  const uv_handle_t *handle = (const uv_handle_t*) handleptr;
   return handle->loop;
 }
 
-void uv_handle_set_data(uv_handle_t* handle, void* data) {
+void uv_handle_set_data(uv_handle_ptr handleptr, void* data) {
+  uv_handle_t *handle = (uv_handle_t*) handleptr;
   handle->data = data;
 }
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -655,7 +655,8 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
 }
 
 
-int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
+int uv_fileno(const_uv_handle_ptr handleptr, uv_os_fd_t* fd) {
+  const uv_handle_t *handle = (const uv_handle_t*) handleptr;
   uv_os_fd_t fd_out;
 
   switch (handle->type) {
@@ -691,7 +692,9 @@ int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
 }
 
 
-int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
+int uv__socket_sockopt(uv_handle_ptr handleptr, int optname, int* value) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
+
   int r;
   int len;
   SOCKET socket;

--- a/src/win/handle.c
+++ b/src/win/handle.c
@@ -64,7 +64,8 @@ int uv_is_active(const uv_handle_t* handle) {
 }
 
 
-void uv_close(uv_handle_t* handle, uv_close_cb cb) {
+void uv_close(uv_handle_ptr handleptr, uv_close_cb cb) {
+  uv_handle_t* handle = (uv_handle_t*) handleptr;
   uv_loop_t* loop = handle->loop;
 
   if (handle->flags & UV_HANDLE_CLOSING) {
@@ -148,7 +149,8 @@ void uv_close(uv_handle_t* handle, uv_close_cb cb) {
 }
 
 
-int uv_is_closing(const uv_handle_t* handle) {
+int uv_is_closing(const_uv_handle_ptr handleptr) {
+  const uv_handle_t* handle = (const uv_handle_t*) handleptr;
   return !!(handle->flags & (UV_HANDLE_CLOSING | UV_HANDLE_CLOSED));
 }
 


### PR DESCRIPTION
API entry points that operated on generic handles were taking the
`uv_handle_t*` type.  This is a base class with no concrete instances,
so clients would -always- have to cast the actual pointer type they
had.  For instance, uv_close:

    uv_close((uv_handle_t*)&tcp_handle, close_cb);

Because this cast is always required, the type signature offers no
safety over taking a void*, which would be more convenient.
*(It actually is -less- safe, because it is discarding the actual type
information that could be checked in a C++ build.)*

This commit introduces a typedef alias for void* called `uv_handle_ptr`.
(Due to C typedef rules, it also needs `const_uv_handle_ptr` since
`const uv_handle_ptr` means the pointer itself is constant, not the
data it is pointed to.)  Using this allows:

    uv_close(&tcp_handle, close_cb);

(In the case of API callbacks that are given uv_handle_t*, those are
left alone, so that the callback can access fields like ->data.)

As an added perk of avoiding casts at the callsite, it's actually
possible for those building as C++ to get type checking at compile
time.  This does so with a C++ definition of uv_handle_ptr as a struct
with constructors from all the handle pointer subclass types, and
then cast operators back to handle_t*.

    uv_buf_t buf;
    uv_close(&buf, close_cb);
    //
    // ^-- gives: error
    //
    // could not convert ‘& buf’ from ‘uv_buf_t*’ to ‘uv_handle_ptr’
    // |   uv_close(&buf, close_cb);
    // |            ^~~~
    // |            |
    // |            uv_buf_t*

Because this is a standard layout struct with one void* in it, C++
builds should be compatible with C-built binaries and vice-versa.

  https://en.cppreference.com/w/cpp/named_req/StandardLayoutType

Separate classes for const_uv_handle_ptr and uv_handle_ptr for the
C++ typecheck are picked over template tricks of making one class
for simplicity.  A template class is possible but way more confusing.