### PR TITLE
src: add complement APIs for event loop integration

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -32,6 +32,10 @@ Data types
 
     Type definition for callback passed to :c:func:`uv_walk`.
 
+.. c:type:: void (*uv_timer_started_cb)(uv_loop_t* loop)
+
+    Type definition for callback passed to :c:func:`uv_loop_set_timer_started_callback`.
+
 
 Public members
 ^^^^^^^^^^^^^^
@@ -246,3 +250,18 @@ API
     Sets `loop->data` to `data`.
 
     .. versionadded:: 1.19.0
+
+.. c:function:: uv_timer_started_cb uv_loop_get_timer_started_callback(const uv_loop_t* loop)
+
+    Returns the callback set by :c:func:`uv_loop_set_timer_started_callback`.
+
+    .. versionadded:: 2.0.0
+
+.. c:function:: void uv_loop_set_timer_started_callback(uv_loop_t* loop, uv_timer_started_cb callback)
+
+    Sets the callback which will be called whenever a timer has been started.
+
+    This is usually used together with :c:func:`uv_backend_fd` and
+    :c:func:`uv_backend_timeout` for implementing event loop integrations.
+
+    .. versionadded:: 2.0.0

--- a/include/uv.h
+++ b/include/uv.h
@@ -324,6 +324,7 @@ typedef void (*uv_check_cb)(uv_check_t* handle);
 typedef void (*uv_idle_cb)(uv_idle_t* handle);
 typedef void (*uv_exit_cb)(uv_process_t*, int64_t exit_status, int term_signal);
 typedef void (*uv_walk_cb)(uv_handle_t* handle, void* arg);
+typedef void (*uv_timer_started_cb)(uv_loop_t* loop);
 typedef void (*uv_fs_cb)(uv_fs_t* req);
 typedef void (*uv_work_cb)(uv_work_t* req);
 typedef void (*uv_after_work_cb)(uv_work_t* req, int status);
@@ -1895,12 +1896,19 @@ struct uv_loop_s {
   void* internal_fields;
   /* Internal flag to signal loop stop. */
   unsigned int stop_flag;
+  /* Callback when a timer is started. */
+  uv_timer_started_cb timer_started_cb;
   void* reserved[4];
   UV_LOOP_PRIVATE_FIELDS
 };
 
 UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
 UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
+
+UV_EXTERN uv_timer_started_cb uv_loop_get_timer_started_callback(
+    const uv_loop_t* loop);
+UV_EXTERN void uv_loop_set_timer_started_callback(uv_loop_t* loop,
+                                                  uv_timer_started_cb callback);
 
 /* Don't export the private CPP symbols. */
 #undef UV_HANDLE_TYPE_PRIVATE

--- a/src/timer.c
+++ b/src/timer.c
@@ -82,6 +82,9 @@ int uv_timer_start(uv_timer_t* handle,
               timer_less_than);
   uv__handle_start(handle);
 
+  if (handle->loop->timer_started_cb)
+    handle->loop->timer_started_cb(handle->loop);
+
   return 0;
 }
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -72,6 +72,7 @@ int uv_loop_init(uv_loop_t* loop) {
   loop->emfile_fd = -1;
 
   loop->timer_counter = 0;
+  loop->timer_started_cb = NULL;
   loop->stop_flag = 0;
 
   err = uv__platform_loop_init(loop);

--- a/src/uv-data-getter-setters.c
+++ b/src/uv-data-getter-setters.c
@@ -121,3 +121,12 @@ void* uv_loop_get_data(const uv_loop_t* loop) {
 void uv_loop_set_data(uv_loop_t* loop, void* data) {
   loop->data = data;
 }
+
+uv_timer_started_cb uv_loop_get_timer_started_callback(const uv_loop_t* loop) {
+  return loop->timer_started_cb;
+}
+
+void uv_loop_set_timer_started_callback(uv_loop_t* loop,
+                                        uv_timer_started_cb callback) {
+  loop->timer_started_cb = callback;
+}

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -148,6 +148,7 @@ int uv_loop_init(uv_loop_t* loop) {
 
   heap_init((struct heap*) &loop->timer_heap);
   loop->timer_counter = 0;
+  loop->timer_started_cb = NULL;
 
   QUEUE_INIT(&loop->check_handles);
   QUEUE_INIT(&loop->prepare_handles);

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -25,42 +25,30 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#ifndef HAVE_KQUEUE
-# if defined(__APPLE__) ||                                                    \
-     defined(__DragonFly__) ||                                                \
-     defined(__FreeBSD__) ||                                                  \
-     defined(__FreeBSD_kernel__) ||                                           \
-     defined(__OpenBSD__) ||                                                  \
-     defined(__NetBSD__)
-#  define HAVE_KQUEUE 1
-# endif
-#endif
-
 #ifndef HAVE_EPOLL
 # if defined(__linux__)
 #  define HAVE_EPOLL 1
 # endif
 #endif
 
-#if defined(HAVE_KQUEUE) || defined(HAVE_EPOLL) || defined(_WIN32)
-
-#if defined(HAVE_KQUEUE)
-# include <sys/types.h>
-# include <sys/event.h>
-# include <sys/time.h>
-#endif
-
 #if defined(HAVE_EPOLL)
 # include <sys/epoll.h>
 #endif
 
+#if !defined(_WIN32)
+# include <sys/types.h>
+# include <sys/time.h>
+#endif
+
+static uv_loop_t main_loop;
+static uv_loop_t external_loop;
 static uv_thread_t embed_thread;
 static uv_sem_t embed_sem;
-static uv_timer_t embed_timer;
 static uv_async_t embed_async;
 static volatile int embed_closed;
 
-static int embed_timer_called;
+static uv_timer_t main_timer;
+static int main_timer_called;
 
 
 #if defined(_WIN32)
@@ -73,7 +61,7 @@ static void embed_thread_poll_win(HANDLE iocp, int timeout) {
                             &bytes,
                             &key,
                             &overlapped,
-                            timeout);
+                            timeout >= 0 ? timeout : INFINITE);
 
   /* Give the event back so the loop can deal with it. */
   if (overlapped != NULL)
@@ -86,16 +74,19 @@ static void embed_thread_poll_win(HANDLE iocp, int timeout) {
 static void embed_thread_poll_unix(int fd, int timeout) {
   int r;
   do {
-#if defined(HAVE_KQUEUE)
-    struct timespec ts;
-    ts.tv_sec = timeout / 1000;
-    ts.tv_nsec = (timeout % 1000) * 1000000;
-    r = kevent(fd, NULL, 0, NULL, 0, &ts);
-#elif defined(HAVE_EPOLL)
-    {
-      struct epoll_event ev;
-      r = epoll_wait(fd, &ev, 1, timeout);
+#if defined(HAVE_EPOLL)
+    struct epoll_event ev;
+    r = epoll_wait(fd, &ev, 1, timeout);
+#else
+    struct timeval tv;
+    if (timeout >= 0) {
+      tv.tv_sec = timeout / 1000;
+      tv.tv_usec = (timeout % 1000) * 1000;
     }
+    fd_set readset;
+    FD_ZERO(&readset);
+    FD_SET(fd, &readset);
+    r = select(fd + 1, &readset, NULL, NULL, timeout >= 0 ? &tv : NULL);
 #endif
   } while (r == -1 && errno == EINTR);
 }
@@ -107,8 +98,10 @@ static void embed_thread_runner(void* arg) {
   int timeout;
 
   while (!embed_closed) {
-    fd = uv_backend_fd(uv_default_loop());
-    timeout = uv_backend_timeout(uv_default_loop());
+    uv_sem_wait(&embed_sem);
+
+    fd = uv_backend_fd(&main_loop);
+    timeout = uv_backend_timeout(&main_loop);
 
 #if defined(_WIN32)
     embed_thread_poll_win(fd, timeout);
@@ -117,56 +110,107 @@ static void embed_thread_runner(void* arg) {
 #endif
 
     uv_async_send(&embed_async);
-    uv_sem_wait(&embed_sem);
   }
 }
 
 
 static void embed_cb(uv_async_t* async) {
-  uv_run(uv_default_loop(), UV_RUN_ONCE);
+  /* Run tasks in main loop */
+  uv_run(&main_loop, UV_RUN_NOWAIT);
 
+  /* Tell embed thread to continue polling */
   uv_sem_post(&embed_sem);
 }
 
 
-static void embed_timer_cb(uv_timer_t* timer) {
-  embed_timer_called++;
+static void main_timer_cb(uv_timer_t* timer) {
+  main_timer_called++;
   embed_closed = 1;
 
   uv_close((uv_handle_t*) &embed_async, NULL);
 }
-#endif
+
+
+static void init_loops() {
+  ASSERT(0 == uv_loop_init(&main_loop));
+  ASSERT(0 == uv_loop_init(&external_loop));
+
+  main_timer_called = 0;
+  embed_closed = 0;
+
+  uv_async_init(&external_loop, &embed_async, embed_cb);
+
+  /* Start worker that will poll main loop and interrupt external loop */
+  uv_sem_init(&embed_sem, 0);
+  uv_thread_create(&embed_thread, embed_thread_runner, NULL);
+}
+
+
+static void run_loop() {
+  /* Run main loop for once to give things a chance to initialize */
+  embed_cb(&embed_async);
+
+  /* Run external loop */
+  uv_run(&external_loop, UV_RUN_DEFAULT);
+
+  uv_thread_join(&embed_thread);
+  uv_sem_destroy(&embed_sem);
+  uv_loop_close(&external_loop);
+  uv_loop_close(&main_loop);
+}
 
 
 TEST_IMPL(embed) {
-#if defined(HAVE_KQUEUE) || defined(HAVE_EPOLL) || defined(_WIN32)
-  uv_loop_t external;
+  init_loops();
 
-  ASSERT(0 == uv_loop_init(&external));
+  /* Start timer in main loop */
+  uv_timer_init(&main_loop, &main_timer);
+  uv_timer_start(&main_timer, main_timer_cb, 250, 0);
 
-  embed_timer_called = 0;
-  embed_closed = 0;
-
-  uv_async_init(&external, &embed_async, embed_cb);
-
-  /* Start timer in default loop */
-  uv_timer_init(uv_default_loop(), &embed_timer);
-  uv_timer_start(&embed_timer, embed_timer_cb, 250, 0);
-
-  /* Start worker that will interrupt external loop */
-  uv_sem_init(&embed_sem, 0);
-  uv_thread_create(&embed_thread, embed_thread_runner, NULL);
-
-  /* But run external loop */
-  uv_run(&external, UV_RUN_DEFAULT);
-
-  uv_thread_join(&embed_thread);
-  uv_loop_close(&external);
-
-  ASSERT(embed_timer_called == 1);
+  run_loop();
+  ASSERT(main_timer_called == 1);
 
   return 0;
-#else
-  RETURN_SKIP("Not supported in the current platform.");
-#endif
+}
+
+
+static uv_async_t main_async;
+static uv_timer_t external_timer;
+
+
+static void wakeup(uv_async_t* async) {
+  uv_close((uv_handle_t*) &main_async, NULL);
+}
+
+
+static void timer_started_cb(uv_loop_t* loop) {
+  /* Interrupt the polling in embed thread so backend timeout is updated */
+  uv_async_send(&main_async);
+}
+
+
+static void external_timer_cb(uv_timer_t* timer) {
+  /* Start timer in main loop */
+  uv_timer_init(&main_loop, &main_timer);
+  uv_timer_start(&main_timer, main_timer_cb, 100, 0);
+}
+
+
+TEST_IMPL(embed_with_external_timer) {
+  init_loops();
+
+  uv_async_init(&main_loop, &main_async, wakeup);
+
+  /* Monitor when a timer is started in main loop */
+  uv_loop_set_timer_started_callback(&main_loop, timer_started_cb);
+
+  /* Start timer in external loop, whose callback will not interrupt the
+     polling in embed thread */
+  uv_timer_init(&external_loop, &external_timer);
+  uv_timer_start(&external_timer, external_timer_cb, 100, 0);
+
+  run_loop();
+  ASSERT(main_timer_called == 1);
+
+  return 0;
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -234,6 +234,7 @@ TEST_DECLARE   (timer_from_check)
 TEST_DECLARE   (timer_is_closing)
 TEST_DECLARE   (timer_null_callback)
 TEST_DECLARE   (timer_early_check)
+TEST_DECLARE   (timer_started_callback)
 TEST_DECLARE   (idle_starvation)
 TEST_DECLARE   (loop_handles)
 TEST_DECLARE   (get_loadavg)
@@ -271,6 +272,7 @@ TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
 TEST_DECLARE   (active)
 TEST_DECLARE   (embed)
+TEST_DECLARE   (embed_with_external_timer)
 TEST_DECLARE   (async)
 TEST_DECLARE   (async_multi)
 TEST_DECLARE   (async_null_cb)
@@ -838,6 +840,7 @@ TASK_LIST_START
   TEST_ENTRY  (timer_is_closing)
   TEST_ENTRY  (timer_null_callback)
   TEST_ENTRY  (timer_early_check)
+  TEST_ENTRY  (timer_started_callback)
 
   TEST_ENTRY  (idle_starvation)
 
@@ -880,6 +883,7 @@ TASK_LIST_START
   TEST_ENTRY  (active)
 
   TEST_ENTRY  (embed)
+  TEST_ENTRY  (embed_with_external_timer)
 
   TEST_ENTRY  (async)
   TEST_ENTRY  (async_multi)

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -345,3 +345,33 @@ TEST_IMPL(timer_early_check) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+
+static int timer_started_callback_called = 0;
+
+
+static void timer_started_callback(uv_loop_t* loop) {
+  timer_started_callback_called = 1;
+}
+
+
+static void noop_timer_callback(uv_timer_t* handle) {
+}
+
+
+TEST_IMPL(timer_started_callback) {
+  uv_loop_t loop;
+  uv_loop_init(&loop);
+  uv_loop_set_timer_started_callback(&loop, timer_started_callback);
+
+  uv_timer_t timer_handle;
+  ASSERT(0 == uv_timer_init(&loop, &timer_handle));
+  ASSERT(0 == timer_started_callback_called);
+
+  ASSERT(0 == uv_timer_start(&timer_handle, noop_timer_callback, 10, 0));
+  ASSERT(1 == timer_started_callback_called);
+
+  uv_loop_close(&loop);
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}


### PR DESCRIPTION
When integrating an uv event loop with other event loops, we usually listen to events on the backend fd of the uv event loop. However in libuv timers do not trigger events on the backend fd, and this would cause problem like, Node's `setTimeout` not working in Electron. (See also https://github.com/libuv/libuv/issues/1565, https://github.com/libuv/libuv/pull/1651.)

To solve this, we need to get notified whenever a timer is started, and then update the timeout when listening to backend fd. This PR adds the `uv_loop_set_timer_started_callback` API for this purpose.

This PR is different from the current approach used in Electron (https://github.com/libuv/libuv/pull/1921), as the latter sends notifications for some unneeded cases.

I have added a test in `test/test-embed.c` to demonstrate the problem of timers with event loop integration, and how this API can be used to fix it.

/cc @bnoordhuis 