### PR TITLE
pipe: remove useless assertion

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1252,7 +1252,6 @@ static DWORD WINAPI uv_pipe_writefile_thread_proc(void* parameter) {
   assert(req != NULL);
   assert(req->type == UV_WRITE);
   assert(handle->type == UV_NAMED_PIPE);
-  assert(req->write_buffer.base);
 
   result = WriteFile(handle->handle,
                      req->write_buffer.base,


### PR DESCRIPTION
This assertion was added when `req->write_buffer` was a pointer. [It was then checking that `write_buffer` itself was not NULL.](https://github.com/libuv/libuv/commit/28234d73364756a25d78621eba95902f30413417#diff-2c02b110847cbf447e1da89d0c32f0b0f4f65eda29a63467c39c510b2ba134b7L729-R729) Checking that `.base` is not NULL is superfluous because `WriteFile` will return error 998 (ERROR_NO_ACCESS) if the input buffer is invalid. This assertion fires on zero-length writes when `base==NULL&&len==0`. Other places in `src/win/pipe.c` that call `WriteFile` don't check `.base`. 