### PR TITLE
feat: add UV_LOOP_INTERRUPT_ON_IO_CHANGE option to uv_loop_configure

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -73,7 +73,16 @@ API
 
       This option is necessary to use :c:func:`uv_metrics_idle_time`.
 
+    - UV_LOOP_INTERRUPT_ON_IO_CHANGE: Interrupt the loop whenever a new IO
+      event has been added or changed.
+
+      This option is usually used when implementing event loop integration, to
+      make the polling of backend fd interrupt to recognize the changes of IO
+      events.
+
     .. versionchanged:: 1.39.0 added the UV_METRICS_IDLE_TIME option.
+    .. versionchanged:: 1.44.0 added the UV_LOOP_INTERRUPT_ON_IO_CHANGE option.
+
 
 .. c:function:: int uv_loop_close(uv_loop_t* loop)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -247,7 +247,8 @@ typedef struct uv_statfs_s uv_statfs_t;
 
 typedef enum {
   UV_LOOP_BLOCK_SIGNAL = 0,
-  UV_METRICS_IDLE_TIME
+  UV_METRICS_IDLE_TIME,
+  UV_LOOP_INTERRUPT_ON_IO_CHANGE
 } uv_loop_option;
 
 typedef enum {

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -38,7 +38,6 @@
 #include <sys/eventfd.h>
 #endif
 
-static void uv__async_send(uv_loop_t* loop);
 static int uv__async_start(uv_loop_t* loop);
 static void uv__cpu_relax(void);
 
@@ -77,7 +76,7 @@ int uv_async_send(uv_async_t* handle) {
     return 0;
 
   /* Wake up the other thread's event loop. */
-  uv__async_send(handle->loop);
+  uv__loop_interrupt(handle->loop);
 
   /* Tell the other thread we're done. */
   expected = 1;
@@ -174,40 +173,6 @@ static void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
     h->async_cb(h);
   }
-}
-
-
-static void uv__async_send(uv_loop_t* loop) {
-  const void* buf;
-  ssize_t len;
-  int fd;
-  int r;
-
-  buf = "";
-  len = 1;
-  fd = loop->async_wfd;
-
-#if defined(__linux__)
-  if (fd == -1) {
-    static const uint64_t val = 1;
-    buf = &val;
-    len = sizeof(val);
-    fd = loop->async_io_watcher.fd;  /* eventfd */
-  }
-#endif
-
-  do
-    r = write(fd, buf, len);
-  while (r == -1 && errno == EINTR);
-
-  if (r == len)
-    return;
-
-  if (r == -1)
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-      return;
-
-  abort();
 }
 
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -895,6 +895,9 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     loop->watchers[w->fd] = w;
     loop->nfds++;
   }
+
+  if (uv__get_internal_fields(loop)->flags & UV_LOOP_INTERRUPT_ON_IO_CHANGE)
+    uv__loop_interrupt(loop);
 }
 
 
@@ -926,6 +929,9 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   }
   else if (QUEUE_EMPTY(&w->watcher_queue))
     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+
+  if (uv__get_internal_fields(loop)->flags & UV_LOOP_INTERRUPT_ON_IO_CHANGE)
+    uv__loop_interrupt(loop);
 }
 
 
@@ -942,6 +948,9 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w) {
   if (QUEUE_EMPTY(&w->pending_queue))
     QUEUE_INSERT_TAIL(&loop->pending_queue, &w->pending_queue);
+
+  if (uv__get_internal_fields(loop)->flags & UV_LOOP_INTERRUPT_ON_IO_CHANGE)
+    uv__loop_interrupt(loop);
 }
 
 

--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -258,6 +258,9 @@ void uv__loop_interrupt(uv_loop_t* loop) {
 
   if (r == len)
     return;
+    
+  if (!uv_loop_alive(loop))
+    return;
 
   if (r == -1)
     if (errno == EAGAIN || errno == EWOULDBLOCK)

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -134,6 +134,8 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
 
 void uv__loop_close(uv_loop_t* loop);
 
+void uv__loop_interrupt(uv_loop_t* loop);
+
 int uv__read_start(uv_stream_t* stream,
                    uv_alloc_cb alloc_cb,
                    uv_read_cb read_cb);
@@ -270,6 +272,10 @@ void uv__threadpool_cleanup(void);
     if (((h)->flags & UV_HANDLE_ACTIVE) != 0) break;                          \
     (h)->flags |= UV_HANDLE_ACTIVE;                                           \
     if (((h)->flags & UV_HANDLE_REF) != 0) uv__active_handle_add(h);          \
+    int loop_flags = uv__get_internal_fields((h)->loop)->flags;               \
+    if ((loop_flags & UV_LOOP_INTERRUPT_ON_IO_CHANGE) != 0) {                 \
+      uv__loop_interrupt((h)->loop);                                          \
+    }                                                                         \
   }                                                                           \
   while (0)
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -384,7 +384,17 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
     return 0;
   }
 
+  if (option == UV_LOOP_INTERRUPT_ON_IO_CHANGE) {
+    lfields->flags |= UV_LOOP_INTERRUPT_ON_IO_CHANGE;
+    return 0;
+  }
+
   return UV_ENOSYS;
+}
+
+
+void uv__loop_interrupt(uv_loop_t* loop) {
+  PostQueuedCompletionStatus(loop->iocp, 0, 0, NULL);
 }
 
 

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -25,54 +25,184 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#if !defined(_WIN32) && !defined(_AIX)
-#include <poll.h>
+#ifndef HAVE_EPOLL
+# if defined(__linux__)
+#  define HAVE_EPOLL 1
+# endif
 #endif
 
-static uv_async_t async;
-static uv_barrier_t barrier;
+#if defined(HAVE_EPOLL)
+# include <sys/epoll.h>
+#endif
+
+#if !defined(_WIN32)
+# include <sys/types.h>
+# include <sys/time.h>
+#endif
+
+static uv_loop_t main_loop;
+static uv_loop_t external_loop;
+static uv_thread_t embed_thread;
+static uv_sem_t embed_sem;
+static uv_async_t embed_async;
+static uv_async_t main_async;
+static volatile int embed_closed;
+
+static uv_timer_t main_timer;
+static int main_timer_called;
 
 
-static void thread_main(void* arg) {
-  ASSERT_LE(0, uv_barrier_wait(&barrier));
-  uv_sleep(250);
-  ASSERT_EQ(0, uv_async_send(&async));
+#if defined(_WIN32)
+static void embed_thread_poll_win(HANDLE iocp, int timeout) {
+  DWORD bytes;
+  ULONG_PTR key;
+  OVERLAPPED* overlapped;
+
+  GetQueuedCompletionStatus(iocp,
+                            &bytes,
+                            &key,
+                            &overlapped,
+                            timeout >= 0 ? timeout : INFINITE);
+
+  /* Give the event back so the loop can deal with it. */
+  if (overlapped != NULL)
+    PostQueuedCompletionStatus(iocp,
+                               bytes,
+                               key,
+                               overlapped);
+}
+#else
+static void embed_thread_poll_unix(int fd, int timeout) {
+  int r;
+  do {
+#if defined(HAVE_EPOLL)
+    struct epoll_event ev;
+    r = epoll_wait(fd, &ev, 1, timeout);
+#else
+    struct timeval tv;
+    if (timeout >= 0) {
+      tv.tv_sec = timeout / 1000;
+      tv.tv_usec = (timeout % 1000) * 1000;
+    }
+    fd_set readset;
+    FD_ZERO(&readset);
+    FD_SET(fd, &readset);
+    r = select(fd + 1, &readset, NULL, NULL, timeout >= 0 ? &tv : NULL);
+#endif
+  } while (r == -1 && errno == EINTR);
+}
+#endif /* !_WIN32 */
+
+
+static void embed_thread_runner(void* arg) {
+  int timeout;
+
+  while (1) {
+    uv_sem_wait(&embed_sem);
+    if (embed_closed)
+      break;
+
+    timeout = uv_backend_timeout(&main_loop);
+
+#if defined(_WIN32)
+    embed_thread_poll_win(main_loop.iocp, timeout);
+#else
+    embed_thread_poll_unix(uv_backend_fd(&main_loop), timeout);
+#endif
+
+    uv_async_send(&embed_async);
+  }
 }
 
 
-static void async_cb(uv_async_t* handle) {
-  uv_close((uv_handle_t*) handle, NULL);
+static void embed_cb(uv_async_t* async) {
+  /* Run tasks in main loop */
+  uv_run(&main_loop, UV_RUN_NOWAIT);
+
+  /* Tell embed thread to continue polling */
+  uv_sem_post(&embed_sem);
+}
+
+
+static void main_timer_cb(uv_timer_t* timer) {
+  main_timer_called++;
+  embed_closed = 1;
+
+  uv_close((uv_handle_t*) &embed_async, NULL);
+  uv_close((uv_handle_t*) &main_async, NULL);
+}
+
+
+static void init_loops(void) {
+  ASSERT_EQ(0, uv_loop_init(&main_loop));
+  ASSERT_EQ(0, uv_loop_init(&external_loop));
+
+  main_timer_called = 0;
+  embed_closed = 0;
+
+  uv_async_init(&external_loop, &embed_async, embed_cb);
+
+  /* Create a dummy async for main loop otherwise backend timeout will
+     always be 0 */
+  uv_async_init(&main_loop, &main_async, embed_cb);
+
+  /* Start worker that will poll main loop and interrupt external loop */
+  uv_sem_init(&embed_sem, 0);
+  uv_thread_create(&embed_thread, embed_thread_runner, NULL);
+}
+
+
+static void run_loop(void) {
+  /* Run main loop for once to give things a chance to initialize */
+  embed_cb(&embed_async);
+
+  /* Run external loop */
+  uv_run(&external_loop, UV_RUN_DEFAULT);
+
+  uv_thread_join(&embed_thread);
+  uv_sem_destroy(&embed_sem);
+  uv_loop_close(&external_loop);
+  uv_loop_close(&main_loop);
 }
 
 
 TEST_IMPL(embed) {
-  uv_thread_t thread;
-  uv_loop_t* loop;
+  init_loops();
 
-  loop = uv_default_loop();
-  ASSERT_EQ(0, uv_async_init(loop, &async, async_cb));
-  ASSERT_EQ(0, uv_barrier_init(&barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, NULL));
-  ASSERT_LE(0, uv_barrier_wait(&barrier));
+  /* Start timer in main loop */
+  uv_timer_init(&main_loop, &main_timer);
+  uv_timer_start(&main_timer, main_timer_cb, 250, 0);
 
-  while (uv_loop_alive(loop)) {
-#if defined(_WIN32) || defined(_AIX)
-    ASSERT_LE(0, uv_run(loop, UV_RUN_ONCE));
-#else
-    int rc;
-    do {
-      struct pollfd p;
-      p.fd = uv_backend_fd(loop);
-      p.events = POLLIN;
-      p.revents = 0;
-      rc = poll(&p, 1, uv_backend_timeout(loop));
-    } while (rc == -1 && errno == EINTR);
-    ASSERT_LE(0, uv_run(loop, UV_RUN_NOWAIT));
-#endif
-  }
+  run_loop();
+  ASSERT_EQ(main_timer_called, 1);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
-  uv_barrier_destroy(&barrier);
+  return 0;
+}
+
+
+static uv_timer_t external_timer;
+
+
+static void external_timer_cb(uv_timer_t* timer) {
+  /* Start timer in main loop */
+  uv_timer_init(&main_loop, &main_timer);
+  uv_timer_start(&main_timer, main_timer_cb, 250, 0);
+}
+
+
+TEST_IMPL(embed_with_external_timer) {
+  init_loops();
+
+  /* Interrupt embed polling when a handle is started */
+  ASSERT_EQ(0, uv_loop_configure(&main_loop, UV_LOOP_INTERRUPT_ON_IO_CHANGE));
+
+  /* Start timer in external loop, whose callback will not interrupt the
+     polling in embed thread */
+  uv_timer_init(&external_loop, &external_timer);
+  uv_timer_start(&external_timer, external_timer_cb, 100, 0);
+
+  run_loop();
+  ASSERT_EQ(main_timer_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -265,6 +265,7 @@ TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
 TEST_DECLARE   (active)
 TEST_DECLARE   (embed)
+TEST_DECLARE   (embed_with_external_timer)
 TEST_DECLARE   (async)
 TEST_DECLARE   (async_null_cb)
 TEST_DECLARE   (eintr_handling)
@@ -868,6 +869,7 @@ TASK_LIST_START
   TEST_ENTRY  (active)
 
   TEST_ENTRY  (embed)
+  TEST_ENTRY  (embed_with_external_timer)
 
   TEST_ENTRY  (async)
   TEST_ENTRY  (async_null_cb)


### PR DESCRIPTION
Close https://github.com/libuv/libuv/issues/3101.

Refs https://github.com/libuv/libuv/pull/3299, https://github.com/libuv/libuv/pull/3234, https://github.com/libuv/libuv/pull/1921, https://github.com/libuv/libuv/issues/1565, https://github.com/libuv/libuv/pull/1568.

When integrating an uv event loop with other event loops, we usually poll the backend fd in a separate thread and do `uv_run` whenever there is an event triggered. However in libuv some types of changes to handles do not trigger events on the backend fd (for example starting new timers), and the polling of backend fd will still use old timeout and old event flags, and this would cause problem like, Node's `setTimeout` not working in Electron. 

This PR adds a `UV_LOOP_INTERRUPT_ON_IO_CHANGE` option to `uv_loop_configure` that, with it the loop will be interrupted whenever a new IO event has been added or changed, and the embedders will get a chance to restart the polling of the backend.

Electron has been using this technique for years and it has been working well.

/cc @bnoordhuis @vtjnash
