### PR TITLE
Fix Android builds without CMake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -390,10 +390,7 @@ if ANDROID
 uvinclude_HEADERS += include/uv/android-ifaddrs.h
 libuv_la_CFLAGS += -D_GNU_SOURCE
 libuv_la_SOURCES += src/unix/android-ifaddrs.c \
-                    src/unix/pthread-fixes.c \
-                    src/unix/random-getrandom.c \
-                    src/unix/random-sysctl-linux.c \
-                    src/unix/epoll.c
+                    src/unix/pthread-fixes.c
 endif
 
 if CYGWIN


### PR DESCRIPTION
See https://github.com/libuv/libuv/issues/2768#issuecomment-731375392

Patch based upon https://github.com/termux/termux-packages/pull/7529
