### PR TITLE
Fix broken links for NetBSD's sysctl manpage

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -732,7 +732,7 @@ API
       :man:`sysctl(2)`.
     - FreeBSD: `getrandom(2) <https://www.freebsd.org/cgi/man.cgi?query=getrandom&sektion=2>_`,
       or `/dev/urandom` after reading from `/dev/random` once.
-    - NetBSD: `KERN_ARND` `sysctl(3) <https://netbsd.gw.com/cgi-bin/man-cgi?sysctl+3+NetBSD-current>_`
+    - NetBSD: `KERN_ARND` `sysctl(7) <https://man.netbsd.org/sysctl.7>_`
     - macOS, OpenBSD: `getentropy(2) <https://man.openbsd.org/getentropy.2>_`
       if available, or `/dev/urandom` after reading from `/dev/random` once.
     - AIX: `/dev/random`.


### PR DESCRIPTION
The broken links were inspected using lychee (https://github.com/lycheeverse/lychee)

Anyways, what about having a GitHub Action which periodically checks for broken links in our documentation? There also exists a GitHub Action for achieving this using lychee https://github.com/lycheeverse/lychee-action
