### PR TITLE
doc: mark SmartOS as Tier 3 support

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -10,7 +10,7 @@
 | IBM i | Tier 2 | >= IBM i 7.2 | Maintainers: @libuv/ibmi |
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |
 | Linux with musl | Tier 2 | musl >= 1.0 | |
-| SmartOS | Tier 2 | >= 14.4 | Maintainers: @libuv/smartos |
+| SmartOS | Tier 3 | >= 14.4 | |
 | Android | Tier 3 | NDK >= r15b | |
 | MinGW | Tier 3 | MinGW32 and MinGW-w64 | |
 | SunOS | Tier 3 | Solaris 121 and later | |


### PR DESCRIPTION
There haven't been active maintainers for this platform for a long time
so back to tier 3 it goes.