### PR TITLE
asan: fix some tests

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -7,11 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          sudo apt-get install ninja-build
       - name: Envinfo
         run: npx envinfo
       - name: ASAN
         run: |
-          mkdir build
-          cd build && cmake .. -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug
-          cmake --build . && ./uv_run_tests_a
-
+          mkdir build-asan
+          (cd build-asan && cmake .. -G Ninja -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug)
+          cmake --build build-asan
+          ./build-asan/uv_run_tests_a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ endif()
 option(ASAN "Enable AddressSanitizer (ASan)" OFF)
 if(ASAN AND CMAKE_C_COMPILER_ID MATCHES "AppleClang|GNU|Clang")
   add_definitions(-D__ASAN__=1)
-  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  set (CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
 endif()
 
@@ -659,6 +659,6 @@ message(STATUS "summary of build options:
     Install prefix:  ${CMAKE_INSTALL_PREFIX}
     Target system:   ${CMAKE_SYSTEM_NAME}
     Compiler:
-      C compiler:    ${CMAKE_C_COMPILER}
+      C compiler:    ${CMAKE_C_COMPILER} (${CMAKE_C_COMPILER_ID})
       CFLAGS:        ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
 ")

--- a/test/task.h
+++ b/test/task.h
@@ -277,7 +277,7 @@ const char* fmt(double d);
 /* Reserved test exit codes. */
 enum test_status {
   TEST_OK = 0,
-  TEST_SKIP
+  TEST_SKIP = 7
 };
 
 #define RETURN_OK()                                                           \

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -96,9 +96,6 @@ static void touch_file(const char* name, unsigned int size) {
 
 
 TEST_IMPL(fs_copyfile) {
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   const char src[] = "test_file_src";
   uv_loop_t* loop;
   uv_fs_t req;

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -674,9 +674,6 @@ TEST_IMPL(fs_event_watch_file_twice) {
 #if defined(NO_FS_EVENTS)
   RETURN_SKIP(NO_FS_EVENTS);
 #endif
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   const char path[] = "test/fixtures/empty_file";
   uv_fs_event_t watchers[2];
   uv_timer_t timer;

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -230,9 +230,6 @@ static void file_opendir_cb(uv_fs_t* req) {
 }
 
 TEST_IMPL(fs_readdir_file) {
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   const char* path;
   int r;
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2897,9 +2897,6 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
 }
 
 TEST_IMPL(fs_scandir_file) {
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   const char* path;
   int r;
 
@@ -3146,9 +3143,6 @@ static void fs_read_bufs(int add_flags) {
   uv_fs_req_cleanup(&close_req);
 }
 TEST_IMPL(fs_read_bufs) {
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   fs_read_bufs(0);
   fs_read_bufs(UV_FS_O_FILEMAP);
 

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -84,6 +84,7 @@ static void pinger_on_close(uv_handle_t* handle) {
 
 static void pinger_after_write(uv_write_t* req, int status) {
   ASSERT_EQ(status, 0);
+  free(req->data);
   free(req);
 }
 
@@ -110,6 +111,7 @@ static void pinger_write_ping(pinger_t* pinger) {
 
   req = malloc(sizeof(*req));
   ASSERT_NOT_NULL(req);
+  req->data = NULL;
   ASSERT_EQ(0, uv_write(req, stream, bufs, nbufs, pinger_after_write));
 
   puts("PING");
@@ -185,6 +187,7 @@ static void ponger_read_cb(uv_stream_t* stream,
   writebuf = uv_buf_init(buf->base, nread);
   req = malloc(sizeof(*req));
   ASSERT_NOT_NULL(req);
+  req->data = buf->base;
   ASSERT_EQ(0, uv_write(req, stream, &writebuf, 1, pinger_after_write));
 }
 

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -76,9 +76,6 @@ TEST_IMPL(pipe_connect_bad_name) {
 
 
 TEST_IMPL(pipe_connect_to_file) {
-#if defined(__ASAN__)
-  RETURN_SKIP("Test does not currently work in ASAN");
-#endif
   const char* path = "test/fixtures/empty_file";
   uv_pipe_t client;
   uv_connect_t req;


### PR DESCRIPTION
Previously they were just being run incorrectly, but nothing wrong with
the test itself. We were also interpreting an ASAN failure as TEST_SKIP,
so test failures would not actually be reported as CI failures.

(I picked a random number for that exit status code which isn't in this list https://github.com/google/sanitizers/issues/1225)