### PR TITLE
build: add experimental TSAN configuration

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -3,7 +3,7 @@ name: Sanitizer checks
 on: [push, pull_request]
 
 jobs:
-  asan:
+  sanitizers:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,6 +12,12 @@ jobs:
           sudo apt-get install ninja-build
       - name: Envinfo
         run: npx envinfo
+      - name: TSAN
+        run: |
+          mkdir build-tsan
+          (cd build-tsan && cmake .. -G Ninja -DBUILD_TESTING=ON -DTSAN=ON -DCMAKE_BUILD_TYPE=Release)
+          cmake --build build-tsan
+          ./build-tsan/uv_run_tests_a || true # currently permit failures
       - name: ASAN
         run: |
           mkdir build-asan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,24 @@ if(QEMU)
 endif()
 
 option(ASAN "Enable AddressSanitizer (ASan)" OFF)
-if(ASAN AND CMAKE_C_COMPILER_ID MATCHES "AppleClang|GNU|Clang")
+option(TSAN "Enable ThreadSanitizer (TSan)" OFF)
+
+if((ASAN OR TSAN) AND NOT (CMAKE_C_COMPILER_ID MATCHES "AppleClang|GNU|Clang"))
+  message(SEND_ERROR "Sanitizer support requires clang or gcc. Try again with -DCMAKE_C_COMPILER.")
+endif()
+
+if(ASAN)
   add_definitions(-D__ASAN__=1)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
   set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+endif()
+
+if(TSAN)
+  add_definitions(-D__TSAN__=1)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
 endif()
 
 # Compiler check


### PR DESCRIPTION
Adds ThreadSanitizer to our CI run, alongside AddressSanitizer. A couple (probably benign) races are reported.