### PR TITLE
build: add macos-latest to ci matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
           $ANDROID_HOME/cmake/3.10.2.4988404/bin/cmake --build .
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
       - name: Envinfo


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/3325