### PR TITLE
Fixing build for mingw32

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1674,9 +1674,8 @@ int uv_os_gethostname(char* buffer, size_t* size) {
 
   uv__once_init(); /* Initialize winsock */
 
-  /* Is there a better error value for "Unsupported" ? */
   if (pGetHostNameW == NULL)
-    return UV_UNKNOWN;
+    return UV_ENOSYS;
 
   if (pGetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
     return uv_translate_sys_error(WSAGetLastError());

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1674,7 +1674,11 @@ int uv_os_gethostname(char* buffer, size_t* size) {
 
   uv__once_init(); /* Initialize winsock */
 
-  if (GetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
+  /* Is there a better error value for "Unsupported" ? */
+  if (pGetHostNameW == NULL)
+    return UV_UNKNOWN;
+
+  if (pGetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
     return uv_translate_sys_error(WSAGetLastError());
 
   convert_result = uv__convert_utf16_to_utf8(buf, -1, &utf8_str);

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -45,12 +45,15 @@ sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
 /* User32.dll function pointer */
 sSetWinEventHook pSetWinEventHook;
 
+/* ws2_32.dll function pointer */
+uv_sGetHostNameW pGetHostNameW;
 
 void uv_winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE powrprof_module;
   HMODULE user32_module;
   HMODULE kernel32_module;
+  HMODULE ws2_32_module;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
@@ -133,5 +136,12 @@ void uv_winapi_init(void) {
   if (user32_module != NULL) {
     pSetWinEventHook = (sSetWinEventHook)
       GetProcAddress(user32_module, "SetWinEventHook");
+  }
+
+  ws2_32_module = LoadLibraryA("ws2_32.dll");
+  if (ws2_32_module != NULL) {
+      pGetHostNameW = (uv_sGetHostNameW)GetProcAddress(
+          ws2_32_module,
+          "GetHostNameW");
   }
 }

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -140,8 +140,8 @@ void uv_winapi_init(void) {
 
   ws2_32_module = LoadLibraryA("ws2_32.dll");
   if (ws2_32_module != NULL) {
-      pGetHostNameW = (uv_sGetHostNameW)GetProcAddress(
-          ws2_32_module,
-          "GetHostNameW");
+    pGetHostNameW = (uv_sGetHostNameW)GetProcAddress(
+        ws2_32_module,
+        "GetHostNameW");
   }
 }

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -140,7 +140,7 @@ void uv_winapi_init(void) {
 
   ws2_32_module = LoadLibraryA("ws2_32.dll");
   if (ws2_32_module != NULL) {
-    pGetHostNameW = (uv_sGetHostNameW)GetProcAddress(
+    pGetHostNameW = (uv_sGetHostNameW) GetProcAddress(
         ws2_32_module,
         "GetHostNameW");
   }

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4759,4 +4759,9 @@ extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotifi
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;
 
+/* ws2_32.dll function pointer */
+/* mingw doesn't have this definition, so let's declare it here locally */
+typedef int(WINAPI *uv_sGetHostNameW)(PWSTR, int);
+extern uv_sGetHostNameW pGetHostNameW;
+
 #endif /* UV_WIN_WINAPI_H_ */

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4761,7 +4761,9 @@ extern sSetWinEventHook pSetWinEventHook;
 
 /* ws2_32.dll function pointer */
 /* mingw doesn't have this definition, so let's declare it here locally */
-typedef int(WINAPI *uv_sGetHostNameW)(PWSTR, int);
+typedef int (WINAPI *uv_sGetHostNameW)
+            (PWSTR,
+             int);
 extern uv_sGetHostNameW pGetHostNameW;
 
 #endif /* UV_WIN_WINAPI_H_ */


### PR DESCRIPTION
Commit e9c524aa from pull request https://github.com/libuv/libuv/pull/3149 introduced a hard dependency on `GetHostnameW`, which isn't declared yet in mingw distributions (see https://github.com/msys2/MINGW-packages/issues/9667).

This prevents the current version of libuv from building on many mingw distributions, until such time the next version of mingw is released with the correct definition for GetHostnameW, preventing a lot of projects depending on libuv from building on mingw properly, as not all distributions will update to head immediately anyway.

Instead of waiting, let's find the definition ourselves using GetProcAddress and use the pointer instead.