### PR TITLE
build: fix build failures with MinGW-w64 new headers

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -45,7 +45,14 @@ typedef struct pollfd {
 #endif
 
 #include <mswsock.h>
+// Disable the typedef in mstcpip.h of MinGW.
+#define _TCP_INITIAL_RTO_PARAMETERS _TCP_INITIAL_RTO_PARAMETERS__AVOID
+#define TCP_INITIAL_RTO_PARAMETERS TCP_INITIAL_RTO_PARAMETERS__AVOID
+#define PTCP_INITIAL_RTO_PARAMETERS PTCP_INITIAL_RTO_PARAMETERS__AVOID
 #include <ws2tcpip.h>
+#undef _TCP_INITIAL_RTO_PARAMETERS
+#undef TCP_INITIAL_RTO_PARAMETERS
+#undef PTCP_INITIAL_RTO_PARAMETERS
 #include <windows.h>
 
 #include <process.h>


### PR DESCRIPTION
A structure definition was added to `mstcpip.h` in mingw-w64-x86_64-headers-git 9.0.0.6327.f29c1101f, which causes a conflict and the build fails. Fix this by changing the name in the definition in `mstcpip.h`.

Ref. https://github.com/msys2/MINGW-packages/issues/9946

<details><summary>Build Log</summary>

```
2021-10-30T11:01:33.6596333Z -- Build files have been written to: D:/a/neovim/neovim/nvim-deps/build/src/libuv
2021-10-30T11:01:34.8718790Z [89/137] cmd.exe /C "cd /D D:\a\neovim\neovim\nvim-deps\build\src\libuv && C:\msys64\mingw64\bin\cmake.exe --build . --config RelWithDebInfo && C:\msys64\mingw64\bin\cmake.exe -E touch D:/a/neovim/neovim/nvim-deps/build/src/libuv-stamp/libuv-build"
2021-10-30T11:01:34.8720621Z FAILED: build/src/libuv-stamp/libuv-build D:/a/neovim/neovim/nvim-deps/build/src/libuv-stamp/libuv-build 
2021-10-30T11:01:34.8722159Z cmd.exe /C "cd /D D:\a\neovim\neovim\nvim-deps\build\src\libuv && C:\msys64\mingw64\bin\cmake.exe --build . --config RelWithDebInfo && C:\msys64\mingw64\bin\cmake.exe -E touch D:/a/neovim/neovim/nvim-deps/build/src/libuv-stamp/libuv-build"
2021-10-30T11:01:34.8723550Z [1/36] Building C object CMakeFiles/uv.dir/src/win/dl.c.obj
2021-10-30T11:01:34.8724228Z FAILED: CMakeFiles/uv.dir/src/win/dl.c.obj 
2021-10-30T11:01:34.8725995Z C:\msys64\mingw64\bin\cc.exe -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600 -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./include -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./src -O2 -g -DNDEBUG -MD -MT CMakeFiles/uv.dir/src/win/dl.c.obj -MF CMakeFiles\uv.dir\src\win\dl.c.obj.d -o CMakeFiles/uv.dir/src/win/dl.c.obj -c D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c
2021-10-30T11:01:34.8727671Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8728519Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:23:
2021-10-30T11:01:34.8729471Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4730:16: error: redefinition of 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8730443Z  4730 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8730985Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8731629Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8732445Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8733227Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8733978Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:22:
2021-10-30T11:01:34.8734794Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:163:16: note: originally defined here
2021-10-30T11:01:34.8735589Z   163 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8736188Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8736829Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8737642Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:23:
2021-10-30T11:01:34.8738708Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:3: error: conflicting types for 'TCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8739750Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8740354Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8741009Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8741848Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8742756Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8743519Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:22:
2021-10-30T11:01:34.8744583Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:3: note: previous declaration of 'TCP_INITIAL_RTO_PARAMETERS' with type 'TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8745591Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8746173Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8746837Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8747656Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:23:
2021-10-30T11:01:34.8748712Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:32: error: conflicting types for 'PTCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS *'
2021-10-30T11:01:34.8749776Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8750388Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8751029Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8751817Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8752611Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8753432Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/dl.c:22:
2021-10-30T11:01:34.8754701Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:32: note: previous declaration of 'PTCP_INITIAL_RTO_PARAMETERS' with type 'PTCP_INITIAL_RTO_PARAMETERS' {aka 'struct _TCP_INITIAL_RTO_PARAMETERS *'}
2021-10-30T11:01:34.8755849Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8756461Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8757050Z [2/36] Building C object CMakeFiles/uv.dir/src/win/core.c.obj
2021-10-30T11:01:34.8757736Z FAILED: CMakeFiles/uv.dir/src/win/core.c.obj 
2021-10-30T11:01:34.8759371Z C:\msys64\mingw64\bin\cc.exe -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600 -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./include -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./src -O2 -g -DNDEBUG -MD -MT CMakeFiles/uv.dir/src/win/core.c.obj -MF CMakeFiles\uv.dir\src\win\core.c.obj.d -o CMakeFiles/uv.dir/src/win/core.c.obj -c D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c
2021-10-30T11:01:34.8761072Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8761892Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:33:
2021-10-30T11:01:34.8762867Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4730:16: error: redefinition of 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8764591Z  4730 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8765126Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8765749Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8766539Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8767295Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8768062Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:32:
2021-10-30T11:01:34.8768866Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:163:16: note: originally defined here
2021-10-30T11:01:34.8769649Z   163 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8770257Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8770890Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8771809Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:33:
2021-10-30T11:01:34.8772890Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:3: error: conflicting types for 'TCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8773916Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8774492Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8775132Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8775951Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8776704Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8777452Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:32:
2021-10-30T11:01:34.8778472Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:3: note: previous declaration of 'TCP_INITIAL_RTO_PARAMETERS' with type 'TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8779500Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8780057Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8780708Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8781501Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:33:
2021-10-30T11:01:34.8782672Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:32: error: conflicting types for 'PTCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS *'
2021-10-30T11:01:34.8783731Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8784318Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8784936Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8785729Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8786462Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8787201Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/core.c:32:
2021-10-30T11:01:34.8788366Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:32: note: previous declaration of 'PTCP_INITIAL_RTO_PARAMETERS' with type 'PTCP_INITIAL_RTO_PARAMETERS' {aka 'struct _TCP_INITIAL_RTO_PARAMETERS *'}
2021-10-30T11:01:34.8789500Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8790073Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8790736Z [3/36] Building C object CMakeFiles/uv.dir/src/win/detect-wakeup.c.obj
2021-10-30T11:01:34.8791562Z FAILED: CMakeFiles/uv.dir/src/win/detect-wakeup.c.obj 
2021-10-30T11:01:34.8793638Z C:\msys64\mingw64\bin\cc.exe -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600 -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./include -ID:/a/neovim/neovim/nvim-deps/build/src/libuv/./src -O2 -g -DNDEBUG -MD -MT CMakeFiles/uv.dir/src/win/detect-wakeup.c.obj -MF CMakeFiles\uv.dir\src\win\detect-wakeup.c.obj.d -o CMakeFiles/uv.dir/src/win/detect-wakeup.c.obj -c D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c
2021-10-30T11:01:34.8795640Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8796516Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:23:
2021-10-30T11:01:34.8797524Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4730:16: error: redefinition of 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8798392Z  4730 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8798940Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8799566Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8800413Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8801166Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8801967Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:22:
2021-10-30T11:01:34.8802863Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:163:16: note: originally defined here
2021-10-30T11:01:34.8803624Z   163 | typedef struct _TCP_INITIAL_RTO_PARAMETERS {
2021-10-30T11:01:34.8804158Z       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8804811Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8805670Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:23:
2021-10-30T11:01:34.8806783Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:3: error: conflicting types for 'TCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8807828Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8808403Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8809000Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8809785Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8810596Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8811404Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:22:
2021-10-30T11:01:34.8812502Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:3: note: previous declaration of 'TCP_INITIAL_RTO_PARAMETERS' with type 'TCP_INITIAL_RTO_PARAMETERS'
2021-10-30T11:01:34.8813553Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8814111Z       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8814758Z In file included from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/internal.h:29,
2021-10-30T11:01:34.8815619Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:23:
2021-10-30T11:01:34.8816749Z D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/winapi.h:4733:32: error: conflicting types for 'PTCP_INITIAL_RTO_PARAMETERS'; have 'struct _TCP_INITIAL_RTO_PARAMETERS *'
2021-10-30T11:01:34.8817798Z  4733 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8818373Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8819004Z In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/ws2tcpip.h:265,
2021-10-30T11:01:34.8819800Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv/win.h:48,
2021-10-30T11:01:34.8820534Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/include/uv.h:64,
2021-10-30T11:01:34.8821354Z                  from D:/a/neovim/neovim/nvim-deps/build/src/libuv/src/win/detect-wakeup.c:22:
2021-10-30T11:01:34.8822611Z C:/msys64/mingw64/x86_64-w64-mingw32/include/mstcpip.h:166:32: note: previous declaration of 'PTCP_INITIAL_RTO_PARAMETERS' with type 'PTCP_INITIAL_RTO_PARAMETERS' {aka 'struct _TCP_INITIAL_RTO_PARAMETERS *'}
2021-10-30T11:01:34.8823741Z   166 | } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
2021-10-30T11:01:34.8824344Z       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-10-30T11:01:34.8824872Z ninja: build stopped: subcommand failed.
```
</details>