### PR TITLE
Fix for issue 3355

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -287,7 +287,7 @@ static int uv__get_cpu_speed(uint64_t* speed) {
           else if (len == 4) {
             uint32_t v;
             memcpy(&v, freq_ref_ptr, 4);
-            *speed = static_cast<uint32_t>(v);
+            *speed = static_cast<uint64_t>(v);
           }
           else
             *speed = 0;

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -287,10 +287,10 @@ static int uv__get_cpu_speed(uint64_t* speed) {
           else if (len == 4) {
             uint32_t v;
             memcpy(&v, freq_ref_ptr, 4);
-            *speed = static_cast<uint64_t>(v);
-          }
-          else
+            *speed = v;
+          } else {
             *speed = 0;
+          }
 
           pCFRelease(freq_ref);
           pCFRelease(data);

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -283,9 +283,12 @@ static int uv__get_cpu_speed(uint64_t* speed) {
           const UInt8* freq_ref_ptr = pCFDataGetBytePtr(freq_ref);
           CFIndex len = pCFDataGetLength(freq_ref);
           if (len == 8)
-            *speed = *(const uint64_t*) freq_ref_ptr;
-          else if (len == 4)
-            *speed = *(const uint32_t*) freq_ref_ptr;
+            memcpy(speed, freq_ref_ptr, 8);
+          else if (len == 4) {
+            uint32_t v;
+            memcpy(&v, freq_ref_ptr, 4);
+            *speed = static_cast<uint32_t>(v);
+          }
           else
             *speed = 0;
 

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -280,14 +280,15 @@ static int uv__get_cpu_speed(uint64_t* speed) {
                                                     NULL,
                                                     0);
         if (freq_ref) {
-          uint32_t freq;
+          const UInt8* freq_ref_ptr = pCFDataGetBytePtr(freq_ref);
           CFIndex len = pCFDataGetLength(freq_ref);
-          CFRange range;
-          range.location = 0;
-          range.length = len;
+          if (len == 8)
+            *speed = *(const uint64_t*) freq_ref_ptr;
+          else if (len == 4)
+            *speed = *(const uint32_t*) freq_ref_ptr;
+          else
+            *speed = 0;
 
-          pCFDataGetBytes(freq_ref, range, (UInt8*)&freq);
-          *speed = freq;
           pCFRelease(freq_ref);
           pCFRelease(data);
           break;


### PR DESCRIPTION
https://github.com/libuv/libuv/issues/3355
The fix is to use the cfdata length related to the data we want to interpret & then cast the data accordingly.