### PR TITLE
thread: initialize uv_thread_self for all threads

### DIFF
--- a/test/test-thread-equal.c
+++ b/test/test-thread-equal.c
@@ -28,6 +28,9 @@ uv_thread_t subthreads[2];
 static void check_thread(void* arg) {
   uv_thread_t *thread_id = arg;
   uv_thread_t self_id = uv_thread_self();
+#ifdef _WIN32
+  ASSERT_NOT_NULL(self_id);
+#endif
   ASSERT(uv_thread_equal(&main_thread_id, &self_id) == 0);
   *thread_id = uv_thread_self();
 }
@@ -35,6 +38,9 @@ static void check_thread(void* arg) {
 TEST_IMPL(thread_equal) {
   uv_thread_t threads[2];
   main_thread_id = uv_thread_self();
+#ifdef _WIN32
+  ASSERT_NOT_NULL(main_thread_id);
+#endif
   ASSERT(0 != uv_thread_equal(&main_thread_id, &main_thread_id));
   ASSERT(0 == uv_thread_create(threads + 0, check_thread, subthreads + 0));
   ASSERT(0 == uv_thread_create(threads + 1, check_thread, subthreads + 1));


### PR DESCRIPTION
In particular, previously the main thread would have an id of NULL, which was then not valid to use with any other API that expected a uv_thread_t handle.

It is expected that if you call `uv_thread_self` on any thread, eventually you will call `uv_thread_join` or `uv_thread_detach` on that thread id, which will release this handle again and avoid a resource leak.