### PR TITLE
stream: permit read after seeing EOF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,6 @@ if(LIBUV_BUILD_TESTS)
        test/test-multiple-listen.c
        test/test-mutexes.c
        test/test-not-readable-nor-writable-on-read-error.c
-       test/test-not-readable-on-eof.c
        test/test-not-writable-after-shutdown.c
        test/test-osx-select.c
        test/test-pass-always.c
@@ -530,6 +529,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-process-title.c
        test/test-queue-foreach-delete.c
        test/test-random.c
+       test/test-readable-on-eof.c
        test/test-ref.c
        test/test-run-nowait.c
        test/test-run-once.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -206,7 +206,6 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-multiple-listen.c \
                          test/test-mutexes.c \
                          test/test-not-readable-nor-writable-on-read-error.c \
-                         test/test-not-readable-on-eof.c \
                          test/test-not-writable-after-shutdown.c \
                          test/test-osx-select.c \
                          test/test-pass-always.c \
@@ -234,6 +233,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-process-title-threadsafe.c \
                          test/test-queue-foreach-delete.c \
                          test/test-random.c \
+                         test/test-readable-on-eof.c \
                          test/test-ref.c \
                          test/test-run-nowait.c \
                          test/test-run-once.c \

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1010,7 +1010,6 @@ uv_handle_type uv__handle_type(int fd) {
 static void uv__stream_eof(uv_stream_t* stream, const uv_buf_t* buf) {
   stream->flags |= UV_HANDLE_READ_EOF;
   stream->flags &= ~UV_HANDLE_READING;
-  stream->flags &= ~UV_HANDLE_READABLE;
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
@@ -1550,15 +1549,12 @@ int uv__read_start(uv_stream_t* stream,
   assert(stream->type == UV_TCP || stream->type == UV_NAMED_PIPE ||
       stream->type == UV_TTY);
 
-  /* The UV_HANDLE_READING flag is irrelevant of the state of the tcp - it just
-   * expresses the desired state of the user.
-   */
+  /* The UV_HANDLE_READING flag is irrelevant of the state of the stream - it
+   * just expresses the desired state of the user. */
   stream->flags |= UV_HANDLE_READING;
+  stream->flags &= ~UV_HANDLE_READ_EOF;
 
   /* TODO: try to do the read inline? */
-  /* TODO: keep track of tcp state. If we've gotten a EOF then we should
-   * not start the IO watcher.
-   */
   assert(uv__stream_fd(stream) >= 0);
   assert(alloc_cb);
 

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1796,7 +1796,6 @@ static void uv_pipe_read_eof(uv_loop_t* loop, uv_pipe_t* handle,
    * it. */
   eof_timer_destroy(handle);
 
-  handle->flags &= ~UV_HANDLE_READABLE;
   uv_read_stop((uv_stream_t*) handle);
 
   handle->read_cb((uv_stream_t*) handle, UV_EOF, &buf);

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1044,7 +1044,6 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
           handle->flags &= ~UV_HANDLE_READING;
           DECREASE_ACTIVE_COUNT(loop, handle);
         }
-        handle->flags &= ~UV_HANDLE_READABLE;
 
         buf.base = 0;
         buf.len = 0;
@@ -1081,7 +1080,7 @@ void uv_process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
           }
         } else {
           /* Connection closed */
-          handle->flags &= ~(UV_HANDLE_READING | UV_HANDLE_READABLE);
+          handle->flags &= ~UV_HANDLE_READING;
           DECREASE_ACTIVE_COUNT(loop, handle);
 
           handle->read_cb((uv_stream_t*)handle, UV_EOF, &buf);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -509,7 +509,7 @@ TEST_DECLARE   (getters_setters)
 
 TEST_DECLARE   (not_writable_after_shutdown)
 TEST_DECLARE   (not_readable_nor_writable_on_read_error)
-TEST_DECLARE   (not_readable_on_eof)
+TEST_DECLARE   (readable_on_eof)
 
 #ifndef _WIN32
 TEST_DECLARE  (fork_timer)
@@ -1145,8 +1145,8 @@ TASK_LIST_START
   TEST_HELPER   (not_writable_after_shutdown, tcp4_echo_server)
   TEST_ENTRY    (not_readable_nor_writable_on_read_error)
   TEST_HELPER   (not_readable_nor_writable_on_read_error, tcp4_echo_server)
-  TEST_ENTRY    (not_readable_on_eof)
-  TEST_HELPER   (not_readable_on_eof, tcp4_echo_server)
+  TEST_ENTRY    (readable_on_eof)
+  TEST_HELPER   (readable_on_eof, tcp4_echo_server)
 
   TEST_ENTRY  (metrics_idle_time)
   TEST_ENTRY  (metrics_idle_time_thread)


### PR DESCRIPTION
On some streams (notably TTYs), it is permitted to continue reading
after getting EOF. So still stop reading on EOF, but allow the user to
reset the stream and try to read again (which may just get EOF).

This relaxes the constraint added in ce15b8405e9d01e221f8390475deab4a40d26e38.
Refs: https://github.com/libuv/libuv/pull/3006
Fixes: https://github.com/JuliaLang/julia/issues/42937