### PR TITLE
include,test,sunos: Oracle Developer Studio support.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -43,6 +43,8 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
+#elif defined(__sun)
+# define UV_EXTERN __global
 #elif __GNUC__ >= 4
 # define UV_EXTERN __attribute__((visibility("default")))
 #else

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -844,8 +844,7 @@ static void check_utime(const char* path,
   } else {
     double st_atim;
     double st_mtim;
-#if !defined(__APPLE__)     && \
-    !defined(__sun)
+#if !defined(__APPLE__) && !defined(__sun)
     /* TODO(vtjnash): would it be better to normalize this? */
     ASSERT_DOUBLE_GE(s->st_atim.tv_nsec, 0);
     ASSERT_DOUBLE_GE(s->st_mtim.tv_nsec, 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -844,7 +844,8 @@ static void check_utime(const char* path,
   } else {
     double st_atim;
     double st_mtim;
-#ifndef __APPLE__
+#if !defined(__APPLE__)     && \
+    !defined(__sun)
     /* TODO(vtjnash): would it be better to normalize this? */
     ASSERT_DOUBLE_GE(s->st_atim.tv_nsec, 0);
     ASSERT_DOUBLE_GE(s->st_mtim.tv_nsec, 0);


### PR DESCRIPTION
Oracle Solaris linker visibility support.  Option "-fvisibility=hidden"
requires public functions to be defined as "__global".

fs_utime_round test failed as timespec.tv_nsec conversion to double
resulted in negative number.  Skipped this test.

Note that it was necessary to compile with C99 language features.