### PR TITLE
Revert "include,test,sunos: Oracle Developer Studio support."

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -43,8 +43,6 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
-#elif defined(__sun)
-# define UV_EXTERN __global
 #elif __GNUC__ >= 4
 # define UV_EXTERN __attribute__((visibility("default")))
 #else

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -844,7 +844,7 @@ static void check_utime(const char* path,
   } else {
     double st_atim;
     double st_mtim;
-#if !defined(__APPLE__) && !defined(__sun)
+#ifndef __APPLE__
     /* TODO(vtjnash): would it be better to normalize this? */
     ASSERT_DOUBLE_GE(s->st_atim.tv_nsec, 0);
     ASSERT_DOUBLE_GE(s->st_mtim.tv_nsec, 0);


### PR DESCRIPTION
Reverts libuv/libuv#3364

The PR was reported to break libuv on Illumos systems.