### PR TITLE
include,test,sunos: Oracle Developer Studio support.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -45,6 +45,8 @@ extern "C" {
 # endif
 #elif __GNUC__ >= 4
 # define UV_EXTERN __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550) /* Sun Studio >= 8 */
+# define UV_EXTERN __global
 #else
 # define UV_EXTERN /* nothing */
 #endif

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -844,7 +844,7 @@ static void check_utime(const char* path,
   } else {
     double st_atim;
     double st_mtim;
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__SUNPRO_C)
     /* TODO(vtjnash): would it be better to normalize this? */
     ASSERT_DOUBLE_GE(s->st_atim.tv_nsec, 0);
     ASSERT_DOUBLE_GE(s->st_mtim.tv_nsec, 0);


### PR DESCRIPTION
Oracle Developer Studio requires public functions to be
defined as "__global" when "-fvisibility=hidden" used as
added by [#3005](https://github.com/libuv/libuv/pull/3005).
For documentation on `__global` see Reducing Symbol Scope in
Oracle Developer Studio C/C++ guide
https://www.oracle.com/solaris/technologies/symbol-scope.html.

fs_utime_round test failed as timespec.tv_nsec conversion to
double resulted in negative number.  Skip this test for
__SPRO_C builds.

Note that it was necessary to have C99 language features
enabled with Studio compiler (-xc99=all) as version v1.41.0
has other commits that have used C99 features.

Tested with:
- cc: Studio 12.6 Sun C 5.15 SunOS_sparc 152881-05 2019/10/30
- gcc (GCC) 11.2.0