### PR TITLE
zos: use destructor for uv__threadpool_cleanup()

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -160,13 +160,20 @@ static void post(QUEUE* q, enum uv__work_kind kind) {
 }
 
 
+#ifdef __MVS__
+/* TODO(itodorov) - zos: revisit when Woz compiler is available. */
+__attribute__((destructor))
+#endif
 void uv__threadpool_cleanup(void) {
   unsigned int i;
 
   if (nthreads == 0)
     return;
 
+#ifndef __MVS__
+  /* TODO(gabylb) - zos: revisit when Woz compiler is available. */
   post(&exit_message, UV__WORK_CPU);
+#endif
 
   for (i = 0; i < nthreads; i++)
     if (uv_thread_join(threads + i))

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -136,6 +136,11 @@ static void maybe_resize(uv__os390_epoll* lst, unsigned int len) {
 }
 
 
+void uv__os390_cleanup(void) {
+  msgctl(uv_backend_fd(uv_default_loop()), IPC_RMID, NULL);
+}
+
+
 static void init_message_queue(uv__os390_epoll* lst) {
   struct {
     long int header;

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -70,5 +70,6 @@ int sem_destroy(UV_PLATFORM_SEM_T* semid);
 int sem_post(UV_PLATFORM_SEM_T* semid);
 int sem_trywait(UV_PLATFORM_SEM_T* semid);
 int sem_wait(UV_PLATFORM_SEM_T* semid);
+void uv__os390_cleanup(void);
 
 #endif /* UV_OS390_SYSCALL_H_ */

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -901,7 +901,12 @@ void uv_library_shutdown(void) {
 
   uv__process_title_cleanup();
   uv__signal_cleanup();
+#ifdef __MVS__
+  /* TODO(itodorov) - zos: revisit when Woz compiler is available. */
+  uv__os390_cleanup();
+#else
   uv__threadpool_cleanup();
+#endif
   uv__store_relaxed(&was_shutdown, 1);
 }
 


### PR DESCRIPTION
This PR resolves the z/OS test failures in #3349

The `uv__threadpool_cleanup()` function cannot be called from inside `uv_library_shutdown()` on z/OS. Instead, the destructor attribute must be used; otherwise, tests will fail with exit code 1 and no output as seen in #3349. Additionally, `post()` does not need to be called when the destructor attribute is used.

Also adds `uv__os390_cleanup()` function to clean System V message queue on z/OS.

We are planning to revisit these changes once the Woz compiler becomes available to see if these changes are still necessary at that time, or if improvements can be made.