### PR TITLE
build: remove Windows 2016 workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {toolchain: Visual Studio 15 2017, arch: Win32, server: 2016}
-          - {toolchain: Visual Studio 15 2017, arch: x64, server: 2016}
           - {toolchain: Visual Studio 16 2019, arch: Win32, server: 2019}
           - {toolchain: Visual Studio 16 2019, arch: x64, server: 2019}
           - {toolchain: Visual Studio 17 2022, arch: Win32, server: 2022}


### PR DESCRIPTION
Refs: https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

cc @vtjnash 