### PR TITLE
win: fix EPERM when trying to write a hidden file

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -606,6 +606,14 @@ void fs__open(uv_fs_t* req) {
     goto einval;
   }
 
+  /* Copy existing attributes to prevent an "Access is denied" error for hidden
+   * and system files. */
+  DWORD existing_attributes = GetFileAttributesW(req->file.pathw);
+  if (existing_attributes != INVALID_FILE_ATTRIBUTES) {
+    attributes |= (existing_attributes
+      & (FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM));
+  }
+
   /* Setting this flag makes it possible to open a directory. */
   attributes |= FILE_FLAG_BACKUP_SEMANTICS;
 


### PR DESCRIPTION
Fix an issue with writing to files marked as hidden on Windows by passing the correct file attributes to `CreateFileW()`. 

As per [documentation](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew):

> If CREATE_ALWAYS and FILE_ATTRIBUTE_NORMAL are specified, CreateFile fails and sets the last error to ERROR_ACCESS_DENIED if the file exists and has the FILE_ATTRIBUTE_HIDDEN or FILE_ATTRIBUTE_SYSTEM attribute. To avoid the error, specify the same attributes as the existing file.

Fixes https://github.com/nodejs/node/issues/41093

Steps to reproduce the bug:

1. Execute `touch hidden-file.txt && attrib +h hidden-file.txt`
2. Compile and run this program:

```c
#include <stdio.h>
#include <string.h>
#include "uv.h"

void on_open(uv_fs_t *req);
void on_write(uv_fs_t *req);

uv_buf_t buffer;
uv_fs_t open_req;
uv_fs_t write_req;
uv_fs_t close_req;

void on_open(uv_fs_t *req) {
    if (req->result < 0) {
        fprintf(stderr, "Open error: %s\n", uv_strerror(req->result));
    }
    else {
        uv_fs_write(uv_default_loop(), &write_req, open_req.result, &buffer, 1, 0, on_write);
    }
}

void on_write(uv_fs_t *req) {
    uv_fs_req_cleanup(req);
    if (req->result < 0) {
        fprintf(stderr, "Write error: %s\n", uv_strerror(req->result));
    }
    else {
        uv_fs_close(uv_default_loop(), &close_req, open_req.result, NULL);
    }
}

int main(int argc, char **argv) {
    time_t ts = time(NULL);
    char *str;
    ssize_t result;

    if (argc < 2) {
        printf("Usage: %s <fileName>\n", argv[0]);
        return 1;
    }

    str = ctime(&ts);
    buffer = uv_buf_init(str, strlen(str));

    uv_fs_open(uv_default_loop(),
               &open_req, argv[1],
               UV_FS_O_CREAT | UV_FS_O_TRUNC | UV_FS_O_WRONLY,
               _S_IREAD | _S_IWRITE,
               on_open);
    uv_run(uv_default_loop(), UV_RUN_DEFAULT);

    return 0;
}
```
