### PR TITLE
The Windows SRWLock primitive can be used for rw locking instead of a custom CRITICAL_SECTION+Semaphore implementation #3382

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -265,19 +265,8 @@ typedef union {
 
 typedef union {
   struct {
-    unsigned int num_readers_;
-    CRITICAL_SECTION num_readers_lock_;
-    HANDLE write_semaphore_;
+    SRWLOCK read_write_lock_;
   } state_;
-  /* TODO: remove me in v2.x. */
-  struct {
-    SRWLOCK unused_;
-  } unused1_;
-  /* TODO: remove me in v2.x. */
-  struct {
-    uv_mutex_t unused1_;
-    uv_mutex_t unused2_;
-  } unused2_;
 } uv_rwlock_t;
 
 typedef struct {

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -267,7 +267,11 @@ typedef union {
   struct {
     SRWLOCK read_write_lock_;
     /* TODO: retained for ABI compatibility; remove me in v2.x */
+#ifdef _WIN64
     unsigned char padding_[72];
+#else
+    unsigned char padding_[44];
+#endif
   } state_;
 } uv_rwlock_t;
 

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -266,6 +266,8 @@ typedef union {
 typedef union {
   struct {
     SRWLOCK read_write_lock_;
+    /* TODO: retained for ABI compatibility; remove me in v2.x */
+    unsigned char padding_[72];
   } state_;
 } uv_rwlock_t;
 

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -263,16 +263,14 @@ typedef union {
   } unused_; /* TODO: retained for ABI compatibility; remove me in v2.x. */
 } uv_cond_t;
 
-typedef union {
-  struct {
-    SRWLOCK read_write_lock_;
-    /* TODO: retained for ABI compatibility; remove me in v2.x */
+typedef struct {
+  SRWLOCK read_write_lock_;
+  /* TODO: retained for ABI compatibility; remove me in v2.x */
 #ifdef _WIN64
-    unsigned char padding_[72];
+  unsigned char padding_[72];
 #else
-    unsigned char padding_[44];
+  unsigned char padding_[44];
 #endif
-  } state_;
 } uv_rwlock_t;
 
 typedef struct {

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -249,7 +249,11 @@ void uv_mutex_unlock(uv_mutex_t* mutex) {
 }
 
 /* Ensure that the ABI for this type remains stable in v1.x */
+#ifdef _WIN64
 STATIC_ASSERT(sizeof(uv_rwlock_t) == 80);
+#else
+STATIC_ASSERT(sizeof(uv_rwlock_t) == 48);
+#endif
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
   memset(rwlock, 0, sizeof(*rwlock));

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -250,111 +250,51 @@ void uv_mutex_unlock(uv_mutex_t* mutex) {
 
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
-  /* Initialize the semaphore that acts as the write lock. */
-  HANDLE handle = CreateSemaphoreW(NULL, 1, 1, NULL);
-  if (handle == NULL)
-    return uv_translate_sys_error(GetLastError());
-  rwlock->state_.write_semaphore_ = handle;
-
-  /* Initialize the critical section protecting the reader count. */
-  InitializeCriticalSection(&rwlock->state_.num_readers_lock_);
-
-  /* Initialize the reader count. */
-  rwlock->state_.num_readers_ = 0;
+  InitializeSRWLock(&rwlock->state_.read_write_lock_);
 
   return 0;
 }
 
 
 void uv_rwlock_destroy(uv_rwlock_t* rwlock) {
-  DeleteCriticalSection(&rwlock->state_.num_readers_lock_);
-  CloseHandle(rwlock->state_.write_semaphore_);
+  // SRWLock does not need explicit destruction so long as there are no waiting threads
+  // See: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks
 }
 
 
 void uv_rwlock_rdlock(uv_rwlock_t* rwlock) {
-  /* Acquire the lock that protects the reader count. */
-  EnterCriticalSection(&rwlock->state_.num_readers_lock_);
-
-  /* Increase the reader count, and lock for write if this is the first
-   * reader.
-   */
-  if (++rwlock->state_.num_readers_ == 1) {
-    DWORD r = WaitForSingleObject(rwlock->state_.write_semaphore_, INFINITE);
-    if (r != WAIT_OBJECT_0)
-      uv_fatal_error(GetLastError(), "WaitForSingleObject");
-  }
-
-  /* Release the lock that protects the reader count. */
-  LeaveCriticalSection(&rwlock->state_.num_readers_lock_);
+  AcquireSRWLockShared(&rwlock->state_.read_write_lock_);
 }
 
 
 int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
-  int err;
-
-  if (!TryEnterCriticalSection(&rwlock->state_.num_readers_lock_))
+  if (!TryAcquireSRWLockShared(&rwlock->state_.read_write_lock_))
     return UV_EBUSY;
 
-  err = 0;
-
-  if (rwlock->state_.num_readers_ == 0) {
-    /* Currently there are no other readers, which means that the write lock
-     * needs to be acquired.
-     */
-    DWORD r = WaitForSingleObject(rwlock->state_.write_semaphore_, 0);
-    if (r == WAIT_OBJECT_0)
-      rwlock->state_.num_readers_++;
-    else if (r == WAIT_TIMEOUT)
-      err = UV_EBUSY;
-    else if (r == WAIT_FAILED)
-      uv_fatal_error(GetLastError(), "WaitForSingleObject");
-
-  } else {
-    /* The write lock has already been acquired because there are other
-     * active readers.
-     */
-    rwlock->state_.num_readers_++;
-  }
-
-  LeaveCriticalSection(&rwlock->state_.num_readers_lock_);
-  return err;
+  return 0;
 }
 
 
 void uv_rwlock_rdunlock(uv_rwlock_t* rwlock) {
-  EnterCriticalSection(&rwlock->state_.num_readers_lock_);
-
-  if (--rwlock->state_.num_readers_ == 0) {
-    if (!ReleaseSemaphore(rwlock->state_.write_semaphore_, 1, NULL))
-      uv_fatal_error(GetLastError(), "ReleaseSemaphore");
-  }
-
-  LeaveCriticalSection(&rwlock->state_.num_readers_lock_);
+  ReleaseSRWLockShared(&rwlock->state_.read_write_lock_);
 }
 
 
 void uv_rwlock_wrlock(uv_rwlock_t* rwlock) {
-  DWORD r = WaitForSingleObject(rwlock->state_.write_semaphore_, INFINITE);
-  if (r != WAIT_OBJECT_0)
-    uv_fatal_error(GetLastError(), "WaitForSingleObject");
+  AcquireSRWLockExclusive(&rwlock->state_.read_write_lock_);
 }
 
 
 int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
-  DWORD r = WaitForSingleObject(rwlock->state_.write_semaphore_, 0);
-  if (r == WAIT_OBJECT_0)
-    return 0;
-  else if (r == WAIT_TIMEOUT)
+  if (!TryAcquireSRWLockExclusive(&rwlock->state_.read_write_lock_))
     return UV_EBUSY;
-  else
-    uv_fatal_error(GetLastError(), "WaitForSingleObject");
+
+  return 0;
 }
 
 
 void uv_rwlock_wrunlock(uv_rwlock_t* rwlock) {
-  if (!ReleaseSemaphore(rwlock->state_.write_semaphore_, 1, NULL))
-    uv_fatal_error(GetLastError(), "ReleaseSemaphore");
+  ReleaseSRWLockExclusive(&rwlock->state_.read_write_lock_);
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -258,7 +258,7 @@ int uv_rwlock_init(uv_rwlock_t* rwlock) {
 
 void uv_rwlock_destroy(uv_rwlock_t* rwlock) {
   // SRWLock does not need explicit destruction so long as there are no waiting threads
-  // See: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks
+  // See: https://docs.microsoft.com/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -248,8 +248,11 @@ void uv_mutex_unlock(uv_mutex_t* mutex) {
   LeaveCriticalSection(mutex);
 }
 
+/* Ensure that the ABI for this type remains stable in v1.x */
+STATIC_ASSERT(sizeof(uv_rwlock_t) == 80);
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
+  memset(rwlock, 0, sizeof(*rwlock));
   InitializeSRWLock(&rwlock->state_.read_write_lock_);
 
   return 0;
@@ -257,8 +260,8 @@ int uv_rwlock_init(uv_rwlock_t* rwlock) {
 
 
 void uv_rwlock_destroy(uv_rwlock_t* rwlock) {
-  // SRWLock does not need explicit destruction so long as there are no waiting threads
-  // See: https://docs.microsoft.com/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks
+  /* SRWLock does not need explicit destruction so long as there are no waiting threads
+     See: https://docs.microsoft.com/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks */
 }
 
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -257,7 +257,7 @@ STATIC_ASSERT(sizeof(uv_rwlock_t) == 48);
 
 int uv_rwlock_init(uv_rwlock_t* rwlock) {
   memset(rwlock, 0, sizeof(*rwlock));
-  InitializeSRWLock(&rwlock->state_.read_write_lock_);
+  InitializeSRWLock(&rwlock->read_write_lock_);
 
   return 0;
 }
@@ -270,12 +270,12 @@ void uv_rwlock_destroy(uv_rwlock_t* rwlock) {
 
 
 void uv_rwlock_rdlock(uv_rwlock_t* rwlock) {
-  AcquireSRWLockShared(&rwlock->state_.read_write_lock_);
+  AcquireSRWLockShared(&rwlock->read_write_lock_);
 }
 
 
 int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
-  if (!TryAcquireSRWLockShared(&rwlock->state_.read_write_lock_))
+  if (!TryAcquireSRWLockShared(&rwlock->read_write_lock_))
     return UV_EBUSY;
 
   return 0;
@@ -283,17 +283,17 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
 
 
 void uv_rwlock_rdunlock(uv_rwlock_t* rwlock) {
-  ReleaseSRWLockShared(&rwlock->state_.read_write_lock_);
+  ReleaseSRWLockShared(&rwlock->read_write_lock_);
 }
 
 
 void uv_rwlock_wrlock(uv_rwlock_t* rwlock) {
-  AcquireSRWLockExclusive(&rwlock->state_.read_write_lock_);
+  AcquireSRWLockExclusive(&rwlock->read_write_lock_);
 }
 
 
 int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
-  if (!TryAcquireSRWLockExclusive(&rwlock->state_.read_write_lock_))
+  if (!TryAcquireSRWLockExclusive(&rwlock->read_write_lock_))
     return UV_EBUSY;
 
   return 0;
@@ -301,7 +301,7 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
 
 
 void uv_rwlock_wrunlock(uv_rwlock_t* rwlock) {
-  ReleaseSRWLockExclusive(&rwlock->state_.read_write_lock_);
+  ReleaseSRWLockExclusive(&rwlock->read_write_lock_);
 }
 
 


### PR DESCRIPTION
Closes #3382 

## Why is this change being made?
The primary motivation is to try and improve runtime performance.  The OS primitive should be _very_ efficient for the intended use case and will be modestly smaller than the existing implementation.  This change also allows a dozen or so lines of code to be deleted in favor of just using the OS SRWLock implementation.

## Briefly summarize what changed
Trim down the `uv_rwlock_t` struct to just the `SRWLock` field.  There are comments about removing things in v2.x so I am unsure whether this is a breaking change, or not.  I can modify it to be non-breaking if that is necessary.

Update the various `uv_rwlock_` methods to call the Windows SRWLock API.  This is mostly deleting a bunch of code and replacing it with one-liners.

## How was the change tested?
I ran the existing test collateral (compiled as Debug for more asserts) and they passed:
```
 Build started...
 1>------ Build started: Project: RUN_TESTS, Configuration: Debug x64 ------
 1>Test project V:/T/libuv/build
 1>    Start 1: uv_test
 1>1/2 Test #1: uv_test ..........................   Passed  168.58 sec
 1>    Start 2: uv_test_a
 1>2/2 Test #2: uv_test_a ........................   Passed  166.91 sec
 1>
 1>100% tests passed, 0 tests failed out of 2
 1>
 1>Total Test time (real) = 335.50 sec
 ========== Build: 1 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========
```

I also ran `build\Release\uv_run_benchmarks_a.exe` to try and benchmark a difference.  However on closer inspection it seems that none of the benchmarks exercise this particular lock primitive.  I verified this by adding debug information and running the benchmark under the debugger and observing that breakpoints in the modified code do not get hit.

I also applied this edit to a local clone of NodeJS (v16.x branch) and tried to benchmark running `npm init react-app` for `create_react_app`.  Node _does_ seem to use the rwlock primitive.  The performance benefit was small but did seem to be there after a 10x run before and after.  It improved the runtime by roughly 0.5 seconds out of 50 seconds (1% improvement).  

(Disclaimer: I am a Microsoft employee)