### PR TITLE
Try to fix memory leakage.

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -163,13 +163,9 @@ uv_buf_t uv_buf_init(char* base, unsigned int len) {
 
 
 static const char* uv__unknown_err_code(int err) {
-  char buf[32];
-  char* copy;
-
+  static char buf[32];
   snprintf(buf, sizeof(buf), "Unknown system error %d", err);
-  copy = uv__strdup(buf);
-
-  return copy != NULL ? copy : "Unknown system error";
+  return buf;
 }
 
 #define UV_ERR_NAME_GEN_R(name, _) \


### PR DESCRIPTION
In my server program, the following error will appear.
```
==15801== 49 bytes in 2 blocks are definitely lost in loss record 1 of 1
==15801==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15801==    by 0x167DE7: uv__malloc (uv-common.c:77)
==15801==    by 0x167D16: uv__strdup (uv-common.c:57)
==15801==    by 0x16810D: uv__unknown_err_code (uv-common.c:170)
==15801==    by 0x16A286: uv_strerror (uv-common.c:216)
==15801==    by 0x13D25C: tunnel_dump_error_info (tunnel.c:694)
```
If this error occurs very quickly, the server program will crash soon for OOM.
Please accept my correction.

Because libuv only runs in a single thread, there is **NO** need to consider the issue of multi-thread synchronization.