### PR TITLE
win: restrict system DLL load paths

### DIFF
--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -126,19 +126,19 @@ void uv_winapi_init(void) {
       kernel32_module,
       "GetQueuedCompletionStatusEx");
 
-  powrprof_module = LoadLibraryA("powrprof.dll");
+  powrprof_module = LoadLibraryExA("powrprof.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (powrprof_module != NULL) {
     pPowerRegisterSuspendResumeNotification = (sPowerRegisterSuspendResumeNotification)
       GetProcAddress(powrprof_module, "PowerRegisterSuspendResumeNotification");
   }
 
-  user32_module = LoadLibraryA("user32.dll");
+  user32_module = LoadLibraryExA("user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (user32_module != NULL) {
     pSetWinEventHook = (sSetWinEventHook)
       GetProcAddress(user32_module, "SetWinEventHook");
   }
 
-  ws2_32_module = LoadLibraryA("ws2_32.dll");
+  ws2_32_module = LoadLibraryExA("ws2_32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (ws2_32_module != NULL) {
     pGetHostNameW = (uv_sGetHostNameW) GetProcAddress(
         ws2_32_module,

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -132,13 +132,13 @@ void uv_winapi_init(void) {
       GetProcAddress(powrprof_module, "PowerRegisterSuspendResumeNotification");
   }
 
-  user32_module = LoadLibraryExA("user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+  user32_module = GetModuleHandleA("user32.dll");
   if (user32_module != NULL) {
     pSetWinEventHook = (sSetWinEventHook)
       GetProcAddress(user32_module, "SetWinEventHook");
   }
 
-  ws2_32_module = LoadLibraryExA("ws2_32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+  ws2_32_module = GetModuleHandleA("ws2_32.dll");
   if (ws2_32_module != NULL) {
     pGetHostNameW = (uv_sGetHostNameW) GetProcAddress(
         ws2_32_module,


### PR DESCRIPTION
Currently `LoadLibraryA` call first attempts to load the given DLL from
the application working directory before loading it from the system DLL
path. [1] This may pose a security risk if an attacker is able to place a
malicious DLL into the application working directory as that DLL will
be loaded instead of the system DLL. This is especially dangerous if
the application is running with elevated privileges.

This changes the DLL loading to use `LoadLibraryExA` method with
`LOAD_LIBRARY_SEARCH_SYSTEM32` flag which restricts the DLL load
path to system DLL path, ignoring any DLLs in the application working
directory.

[1]: https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-desktop-applications