### PR TITLE
zos,fs: check F_OK separately in uv_fs_access()

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1580,6 +1580,19 @@ TEST_IMPL(fs_access) {
   ASSERT(access_cb_count == 1);
   access_cb_count = 0; /* reset for the next test */
 
+  /* File should grant read and write permission */
+  r = uv_fs_access(NULL, &req, "test_file", F_OK | R_OK | W_OK, NULL);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
+  uv_fs_req_cleanup(&req);
+
+  /* File should grant read and write permission */
+  r = uv_fs_access(loop, &req, "test_file", F_OK | R_OK | W_OK, access_cb);
+  ASSERT_EQ(r, 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT_EQ(access_cb_count, 1);
+  access_cb_count = 0; /* reset for the next test */
+
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT(r == 0);


### PR DESCRIPTION
On z/OS, `F_OK` is 8 instead of 0. This PR creates an internal `uv__fs_access()` function, where the access check for `F_OK` needs to be separated from `R_OK`, `W_OK`, and `X_OK` on z/OS. Otherwise, checking that a file grants read and write permissions using `F_OK | R_OK | W_OK` will fail.

Also updates the `fs_access` test to include this edge case.