### PR TITLE
unix: Fix STATIC_ASSERT to check what it means to check

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -96,9 +96,9 @@ static int uv__run_pending(uv_loop_t* loop);
 
 /* Verify that uv_buf_t is ABI-compatible with struct iovec. */
 STATIC_ASSERT(sizeof(uv_buf_t) == sizeof(struct iovec));
-STATIC_ASSERT(sizeof(&((uv_buf_t*) 0)->base) ==
+STATIC_ASSERT(sizeof(((uv_buf_t*) 0)->base) ==
               sizeof(((struct iovec*) 0)->iov_base));
-STATIC_ASSERT(sizeof(&((uv_buf_t*) 0)->len) ==
+STATIC_ASSERT(sizeof(((uv_buf_t*) 0)->len) ==
               sizeof(((struct iovec*) 0)->iov_len));
 STATIC_ASSERT(offsetof(uv_buf_t, base) == offsetof(struct iovec, iov_base));
 STATIC_ASSERT(offsetof(uv_buf_t, len) == offsetof(struct iovec, iov_len));


### PR DESCRIPTION
Currently it's checking pointers to the uv_buf_t fields match the size
of the iovec fields. This is true on traditional architectures where
pointers are just machine word-sized integers, but not on CHERI, and
thus Arm's Morello prototype, where pointers contain additional metadata
(including bounds and permissions). Drop the & to fix this.