### PR TITLE
unix: don't allow too small thread stack size

### DIFF
--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -273,6 +273,11 @@ TEST_IMPL(thread_stack_size_explicit) {
                                   thread_check_stack, &options));
   ASSERT(0 == uv_thread_join(&thread));
 
+  options.stack_size = 42;
+  ASSERT(0 == uv_thread_create_ex(&thread, &options,
+                                  thread_check_stack, &options));
+  ASSERT(0 == uv_thread_join(&thread));
+
 #ifdef PTHREAD_STACK_MIN
   options.stack_size = PTHREAD_STACK_MIN - 42;  /* unaligned size */
   ASSERT(0 == uv_thread_create_ex(&thread, &options,


### PR DESCRIPTION
uv_thread_create_ex() lets you set a stack size that is smaller than is
safe. It enforces a lower bound of PTHREAD_STACK_MIN (when that constant
is defined) but with musl libc that's still too small to receive signals
on.

Put the lower bound at 8192 or PTHREAD_STACK_MIN, whichever is greater.
The same restriction was already in place for the _default_ stack size.

<hr>

Coincidentally fixes a couple of -Wsign-compare warnings. Diff is probably easiest to review side-by-side.