### PR TITLE
test: fix flaky uv_fs_lutime test

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -851,6 +851,10 @@ static void check_utime(const char* path,
 #endif
     st_atim = s->st_atim.tv_sec + s->st_atim.tv_nsec / 1e9;
     st_mtim = s->st_mtim.tv_sec + s->st_mtim.tv_nsec / 1e9;
+    /*
+     * Linux does not allow reading reliably the atime of a symlink
+     * since readlink() can update it
+     */
     if (!test_lutime)
       ASSERT_DOUBLE_EQ(st_atim, atime);
     ASSERT_DOUBLE_EQ(st_mtim, mtime);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -851,7 +851,8 @@ static void check_utime(const char* path,
 #endif
     st_atim = s->st_atim.tv_sec + s->st_atim.tv_nsec / 1e9;
     st_mtim = s->st_mtim.tv_sec + s->st_mtim.tv_nsec / 1e9;
-    ASSERT_DOUBLE_EQ(st_atim, atime);
+    if (!test_lutime)
+      ASSERT_DOUBLE_EQ(st_atim, atime);
     ASSERT_DOUBLE_EQ(st_mtim, mtime);
   }
 


### PR DESCRIPTION
Disable `atime` testing for symlink as this test
is dependant on a race condition on some OSes
(Linux is one) given that `lstat` updates the `atime`
As both `mtime` and `atime` are set by the same
syscall, barring an eventual kernel bug, this
test does not omit any error case