### PR TITLE
bsd: ensure mutex is initialized

### DIFF
--- a/src/unix/bsd-proctitle.c
+++ b/src/unix/bsd-proctitle.c
@@ -38,6 +38,7 @@ static void init_process_title_mutex_once(void) {
 
 
 void uv__process_title_cleanup(void) {
+  uv_once(&process_title_mutex_once, init_process_title_mutex_once);
   uv_mutex_destroy(&process_title_mutex);
 }
 


### PR DESCRIPTION
The process title mutex was destroyed on library unload without ensuring
it was initialized - and it may not be because it's initialized lazily.

On most platforms it worked by accident because an "all zeroes" mutex is
synonymous with an initialized and unlocked mutex, but not on NetBSD.

Refs: https://github.com/libuv/libuv/pull/3286#issuecomment-1014058782