### PR TITLE
build: rename CFLAGS to AM_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,8 +27,8 @@ uvinclude_HEADERS = include/uv/errno.h \
 CLEANFILES =
 
 lib_LTLIBRARIES = libuv.la
-libuv_la_CFLAGS = @CFLAGS@
-libuv_la_LDFLAGS = -no-undefined -version-info 1:0:0
+libuv_la_CFLAGS = $(AM_CFLAGS)
+libuv_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 1:0:0
 libuv_la_SOURCES = src/fs-poll.c \
                    src/heap-inl.h \
                    src/idna.c \
@@ -131,7 +131,7 @@ EXTRA_DIST = test/fixtures/empty_file \
 
 TESTS = test/run-tests
 check_PROGRAMS = test/run-tests
-test_run_tests_CFLAGS =
+test_run_tests_CFLAGS = $(AM_CFLAGS)
 
 if SUNOS
 # Can't be turned into a CC_CHECK_CFLAGS in configure.ac, it makes compilers
@@ -139,7 +139,7 @@ if SUNOS
 test_run_tests_CFLAGS += -pthreads
 endif
 
-test_run_tests_LDFLAGS =
+test_run_tests_LDFLAGS = $(AM_LDFLAGS)
 test_run_tests_SOURCES = test/blackhole-server.c \
                          test/echo-server.c \
                          test/run-tests.c \

--- a/m4/libuv-check-flags.m4
+++ b/m4/libuv-check-flags.m4
@@ -1,6 +1,7 @@
 dnl Macros to check the presence of generic (non-typed) symbols.
 dnl Copyright (c) 2006-2008 Diego Pettenò <flameeyes gmail com>
 dnl Copyright (c) 2006-2008 xine project
+dnl Copyright (c) 2021 libuv project
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -63,7 +64,7 @@ AC_DEFUN([CC_CHECK_CFLAGS], [
 ])
 
 dnl CC_CHECK_CFLAG_APPEND(FLAG, [action-if-found], [action-if-not-found])
-dnl Check for CFLAG and appends them to CFLAGS if supported
+dnl Check for CFLAG and appends them to AM_CFLAGS if supported
 AC_DEFUN([CC_CHECK_CFLAG_APPEND], [
   AC_CACHE_CHECK([if $CC supports $1 flag],
     AS_TR_SH([cc_cv_cflags_$1]),
@@ -71,7 +72,7 @@ AC_DEFUN([CC_CHECK_CFLAG_APPEND], [
   )
 
   AS_IF([eval test x$]AS_TR_SH([cc_cv_cflags_$1])[ = xyes],
-    [CFLAGS="$CFLAGS $1"; DEBUG_CFLAGS="$DEBUG_CFLAGS $1"; $2], [$3])
+    [AM_CFLAGS="$AM_CFLAGS $1"; DEBUG_CFLAGS="$DEBUG_CFLAGS $1"; $2], [$3])
 ])
 
 dnl CC_CHECK_CFLAGS_APPEND([FLAG1 FLAG2], [action-if-found], [action-if-not])


### PR DESCRIPTION
The CFLAGS variable is reserved and should never be set:
https://www.gnu.org/software/automake/manual/html_node/User-Variables.html

I had run into some issues with this, where the compiler did not like that this configuration meant we were attempting to list all CFLAGS variables twice on the command line.

I also simultaneously dropped support for automake < 1.14, released in 2013.