### PR TITLE
process,bsd: handle kevent NOTE_EXIT failure

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -145,7 +145,8 @@ typedef struct uv__stream_queued_fds_s uv__stream_queued_fds_t;
 
 /* loop flags */
 enum {
-  UV_LOOP_BLOCK_SIGPROF = 1
+  UV_LOOP_BLOCK_SIGPROF = 0x1,
+  UV_LOOP_REAP_CHILDREN = 0x2
 };
 
 /* flags of excluding ifaddr */

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -285,7 +285,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     for (i = 0; i < nfds; i++) {
       ev = events + i;
       if (ev->filter == EVFILT_PROC) {
-        uv__wait_children(loop);
+        loop->flags |= UV_LOOP_REAP_CHILDREN;
         nevents++;
         continue;
       }
@@ -380,6 +380,11 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       }
 
       nevents++;
+    }
+
+    if (loop->flags & UV_LOOP_REAP_CHILDREN) {
+      loop->flags &= ~UV_LOOP_REAP_CHILDREN;
+      uv__wait_children(loop);
     }
 
     if (reset_timeout != 0) {


### PR DESCRIPTION
The kernel may return ESRCH if the child has already exited here.
This is rather annoying, and means we must indirectly handle
notification to our event loop of the process exit.

Refs: https://github.com/libuv/libuv/pull/3441
Refs: https://github.com/libuv/libuv/pull/3257