### PR TITLE
win: uv_uptime return fractional seconds on win

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -312,7 +312,7 @@ API
 
 .. c:function:: int uv_uptime(double* uptime)
 
-    Gets the current system uptime.
+    Gets the current system uptime. Depending on the system full or fractional seconds are returned.
 
 .. c:function:: int uv_getrusage(uv_rusage_t* rusage)
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -608,8 +608,8 @@ int uv_uptime(double* uptime) {
         BYTE* address = (BYTE*) object_type + object_type->DefinitionLength +
                         counter_definition->CounterOffset;
         uint64_t value = *((uint64_t*) address);
-        *uptime = floor((double) (object_type->PerfTime.QuadPart - value) /
-                        (double) object_type->PerfFreq.QuadPart);
+        *uptime = (double) (object_type->PerfTime.QuadPart - value) /
+                  (double) object_type->PerfFreq.QuadPart;
         uv__free(malloced_buffer);
         return 0;
       }


### PR DESCRIPTION
Some systems return fractional seconds, some return full seconds.
On windows uptime was artificially rounded down.

As discussed in #3447.