### PR TITLE
Raise events on stream close after shutdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-pending-instances.c
        test/test-pipe-sendmsg.c
        test/test-pipe-server-close.c
+       test/test-pipe-half-close.c
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
        test/test-platform-output.c
@@ -571,6 +572,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-tcp-write-queue-order.c
        test/test-tcp-write-to-half-open-connection.c
        test/test-tcp-writealot.c
+       test/test-tcp-half-close.c
        test/test-test-macros.c
        test/test-thread-equal.c
        test/test-thread.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -219,6 +219,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-pending-instances.c \
                          test/test-pipe-sendmsg.c \
                          test/test-pipe-server-close.c \
+                         test/test-pipe-half-close.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
@@ -276,6 +277,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-tcp-try-write.c \
                          test/test-tcp-try-write-error.c \
                          test/test-tcp-write-queue-order.c \
+                         test/test-tcp-half-close.c \
                          test/test-test-macros.c \
                          test/test-thread-equal.c \
                          test/test-thread.c \

--- a/include/uv.h
+++ b/include/uv.h
@@ -516,6 +516,8 @@ UV_EXTERN int uv_read_start(uv_stream_t*,
                             uv_read_cb read_cb);
 UV_EXTERN int uv_read_stop(uv_stream_t*);
 
+UV_EXTERN int uv_read_err_enable(uv_stream_t*);
+
 UV_EXTERN int uv_write(uv_write_t* req,
                        uv_stream_t* handle,
                        const uv_buf_t bufs[],

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -889,7 +889,8 @@ void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
 
 
 void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
-  assert(0 == (events & ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI)));
+  assert(0 == (events & 
+               ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI | POLLERR)));
   assert(0 != events);
   assert(w->fd >= 0);
   assert(w->fd < INT_MAX);
@@ -917,7 +918,8 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
 
 void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
-  assert(0 == (events & ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI)));
+  assert(0 == (events & 
+               ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI | POLLERR)));
   assert(0 != events);
 
   if (w->fd == -1)
@@ -948,7 +950,8 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
 
 void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
-  uv__io_stop(loop, w, POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI);
+  uv__io_stop(loop, w, 
+              POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI | POLLERR);
   QUEUE_REMOVE(&w->pending_queue);
 
   /* Remove stale events for this file descriptor */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -203,6 +203,8 @@ TEST_DECLARE   (pipe_getsockname_blocking)
 TEST_DECLARE   (pipe_pending_instances)
 TEST_DECLARE   (pipe_sendmsg)
 TEST_DECLARE   (pipe_server_close)
+TEST_DECLARE   (pipe_half_close)
+TEST_DECLARE   (tcp_half_close)
 TEST_DECLARE   (connection_fail)
 TEST_DECLARE   (connection_fail_doesnt_auto_close)
 TEST_DECLARE   (shutdown_close_tcp)
@@ -578,6 +580,9 @@ TASK_LIST_START
   TEST_ENTRY  (pipe_connect_on_prepare)
 
   TEST_ENTRY  (pipe_server_close)
+
+  TEST_ENTRY  (pipe_half_close)
+  TEST_ENTRY  (tcp_half_close)
 #ifndef _WIN32
   TEST_ENTRY  (pipe_close_stdout_read_stdin)
 #endif

--- a/test/test-pipe-half-close.c
+++ b/test/test-pipe-half-close.c
@@ -1,0 +1,228 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <string.h>
+#include <errno.h>
+
+/* Expected sequence:
+ * # Output from process `pipe_half_close`:
+ * # Loop count: 1
+ * #   Listen CB with status 0
+ * #   Client connect CB with status 0
+ * #   Client write CB with status 0
+ * #   Client shutdown CB with status 0
+ * # Loop count: 2
+ * #   Read 33 from server.
+ * # Loop count: 3
+ * #   Read -4095 from server.
+ * #   Got EOF
+ * #   Server write CB with status 0
+ * # Loop count: 4
+ * #   Read 39 from client.
+ * #   Client close CB
+ * # Loop count: 5
+ * #   Read -32 from server.
+ * #   Listen close CB
+ * #   Server close CB
+ */
+
+/* Original broken sequence:
+ * # Output from process `pipe_half_close`:
+ * # Loop count: 1
+ * #   Listen CB with status 0
+ * #   Client connect CB with status 0
+ * #   Client write CB with status 0
+ * #   Client shutdown CB with status 0
+ * # Loop count: 2
+ * #   Read 33 from server.
+ * # Loop count: 3
+ * #   Read -4095 from server.
+ * #   Got EOF
+ * #   Server write CB with status 0
+ * # Loop count: 4
+ * #   Read 39 from client.
+ * #   Client close CB
+ * # Loop count: 5
+ * # Loop count: 6
+ * # Assertion failed in .../test-pipe-half-close.c on line 175: loop_cnt <= 5
+ */
+
+static uv_pipe_t pipe_client;
+static uv_pipe_t pipe_listen;
+static uv_pipe_t pipe_server;
+static uv_connect_t connect_req;
+static uv_write_t write_req;
+static uv_shutdown_t shutdown_req;
+static uv_idle_t idle_handle;
+static uv_buf_t start_write_buf[] = {
+  {.base = "{\"start_job\": \"some job details\"}", .len=33}
+};
+static uv_buf_t result_write_buf[] = {
+  {.base = "{\"result\": \"In progress, ETA 3 hours.\"}", .len=39}
+};
+static unsigned int loop_cnt = 0;
+
+
+static int pipe_server_read_cb_called = 0;
+
+static void malloc_cb(uv_handle_t* handle,
+                      size_t suggested_size,
+                      uv_buf_t* buf) {
+  buf->len = 0;
+  buf->base = malloc(suggested_size);
+  if (buf->base != NULL) {
+    buf->len = suggested_size;
+  }
+}
+
+static void pipe_client_write_cb(uv_write_t* req, int status) {
+  fprintf(stderr, "  Client write CB with status %d\n", status);
+}
+
+static void pipe_server_write_cb(uv_write_t* req, int status) {
+  fprintf(stderr, "  Server write CB with status %d\n", status);
+}
+
+static void pipe_client_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Client close CB\n");
+}
+
+static void pipe_server_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Server close CB\n");
+}
+
+static void pipe_listen_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Listen close CB\n");
+}
+
+static void pipe_client_shutdown_cb(uv_shutdown_t* req, int status) {
+  fprintf(stderr, "  Client shutdown CB with status %d\n", status);
+  ASSERT(status == 0);
+}
+
+static void pipe_client_connect_cb(uv_connect_t* req, int status) {
+  fprintf(stderr, "  Client connect CB with status %d\n", status);
+  ASSERT(status == 0);
+
+  uv_write(&write_req,
+           (uv_stream_t*)&pipe_client,
+           start_write_buf,
+           1,
+           pipe_client_write_cb);
+  uv_shutdown(&shutdown_req,
+              (uv_stream_t*)&pipe_client,
+              pipe_client_shutdown_cb);
+}
+
+static void pipe_server_read_cb(uv_stream_t* stream,
+                               ssize_t nread,
+                               const uv_buf_t* buf) {
+  fprintf(stderr, "  Read %ld from server.\n", nread);
+  if (nread > 0) {
+    ASSERT(memcmp(start_write_buf->base, buf->base, nread) == 0);
+  }
+  else if (nread == UV_EOF) {
+    ASSERT(pipe_server_read_cb_called == 1);
+    fprintf(stderr, "  Got EOF\n");
+    uv_write(&write_req,
+             (uv_stream_t*)&pipe_server,
+             result_write_buf,
+             1,
+             pipe_server_write_cb);
+  }
+  else if (nread == UV_EPIPE) {
+    ASSERT(pipe_server_read_cb_called == 2);
+    uv_close((uv_handle_t*)&pipe_server, pipe_server_close_cb);
+    uv_close((uv_handle_t*)&pipe_listen, pipe_listen_close_cb);
+    uv_idle_stop(&idle_handle);
+  }
+  else {
+    ASSERT(0);
+  }
+  pipe_server_read_cb_called++;
+}
+
+static void pipe_listen_connection_cb(uv_stream_t* handle, int status) {
+  fprintf(stderr, "  Listen CB with status %d\n", status);
+  ASSERT(status == 0);
+  int r;
+  r = uv_pipe_init(handle->loop, &pipe_server, 0);
+  ASSERT(r == 0);
+  r = uv_accept(handle, (uv_stream_t*)&pipe_server);
+  ASSERT(r == 0);
+  uv_read_start((uv_stream_t*)&pipe_server, malloc_cb, pipe_server_read_cb);
+}
+
+static void pipe_client_read_cb(uv_stream_t* stream,
+                               ssize_t nread,
+                               const uv_buf_t* buf) {
+  fprintf(stderr, "  Read %ld from client.\n", nread);
+  ASSERT(nread > 0);
+  ASSERT((size_t)nread == result_write_buf->len);
+  ASSERT(memcmp(result_write_buf->base, buf->base, nread) == 0);
+  uv_close((uv_handle_t*)&pipe_client, pipe_client_close_cb);
+}
+
+static void idle_cb(uv_idle_t* handle) {
+  fprintf(stderr, "Loop count: %u\n", ++loop_cnt);
+  ASSERT(loop_cnt <= 5);
+}
+
+TEST_IMPL(pipe_half_close) {
+#if defined(NO_SELF_CONNECT)
+  RETURN_SKIP(NO_SELF_CONNECT);
+#endif
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+  ASSERT_NOT_NULL(loop);
+
+  r = uv_idle_init(loop, &idle_handle);
+  ASSERT(r == 0);
+  uv_idle_start(&idle_handle, idle_cb);
+
+  r = uv_pipe_init(loop, &pipe_listen, 0);
+  ASSERT(r == 0);
+
+  r = uv_pipe_bind(&pipe_listen, TEST_PIPENAME);
+  ASSERT(r == 0);
+
+  r = uv_listen((uv_stream_t*) &pipe_listen, 0, pipe_listen_connection_cb);
+  ASSERT(r == 0);
+
+  r = uv_pipe_init(loop, &pipe_client, 0);
+  ASSERT(r == 0);
+
+  uv_pipe_connect(&connect_req,
+                 &pipe_client,
+                 TEST_PIPENAME,
+                 pipe_client_connect_cb);
+  uv_read_start((uv_stream_t*)&pipe_client, malloc_cb, pipe_client_read_cb);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-pipe-half-close.c
+++ b/test/test-pipe-half-close.c
@@ -172,6 +172,7 @@ static void pipe_listen_connection_cb(uv_stream_t* handle, int status) {
   r = uv_accept(handle, (uv_stream_t*)&pipe_server);
   ASSERT(r == 0);
   uv_read_start((uv_stream_t*)&pipe_server, malloc_cb, pipe_server_read_cb);
+  uv_read_err_enable((uv_stream_t*)&pipe_server);
 }
 
 static void pipe_client_read_cb(uv_stream_t* stream,
@@ -220,6 +221,7 @@ TEST_IMPL(pipe_half_close) {
                  TEST_PIPENAME,
                  pipe_client_connect_cb);
   uv_read_start((uv_stream_t*)&pipe_client, malloc_cb, pipe_client_read_cb);
+  uv_read_err_enable((uv_stream_t*)&pipe_client);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-tcp-half-close.c
+++ b/test/test-tcp-half-close.c
@@ -1,0 +1,231 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <string.h>
+#include <errno.h>
+
+/* Expected sequence:
+ * # Output from process `tcp_half_close`:
+ * # Loop count: 1
+ * #   Listen CB with status 0
+ * #   Client connect CB with status 0
+ * #   Client write CB with status 0
+ * #   Client shutdown CB with status 0
+ * # Loop count: 2
+ * #   Read 33 from server.
+ * # Loop count: 3
+ * #   Read -4095 from server.
+ * #   Got EOF
+ * #   Server write CB with status 0
+ * # Loop count: 4
+ * #   Read 39 from client.
+ * #   Client close CB
+ * # Loop count: 5
+ * #   Read -32 from server.
+ * #   Listen close CB
+ * #   Server close CB
+ */
+
+/* Original broken sequence:
+ * # Output from process `tcp_half_close`:
+ * # Loop count: 1
+ * #   Listen CB with status 0
+ * #   Client connect CB with status 0
+ * #   Client write CB with status 0
+ * #   Client shutdown CB with status 0
+ * # Loop count: 2
+ * #   Read 33 from server.
+ * # Loop count: 3
+ * #   Read -4095 from server.
+ * #   Got EOF
+ * #   Server write CB with status 0
+ * # Loop count: 4
+ * #   Read 39 from client.
+ * #   Client close CB
+ * # Loop count: 5
+ * # Loop count: 6
+ * # Assertion failed in .../test-tcp-half-close.c on line 175: loop_cnt <= 5
+ */
+
+static uv_tcp_t tcp_client;
+static uv_tcp_t tcp_listen;
+static uv_tcp_t tcp_server;
+static uv_connect_t connect_req;
+static uv_write_t write_req;
+static uv_shutdown_t shutdown_req;
+static uv_idle_t idle_handle;
+static uv_buf_t start_write_buf[] = {
+  {.base = "{\"start_job\": \"some job details\"}", .len=33}
+};
+static uv_buf_t result_write_buf[] = {
+  {.base = "{\"result\": \"In progress, ETA 3 hours.\"}", .len=39}
+};
+static unsigned int loop_cnt = 0;
+
+static int tcp_server_read_cb_called = 0;
+
+static void malloc_cb(uv_handle_t* handle,
+                      size_t suggested_size,
+                      uv_buf_t* buf) {
+  buf->len = 0;
+  buf->base = malloc(suggested_size);
+  if (buf->base != NULL) {
+    buf->len = suggested_size;
+  }
+}
+
+static void tcp_client_write_cb(uv_write_t* req, int status) {
+  fprintf(stderr, "  Client write CB with status %d\n", status);
+}
+
+static void tcp_server_write_cb(uv_write_t* req, int status) {
+  fprintf(stderr, "  Server write CB with status %d\n", status);
+}
+
+static void tcp_client_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Client close CB\n");
+}
+
+static void tcp_server_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Server close CB\n");
+}
+
+static void tcp_listen_close_cb(uv_handle_t* handle) {
+  fprintf(stderr, "  Listen close CB\n");
+}
+
+static void tcp_client_shutdown_cb(uv_shutdown_t* req, int status) {
+  fprintf(stderr, "  Client shutdown CB with status %d\n", status);
+  ASSERT(status == 0);
+}
+
+static void tcp_client_connect_cb(uv_connect_t* req, int status) {
+  fprintf(stderr, "  Client connect CB with status %d\n", status);
+  ASSERT(status == 0);
+
+  uv_write(&write_req,
+           (uv_stream_t*)&tcp_client,
+           start_write_buf,
+           1,
+           tcp_client_write_cb);
+  uv_shutdown(&shutdown_req,
+              (uv_stream_t*)&tcp_client,
+              tcp_client_shutdown_cb);
+}
+
+static void tcp_server_read_cb(uv_stream_t* stream,
+                               ssize_t nread,
+                               const uv_buf_t* buf) {
+  fprintf(stderr, "  Read %ld from server.\n", nread);
+  if (nread > 0) {
+    ASSERT(memcmp(start_write_buf->base, buf->base, nread) == 0);
+  }
+  else if (nread == UV_EOF) {
+    ASSERT(tcp_server_read_cb_called == 1);
+    fprintf(stderr, "  Got EOF\n");
+    uv_write(&write_req,
+             (uv_stream_t*)&tcp_server,
+             result_write_buf,
+             1,
+             tcp_server_write_cb);
+  }
+  else if (nread == UV_EPIPE) {
+    ASSERT(tcp_server_read_cb_called == 2);
+    uv_close((uv_handle_t*)&tcp_server, tcp_server_close_cb);
+    uv_close((uv_handle_t*)&tcp_listen, tcp_listen_close_cb);
+    uv_idle_stop(&idle_handle);
+  }
+  else {
+    ASSERT(0);
+  }
+  tcp_server_read_cb_called++;
+}
+
+static void tcp_listen_connection_cb(uv_stream_t* handle, int status) {
+  fprintf(stderr, "  Listen CB with status %d\n", status);
+  ASSERT(status == 0);
+  int r;
+  r = uv_tcp_init(handle->loop, &tcp_server);
+  ASSERT(r == 0);
+  r = uv_accept(handle, (uv_stream_t*)&tcp_server);
+  ASSERT(r == 0);
+  uv_read_start((uv_stream_t*)&tcp_server, malloc_cb, tcp_server_read_cb);
+}
+
+static void tcp_client_read_cb(uv_stream_t* stream,
+                               ssize_t nread,
+                               const uv_buf_t* buf) {
+  fprintf(stderr, "  Read %ld from client.\n", nread);
+  ASSERT(nread > 0);
+  ASSERT((size_t)nread == result_write_buf->len);
+  ASSERT(memcmp(result_write_buf->base, buf->base, nread) == 0);
+  uv_tcp_close_reset(&tcp_client, tcp_client_close_cb);
+}
+
+static void idle_cb(uv_idle_t* handle) {
+  fprintf(stderr, "Loop count: %u\n", ++loop_cnt);
+  ASSERT(loop_cnt <= 5);
+}
+
+TEST_IMPL(tcp_half_close) {
+#if defined(NO_SELF_CONNECT)
+  RETURN_SKIP(NO_SELF_CONNECT);
+#endif
+  uv_loop_t* loop;
+  struct sockaddr_in addr;
+  int r;
+
+  loop = uv_default_loop();
+  ASSERT_NOT_NULL(loop);
+
+  r = uv_idle_init(loop, &idle_handle);
+  ASSERT(r == 0);
+  uv_idle_start(&idle_handle, idle_cb);
+
+  r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+  ASSERT(r == 0);
+
+  r = uv_tcp_init(loop, &tcp_listen);
+  ASSERT(r == 0);
+
+  r = uv_tcp_bind(&tcp_listen, (const struct sockaddr*) &addr, 0);
+  ASSERT(r == 0);
+
+  r = uv_listen((uv_stream_t*)&tcp_listen, 128, tcp_listen_connection_cb);
+  ASSERT(r == 0);
+
+  r = uv_tcp_init(loop, &tcp_client);
+  ASSERT(r == 0);
+
+  uv_tcp_connect(&connect_req,
+                 &tcp_client,
+                 (const struct sockaddr*) &addr,
+                 tcp_client_connect_cb);
+  uv_read_start((uv_stream_t*)&tcp_client, malloc_cb, tcp_client_read_cb);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-tcp-half-close.c
+++ b/test/test-tcp-half-close.c
@@ -171,6 +171,7 @@ static void tcp_listen_connection_cb(uv_stream_t* handle, int status) {
   r = uv_accept(handle, (uv_stream_t*)&tcp_server);
   ASSERT(r == 0);
   uv_read_start((uv_stream_t*)&tcp_server, malloc_cb, tcp_server_read_cb);
+  uv_read_err_enable((uv_stream_t*)&tcp_server);
 }
 
 static void tcp_client_read_cb(uv_stream_t* stream,
@@ -223,6 +224,7 @@ TEST_IMPL(tcp_half_close) {
                  (const struct sockaddr*) &addr,
                  tcp_client_connect_cb);
   uv_read_start((uv_stream_t*)&tcp_client, malloc_cb, tcp_client_read_cb);
+  uv_read_err_enable((uv_stream_t*)&tcp_client);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
 


### PR DESCRIPTION
This addresses issue #3449 with a new `uv_read_err_enable` which adds POLLERR to the events that can trigger a read callback with error. I debated a whole new callback, but that seemed like it would be too disruptive to the ABI.

Originally I had made this implicit on `uv_read_start()` but that caused some regressions in the tests and may upset existing systems relying on current behavior.

Similar issues may exist on MacOS or Windows, but I do not have the ability to develop or test against those. I'm happy to assist as I can if someone does want to extend this to include those platforms.

Fixes #3449