### PR TITLE
test: remove flaky test ipc_closed_handle

### DIFF
--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -49,7 +49,6 @@ __attribute__((constructor)) void init() {
 int ipc_helper(int listen_after_write);
 int ipc_helper_heavy_traffic_deadlock_bug(void);
 int ipc_helper_tcp_connection(void);
-int ipc_helper_closed_handle(void);
 int ipc_send_recv_helper(void);
 int ipc_helper_bind_twice(void);
 int ipc_helper_send_zero(void);
@@ -117,10 +116,6 @@ static int maybe_run_test(int argc, char **argv) {
 
   if (strcmp(argv[1], "ipc_helper_tcp_connection") == 0) {
     return ipc_helper_tcp_connection();
-  }
-
-  if (strcmp(argv[1], "ipc_helper_closed_handle") == 0) {
-    return ipc_helper_closed_handle();
   }
 
   if (strcmp(argv[1], "ipc_helper_bind_twice") == 0) {

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -45,8 +45,6 @@ static int close_cb_called;
 static int connection_accepted;
 static int tcp_conn_read_cb_called;
 static int tcp_conn_write_cb_called;
-static int closed_handle_data_read;
-static int closed_handle_write;
 static int send_zero_write;
 
 typedef struct {
@@ -57,15 +55,6 @@ typedef struct {
 
 #define CONN_COUNT 100
 #define BACKLOG 128
-#define LARGE_SIZE 100000
-
-static uv_buf_t large_buf;
-static char buffer[LARGE_SIZE];
-static uv_write_t write_reqs[300];
-static int write_reqs_completed;
-
-static unsigned int write_until_data_queued(void);
-static void send_handle_and_close(void);
 
 
 static void close_server_conn_cb(uv_handle_t* handle) {
@@ -417,26 +406,6 @@ static void on_read_connection(uv_stream_t* handle,
 }
 
 
-#ifndef _WIN32
-static void on_read_closed_handle(uv_stream_t* handle,
-                                  ssize_t nread,
-                                  const uv_buf_t* buf) {
-  if (nread == 0 || nread == UV_EOF) {
-    free(buf->base);
-    return;
-  }
-
-  if (nread < 0) {
-    printf("error recving on channel: %s\n", uv_strerror(nread));
-    abort();
-  }
-
-  closed_handle_data_read += nread;
-  free(buf->base);
-}
-#endif
-
-
 static void on_read_send_zero(uv_stream_t* handle,
                               ssize_t nread,
                               const uv_buf_t* buf) {
@@ -497,15 +466,6 @@ TEST_IMPL(ipc_tcp_connection) {
   ASSERT_EQ(exit_cb_called, 1);
   return r;
 }
-
-#ifndef _WIN32
-TEST_IMPL(ipc_closed_handle) {
-  int r;
-  r = run_ipc_test("ipc_helper_closed_handle", on_read_closed_handle);
-  ASSERT_EQ(r, 0);
-  return 0;
-}
-#endif
 
 
 #ifdef _WIN32
@@ -599,23 +559,6 @@ static void tcp_connection_write_cb(uv_write_t* req, int status) {
   uv_close((uv_handle_t*)&channel, close_cb);
   uv_close((uv_handle_t*)&tcp_server, close_cb);
   tcp_conn_write_cb_called++;
-}
-
-
-static void closed_handle_large_write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
-  ASSERT(closed_handle_data_read = LARGE_SIZE);
-  if (++write_reqs_completed == ARRAY_SIZE(write_reqs)) {
-    write_reqs_completed = 0;
-    if (write_until_data_queued() > 0)
-      send_handle_and_close();
-  }
-}
-
-
-static void closed_handle_write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, UV_EBADF);
-  closed_handle_write = 1;
 }
 
 
@@ -834,76 +777,6 @@ int ipc_helper_tcp_connection(void) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
-
-static unsigned int write_until_data_queued() {
-  unsigned int i;
-  int r;
-
-  i = 0;
-  do {
-    r = uv_write(&write_reqs[i],
-                 (uv_stream_t*)&channel,
-                 &large_buf,
-                 1,
-                 closed_handle_large_write_cb);
-    ASSERT_EQ(r, 0);
-    i++;
-  } while (channel.write_queue_size == 0 &&
-           i < ARRAY_SIZE(write_reqs));
-
-  return channel.write_queue_size;
-}
-
-static void send_handle_and_close() {
-  int r;
-  struct sockaddr_in addr;
-
-  r = uv_tcp_init(uv_default_loop(), &tcp_server);
-  ASSERT_EQ(r, 0);
-
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
-
-  r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
-
-  r = uv_write2(&write_req,
-                (uv_stream_t*)&channel,
-                &large_buf,
-                1,
-                (uv_stream_t*)&tcp_server,
-                closed_handle_write_cb);
-  ASSERT_EQ(r, 0);
-
-  uv_close((uv_handle_t*)&tcp_server, NULL);
-}
-
-int ipc_helper_closed_handle(void) {
-  int r;
-
-  memset(buffer, '.', LARGE_SIZE);
-  large_buf = uv_buf_init(buffer, LARGE_SIZE);
-
-  r = uv_pipe_init(uv_default_loop(), &channel, 1);
-  ASSERT_EQ(r, 0);
-
-  uv_pipe_open(&channel, 0);
-
-  ASSERT_EQ(1, uv_is_readable((uv_stream_t*) &channel));
-  ASSERT_EQ(1, uv_is_writable((uv_stream_t*) &channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &channel));
-
-  if (write_until_data_queued() > 0)
-    send_handle_and_close();
-
-  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
-
-  ASSERT_EQ(closed_handle_write, 1);
-
-  MAKE_VALGRIND_HAPPY();
-  return 0;
-}
-
 
 int ipc_helper_bind_twice(void) {
   /*

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -91,9 +91,6 @@ TEST_DECLARE   (ipc_send_recv_tcp)
 TEST_DECLARE   (ipc_send_recv_tcp_inprocess)
 TEST_DECLARE   (ipc_tcp_connection)
 TEST_DECLARE   (ipc_send_zero)
-#ifndef _WIN32
-TEST_DECLARE   (ipc_closed_handle)
-#endif
 TEST_DECLARE   (tcp_alloc_cb_fail)
 TEST_DECLARE   (tcp_ping_pong)
 TEST_DECLARE   (tcp_ping_pong_vec)
@@ -628,9 +625,6 @@ TASK_LIST_START
   TEST_ENTRY  (ipc_send_recv_tcp_inprocess)
   TEST_ENTRY  (ipc_tcp_connection)
   TEST_ENTRY  (ipc_send_zero)
-#ifndef _WIN32
-  TEST_ENTRY  (ipc_closed_handle)
-#endif
 
   TEST_ENTRY  (tcp_alloc_cb_fail)
 


### PR DESCRIPTION
The test is very flaky, both on the CI and on people's local machines.

I spent some time trying to fix it but its design is fairly questionable
and it fails to test what it should more often than not because on fast
machines no queueing of data takes place.

Fixes #2307.