### PR TITLE
core: change uv_get_password uid/gid to unsigned

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1133,8 +1133,8 @@ struct uv_interface_address_s {
 
 struct uv_passwd_s {
   char* username;
-  long uid;
-  long gid;
+  unsigned long uid;
+  unsigned long gid;
   char* shell;
   char* homedir;
 };

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -22,6 +22,10 @@
 #include "uv.h"
 #include "task.h"
 #include <string.h>
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/types.h>
+#endif
 
 TEST_IMPL(get_passwd) {
 /* TODO(gengjiawen): Fix test on QEMU. */
@@ -64,11 +68,15 @@ TEST_IMPL(get_passwd) {
 #endif
 
 #ifdef _WIN32
-  ASSERT(pwd.uid == -1);
-  ASSERT(pwd.gid == -1);
+  ASSERT_EQ(pwd.uid, (unsigned)-1);
+  ASSERT_EQ(pwd.gid, (unsigned)-1);
 #else
-  ASSERT(pwd.uid >= 0);
-  ASSERT(pwd.gid >= 0);
+  ASSERT_NE(pwd.uid, (unsigned)-1);
+  ASSERT_NE(pwd.gid, (unsigned)-1);
+  ASSERT_EQ(pwd.uid, geteuid());
+  if (pwd.uid != 0 && pwd.gid != getgid())
+    /* This will be likely true, as only root could have changed it. */
+    ASSERT_EQ(pwd.gid, getegid());
 #endif
 
   /* Test uv_os_free_passwd() */


### PR DESCRIPTION
Added in https://github.com/libuv/libuv/pull/742, these values are
typically defined as unsigned (since Linux 2.4). Only -1 is special,
representing an invalid id (e.g. see setreuid).