### PR TITLE
doc: clarify android api level

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -11,7 +11,7 @@
 | z/OS | Tier 2 | >= V2R2 | Maintainers: @libuv/zos |
 | Linux with musl | Tier 2 | musl >= 1.0 | |
 | SmartOS | Tier 3 | >= 14.4 | |
-| Android | Tier 3 | NDK >= r15b | Android 7.0 and up |
+| Android | Tier 3 | NDK >= r15b | Android 7.0, `-DANDROID_PLATFORM=android-24` |
 | MinGW | Tier 3 | MinGW32 and MinGW-w64 | |
 | SunOS | Tier 3 | Solaris 121 and later | |
 | Other | Tier 3 | N/A | |


### PR DESCRIPTION
Google goes to great lengths to obscure the relationship between the two
so explicitly call out the API version matching Android 7.0.