### PR TITLE
net: set tcp keepalive delay only if > 0

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -60,7 +60,7 @@ API
     Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
     ignored when `enable` is zero. 
     
-    A `delay` of 0 will imply using the system default setting for tcp keepalives,
+    A `delay` of 0 will imply using the system default setting for TCP keepalives,
     or if `delay` was previously set to a non-zero value, leave the value unchanged
     from the prior setting.
 

--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -58,7 +58,11 @@ API
 .. c:function:: int uv_tcp_keepalive(uv_tcp_t* handle, int enable, unsigned int delay)
 
     Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
-    ignored when `enable` is zero.
+    ignored when `enable` is zero. 
+    
+    A `delay` of 0 will imply using the system default setting for tcp keepalives,
+    or if `delay` was previously set to a non-zero value, leave the value unchanged
+    from the prior setting.
 
     After `delay` has been reached, 10 successive probes, each spaced 1 second
     from the previous one, will still happen. If the connection is still lost

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -385,7 +385,7 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
     return UV__ERR(errno);
 
 #ifdef TCP_KEEPIDLE
-  if (on) {
+  if (on && delay) { /* only attempt to change settings if delay is non-zero */
     int intvl = 1;  /*  1 second; same as default on Win32 */
     int cnt = 10;  /* 10 retries; same as hardcoded on Win32 */
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &delay, sizeof(delay)))

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -66,7 +66,7 @@ static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsign
     return WSAGetLastError();
   }
 
-  if (enable && setsockopt(socket,
+  if (enable && delay > 0 && setsockopt(socket,
                            IPPROTO_TCP,
                            TCP_KEEPALIVE,
                            (const char*)&delay,

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -29,11 +29,17 @@
 TEST_IMPL(tcp_flags) {
   uv_loop_t* loop;
   uv_tcp_t handle;
+  struct sockaddr_in addr;
   int r;
 
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &handle);
+  ASSERT(r == 0);
+
+  r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
+  ASSERT(r == 0);
+  r = uv_tcp_bind(&handle, (const struct sockaddr*) &addr, 0);
   ASSERT(r == 0);
 
   r = uv_tcp_nodelay(&handle, 1);

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -41,6 +41,10 @@ TEST_IMPL(tcp_flags) {
 
   r = uv_tcp_keepalive(&handle, 1, 60);
   ASSERT(r == 0);
+  r = uv_tcp_keepalive(&handle, 0, 0);
+  ASSERT(r == 0);
+  r = uv_tcp_keepalive(&handle, 1, 0);
+  ASSERT(r == 0);
 
   uv_close((uv_handle_t*)&handle, NULL);
 


### PR DESCRIPTION
If tcpkeepalive delay is zero, don't set the TCP_KEEPALIVE sock option.
This will result in a) using the windows system settings or b) if
previously set, no change.