### PR TITLE
checkout < check out

### DIFF
--- a/docs/src/design.rst
+++ b/docs/src/design.rst
@@ -125,7 +125,7 @@ File I/O
 Unlike network I/O, there are no platform-specific file I/O primitives libuv could rely on,
 so the current approach is to run blocking file I/O operations in a thread pool.
 
-For a thorough explanation of the cross-platform file I/O landscape, checkout
+For a thorough explanation of the cross-platform file I/O landscape, check out
 `this post <https://blog.libtorrent.org/2012/10/asynchronous-disk-io/>`_.
 
 libuv currently uses a global thread pool on which all loops can queue work. 3 types of


### PR DESCRIPTION
"check out" is a verb phrase, but "checkout" is a noun.  Since it is being used as a verb, the spelling "check out" is required.