### PR TITLE
test: use closefd in runner-unix.c

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -333,8 +333,8 @@ int process_wait(process_info_t* vec, int n, int timeout) {
     abort();
 
 terminate:
-  close(args.pipe[0]);
-  close(args.pipe[1]);
+  closefd(args.pipe[0]);
+  closefd(args.pipe[1]);
   return retval;
 }
 


### PR DESCRIPTION
This commit changes the plain close calls to
the closefd function, which will properly check if
close() returns an error.

Closes #3306 