### PR TITLE
unix,win: add uv_available_parallelism()

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -334,10 +334,29 @@ API
 
     .. versionadded:: 1.16.0
 
+.. c:function:: unsigned int uv_available_parallelism(void)
+
+    Returns an estimate of the default amount of parallelism a program should
+    use. Always returns a non-zero value.
+
+    On Linux, inspects the calling thread's CPU affinity mask to determine if
+    it has been pinned to specific CPUs.
+
+    On Windows, the available parallelism may be underreported on systems with
+    more than 64 logical CPUs.
+
+    On other platforms, reports the number of CPUs that the operating system
+    considers to be online.
+
+    .. versionadded:: 1.44.0
+
 .. c:function:: int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count)
 
     Gets information about the CPUs on the system. The `cpu_infos` array will
     have `count` elements and needs to be freed with :c:func:`uv_free_cpu_info`.
+
+    Use :c:func:`uv_available_parallelism` if you need to know how many CPUs
+    are available for threads or child processes.
 
 .. c:function:: void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1242,6 +1242,7 @@ UV_EXTERN uv_pid_t uv_os_getppid(void);
 UV_EXTERN int uv_os_getpriority(uv_pid_t pid, int* priority);
 UV_EXTERN int uv_os_setpriority(uv_pid_t pid, int priority);
 
+UV_EXTERN unsigned int uv_available_parallelism(void);
 UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);
 UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -540,9 +540,8 @@ unsigned int uv_available_parallelism(void) {
   SYSTEM_INFO info;
   unsigned rc;
 
-  /* TODO(bnoordhuis) Should probably use GetLogicalProcessorInformationEx()
-   * to support systems with > 64 CPUs? On the other hand, uv_cpu_info() uses
-   * GetSystemInfo() too and so far no one has complained.
+  /* TODO(bnoordhuis) Use GetLogicalProcessorInformationEx() to support systems
+   * with > 64 CPUs? See https://github.com/libuv/libuv/pull/3458
    */
   GetSystemInfo(&info);
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -536,6 +536,24 @@ int uv_uptime(double* uptime) {
 }
 
 
+unsigned int uv_available_parallelism(void) {
+  SYSTEM_INFO info;
+  unsigned rc;
+
+  /* TODO(bnoordhuis) Should probably use GetLogicalProcessorInformationEx()
+   * to support systems with > 64 CPUs? On the other hand, uv_cpu_info() uses
+   * GetSystemInfo() too and so far no one has complained.
+   */
+  GetSystemInfo(&info);
+
+  rc = info.dwNumberOfProcessors;
+  if (rc < 1)
+    rc = 1;
+
+  return rc;
+}
+
+
 int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
   uv_cpu_info_t* cpu_infos;
   SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION* sppi;

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -41,6 +41,7 @@ TEST_IMPL(platform_output) {
   uv_interface_address_t* interfaces;
   uv_passwd_t pwd;
   uv_utsname_t uname;
+  unsigned par;
   int count;
   int i;
   int err;
@@ -87,6 +88,10 @@ TEST_IMPL(platform_output) {
   printf("  page faults: %llu\n", (unsigned long long) rusage.ru_majflt);
   printf("  maximum resident set size: %llu\n",
          (unsigned long long) rusage.ru_maxrss);
+
+  par = uv_available_parallelism();
+  ASSERT_GE(par, 1);
+  printf("uv_available_parallelism: %u\n", par);
 
   err = uv_cpu_info(&cpus, &count);
 #if defined(__CYGWIN__) || defined(__MSYS__)


### PR DESCRIPTION
Replacement for the usage pattern where people use uv_cpu_info() as an
imperfect heuristic for determining the amount of parallelism that is
available to their programs.

Fixes #3493.

<hr>

You can test the linux behavior with:
```
$ taskset 3 ./build/uv_run_tests_a platform_output platform_output | grep uv_available_parallelism
uv_available_parallelism: 2

$ taskset 0xffffffff ./build/uv_run_tests_a platform_output platform_output | grep uv_available_parallelism
uv_available_parallelism: 12
```