### PR TITLE
build: add `UV_QUIET` for silencing CMake options summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,3 +684,13 @@ install(EXPORT libuvConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv)
 if(MSVC)
   set(CMAKE_DEBUG_POSTFIX d)
 endif()
+
+if(NOT UV_QUIET)
+  message(STATUS "Summary of build options:
+      Install prefix:  ${CMAKE_INSTALL_PREFIX}
+      Target system:   ${CMAKE_SYSTEM_NAME}
+      Compiler:
+        C compiler:    ${CMAKE_C_COMPILER} (${CMAKE_C_COMPILER_ID})
+        CFLAGS:        ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
+  ")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,11 +684,3 @@ install(EXPORT libuvConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv)
 if(MSVC)
   set(CMAKE_DEBUG_POSTFIX d)
 endif()
-
-message(STATUS "summary of build options:
-    Install prefix:  ${CMAKE_INSTALL_PREFIX}
-    Target system:   ${CMAKE_SYSTEM_NAME}
-    Compiler:
-      C compiler:    ${CMAKE_C_COMPILER} (${CMAKE_C_COMPILER_ID})
-      CFLAGS:        ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
-")


### PR DESCRIPTION
The summary was showing up when including libuv as a subproject of another CMake build.