### PR TITLE
macos: implement async getaddrinfo and getnameinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,15 @@ endif()
 
 option(ASAN "Enable AddressSanitizer (ASan)" OFF)
 option(TSAN "Enable ThreadSanitizer (TSan)" OFF)
+option(ENABLE_ASYNC_ADDRINFO_ON_OSX "Enable async getaddrinfo on OSX" ON)
+if(ENABLE_ASYNC_ADDRINFO_ON_OSX)
+  add_definitions(-D_USE_ASYNC_ADDR_INFO=1)
+endif()
+
+option(ENABLE_ASYNC_GETNAMEINFO_ON_OSX "Enable async getnameinfo on OSX" ON)
+if(ENABLE_ASYNC_GETNAMEINFO_ON_OSX)
+  add_definitions(-D_USE_ASYNC_GETNAME_INFO=1)
+endif()
 
 if((ASAN OR TSAN) AND NOT (CMAKE_C_COMPILER_ID MATCHES "AppleClang|GNU|Clang"))
   message(SEND_ERROR "Sanitizer support requires clang or gcc. Try again with -DCMAKE_C_COMPILER.")

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,14 @@ AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_SEARCH_LIBS([sendfile], [sendfile])
 AC_SEARCH_LIBS([socket], [socket])
 AC_SYS_LARGEFILE
+AC_ARG_ENABLE(async-getaddrinfo-on-osx,
+              AS_HELP_STRING([--disable-async-getaddrinfo-on-osx],
+                             [don't use async getaddrinfo on OS X]),
+              , enable_async_addrinfo_on_osx=yes)
+AC_ARG_ENABLE(async-getnameinfo-on-osx,
+              AS_HELP_STRING([--disable-async-getnameinfo-on-osx],
+                             [don't use async getnameinfo on OS X]),
+              , enable_async_nameinfo_on_osx=yes)
 AM_CONDITIONAL([AIX],      [AS_CASE([$host_os],[aix*],          [true], [false])])
 AM_CONDITIONAL([ANDROID],  [AS_CASE([$host_os],[linux-android*],[true], [false])])
 AM_CONDITIONAL([CYGWIN],   [AS_CASE([$host_os],[cygwin*],       [true], [false])])
@@ -79,6 +87,12 @@ AS_CASE([$host_os], [kfreebsd*], [
 ])
 AS_CASE([$host_os], [haiku], [
     LIBS="$LIBS -lnetwork"
+])
+AS_CASE(["x$enable_async_addrinfo_on_osx"], ["xyes"], [
+  CFLAGS="$CFLAGS -D_USE_ASYNC_ADDR_INFO=1"
+])
+AS_CASE(["x$enable_async_nameinfo_on_osx"], ["xyes"], [
+  CFLAGS="$CFLAGS -D_USE_ASYNC_GETNAME_INFO=1"
 ])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])

--- a/include/uv/darwin.h
+++ b/include/uv/darwin.h
@@ -30,9 +30,45 @@
 # define UV_PLATFORM_SEM_T semaphore_t
 #endif
 
+#if !defined(_USE_ASYNC_ADDR_INFO) && !defined(_USE_ASYNC_GETNAME_INFO)
+# define UV_IO_PRIVATE_PLATFORM_EXTRA_FIELDS /* empty */
+
+#elif defined(_USE_ASYNC_ADDR_INFO) && defined(_USE_ASYNC_GETNAME_INFO)
+# define UV_IO_PRIVATE_PLATFORM_EXTRA_FIELDS                                  \
+  unsigned int  is_mach_port;                                                 \
+  struct uv_getaddrinfo_s *getaddrinfo_req;                                   \
+  struct uv_getnameinfo_s *getnameinfo_req;
+
+#elif defined(_USE_ASYNC_ADDR_INFO) && !defined(_USE_ASYNC_GETNAME_INFO)
+# define UV_IO_PRIVATE_PLATFORM_EXTRA_FIELDS                                  \
+  unsigned int  is_mach_port;                                                 \
+  struct uv_getaddrinfo_s *getaddrinfo_req;
+
+#elif !defined(_USE_ASYNC_ADDR_INFO) && defined(_USE_ASYNC_GETNAME_INFO)
+# define UV_IO_PRIVATE_PLATFORM_EXTRA_FIELDS                                  \
+  unsigned int  is_mach_port;                                                 \
+  struct uv_getnameinfo_s *getnameinfo_req;
+
+#endif
+
+#if defined(_USE_ASYNC_ADDR_INFO)
+# define UV_GETADDRINFO_PLATFORM_PRIVATE_EXTRA_FIELDS                         \
+    uv__io_t async_addrinfo_io;
+#else
+# define UV_GETADDRINFO_PLATFORM_PRIVATE_EXTRA_FIELDS /* empty */
+#endif
+
+#if defined(_USE_ASYNC_GETNAME_INFO)
+# define UV_GETNAMEINFO_PLATFORM_PRIVATE_EXTRA_FIELDS                         \
+    uv__io_t async_getnameinfo_io;
+#else
+# define UV_GETNAMEINFO_PLATFORM_PRIVATE_EXTRA_FIELDS /* empty */
+#endif
+
 #define UV_IO_PRIVATE_PLATFORM_FIELDS                                         \
   int rcount;                                                                 \
   int wcount;                                                                 \
+  UV_IO_PRIVATE_PLATFORM_EXTRA_FIELDS                                         \
 
 #define UV_PLATFORM_LOOP_FIELDS                                               \
   uv_thread_t cf_thread;                                                      \
@@ -55,6 +91,12 @@
 
 #define UV_STREAM_PRIVATE_PLATFORM_FIELDS                                     \
   void* select;                                                               \
+
+#define UV_GETADDRINFO_PLATFORM_PRIVATE_FIELDS                                \
+  UV_GETADDRINFO_PLATFORM_PRIVATE_EXTRA_FIELDS                                \
+
+#define UV_GETNAMEINFO_PLATFORM_PRIVATE_FIELDS                                \
+  UV_GETNAMEINFO_PLATFORM_PRIVATE_EXTRA_FIELDS                                \
 
 #define UV_HAVE_KQUEUE 1
 

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -117,6 +117,14 @@ struct uv__io_s {
 # define UV_STREAM_PRIVATE_PLATFORM_FIELDS /* empty */
 #endif
 
+#ifndef UV_GETADDRINFO_PLATFORM_PRIVATE_FIELDS
+# define UV_GETADDRINFO_PLATFORM_PRIVATE_FIELDS /* empty */
+#endif
+
+#ifndef UV_GETNAMEINFO_PLATFORM_PRIVATE_FIELDS
+# define UV_GETNAMEINFO_PLATFORM_PRIVATE_FIELDS /* empty */
+#endif
+
 /* Note: May be cast to struct iovec. See writev(2). */
 typedef struct uv_buf_t {
   char* base;
@@ -341,7 +349,8 @@ typedef struct {
   char* hostname;                                                             \
   char* service;                                                              \
   struct addrinfo* addrinfo;                                                  \
-  int retcode;
+  int retcode;                                                                \
+  UV_GETADDRINFO_PLATFORM_PRIVATE_FIELDS                                      \
 
 #define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
   struct uv__work work_req;                                                   \
@@ -350,7 +359,8 @@ typedef struct {
   int flags;                                                                  \
   char host[NI_MAXHOST];                                                      \
   char service[NI_MAXSERV];                                                   \
-  int retcode;
+  int retcode;                                                                \
+  UV_GETNAMEINFO_PLATFORM_PRIVATE_FIELDS                                      \
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
   void* queue[2];                                                             \

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -370,10 +370,22 @@ int uv_cancel(uv_req_t* req) {
     wreq = &((uv_fs_t*) req)->work_req;
     break;
   case UV_GETADDRINFO:
+#if defined(__APPLE__) && defined(_USE_ASYNC_ADDR_INFO)
+    if (((uv_getaddrinfo_t*) req)->async_addrinfo_io.is_mach_port) {
+      uv__getaddrinfo_cancel((uv_getaddrinfo_t*) req);
+      return 0;
+    }
+#endif
     loop =  ((uv_getaddrinfo_t*) req)->loop;
     wreq = &((uv_getaddrinfo_t*) req)->work_req;
     break;
   case UV_GETNAMEINFO:
+#if defined(__APPLE__) && defined(_USE_ASYNC_GETNAME_INFO)
+    if (((uv_getnameinfo_t*) req)->async_getnameinfo_io.is_mach_port) {
+      uv__getnameinfo_cancel((uv_getnameinfo_t*) req);
+      return 0;
+    }
+#endif
     loop = ((uv_getnameinfo_t*) req)->loop;
     wreq = &((uv_getnameinfo_t*) req)->work_req;
     break;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -885,6 +885,20 @@ void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
 #if defined(UV_HAVE_KQUEUE)
   w->rcount = 0;
   w->wcount = 0;
+
+#if defined(__APPLE__)
+  w->is_mach_port = 0;
+
+#if defined(_USE_ASYNC_ADDR_INFO)
+  w->getaddrinfo_req = NULL;
+#endif
+
+#if defined(_USE_ASYNC_GETNAME_INFO)
+  w->getnameinfo_req = NULL;
+#endif
+
+#endif /* defined(__APPLE__) */
+
 #endif /* defined(UV_HAVE_KQUEUE) */
 }
 

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -39,10 +39,26 @@ static uv_once_t once = UV_ONCE_INIT;
 static uint64_t (*time_func)(void);
 static mach_timebase_info_data_t timebase;
 
+#if defined(_USE_ASYNC_ADDR_INFO)
+static uv_once_t init_getaddrinfo_once = UV_ONCE_INIT;
+#endif
+
+#if defined(_USE_ASYNC_GETNAME_INFO)
+static uv_once_t init_getnameinfo_once = UV_ONCE_INIT;
+#endif
+
 typedef unsigned char UInt8;
 
 int uv__platform_loop_init(uv_loop_t* loop) {
   loop->cf_state = NULL;
+
+#if defined(_USE_ASYNC_ADDR_INFO)
+  uv_once(&init_getaddrinfo_once, uv__getaddrinfo_init);
+#endif
+
+#if defined(_USE_ASYNC_GETNAME_INFO)
+  uv_once(&init_getnameinfo_once, uv__getnameinfo_init);
+#endif
 
   if (uv__kqueue_init(loop))
     return UV__ERR(errno);

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -27,6 +27,55 @@
 #include "uv.h"
 #include "internal.h"
 
+static void uv__getnameinfo_common_done(uv_getnameinfo_t* req, int status);
+
+#if defined(__APPLE__) && defined(_USE_ASYNC_GETNAME_INFO)
+#include <dlfcn.h>
+#include <mach/mach.h>
+
+typedef void (*getnameinfo_async_callback)(int32_t status, char *host, char *serv, void *context);
+static int32_t (*getnameinfo_async_start)(mach_port_t *p, const struct sockaddr *, size_t, int, getnameinfo_async_callback, void *);
+static int32_t (*getnameinfo_async_handle_reply)(void *);
+static void (*getnameinfo_async_cancel)(mach_port_t);
+
+void uv__getnameinfo_init(void) {
+  LOAD_LIBINFO_HANDLES(getnameinfo_async_start,
+                       getnameinfo_async_handle_reply,
+                       getnameinfo_async_cancel);
+}
+
+static void uv__getnameinfo_async_done(int32_t status, char *host, char *service, void *context) {
+  uv_getnameinfo_t *req;
+
+  req = context;
+  snprintf(req->host, sizeof(req->host), "%s", host);
+  snprintf(req->service, sizeof(req->service), "%s", service);
+  if (status == UV_UNKNOWN || status == UV_EAI_CANCELED)
+    req->retcode = status;
+  else
+    req->retcode = uv__getaddrinfo_translate_error(status);
+  uv__io_close(req->loop, &req->async_getnameinfo_io);
+  uv__req_unregister(req->loop, req);
+  uv__getnameinfo_common_done(req, status);
+}
+
+static void uv__getnameinfo_async_work(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
+  READ_MACH_MSG_AND_HANDLE_DATA(w,
+                                getnameinfo_async_handle_reply,
+                                uv__getnameinfo_async_done,
+                                UV_UNKNOWN,
+                                NULL,
+                                NULL,
+                                w->getnameinfo_req);
+}
+
+void uv__getnameinfo_cancel(uv_getnameinfo_t* req) {
+  assert(req->async_getnameinfo_io.fd != 0);
+  getnameinfo_async_cancel(req->async_getnameinfo_io.fd);
+  uv__getnameinfo_async_done(UV_EAI_CANCELED, NULL, NULL, req);
+}
+#endif
+
 
 static void uv__getnameinfo_work(struct uv__work* w) {
   uv_getnameinfo_t* req;
@@ -52,13 +101,9 @@ static void uv__getnameinfo_work(struct uv__work* w) {
   req->retcode = uv__getaddrinfo_translate_error(err);
 }
 
-static void uv__getnameinfo_done(struct uv__work* w, int status) {
-  uv_getnameinfo_t* req;
+static void uv__getnameinfo_common_done(uv_getnameinfo_t* req, int status) {
   char* host;
   char* service;
-
-  req = container_of(w, uv_getnameinfo_t, work_req);
-  uv__req_unregister(req->loop, req);
   host = service = NULL;
 
   if (status == UV_ECANCELED) {
@@ -71,6 +116,14 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
 
   if (req->getnameinfo_cb)
     req->getnameinfo_cb(req, req->retcode, host, service);
+}
+
+static void uv__getnameinfo_done(struct uv__work* w, int status) {
+  uv_getnameinfo_t* req;
+
+  req = container_of(w, uv_getnameinfo_t, work_req);
+  uv__req_unregister(req->loop, req);
+  uv__getnameinfo_common_done(req, status);
 }
 
 /*
@@ -86,14 +139,18 @@ int uv_getnameinfo(uv_loop_t* loop,
   if (req == NULL || addr == NULL)
     return UV_EINVAL;
 
+  size_t salen;
+
   if (addr->sa_family == AF_INET) {
+    salen = sizeof(struct sockaddr_in);
     memcpy(&req->storage,
            addr,
-           sizeof(struct sockaddr_in));
+           salen);
   } else if (addr->sa_family == AF_INET6) {
+    salen = sizeof(struct sockaddr_in6);
     memcpy(&req->storage,
            addr,
-           sizeof(struct sockaddr_in6));
+           salen);
   } else {
     return UV_EINVAL;
   }
@@ -107,6 +164,27 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->retcode = 0;
 
   if (getnameinfo_cb) {
+#if defined(__APPLE__) && defined(_USE_ASYNC_GETNAME_INFO)
+    if (getnameinfo_async_start && getnameinfo_async_handle_reply && getnameinfo_async_cancel) {
+      int32_t get_nameinfo_result;
+      mach_port_t port;
+
+      get_nameinfo_result = getnameinfo_async_start(&port,
+                                                    (struct sockaddr*) &req->storage,
+                                                    salen,
+                                                    req->flags,
+                                                    uv__getnameinfo_async_done,
+                                                    req);
+      if (get_nameinfo_result == -1) {
+        return get_nameinfo_result;
+      }
+      uv__io_init(&req->async_getnameinfo_io, uv__getnameinfo_async_work, port);
+      req->async_getnameinfo_io.getnameinfo_req = req;
+      req->async_getnameinfo_io.is_mach_port = 1;
+      uv__io_start(req->loop, &req->async_getnameinfo_io, POLLIN);
+      return 0;
+    }
+#endif
     uv__work_submit(loop,
                     &req->work_req,
                     UV__WORK_SLOW_IO,

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -184,12 +184,19 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   r = uv_getaddrinfo(loop, reqs + 3, getaddrinfo_cb, "fail", NULL, &hints);
   ASSERT(r == 0);
 
+#if defined(__APPLE__) && defined(_USE_ASYNC_ADDR_INFO)
+  # define TIMEOUT 0
+#else
+  # define TIMEOUT 10
+#endif
+
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, TIMEOUT, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == timer_cb_called);
 
   MAKE_VALGRIND_HAPPY();
+#undef TIMEOUT
   return 0;
 }
 
@@ -220,12 +227,19 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   r = uv_getnameinfo(loop, reqs + 3, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
   ASSERT(r == 0);
 
+#if defined(__APPLE__) && defined(_USE_ASYNC_GETNAME_INFO)
+  # define TIMEOUT 0
+#else
+  # define TIMEOUT 10
+#endif
+
   ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, TIMEOUT, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == timer_cb_called);
 
   MAKE_VALGRIND_HAPPY();
+#undef TIMEOUT
   return 0;
 }
 


### PR DESCRIPTION
This commit allows OS X/iPhone users to enable these
two function using non-blocking calls, which allows
libuv to save resources by not creating threads to
handle these operations.

Closes #2349