### PR TITLE
zos: fix build breakage

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1671,6 +1671,8 @@ unsigned int uv_available_parallelism(void) {
     rc = 1;
 
   return (unsigned) rc;
+#elif defined(__MVS__)
+  return 1;  /* TODO(bnoordhuis) Read from CSD_NUMBER_ONLINE_CPUS? */
 #else  /* __linux__ */
   long rc;
 


### PR DESCRIPTION
Introduced earlier today in commit f250c6c7. _SC_NPROCESSORS_ONLN does
not seem to be defined on that platform.

cc @vtjnash @libuv/zos