### PR TITLE
unix: remove uv__cloexec_ioctl()

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -599,20 +599,6 @@ int uv__nonblock_ioctl(int fd, int set) {
 
   return 0;
 }
-
-
-int uv__cloexec_ioctl(int fd, int set) {
-  int r;
-
-  do
-    r = ioctl(fd, set ? FIOCLEX : FIONCLEX);
-  while (r == -1 && errno == EINTR);
-
-  if (r)
-    return UV__ERR(errno);
-
-  return 0;
-}
 #endif
 
 
@@ -647,7 +633,7 @@ int uv__nonblock_fcntl(int fd, int set) {
 }
 
 
-int uv__cloexec_fcntl(int fd, int set) {
+int uv__cloexec(int fd, int set) {
   int flags;
   int r;
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -175,11 +175,9 @@ struct uv__stream_queued_fds_s {
     defined(__linux__) || \
     defined(__OpenBSD__) || \
     defined(__NetBSD__)
-#define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
 #define UV__NONBLOCK_IS_IOCTL 1
 #else
-#define uv__cloexec uv__cloexec_fcntl
 #define uv__nonblock uv__nonblock_fcntl
 #define UV__NONBLOCK_IS_IOCTL 0
 #endif
@@ -197,8 +195,7 @@ struct uv__stream_queued_fds_s {
 #endif
 
 /* core */
-int uv__cloexec_ioctl(int fd, int set);
-int uv__cloexec_fcntl(int fd, int set);
+int uv__cloexec(int fd, int set);
 int uv__nonblock_ioctl(int fd, int set);
 int uv__nonblock_fcntl(int fd, int set);
 int uv__close(int fd); /* preserves errno */

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -283,7 +283,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (pipes[fd][1] == -1)
       uv__write_errno(error_fd);
 #ifndef F_DUPFD_CLOEXEC /* POSIX 2008 */
-    n = uv__cloexec_fcntl(pipes[fd][1], 1);
+    n = uv__cloexec(pipes[fd][1], 1);
     if (n) {
       uv__write_int(error_fd, n);
       _exit(127);
@@ -312,7 +312,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
 
     if (fd == use_fd) {
       if (close_fd == -1) {
-        n = uv__cloexec_fcntl(use_fd, 0);
+        n = uv__cloexec(use_fd, 0);
         if (n) {
           uv__write_int(error_fd, n);
           _exit(127);


### PR DESCRIPTION
Now that uv__cloexec_fcntl() is simplified (https://github.com/libuv/libuv/pull/3492), there is no benefit to maintaining duplicate code paths for the same thing.