### PR TITLE
linux: retry uv_cpu_info() when online/offline CPU race

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -266,6 +266,7 @@ static int uv__cpu_num(FILE* statfile_fp, unsigned int* numcpus) {
 
 
 int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
+  static const int max_retry = 3;
   unsigned int numcpus;
   unsigned int numread;
   uv_cpu_info_t* ci;
@@ -280,7 +281,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   if (statfile_fp == NULL)
     return UV__ERR(errno);
 
-  for (i = 0; i < 3; i += 1) {
+  for (i = 0; i < max_retry; i += 1) {
     err = uv__cpu_num(statfile_fp, &numcpus);
     if (err < 0)
       goto out;
@@ -534,8 +535,7 @@ static int read_models(unsigned int numcpus, uv_cpu_info_t* ci) {
 }
 
 
-/* Returns numcpus read.
- */
+/* Return numcpus read (always <= numcpus input as argument). */
 static unsigned int read_times(FILE* statfile_fp,
                                unsigned int numcpus,
                                uv_cpu_info_t* ci) {

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -315,7 +315,6 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     if (ci[0].speed == 0)
       read_speeds(numcpus, ci);
 
-
     *cpu_infos = ci;
     *count = numcpus;
     err = 0;

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -266,9 +266,9 @@ static int uv__cpu_num(FILE* statfile_fp, unsigned int* numcpus) {
 
 
 int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
-  static const int max_retry = 3;
+  static const int max_retry = 2;
   unsigned int numcpus;
-  unsigned int numread;
+  unsigned int numread = 0;
   uv_cpu_info_t* ci;
   int err;
   int i;


### PR DESCRIPTION
`uv_cpu_info()` on Linux:

1. First consults `/proc/stat` to get the number of online CPUs, then
2. Reads the CPU info from `/proc/cpuinfo`, then
3. Reads idle/irq/nice/user/sys from `/proc/stat`

There is a time window between (1) and (2) and (2) and (3) where a CPU could come online or go offline.

This PR handles this by:

1. Meticulously checking if the number of observed CPU entries in (2) and (3) matches the expected number of CPUs, and
2. Restart from (1) if that isn't the case.


Fixes https://github.com/libuv/libuv/issues/2351
Supercedes part of https://github.com/libuv/libuv/pull/2359