### PR TITLE
doc: update active maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,7 @@
-
 # Project Maintainers
 
 libuv is currently managed by the following individuals:
 
-* **Anna Henningsen** ([@addaleax](https://github.com/addaleax))
-* **Bartosz Sosnowski** ([@bzoz](https://github.com/bzoz))
 * **Ben Noordhuis** ([@bnoordhuis](https://github.com/bnoordhuis))
   - GPG key: D77B 1E34 243F BAF0 5F8E  9CC3 4F55 C8C8 46AB 89B9 (pubkey-bnoordhuis)
 * **Bert Belder** ([@piscisaureus](https://github.com/piscisaureus))
@@ -13,13 +10,10 @@ libuv is currently managed by the following individuals:
   - GPG key: 5735 3E0D BDAA A7E8 39B6  6A1A FF47 D5E4 AD8B 4FDC (pubkey-cjihrig-kb)
 * **Fedor Indutny** ([@indutny](https://github.com/indutny))
   - GPG key: AF2E EA41 EC34 47BF DD86  FED9 D706 3CCE 19B7 E890 (pubkey-indutny)
-* **Imran Iqbal** ([@imran-iq](https://github.com/imran-iq))
-  - GPG key: 9DFE AA5F 481B BF77 2D90  03CE D592 4925 2F8E C41A (pubkey-iwuzhere)
 * **Jameson Nash** ([@vtjnash](https://github.com/vtjnash))
   - GPG key: AEAD 0A4B 6867 6775 1A0E  4AEF 34A2 5FB1 2824 6514 (pubkey-vtjnash)
   - GPG key: CFBB 9CA9 A5BE AFD7 0E2B  3C5A 79A6 7C55 A367 9C8B (pubkey2022-vtjnash)
 * **Jiawen Geng** ([@gengjiawen](https://github.com/gengjiawen))
-* **John Barboza** ([@jbarz](https://github.com/jbarz))
 * **Kaoru Takanashi** ([@erw7](https://github.com/erw7))
   - GPG Key: 5804 F999 8A92 2AFB A398  47A0 7183 5090 6134 887F (pubkey-erw7)
 * **Richard Lau** ([@richardlau](https://github.com/richardlau))
@@ -28,6 +22,13 @@ libuv is currently managed by the following individuals:
   - GPG key: 612F 0EAD 9401 6223 79DF  4402 F28C 3C8D A33C 03BE (pubkey-santigimeno)
 * **Saúl Ibarra Corretgé** ([@saghul](https://github.com/saghul))
   - GPG key: FDF5 1936 4458 319F A823  3DC9 410E 5553 AE9B C059 (pubkey-saghul)
+
+## Project Maintainers emeriti
+
+* **Anna Henningsen** ([@addaleax](https://github.com/addaleax))
+* **Bartosz Sosnowski** ([@bzoz](https://github.com/bzoz))
+* **Imran Iqbal** ([@imran-iq](https://github.com/imran-iq))
+* **John Barboza** ([@jbarz](https://github.com/jbarz))
 
 ## Storing a maintainer key in Git
 


### PR DESCRIPTION
I removed people that haven't been active in over a year. Imran's GPG key has never been used to sign a release so should be okay to remove.