### PR TITLE
build: make CI a bit noisier

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,11 +27,19 @@ jobs:
           cd build
           cmake .. -DBUILD_TESTING=ON -G "${{ matrix.config.toolchain }}" -A ${{ matrix.config.arch }}
           cmake --build .
+      - name: platform_output
+        shell: cmd
+        run: |
+          cd build && uv_run_tests.exe platform_output
+      - name: platform_output_a
+        shell: cmd
+        run: |
+          cd build && uv_run_tests_a.exe platform_output
       - name: Test
         shell: cmd
         run: |
           cd build
-          ctest -C Debug --output-on-failure
+          ctest -C Debug -V
 
   build-android:
     runs-on: ubuntu-latest
@@ -62,6 +70,14 @@ jobs:
           cd build && cmake .. -DBUILD_TESTING=ON -G Ninja
           cmake --build .
           ls -lh
+      - name: platform_output
+        shell: cmd
+        run: |
+          cd build && uv_run_tests platform_output
+      - name: platform_output_a
+        shell: cmd
+        run: |
+          cd build && uv_run_tests_a platform_output
       - name: Test
         run: |
           cd build && ctest -V

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,11 +71,9 @@ jobs:
           cmake --build .
           ls -lh
       - name: platform_output
-        shell: cmd
         run: |
           ./build/uv_run_tests platform_output
       - name: platform_output_a
-        shell: cmd
         run: |
           ./build/uv_run_tests_a platform_output
       - name: Test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,11 +30,11 @@ jobs:
       - name: platform_output
         shell: cmd
         run: |
-          cd build && uv_run_tests.exe platform_output
+          build\\Debug\\uv_run_tests.exe platform_output
       - name: platform_output_a
         shell: cmd
         run: |
-          cd build && uv_run_tests_a.exe platform_output
+          build\\Debug\\uv_run_tests_a.exe platform_output
       - name: Test
         shell: cmd
         run: |
@@ -73,11 +73,11 @@ jobs:
       - name: platform_output
         shell: cmd
         run: |
-          cd build && uv_run_tests platform_output
+          ./build/uv_run_tests platform_output
       - name: platform_output_a
         shell: cmd
         run: |
-          cd build && uv_run_tests_a platform_output
+          ./build/uv_run_tests_a platform_output
       - name: Test
         run: |
           cd build && ctest -V


### PR DESCRIPTION
Github Actions will already hide the output, so we don't need to also suppress the output. That can sometimes hide problems that might have only been visible on inspection.