### PR TITLE
[v2] fs: remove incorrect ARRAY_SIZE call

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2856,14 +2856,18 @@ void uv_fs_req_cleanup(uv_fs_t* req) {
       uv__free(req->ptr);
   }
 
-  if (req->fs.info.bufs != req->fs.info.bufsml &&
-      ARRAY_SIZE(req->fs.info.bufs) > 0)
-    uv__free(req->fs.info.bufs);
+  if (req->fs_type != UV_FS_UTIME &&
+      req->fs_type != UV_FS_FUTIME &&
+      req->fs_type != UV_FS_LUTIME) {
+    if (req->fs.info.bufs != req->fs.info.bufsml)
+      uv__free(req->fs.info.bufs);
+    req->fs.info.new_pathw = NULL;
+    req->fs.info.bufs = NULL;
+    req->fs.info.nbufs = 0;
+  }
 
   req->path = NULL;
   req->file.pathw = NULL;
-  req->fs.info.new_pathw = NULL;
-  req->fs.info.bufs = NULL;
   req->ptr = NULL;
 
   req->flags |= UV_FS_CLEANEDUP;


### PR DESCRIPTION
The `bufs` variable is a `uv_buf_t *`, so this check does not make sense. It also got added in unrelated work https://github.com/libuv/libuv/pull/590, so I am not sure of what the intent of this change was. It was discussed briefly there at https://github.com/libuv/libuv/pull/590#issuecomment-385607866.

Refs: https://github.com/libuv/libuv/pull/1070
CI: https://ci.nodejs.org/job/libuv-test-commit-windows-cmake/438/