### PR TITLE
[v2] win: cast UV_STDIN_FD to unsigned

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -525,9 +525,9 @@ static INLINE uv_os_fd_t uv_convert_fd_to_handle(int fd) {
 
 
 #ifdef _WIN32
-#define UV_STDIN_FD    ((HANDLE)-10)
-#define UV_STDOUT_FD   ((HANDLE)-11)
-#define UV_STDERR_FD   ((HANDLE)-12)
+#define UV_STDIN_FD    ((HANDLE)(DWORD)-10)
+#define UV_STDOUT_FD   ((HANDLE)(DWORD)-11)
+#define UV_STDERR_FD   ((HANDLE)(DWORD)-12)
 #else
 #define UV_STDIN_FD    (0)
 #define UV_STDOUT_FD   (1)


### PR DESCRIPTION
This value, officially, is (DWORD)-11, with the high bits cleared. Though Windows does not care, wine sometimes does care.

And while we do not normally pass the value through to the native API, we are attempting to be directly compatible with it, so let's try to use the same constant definition.