### PR TITLE
zos: implement cmpxchgi() using assembly

### DIFF
--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -37,12 +37,11 @@ UV_UNUSED(static int cmpxchgi(int* ptr, int oldval, int newval)) {
                         : "memory");
   return out;
 #elif defined(__MVS__)
-  unsigned int op4;
-  if (__plo_CSST(ptr, (unsigned int*) &oldval, newval,
-                (unsigned int*) ptr, *ptr, &op4))
-    return oldval;
-  else
-    return op4;
+  /* Use hand-rolled assembly because codegen from builtin __plo_CSST results in
+   * a runtime bug.
+   */
+  __asm(" cs %0,%2,%1 \n " : "+r"(oldval), "+m"(*ptr) : "r"(newval) :);
+  return oldval;
 #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
   return atomic_cas_uint((uint_t *)ptr, (uint_t)oldval, (uint_t)newval);
 #else


### PR DESCRIPTION
We found a runtime bug on z/OS with the atomic operations that was related to the codegen from builtin `__plo_CSST`. So this PR changes `cmpxchgi()` to use use hand-rolled assembly instead of `__plo_CSST` to resolve this bug.