### PR TITLE
build: AC_SUBST for AM_CFLAGS

### DIFF
--- a/m4/libuv-check-flags.m4
+++ b/m4/libuv-check-flags.m4
@@ -73,6 +73,8 @@ AC_DEFUN([CC_CHECK_CFLAG_APPEND], [
 
   AS_IF([eval test x$]AS_TR_SH([cc_cv_cflags_$1])[ = xyes],
     [AM_CFLAGS="$AM_CFLAGS $1"; DEBUG_CFLAGS="$DEBUG_CFLAGS $1"; $2], [$3])
+
+  AC_SUBST([AM_CFLAGS])
 ])
 
 dnl CC_CHECK_CFLAGS_APPEND([FLAG1 FLAG2], [action-if-found], [action-if-not])


### PR DESCRIPTION
Using autoconf 2.71 and automake 1.16.5 the CFLAGS from
CC_CHECK_CFLAGS_APPEND does not get set in the Makefile without AC_SUBST
causing compilation to fail on Solaris due to missing -std=gnu89