### PR TITLE
release: check versions of autogen scripts are newer

### DIFF
--- a/m4/libuv-check-versions.m4
+++ b/m4/libuv-check-versions.m4
@@ -1,0 +1,7 @@
+
+AC_PREREQ(2.71)
+AC_INIT([libuv-release-check], [0.0])
+AM_INIT_AUTOMAKE([1.16.5])
+LT_PREREQ(2.4.6)
+AC_OUTPUT
+


### PR DESCRIPTION
There was a risk of introducing a regression during the release process itself, as the autogen script might copy older versions of files when making the autotools source. To mitigate that risk, we record here the versions of the tools used, and require that each release must use the same or newer versions of these files. The most common reason for updates is the `config.guess` script.

Use libtoolize --force to ensure it updates m4 directory with the
latest files. Add an option "release" to the autogen.sh script that
checks the versions of the input tools, so that we know they are always
using the latest version for each release.

