### PR TITLE
process: removes TARGET_OS_IPHONE for process.c ios build break

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build android arm64
         run: |
           $ANDROID_HOME/cmake/3.10.2.4988404/bin/cmake --build build
+          ls -lh build
 
   build-macos:
     runs-on: macos-10.15
@@ -69,10 +70,9 @@ jobs:
           cd build-ios
           cmake .. -GXcode -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DCMAKE_CONFIGURATION_TYPES:STRING=Release
       - name: Build
-        continue-on-error: true # XXX: allow failure
         run: |
           cmake --build build-ios
-          ls -lh
+          ls -lh build-ios
 
   build-cross-qemu:
     runs-on: ubuntu-latest
@@ -123,7 +123,7 @@ jobs:
       - name: Build
         run: |
           cmake --build build
-          ls -lh
+          ls -lh build
       - name: Test
         run: |
           ${{ matrix.config.qemu }} build/uv_run_tests_a

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -35,7 +35,7 @@
 #include <fcntl.h>
 #include <poll.h>
 
-#if defined(__APPLE__) && !TARGET_OS_IPHONE
+#if defined(__APPLE__)
 # include <spawn.h>
 # include <paths.h>
 # include <sys/kauth.h>


### PR DESCRIPTION
Removing TARGET_OS_IPHONE macro to include posix spawn headers for iOS build. Previously #3257 introduced posix spawn with \_\_APPLE\_\_ platform only, which resulted in a number of spawn related definitions not found for ios (e.g. [uv__posix_spawn_fncs_tag](https://github.com/libuv/libuv/blob/739e441d4d4135e411e94a6e4c190a7fa32ac400/src/unix/process.c#L390)).  

----
cc @drfloob  @HannahShiSFB