### PR TITLE
Revert "win,errors: remap ERROR_ACCESS_DENIED to UV_EACCES (#3193)"

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -73,7 +73,6 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
     case ERROR_CANT_ACCESS_FILE:            return UV_EACCES;
-    case ERROR_ACCESS_DENIED:               return UV_EACCES;
     case ERROR_ADDRESS_ALREADY_ASSOCIATED:  return UV_EADDRINUSE;
     case WSAEADDRINUSE:                     return UV_EADDRINUSE;
     case WSAEADDRNOTAVAIL:                  return UV_EADDRNOTAVAIL;
@@ -155,6 +154,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAENOTSOCK:                       return UV_ENOTSOCK;
     case ERROR_NOT_SUPPORTED:               return UV_ENOTSUP;
     case ERROR_BROKEN_PIPE:                 return UV_EOF;
+    case ERROR_ACCESS_DENIED:               return UV_EPERM;
     case ERROR_PRIVILEGE_NOT_HELD:          return UV_EPERM;
     case ERROR_BAD_PIPE:                    return UV_EPIPE;
     case ERROR_NO_DATA:                     return UV_EPIPE;


### PR DESCRIPTION
Although the change remapped the error code to the correct one, a lot of
code already depends on the incorrect one, so it's not worth the
breakage.

This reverts commit 04a35efe69001a27e177aebde6c8db6f4cca7e4b.

Refs: https://github.com/nodejs/node/pull/42340
Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @vtjnash 