### PR TITLE
separate the static variables by test cases

### DIFF
--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -25,6 +25,8 @@
 
 static int once_cb_called = 0;
 static int once_close_cb_called = 0;
+static int twice_cb_called = 0;
+static int twice_close_cb_called = 0;
 static int repeat_cb_called = 0;
 static int repeat_close_cb_called = 0;
 static int order_cb_called = 0;
@@ -57,6 +59,27 @@ static void once_cb(uv_timer_t* handle) {
   /* Just call this randomly for the code coverage. */
   uv_update_time(uv_default_loop());
 }
+
+static void twice_close_cb(uv_handle_t* handle) {
+  printf("TWICE_CLOSE_CB\n");
+
+  ASSERT(handle != NULL);
+  ASSERT(0 == uv_is_active(handle));
+
+  twice_close_cb_called++;
+}
+
+static void twice_cb(uv_timer_t* handle) {
+  printf("TWICE_CB %d\n", twice_cb_called);
+
+  ASSERT(handle != NULL);
+  ASSERT(0 == uv_is_active((uv_handle_t*) handle));
+
+  twice_cb_called++;
+
+  uv_close((uv_handle_t*)handle, twice_close_cb);
+}
+
 
 
 static void repeat_close_cb(uv_handle_t* handle) {
@@ -144,12 +167,12 @@ TEST_IMPL(timer_start_twice) {
   ASSERT(r == 0);
   r = uv_timer_start(&once, never_cb, 86400 * 1000, 0);
   ASSERT(r == 0);
-  r = uv_timer_start(&once, once_cb, 10, 0);
+  r = uv_timer_start(&once, twice_cb, 10, 0);
   ASSERT(r == 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  ASSERT(once_cb_called == 1);
+  ASSERT(twice_cb_called == 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -63,7 +63,7 @@ static void once_cb(uv_timer_t* handle) {
 static void twice_close_cb(uv_handle_t* handle) {
   printf("TWICE_CLOSE_CB\n");
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(0 == uv_is_active(handle));
 
   twice_close_cb_called++;
@@ -72,7 +72,7 @@ static void twice_close_cb(uv_handle_t* handle) {
 static void twice_cb(uv_timer_t* handle) {
   printf("TWICE_CB %d\n", twice_cb_called);
 
-  ASSERT(handle != NULL);
+  ASSERT_NOT_NULL(handle);
   ASSERT(0 == uv_is_active((uv_handle_t*) handle));
 
   twice_cb_called++;


### PR DESCRIPTION
This PR includes:
1. separate the static variables by test cases, 
2. add callback for test case timer_start_twice

The static variables were used by multi test cases, it was OK since other languages use fork and count separately. But in iOS test, we have to run all tests in the same process, so we need separate variables to count separately.

https://github.com/grpc/grpc/pull/28570
