### PR TITLE
CI: filter by paths and branches

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -1,44 +1,19 @@
-name: CI
+name: CI-unix
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-unix.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
 
 jobs:
-  build-windows:
-    runs-on: windows-${{ matrix.config.server }}
-    name: build-${{ matrix.config.toolchain}}-${{ matrix.config.arch}}
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {toolchain: Visual Studio 16 2019, arch: Win32, server: 2019}
-          - {toolchain: Visual Studio 16 2019, arch: x64, server: 2019}
-          - {toolchain: Visual Studio 17 2022, arch: Win32, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Envinfo
-        run: npx envinfo
-      - name: Build
-        shell: cmd
-        run: |
-          mkdir -p build
-          cd build
-          cmake .. -DBUILD_TESTING=ON -G "${{ matrix.config.toolchain }}" -A ${{ matrix.config.arch }}
-          cmake --build .
-      - name: platform_output
-        shell: cmd
-        run: |
-          build\\Debug\\uv_run_tests.exe platform_output
-      - name: platform_output_a
-        shell: cmd
-        run: |
-          build\\Debug\\uv_run_tests_a.exe platform_output
-      - name: Test
-        shell: cmd
-        run: |
-          cd build
-          ctest -C Debug -V
-
   build-android:
     runs-on: ubuntu-latest
     container: reactnativecommunity/react-native-android:2020-5-20

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -1,0 +1,51 @@
+name: CI-win
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-win.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
+
+jobs:
+  build-windows:
+    runs-on: windows-${{ matrix.config.server }}
+    name: build-${{ matrix.config.toolchain}}-${{ matrix.config.arch}}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {toolchain: Visual Studio 16 2019, arch: Win32, server: 2019}
+          - {toolchain: Visual Studio 16 2019, arch: x64, server: 2019}
+          - {toolchain: Visual Studio 17 2022, arch: Win32, server: 2022}
+          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Envinfo
+        run: npx envinfo
+      - name: Build
+        shell: cmd
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DBUILD_TESTING=ON -G "${{ matrix.config.toolchain }}" -A ${{ matrix.config.arch }}
+          cmake --build .
+      - name: platform_output
+        shell: cmd
+        run: |
+          build\\Debug\\uv_run_tests.exe platform_output
+      - name: platform_output_a
+        shell: cmd
+        run: |
+          build\\Debug\\uv_run_tests_a.exe platform_output
+      - name: Test
+        shell: cmd
+        run: |
+          cd build
+          ctest -C Debug -V

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,6 +1,16 @@
 name: Sanitizer checks
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!.**'
+      - '.github/workflows/sanitizer.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
 
 jobs:
   sanitizers:
@@ -12,15 +22,20 @@ jobs:
           sudo apt-get install ninja-build
       - name: Envinfo
         run: npx envinfo
-      - name: TSAN
+      - name: TSAN Build
         run: |
           mkdir build-tsan
           (cd build-tsan && cmake .. -G Ninja -DBUILD_TESTING=ON -DTSAN=ON -DCMAKE_BUILD_TYPE=Release)
           cmake --build build-tsan
-          ./build-tsan/uv_run_tests_a || true # currently permit failures
-      - name: ASAN
+      - name: TSAN Test
+        continue-on-error: true # currently permit failures
+        run: |
+          ./build-tsan/uv_run_tests_a
+      - name: ASAN Build
         run: |
           mkdir build-asan
           (cd build-asan && cmake .. -G Ninja -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug)
           cmake --build build-asan
+      - name: ASAN Test
+        run: |
           ./build-asan/uv_run_tests_a


### PR DESCRIPTION
1. filter CI by path, so we only run unix/win if those files even changed
~~2. update RTD to the latest versions and syntax~~
~~3. add CI for docs, so we will observe any build failures early (currently only subtly visible in https://readthedocs.org/projects/libuv/ for v1.x commits)~~