### PR TITLE
win: fix incompatible types warning

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -1087,7 +1087,7 @@ int uv__udp_disconnect(uv_udp_t* handle) {
 
     memset(&addr, 0, sizeof(addr));
 
-    err = connect(handle->socket, &addr, sizeof(addr));
+    err = connect(handle->socket, (struct sockaddr*) &addr, sizeof(addr));
     if (err)
       return uv_translate_sys_error(WSAGetLastError());
 


### PR DESCRIPTION
Warnings are treated as errors on our CI build, so we got some build errors.

Introduced by #3350
```
libuv\src\win\udp.c(1090,40): warning C4133: 'function': incompatible types - from 'sockaddr_storage *' to 'const sockaddr *'
```

