### PR TITLE
Revert "loop: add pending work to loop-alive check (#3466)"

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -336,36 +336,35 @@ int uv_backend_fd(const uv_loop_t* loop) {
 }
 
 
+int uv_backend_timeout(const uv_loop_t* loop) {
+  if (loop->stop_flag != 0)
+    return 0;
+
+  if (!uv__has_active_handles(loop) && !uv__has_active_reqs(loop))
+    return 0;
+
+  if (!QUEUE_EMPTY(&loop->idle_handles))
+    return 0;
+
+  if (!QUEUE_EMPTY(&loop->pending_queue))
+    return 0;
+
+  if (loop->closing_handles)
+    return 0;
+
+  return uv__next_timeout(loop);
+}
+
+
 static int uv__loop_alive(const uv_loop_t* loop) {
   return uv__has_active_handles(loop) ||
          uv__has_active_reqs(loop) ||
-         !QUEUE_EMPTY(&loop->pending_queue) ||
          loop->closing_handles != NULL;
 }
 
 
-static int uv__backend_timeout(const uv_loop_t* loop) {
-  if (loop->stop_flag == 0 &&
-      /* uv__loop_alive(loop) && */
-      (uv__has_active_handles(loop) || uv__has_active_reqs(loop)) &&
-      QUEUE_EMPTY(&loop->pending_queue) &&
-      QUEUE_EMPTY(&loop->idle_handles) &&
-      loop->closing_handles == NULL)
-    return uv__next_timeout(loop);
-  return 0;
-}
-
-
-int uv_backend_timeout(const uv_loop_t* loop) {
-  if (QUEUE_EMPTY(&loop->watcher_queue))
-    return uv__backend_timeout(loop);
-  /* Need to call uv_run to update the backend fd state. */
-  return 0;
-}
-
-
 int uv_loop_alive(const uv_loop_t* loop) {
-  return uv__loop_alive(loop);
+    return uv__loop_alive(loop);
 }
 
 
@@ -387,7 +386,7 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
     timeout = 0;
     if ((mode == UV_RUN_ONCE && !ran_pending) || mode == UV_RUN_DEFAULT)
-      timeout = uv__backend_timeout(loop);
+      timeout = uv_backend_timeout(loop);
 
     uv__io_poll(loop, timeout);
 

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -28,7 +28,7 @@ TEST_IMPL(loop_update_time) {
 
   start = uv_now(uv_default_loop());
   while (uv_now(uv_default_loop()) - start < 1000)
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -43,26 +43,20 @@ TEST_IMPL(loop_backend_timeout) {
   uv_timer_t timer;
   int r;
 
-  /* The default loop has some internal watchers to initialize. */
-  loop->active_handles++;
-  r = uv_run(loop, UV_RUN_NOWAIT);
-  ASSERT_EQ(r, 1);
-  loop->active_handles--;
-  ASSERT_EQ(uv_loop_alive(loop), 0);
-
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT(r == 0);
 
-  ASSERT_EQ(uv_loop_alive(loop), 0);
-  ASSERT_EQ(uv_backend_timeout(loop), 0);
+  ASSERT(!uv_loop_alive(loop));
+  ASSERT(uv_backend_timeout(loop) == 0);
 
   r = uv_timer_start(&timer, cb, 1000, 0); /* 1 sec */
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(uv_backend_timeout(loop), 1000);
+  ASSERT(r == 0);
+  ASSERT(uv_backend_timeout(loop) > 100); /* 0.1 sec */
+  ASSERT(uv_backend_timeout(loop) <= 1000); /* 1 sec */
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(uv_backend_timeout(loop), 0);
+  ASSERT(r == 0);
+  ASSERT(uv_backend_timeout(loop) == 0);
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
This reverts commit 939a05633f99eeba8f4fb5dfff0e7bab940f361b.
This reverts commit cc7dbaa3a18d54ef4735efa4c54c32a24cdf7e5b.

Reverted for causing a regression in the Node.js test suite.

Also revert "fix oopsie from #3466 (#3475)".

Refs: https://github.com/nodejs/node/pull/42340