### PR TITLE
unix,win: fix UV_RUN_ONCE + uv_idle_stop loop hang

### DIFF
--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -138,13 +138,13 @@ INLINE static void uv__insert_pending_req(uv_loop_t* loop, uv_req_t* req) {
   } while (0)
 
 
-INLINE static int uv__process_reqs(uv_loop_t* loop) {
+INLINE static void uv__process_reqs(uv_loop_t* loop) {
   uv_req_t* req;
   uv_req_t* first;
   uv_req_t* next;
 
   if (loop->pending_reqs_tail == NULL)
-    return 0;
+    return;
 
   first = loop->pending_reqs_tail->next_req;
   next = first;
@@ -214,8 +214,6 @@ INLINE static int uv__process_reqs(uv_loop_t* loop) {
         assert(0);
     }
   }
-
-  return 1;
 }
 
 #endif /* UV_WIN_REQ_INL_H_ */

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -97,3 +97,24 @@ TEST_IMPL(idle_starvation) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+
+TEST_IMPL(idle_check) {
+  ASSERT_EQ(0, uv_idle_init(uv_default_loop(), &idle_handle));
+  ASSERT_EQ(0, uv_idle_start(&idle_handle, (uv_idle_cb) uv_idle_stop));
+
+  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+
+  ASSERT_EQ(1, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(1, check_cb_called);
+
+  ASSERT_EQ(0, close_cb_called);
+  uv_close((uv_handle_t*) &idle_handle, close_cb);
+  uv_close((uv_handle_t*) &check_handle, close_cb);
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(2, close_cb_called);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -99,9 +99,14 @@ TEST_IMPL(idle_starvation) {
 }
 
 
+static void idle_stop(uv_idle_t* handle) {
+  uv_idle_stop(handle);
+}
+
+
 TEST_IMPL(idle_check) {
   ASSERT_EQ(0, uv_idle_init(uv_default_loop(), &idle_handle));
-  ASSERT_EQ(0, uv_idle_start(&idle_handle, (uv_idle_cb) uv_idle_stop));
+  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_stop));
 
   ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
   ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -225,6 +225,7 @@ TEST_DECLARE   (timer_is_closing)
 TEST_DECLARE   (timer_null_callback)
 TEST_DECLARE   (timer_early_check)
 TEST_DECLARE   (idle_starvation)
+TEST_DECLARE   (idle_check)
 TEST_DECLARE   (loop_handles)
 TEST_DECLARE   (get_loadavg)
 TEST_DECLARE   (walk_handles)
@@ -819,6 +820,7 @@ TASK_LIST_START
   TEST_ENTRY  (timer_early_check)
 
   TEST_ENTRY  (idle_starvation)
+  TEST_ENTRY  (idle_check)
 
   TEST_ENTRY  (ref)
   TEST_ENTRY  (idle_ref)


### PR DESCRIPTION
Wrong accounting of idle handles in uv_run() made it sleep when there
was nothing left to do. Do a non-blocking poll for I/O instead.