### PR TITLE
Add libuv:: namespace to exported libuvConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,7 +736,9 @@ install(FILES ${PROJECT_BINARY_DIR}/libuv-static.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(TARGETS uv_a EXPORT libuvConfig
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(EXPORT libuvConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv)
+install(EXPORT libuvConfig
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
+	NAMESPACE libuv::)
 
 if(LIBUV_BUILD_SHARED)
   # The version in the filename is mirroring the behaviour of autotools.


### PR DESCRIPTION
I believe this was an oversight when the `install(EXPORT` was added last year in https://github.com/libuv/libuv/pull/3293. @pemensik please correct me if I'm wrong about that.