### PR TITLE
win: return IOCP HANDLE in uv_backend_fd

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -133,10 +133,10 @@ API
     Returns the size of the `uv_loop_t` structure. Useful for FFI binding
     writers who don't want to know the structure layout.
 
-.. c:function:: int uv_backend_fd(const uv_loop_t* loop)
+.. c:function:: uv_os_fd_t uv_backend_fd(const uv_loop_t* loop)
 
-    Get backend file descriptor. Only kqueue, epoll and event ports are
-    supported.
+    Get backend file descriptor. Returns the epoll / kqueue / event ports file
+    descriptor on Unix and the IOCP `HANDLE` on Windows.
 
     This can be used in conjunction with `uv_run(loop, UV_RUN_NOWAIT)` to
     poll in one thread and run the event loop's callbacks in another see
@@ -145,6 +145,9 @@ API
     .. note::
         Embedding a kqueue fd in another kqueue pollset doesn't work on all platforms. It's not
         an error to add the fd but it never generates events.
+
+    .. versionchanged:: 1.45 added support for Windows and changed return type
+        to ``uv_os_fd_t``.
 
 .. c:function:: int uv_backend_timeout(const uv_loop_t* loop)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -307,7 +307,7 @@ UV_EXTERN int uv_has_ref(const uv_handle_t*);
 UV_EXTERN void uv_update_time(uv_loop_t*);
 UV_EXTERN uint64_t uv_now(const uv_loop_t*);
 
-UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+UV_EXTERN uv_os_fd_t uv_backend_fd(const uv_loop_t*);
 UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
 
 typedef void (*uv_alloc_cb)(uv_handle_t* handle,

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -341,7 +341,7 @@ int uv_is_closing(const uv_handle_t* handle) {
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
+uv_os_fd_t uv_backend_fd(const uv_loop_t* loop) {
   return loop->backend_fd;
 }
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -388,8 +388,8 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
 }
 
 
-int uv_backend_fd(const uv_loop_t* loop) {
-  return -1;
+uv_os_fd_t uv_backend_fd(const uv_loop_t* loop) {
+  return loop->iocp;
 }
 
 


### PR DESCRIPTION
This is a back-port of commit daf8a45d4 from the master branch that
changes the return type of `uv_backend_fd()` from `int` to `uv_os_fd_t`.

It's a non-functional change on Unices because `uv_os_fd_t` is an int.

It should be safe in the API/ABI compatibility sense on Windows because
`uv_backend_fd()` on that platform was previously unusable and therefore
not expected to be in use.

Original commit log follows:

Change the return type from int to uv_os_fd_t so we can return an int on
Unix and a HANDLE on Windows.

Applications can use this to poll the libuv event loop from another
thread as is now possible on Unix.

The test implementation is based on what Electron does:
~~https://github.com/electron/electron/blob/master/atom/common/node_bindings_win.cc~~
UPDATED: https://github.com/electron/electron/blob/c119b1ebef0afe3b8dbedc4f869a1c67684d6009/shell/common/node_bindings_win.cc#L39-L43

Refs: https://github.com/libuv/libuv/issues/965
PR-URL: https://github.com/libuv/libuv/pull/1007
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Imran Iqbal <imran@imraniqbal.org>

<hr>

Note: this should go into 1.45.0, not 1.44.2.