### PR TITLE
[wip] unix: use sendmsg(MSG_DONTWAIT) for uv_tty_t fds

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -454,12 +454,8 @@ TEST_IMPL(tty_pty) {
   ASSERT(uv_is_writable((uv_stream_t*) &slave_tty));
   ASSERT(uv_is_readable((uv_stream_t*) &master_tty));
   ASSERT(uv_is_writable((uv_stream_t*) &master_tty));
-  /* Check if the file descriptor was reopened. If it is,
-   * UV_HANDLE_BLOCKING_WRITES (value 0x100000) isn't set on flags.
-   */
-  ASSERT(0 == (slave_tty.flags & 0x100000));
-  /* The master_fd of a pty should never be reopened.
-   */
+  /* Check that UV_HANDLE_BLOCKING_WRITES (value 0x100000) is set. */
+  ASSERT(slave_tty.flags & 0x100000);
   ASSERT(master_tty.flags & 0x100000);
   ASSERT(0 == close(slave_fd));
   uv_close((uv_handle_t*) &slave_tty, NULL);


### PR DESCRIPTION
uv_tty_init() dup'd or reopened the file descriptor in order to set the
O_NONBLOCK flag without affecting other processes it shares the file
descriptor with but that is laborious and fickle. Use sendmsg() with
the MSG_DONTWAIT flag instead.

Fixes: https://github.com/libuv/libuv/issues/2062
Fixes: https://github.com/libuv/libuv/issues/3602

<hr>

WIP because I still need to do the recvmsg() side.

Observation: `UV_HANDLE_BLOCKING_WRITES` means different things on Unix and Windows:
- unix: clears the O_NONBLOCK flag so it really means `UV_HANDLE_BLOCKING_IO`
- windows: turns on sync I/O for the write (not read) side of pipes (and only pipes)