### PR TITLE
win: Fix pipe resource leak if closed during connect (and other bugs)

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -377,6 +377,12 @@ typedef struct {
       OVERLAPPED overlapped;                                                  \
       size_t queued_bytes;                                                    \
     } io;                                                                     \
+    /* in v2, we can move these to the UV_CONNECT_PRIVATE_FIELDS */           \
+    struct {                                                                  \
+      ULONG_PTR result; /* overlapped.Internal is reused to hold the result */\
+      HANDLE pipeHandle;                                                      \
+      DWORD duplex_flags;                                                     \
+    } connect;                                                                \
   } u;                                                                        \
   struct uv_req_s* next_req;
 

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -479,13 +479,13 @@ static int uv__set_pipe_handle(uv_loop_t* loop,
                                    NULL, NULL, 0)) {
         return uv_translate_sys_error(GetLastError());
       } else if (current_mode & PIPE_NOWAIT) {
-        return uv_translate_sys_error(ERROR_ACCESS_DENIED);
+        return UV_EACCES;
       }
     } else {
       /* If this returns ERROR_INVALID_PARAMETER we probably opened
        * something that is not a pipe. */
       if (err == ERROR_INVALID_PARAMETER) {
-        return uv_translate_sys_error(WSAENOTSOCK);
+        return UV_ENOTSOCK;
       }
       return uv_translate_sys_error(err);
     }

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -941,7 +941,7 @@ void uv__pipe_interrupt_read(uv_pipe_t* handle) {
     /* Cancel asynchronous read. */
     r = CancelIoEx(handle->handle, &handle->read_req.u.io.overlapped);
     assert(r || GetLastError() == ERROR_NOT_FOUND);
-    (void)r;
+    (void) r;
   } else {
     /* Cancel synchronous read (which is happening in the thread pool). */
     HANDLE thread;
@@ -2210,7 +2210,8 @@ static void eof_timer_init(uv_pipe_t* pipe) {
   pipe->pipe.conn.eof_timer = (uv_timer_t*) uv__malloc(sizeof *pipe->pipe.conn.eof_timer);
 
   r = uv_timer_init(pipe->loop, pipe->pipe.conn.eof_timer);
-  assert(r == 0); (void)r; /* timers can't fail */
+  assert(r == 0);  /* timers can't fail */
+  (void) r;
   pipe->pipe.conn.eof_timer->data = pipe;
   uv_unref((uv_handle_t*) pipe->pipe.conn.eof_timer);
 }


### PR DESCRIPTION
_From https://github.com/libuv/libuv/pull/3598#issuecomment-1111513567_

>> [test.parallel/test-http-client-abort-unix-socket](https://ci.nodejs.org/job/node-test-binary-windows-js-suites/14497/RUN_SUBSET=1,nodes=win2012r2-COMPILED_BY-vs2019-x86/testReport/(root)/test/parallel_test_http_client_abort_unix_socket/) timeout
>
> this seems somewhat concerning and needs to be investigated


Investigation revealed this to be a somewhat uncommon resource leak. There is a relatively direct fix for that of just adding this to the happy path of `uv__process_pipe_connect_req`:
```
    if (handle->flags & UV_HANDLE_CLOSING)
      close_pipe(handle);
```
But that might risk hanging for a long time in the background thread waiting for the 30 second (recurring) timeout. Thus I have reordered the logic to check and set the flag early (uv__pipe_connection_init ) that is required for correct cleanup. The old code also had a significant data race mistake, which we fix here by introducing new fields into the connect_req object. There was also a variety of other resource management bugs, which turned out to make this a lot larger than initially expected.

n.b. the commits are loosely separated, but not independently functional and should be squashed