### PR TITLE
win: flag LOAD_LIBRARY_SEARCH_SYSTEM32 missing

### DIFF
--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -126,6 +126,9 @@ void uv__winapi_init(void) {
       kernel32_module,
       "GetQueuedCompletionStatusEx");
 
+#ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
+#define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
+#endif
   powrprof_module = LoadLibraryExA("powrprof.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (powrprof_module != NULL) {
     pPowerRegisterSuspendResumeNotification = (sPowerRegisterSuspendResumeNotification)


### PR DESCRIPTION
When I using `cmake -G "Visual Studio 10 2010" ..` and `cmake --build . --config Debug` to build libuv, I meet the error
```
  winapi.c
..\libuv\src\win\winapi.c(129): error C2065: 'LOAD_LIBRARY_SEARCH_SYSTEM32' : undeclared identifier [D:\libuv
\uv_a.vcxproj]
```
I google it, I find a resolve 
https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa

Please review it.