### PR TITLE
zos: avoid callbacks on closed fs event handles

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -160,10 +160,10 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
 
   case UV_FS_EVENT:
     uv__fs_event_close((uv_fs_event_t*)handle);
-#if defined(__sun)
+#if defined(__sun) || defined(__MVS__)
     /*
-     * On Solaris and illumos, we will not be able to dissociate the watcher
-     * for an event which is pending delivery, so we cannot always call
+     * On Solaris, illumos, and z/OS we will not be able to dissociate the
+     * watcher for an event which is pending delivery, so we cannot always call
      * uv__make_close_pending() straight away. The backend will call the
      * function once the event has cleared.
      */


### PR DESCRIPTION
This resolves https://github.com/libuv/libuv/issues/3601.

The reason for the failure is because once a change notification is generated for a file, the notification cannot be cancelled by `uv_fs_event_stop()`. This means that change notifications received in `os390_message_queue_handler()` may refer to a `uv_fs_event_t` handle that have already been closed. In that case, their callback should be prevented from being called. So explicitly check if the handle is closed before calling the callback function.
