### PR TITLE
Aix & IBM i: Fix embed test

### DIFF
--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(_AIX)
 #include <poll.h>
 #endif
 
@@ -56,7 +56,7 @@ TEST_IMPL(embed) {
   ASSERT_LE(0, uv_barrier_wait(&barrier));
 
   while (uv_loop_alive(loop)) {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(_AIX)
     ASSERT_LE(0, uv_run(loop, UV_RUN_ONCE));
 #else
     int rc;


### PR DESCRIPTION
`uv_backend_fd` is not supported on Aix & IBM i according to docs: http://docs.libuv.org/en/v1.x/loop.html. Avoid using it in embed test and call `uv_run` directly.

Issue: https://github.com/libuv/libuv/issues/3614
