### PR TITLE
Enable MSVC_RUNTIME_LIBRARY setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.4)
-project(libuv LANGUAGES C)
 
 cmake_policy(SET CMP0057 NEW) # Enable IN_LIST operator
 cmake_policy(SET CMP0064 NEW) # Support if (TEST) operator
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW) # Enable MSVC_RUNTIME_LIBRARY setting
+endif()
+
+project(libuv LANGUAGES C)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../TC-clang-msvc-cl.cmake -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded"
cat CMakeFiles/uv_a.dir/flags.make
will get C_FLAGS = ... /O2 /Ob2 /DNDEBUG -MT ...
and
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../TC-clang-msvc-cl.cmake -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL"
cat CMakeFiles/uv_a.dir/flags.make
will get C_FLAGS = ... /O2 /Ob2 /DNDEBUG -MD ...