### PR TITLE
kqueue: skip EVFILT_PROC events when invalidating events for an fd.

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -456,7 +456,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 
   /* Invalidate events with same file descriptor */
   for (i = 0; i < nfds; i++)
-    if ((int) events[i].ident == fd)
+    if ((int) events[i].ident == fd && events[i].filter != EVFILT_PROC)
       events[i].ident = -1;
 }
 


### PR DESCRIPTION
On NetBSD with libuv 1.44.1 we see that cmake occasionally hangs waiting for a child process to exit, with libuv waiting forever for kevent() to deliver more events that never come.  The child process has already exited and is waiting to be collected with waitpid().  The symptoms are similar to libuv#3521 but this is a different problem.

This time, the hang occurs when the batch of events returned by one call to kevent() contains both a EVFILT_READ event for an fd and a later EVFILT_PROC record for the PID with the same value as the earlier fd.  What happens is that  uv__platform_invalidate_fd() is called to invalidate events later in the same batch for the fd, but uv__platform_invalidate_fd() invalidates the later EVFILT_PROC event too because it sees the same "ident" value and does not check the "filter" value to differentiate "ident" values that refer to fds vs. "ident" values that refer to PIDs.

This patch adds a check for the "filter" value to avoid confusing these two different kinds of event "ident" values, and with this patch applied to libuv then the cmake hangs no longer occur.