### PR TITLE
libuv: fix atomic-ops.h for Darwin, fixes ppc64 build

### DIFF
--- a/src/unix/atomic-ops.h
+++ b/src/unix/atomic-ops.h
@@ -54,7 +54,9 @@ UV_UNUSED(static void cpu_relax(void)) {
   __asm__ __volatile__ ("rep; nop" ::: "memory");  /* a.k.a. PAUSE */
 #elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
   __asm__ __volatile__ ("yield" ::: "memory");
-#elif defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
+#elif (defined(__ppc__) || defined(__ppc64__)) && defined(__APPLE__)
+  __asm volatile ("" : : : "memory");
+#elif !defined(__APPLE__) && (defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__))
   __asm__ __volatile__ ("or 1,1,1; or 2,2,2" ::: "memory");
 #endif
 }


### PR DESCRIPTION
This fixes `libuv` build for `ppc64` on Darwin (as well as `+universal` with `ppc+ppc64`).
Definition used for `cpu_relax` borrowed from `libitm`: https://github.com/gcc-mirror/gcc/blob/master/libitm/config/powerpc/target.h
Where, FWIU, it was introduced by @iains

This closes my own ticket: https://github.com/libuv/libuv/issues/3623#issuecomment-1125921373