### PR TITLE
udp,win: fix UDP compiler warning

### DIFF
--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -1146,6 +1146,7 @@ int uv__udp_try_send(uv_udp_t* handle,
     err = uv__convert_to_localhost_if_unspecified(addr, &converted);
     if (err)
       return err;
+    addr = (const struct sockaddr*) &converted;
   }
 
   /* Already sending a message.*/
@@ -1169,7 +1170,7 @@ int uv__udp_try_send(uv_udp_t* handle,
                   nbufs,
                   &bytes,
                   0,
-                  (const struct sockaddr*) &converted,
+                  addr,
                   addrlen,
                   NULL,
                   NULL);


### PR DESCRIPTION
Previously it would pass a pointer to uninitialized memory to WSASendTo,
which triggered a compiler warning. However, `addrlen` will be 0, so it
seems unlikely to trigger an error or uninitialized memory access.

Refs: https://github.com/libuv/leps/pull/10
Refs: https://github.com/libuv/libuv/pull/1872
Refs: https://github.com/libuv/libuv/pull/2217