### PR TITLE
zos: implement uv_available_parallelism()

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -81,7 +81,8 @@ extern char** environ;
 #endif
 
 #if defined(__MVS__)
-#include <sys/ioctl.h>
+# include <sys/ioctl.h>
+# include "zos-sys-info.h"
 #endif
 
 #if defined(__linux__)
@@ -1647,7 +1648,13 @@ unsigned int uv_available_parallelism(void) {
 
   return (unsigned) rc;
 #elif defined(__MVS__)
-  return 1;  /* TODO(bnoordhuis) Read from CSD_NUMBER_ONLINE_CPUS? */
+  int rc;
+
+  rc = __get_num_online_cpus();
+  if (rc < 1)
+    rc = 1;
+
+  return (unsigned) rc;
 #else  /* __linux__ */
   long rc;
 


### PR DESCRIPTION
This PR implements `uv_available_parallelism()` for z/OS by leveraging the [`__get_num_online_cpus()`](https://ibmruntimes.github.io/zoslib/zos-sys-info_8cc.html#a3b2ad7fe0aee30edf781eefd73ee5b88) function provided by ZOSLIB to report the number of CPUs that the operating system considers to be online.

`__get_num_online_cpus()` gets this information from the cpu management control table.