### PR TITLE
zos: fix early exit of epoll_wait()

### DIFF
--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -1030,6 +1030,5 @@ int uv__io_fork(uv_loop_t* loop) {
   */
   loop->ep = NULL;
 
-  uv__platform_loop_delete(loop);
   return uv__platform_loop_init(loop);
 }


### PR DESCRIPTION
This PR fixes a bug in z/OS implementation of `epoll_wait()` where it's possible for `reventcount` to become greater than `pollret`. This indicates an early exit of the loop, resulting in some file events not being correctly captured.

The reason this happens is because the previous implementation incremented `reventcount` by 2 when both `POLLIN` and `POLLOUT` revents were set for a fd. However, `reventcount` should still only be incremented by 1 in this case, because `_NFDS` counts as 1 even for fds with multiple revents set. 

Additionally, this PR makes a few minor improvements to remove redundant checks for epoll:

- `lst->size` should never be 0 or negative, so we can remove the check and the `_SET_FDS_MSGS(size, 0, 0)` branch entirely.
- Message queue is always the last entry of `lst->items`. We can handle it separately at the end to avoid going through the entire for loop in cases where we receive message queue events without receiving any fd events.
- Removed `uv__platform_loop_delete()` call in `uv__io_fork()`, since we already set `loop->ep = NULL`.