### PR TITLE
unix: fix c99 comments

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -924,7 +924,6 @@ static void uv__write(uv_stream_t* stream) {
   }
 
   req->error = n;
-  // XXX(jwn): this must call uv__stream_flush_write_queue(stream, n) here, since we won't generate any more events
   uv__write_req_finish(req);
   uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);
   uv__stream_osx_interrupt_select(stream);

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -344,13 +344,14 @@ uv_handle_type uv_guess_handle(uv_file file) {
 
   if (fstat(file, &s)) {
 #if defined(__PASE__)
-    // On ibmi receiving RST from TCP instead of FIN immediately puts fd into
-    // an error state. fstat will return EINVAL, getsockname will also return
-    // EINVAL, even if sockaddr_storage is valid. (If file does not refer to a
-    // socket, ENOTSOCK is returned instead.)
-    // In such cases, we will permit the user to open the connection as uv_tcp
-    // still, so that the user can get immediately notified of the error in
-    // their read callback and close this fd.
+    /* On ibmi receiving RST from TCP instead of FIN immediately puts fd into
+     * an error state. fstat will return EINVAL, getsockname will also return
+     * EINVAL, even if sockaddr_storage is valid. (If file does not refer to a
+     * socket, ENOTSOCK is returned instead.)
+     * In such cases, we will permit the user to open the connection as uv_tcp
+     * still, so that the user can get immediately notified of the error in
+     * their read callback and close this fd.
+     */
     len = sizeof(ss);
     if (getsockname(file, (struct sockaddr*) &ss, &len)) {
       if (errno == EINVAL)
@@ -375,12 +376,13 @@ uv_handle_type uv_guess_handle(uv_file file) {
   len = sizeof(ss);
   if (getsockname(file, (struct sockaddr*) &ss, &len)) {
 #if defined(_AIX)
-    // On aix receiving RST from TCP instead of FIN immediately puts fd into
-    // an error state. In such case getsockname will return EINVAL, even if
-    // sockaddr_storage is valid.
-    // In such cases, we will permit the user to open the connection as uv_tcp
-    // still, so that the user can get immediately notified of the error in
-    // their read callback and close this fd.
+    /* On aix receiving RST from TCP instead of FIN immediately puts fd into
+     * an error state. In such case getsockname will return EINVAL, even if
+     * sockaddr_storage is valid.
+     * In such cases, we will permit the user to open the connection as uv_tcp
+     * still, so that the user can get immediately notified of the error in
+     * their read callback and close this fd.
+     */
     if (errno == EINVAL) {
       return UV_TCP;
     }

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -705,10 +705,11 @@ int uv__udp_disconnect(uv_udp_t* handle) {
     do {
       errno = 0;
 #ifdef __PASE__
-      // On IBMi a connectionless transport socket can be disconnected by
-      // either setting the addr parameter to NULL or setting the
-      // addr_length parameter to zero, and issuing another connect().
-      // https://www.ibm.com/docs/en/i/7.4?topic=ssw_ibm_i_74/apis/connec.htm
+      /* On IBMi a connectionless transport socket can be disconnected by
+       * either setting the addr parameter to NULL or setting the
+       * addr_length parameter to zero, and issuing another connect().
+       * https://www.ibm.com/docs/en/i/7.4?topic=ssw_ibm_i_74/apis/connec.htm
+       */
       r = connect(handle->io_watcher.fd, (struct sockaddr*) NULL, 0);
 #else
       r = connect(handle->io_watcher.fd, (struct sockaddr*) &addr, sizeof(addr));


### PR DESCRIPTION
Causes compilation errors for people that build libuv with a C89
compiler.

Refs: https://github.com/libuv/libuv/discussions/3666