### PR TITLE
unix: don't accept() connections in a loop

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -867,11 +867,6 @@ void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
   w->fd = fd;
   w->events = 0;
   w->pevents = 0;
-
-#if defined(UV_HAVE_KQUEUE)
-  w->rcount = 0;
-  w->wcount = 0;
-#endif /* defined(UV_HAVE_KQUEUE) */
 }
 
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -333,7 +333,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (ev->filter == EVFILT_READ) {
         if (w->pevents & POLLIN) {
           revents |= POLLIN;
-          w->rcount = ev->data;
         } else {
           /* TODO batch up */
           struct kevent events[1];
@@ -349,7 +348,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (ev->filter == EV_OOBAND) {
         if (w->pevents & UV__POLLPRI) {
           revents |= UV__POLLPRI;
-          w->rcount = ev->data;
         } else {
           /* TODO batch up */
           struct kevent events[1];
@@ -363,7 +361,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (ev->filter == EVFILT_WRITE) {
         if (w->pevents & POLLOUT) {
           revents |= POLLOUT;
-          w->wcount = ev->data;
         } else {
           /* TODO batch up */
           struct kevent events[1];

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -338,23 +338,11 @@ int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb) {
 
 
 int uv__tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb) {
-  static int single_accept_cached = -1;
   unsigned long flags;
-  int single_accept;
   int err;
 
   if (tcp->delayed_error)
     return tcp->delayed_error;
-
-  single_accept = uv__load_relaxed(&single_accept_cached);
-  if (single_accept == -1) {
-    const char* val = getenv("UV_TCP_SINGLE_ACCEPT");
-    single_accept = (val != NULL && atoi(val) != 0);  /* Off by default. */
-    uv__store_relaxed(&single_accept_cached, single_accept);
-  }
-
-  if (single_accept)
-    tcp->flags |= UV_HANDLE_TCP_SINGLE_ACCEPT;
 
   flags = 0;
 #if defined(__MVS__)
@@ -460,10 +448,6 @@ int uv_tcp_keepalive(uv_tcp_t* handle, int on, unsigned int delay) {
 
 
 int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable) {
-  if (enable)
-    handle->flags &= ~UV_HANDLE_TCP_SINGLE_ACCEPT;
-  else
-    handle->flags |= UV_HANDLE_TCP_SINGLE_ACCEPT;
   return 0;
 }
 


### PR DESCRIPTION
After analysis of many real-world programs I've come to conclude that
accepting in a loop is nearly always suboptimal.

1. 99.9% of the time the second accept() call fails with EAGAIN, meaning
   there are no additional connections to accept. Not super expensive
   in isolation but it adds up.

2. When there are more connections to accept but the listen socket is
   shared between multiple processes (ex. the Node.js cluster module),
   libuv's greedy behavior necessitated the UV_TCP_SINGLE_ACCEPT hack
   to slow it down in order to give other processes a chance.

Accepting a single connection and relying on level-triggered polling to
get notified on the next incoming connection both simplifies the code
and optimizes for the common case.

<hr>

I'm curious if the above lines up with other people's experiences.