### PR TITLE
unix,win: remove UV_HANDLE_SHUTTING flag

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -317,7 +317,7 @@ int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb) {
   struct linger l = { 1, 0 };
 
   /* Disallow setting SO_LINGER to zero due to some platform inconsistencies */
-  if (handle->flags & UV_HANDLE_SHUTTING)
+  if (uv__is_stream_shutting(handle))
     return UV_EINVAL;
 
   fd = uv__stream_fd(handle);

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -78,7 +78,6 @@ enum {
   /* Used by streams. */
   UV_HANDLE_LISTENING                   = 0x00000040,
   UV_HANDLE_CONNECTION                  = 0x00000080,
-  UV_HANDLE_SHUTTING                    = 0x00000100,
   UV_HANDLE_SHUT                        = 0x00000200,
   UV_HANDLE_READ_PARTIAL                = 0x00000400,
   UV_HANDLE_READ_EOF                    = 0x00000800,
@@ -257,6 +256,14 @@ void uv__threadpool_cleanup(void);
 
 #define uv__is_closing(h)                                                     \
   (((h)->flags & (UV_HANDLE_CLOSING | UV_HANDLE_CLOSED)) != 0)
+
+#if defined(_WIN32)
+# define uv__is_stream_shutting(h)                                            \
+  (h->stream.conn.shutdown_req != NULL)
+#else
+# define uv__is_stream_shutting(h)                                            \
+  (h->shutdown_req != NULL)
+#endif
 
 #define uv__handle_start(h)                                                   \
   do {                                                                        \

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2069,9 +2069,9 @@ void uv__process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
     uv__queue_non_overlapped_write(handle);
   }
 
-  if (handle->stream.conn.write_reqs_pending == 0)
-    if (handle->flags & UV_HANDLE_SHUTTING)
-      uv__pipe_shutdown(loop, handle, handle->stream.conn.shutdown_req);
+  if (handle->stream.conn.write_reqs_pending == 0 &&
+      uv__is_stream_shutting(handle))
+    uv__pipe_shutdown(loop, handle, handle->stream.conn.shutdown_req);
 
   DECREASE_PENDING_REQ_COUNT(handle);
 }
@@ -2149,7 +2149,6 @@ void uv__process_pipe_shutdown_req(uv_loop_t* loop, uv_pipe_t* handle,
 
   /* Clear the shutdown_req field so we don't go here again. */
   handle->stream.conn.shutdown_req = NULL;
-  handle->flags &= ~UV_HANDLE_SHUTTING;
   UNREGISTER_HANDLE_REQ(loop, handle, req);
 
   if (handle->flags & UV_HANDLE_CLOSING) {

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -204,7 +204,7 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
   uv_loop_t* loop = handle->loop;
 
   if (!(handle->flags & UV_HANDLE_WRITABLE) ||
-      handle->flags & UV_HANDLE_SHUTTING ||
+      uv__is_stream_shutting(handle) ||
       uv__is_closing(handle)) {
     return UV_ENOTCONN;
   }
@@ -214,7 +214,6 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
   req->cb = cb;
 
   handle->flags &= ~UV_HANDLE_WRITABLE;
-  handle->flags |= UV_HANDLE_SHUTTING;
   handle->stream.conn.shutdown_req = req;
   handle->reqs_pending++;
   REGISTER_HANDLE_REQ(loop, handle, req);

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2234,11 +2234,11 @@ void uv__process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
 
 
   handle->stream.conn.write_reqs_pending--;
-  if (handle->stream.conn.write_reqs_pending == 0)
-    if (handle->flags & UV_HANDLE_SHUTTING)
-      uv__process_tty_shutdown_req(loop,
-                                   handle,
-                                   handle->stream.conn.shutdown_req);
+  if (handle->stream.conn.write_reqs_pending == 0 &&
+      uv__is_stream_shutting(handle))
+    uv__process_tty_shutdown_req(loop,
+                                 handle,
+                                 handle->stream.conn.shutdown_req);
 
   DECREASE_PENDING_REQ_COUNT(handle);
 }
@@ -2269,7 +2269,6 @@ void uv__process_tty_shutdown_req(uv_loop_t* loop, uv_tty_t* stream, uv_shutdown
   assert(req);
 
   stream->stream.conn.shutdown_req = NULL;
-  stream->flags &= ~UV_HANDLE_SHUTTING;
   UNREGISTER_HANDLE_REQ(loop, stream, req);
 
   /* TTY shutdown is really just a no-op */


### PR DESCRIPTION
Replace it with a `uv__is_stream_shutting()` macro that checks the
`shutdown_req` field.

It partially fixes: https://github.com/libuv/libuv/issues/3663.