### PR TITLE
build: switch ci from macos-10.15 to macos-11

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -33,7 +33,7 @@ jobs:
           ls -lh build
 
   build-macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Envinfo
@@ -61,7 +61,7 @@ jobs:
           cd build && ctest -V
 
   build-ios:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Configure


### PR DESCRIPTION
The former will be removed by GitHub in August.

Fixes: https://github.com/libuv/libuv/issues/3697