### PR TITLE
unix: implement uv__async_wait for platforms where wait is better than spin & yield

### DIFF
--- a/include/uv/darwin.h
+++ b/include/uv/darwin.h
@@ -22,26 +22,12 @@
 #ifndef UV_DARWIN_H
 #define UV_DARWIN_H
 
-#if defined(__APPLE__)
-# if defined(__MACH__)
-#  include <mach/mach.h>
-#  include <mach/task.h>
-#  include <mach/semaphore.h>
-#  define UV_PLATFORM_SEM_T semaphore_t
-# endif
-
+#if defined(__APPLE__) && defined(__MACH__)
+# include <mach/mach.h>
+# include <mach/task.h>
+# include <mach/semaphore.h>
 # include <TargetConditionals.h>
-# include <AvailabilityMacros.h>
-# include <os/lock.h>
-
-# if defined (MAC_OS_VERSION_12_0)                                            \
-    && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_0)
-#  define UV_PREFER_UNFAIR_LOCK 1
-# endif
-
-# if defined(__aarch64__)
-#  define UV_PREFER_WAIT 1
-# endif
+# define UV_PLATFORM_SEM_T semaphore_t
 #endif
 
 #define UV_IO_PRIVATE_PLATFORM_FIELDS                                         \
@@ -69,6 +55,13 @@
 
 #define UV_STREAM_PRIVATE_PLATFORM_FIELDS                                     \
   void* select;                                                               \
+
+#if defined(__APPLE__) && defined(__aarch64__)
+# define UV_PREFER_WAIT 1
+# define UV_ASYNC_PRIVATE_PLATFORM_FIELDS                                     \
+  uv_mutex_t mutex;                                                           \
+  uv_cond_t not_busy;
+#endif
 
 #define UV_HAVE_KQUEUE 1
 

--- a/include/uv/darwin.h
+++ b/include/uv/darwin.h
@@ -22,12 +22,26 @@
 #ifndef UV_DARWIN_H
 #define UV_DARWIN_H
 
-#if defined(__APPLE__) && defined(__MACH__)
-# include <mach/mach.h>
-# include <mach/task.h>
-# include <mach/semaphore.h>
+#if defined(__APPLE__)
+# if defined(__MACH__)
+#  include <mach/mach.h>
+#  include <mach/task.h>
+#  include <mach/semaphore.h>
+#  define UV_PLATFORM_SEM_T semaphore_t
+# endif
+
 # include <TargetConditionals.h>
-# define UV_PLATFORM_SEM_T semaphore_t
+# include <AvailabilityMacros.h>
+# include <os/lock.h>
+
+# if defined (MAC_OS_VERSION_12_0)                                            \
+    && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_0)
+#  define UV_PREFER_UNFAIR_LOCK 1
+# endif
+
+# if defined(__aarch64__)
+#  define UV_PREFER_WAIT 1
+# endif
 #endif
 
 #define UV_IO_PRIVATE_PLATFORM_FIELDS                                         \

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -117,6 +117,10 @@ struct uv__io_s {
 # define UV_STREAM_PRIVATE_PLATFORM_FIELDS /* empty */
 #endif
 
+#ifndef UV_ASYNC_PRIVATE_PLATFORM_FIELDS
+# define UV_ASYNC_PRIVATE_PLATFORM_FIELDS /* empty */
+#endif
+
 /* Note: May be cast to struct iovec. See writev(2). */
 typedef struct uv_buf_t {
   char* base;
@@ -322,19 +326,11 @@ typedef struct {
   uv_idle_cb idle_cb;                                                         \
   void* queue[2];                                                             \
 
-#if defined(UV_PREFER_WAIT)
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   uv_async_cb async_cb;                                                       \
   void* queue[2];                                                             \
   int pending;                                                                \
-  uv_mutex_t mutex;                                                           \
-  uv_cond_t not_busy;
-#else
-#define UV_ASYNC_PRIVATE_FIELDS                                               \
-  uv_async_cb async_cb;                                                       \
-  void* queue[2];                                                             \
-  int pending;
-#endif
+  UV_ASYNC_PRIVATE_PLATFORM_FIELDS                                            \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
   uv_timer_cb timer_cb;                                                       \

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -322,10 +322,19 @@ typedef struct {
   uv_idle_cb idle_cb;                                                         \
   void* queue[2];                                                             \
 
+#if defined(UV_PREFER_WAIT)
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   uv_async_cb async_cb;                                                       \
   void* queue[2];                                                             \
   int pending;                                                                \
+  uv_mutex_t mutex;                                                           \
+  uv_cond_t not_busy;
+#else
+#define UV_ASYNC_PRIVATE_FIELDS                                               \
+  uv_async_cb async_cb;                                                       \
+  void* queue[2];                                                             \
+  int pending;
+#endif
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
   uv_timer_cb timer_cb;                                                       \

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -89,11 +89,13 @@ int uv_async_send(uv_async_t* handle) {
 
   /* Tell the other thread we're done. */
   expected = 1;
+#if defined(UV_PREFER_WAIT)
+  uv_mutex_lock(&handle->mutex);
+#endif
   if (!atomic_compare_exchange_strong(pending, &expected, 2))
     abort();
 #if defined(UV_PREFER_WAIT)
   if (handle->pending != 1) {
-    uv_mutex_lock(&handle->mutex);
     uv_cond_broadcast(&handle->not_busy);
     uv_mutex_unlock(&handle->mutex);
   }

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -64,7 +64,11 @@ static int isreallyatty(int file) {
 
 static int orig_termios_fd = -1;
 static struct termios orig_termios;
+#if defined(UV_PREFER_UNFAIR_LOCK)
+os_unfair_lock termios_unfair_lock = OS_UNFAIR_LOCK_INIT;
+#else
 static _Atomic int termios_spinlock;
+#endif
 
 int uv__tcsetattr(int fd, int how, const struct termios *term) {
   int rc;
@@ -280,7 +284,9 @@ static void uv__tty_make_raw(struct termios* tio) {
 
 int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   struct termios tmp;
+#if !defined(UV_PREFER_UNFAIR_LOCK)
   int expected;
+#endif
   int fd;
   int rc;
 
@@ -297,16 +303,23 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
       return UV__ERR(errno);
 
     /* This is used for uv_tty_reset_mode() */
+#if defined(UV_PREFER_UNFAIR_LOCK)
+    os_unfair_lock_lock(&termios_unfair_lock);
+#else
     do
       expected = 0;
     while (!atomic_compare_exchange_strong(&termios_spinlock, &expected, 1));
+#endif
 
     if (orig_termios_fd == -1) {
       orig_termios = tty->orig_termios;
       orig_termios_fd = fd;
     }
-
+#if defined(UV_PREFER_UNFAIR_LOCK)
+    os_unfair_lock_unlock(&termios_unfair_lock);
+#else
     atomic_store(&termios_spinlock, 0);
+#endif
   }
 
   tmp = tty->orig_termios;
@@ -447,20 +460,29 @@ uv_handle_type uv_guess_handle(uv_file file) {
  */
 int uv_tty_reset_mode(void) {
   int saved_errno;
+#if !defined(UV_PREFER_UNFAIR_LOCK)
   int expected;
+#endif
   int err;
 
   saved_errno = errno;
-
+#if defined(UV_PREFER_UNFAIR_LOCK)
+  if (!os_unfair_lock_trylock(&termios_unfair_lock))
+#else
   expected = 0;
   if (!atomic_compare_exchange_strong(&termios_spinlock, &expected, 1))
+#endif
     return UV_EBUSY;  /* In uv_tty_set_mode(). */
 
   err = 0;
   if (orig_termios_fd != -1)
     err = uv__tcsetattr(orig_termios_fd, TCSANOW, &orig_termios);
 
+#if defined(UV_PREFER_UNFAIR_LOCK)
+  os_unfair_lock_unlock(&termios_unfair_lock);
+#else
   atomic_store(&termios_spinlock, 0);
+#endif
   errno = saved_errno;
 
   return err;


### PR DESCRIPTION
This patch avoids behaviors that are not performant on Apple silicon: spin waiting and yielding. 

This also replaces a spin lock with os_unfair_lock as that’s a better lock for macOS.

(See “Don’t Keep Threads Active And Idle” section here: https://developer.apple.com/documentation/apple-silicon/tuning-your-code-s-performance-for-apple-silicon)

**Test results before change**

```
ok 1 - async1
# async1: 6.04 sec (165,466/sec)
uv_run_benchmarks_a[50226] Lifetime Usage
-----------------------------------------
CPU
     4.555 ms cpu_time       
     19512 kI cpu_instrs     

ok 1 - async2
# async2: 8.27 sec (120,967/sec)
uv_run_benchmarks_a[50238] Lifetime Usage
-----------------------------------------
CPU
      2.76 ms cpu_time       
     18952 kI cpu_instrs     

ok 1 - async4
# async4: 12.99 sec (76,972/sec)
uv_run_benchmarks_a[50242] Lifetime Usage
-----------------------------------------
CPU
     5.334 ms cpu_time       
     19316 kI cpu_instrs     

ok 1 - async8
# async8: 21.26 sec (47,040/sec)
uv_run_benchmarks_a[50246] Lifetime Usage
-----------------------------------------
CPU
     5.681 ms cpu_time       
     19346 kI cpu_instrs     

ok 1 - async_pummel_1
# async_pummel_1: 1,000,000 callbacks in 4.12 seconds (242,991/sec)
uv_run_benchmarks_a[50252] Lifetime Usage
-----------------------------------------
CPU
     5.469 ms cpu_time       
     19229 kI cpu_instrs     

ok 1 - async_pummel_2
# async_pummel_2: 1,000,000 callbacks in 3.68 seconds (271,907/sec)
uv_run_benchmarks_a[50255] Lifetime Usage
-----------------------------------------
CPU
     2.637 ms cpu_time       
     19118 kI cpu_instrs     

ok 1 - async_pummel_4
# async_pummel_4: 1,000,000 callbacks in 3.45 seconds (290,224/sec)
uv_run_benchmarks_a[50259] Lifetime Usage
-----------------------------------------
CPU
     5.431 ms cpu_time       
     19361 kI cpu_instrs     

ok 1 - async_pummel_8
# async_pummel_8: 1,000,000 callbacks in 11.38 seconds (87,911/sec)
uv_run_benchmarks_a[50262] Lifetime Usage
-----------------------------------------
CPU
     3.007 ms cpu_time       
     19254 kI cpu_instrs     

ok 1 - million_async
# 9,898,832 async events in 5.0 seconds (1,979,766/s, 1,048,576 unique handles seen)
uv_run_benchmarks_a[50267] Lifetime Usage
-----------------------------------------
CPU
     4.403 ms cpu_time       
     19170 kI cpu_instrs     

```

**Test results after change**

```
ok 1 - async1
# async1: 6.16 sec (162,441/sec)
uv_run_benchmarks_a[48720] Lifetime Usage
-----------------------------------------
CPU
     2.355 ms cpu_time       
     18939 kI cpu_instrs     

ok 1 - async2
# async2: 8.08 sec (123,739/sec)
uv_run_benchmarks_a[48723] Lifetime Usage
-----------------------------------------
CPU
     2.656 ms cpu_time       
     19108 kI cpu_instrs     

ok 1 - async4
# async4: 11.00 sec (90,915/sec)
uv_run_benchmarks_a[48727] Lifetime Usage
-----------------------------------------
CPU
     2.411 ms cpu_time       
     19057 kI cpu_instrs     

ok 1 - async8
# async8: 16.85 sec (59,338/sec)
uv_run_benchmarks_a[48732] Lifetime Usage
-----------------------------------------
CPU
      2.73 ms cpu_time       
     19111 kI cpu_instrs     

ok 1 - async_pummel_1
# async_pummel_1: 1,000,000 callbacks in 4.09 seconds (244,564/sec)
uv_run_benchmarks_a[48738] Lifetime Usage
-----------------------------------------
CPU
     2.489 ms cpu_time       
     18993 kI cpu_instrs     

ok 1 - async_pummel_2
# async_pummel_2: 1,000,000 callbacks in 3.83 seconds (261,386/sec)
uv_run_benchmarks_a[48742] Lifetime Usage
-----------------------------------------
CPU
     2.505 ms cpu_time       
     19008 kI cpu_instrs     

ok 1 - async_pummel_4
# async_pummel_4: 1,000,000 callbacks in 3.71 seconds (269,180/sec)
uv_run_benchmarks_a[48745] Lifetime Usage
-----------------------------------------
CPU
     2.514 ms cpu_time       
     19008 kI cpu_instrs     

ok 1 - async_pummel_8
# async_pummel_8: 1,000,000 callbacks in 12.06 seconds (82,894/sec)
uv_run_benchmarks_a[48749] Lifetime Usage
-----------------------------------------
CPU
     2.368 ms cpu_time       
     19046 kI cpu_instrs     

ok 1 - million_async
# 8,879,409 async events in 5.0 seconds (1,775,881/s, 1,048,576 unique handles seen)
uv_run_benchmarks_a[48753] Lifetime Usage
-----------------------------------------
CPU
     2.407 ms cpu_time       
     18882 kI cpu_instrs     



```