### PR TITLE
win: support Windows 11 on uv_os_uname()

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1777,6 +1777,22 @@ int uv_os_uname(uv_utsname_t* buffer) {
     RegCloseKey(registry_key);
 
     if (r == ERROR_SUCCESS) {
+      /* Windows 11 shares dwMajorVersion with Windows 10
+       * this workaround tries to disambiguate that by checking
+       * if the dwBuildNumber is from Windows 11 releases (>= 22000).
+       *
+       * This workaround replaces the ProductName key value
+       * from "Windows 10 *" to "Windows 11 *" */
+      if (os_info.dwMajorVersion == 10 &&
+          os_info.dwBuildNumber >= 22000 &&
+          product_name_w_size >= ARRAY_SIZE(L"Windows 10")) {
+        /* If ProductName starts with "Windows 10" */
+        if (wcsncmp(product_name_w, L"Windows 10", ARRAY_SIZE(L"Windows 10") - 1) == 0) {
+          /* Bump 10 to 11 */
+          product_name_w[9] = '1';
+        }
+      }
+
       version_size = WideCharToMultiByte(CP_UTF8,
                                          0,
                                          product_name_w,


### PR DESCRIPTION
This pull request adds Windows 11 support so it can be reported as Windows 11 on `uv_os_uname`.

Although I think this is a workaround, it seems to be as reliable as it gets without dropping the registry key value as the source.

Refs: https://docs.microsoft.com/en-us/answers/questions/586619/windows-11-build-ver-is-still-10022000194.html
"This is correct. Anything above 10.0.22000.0 is Win 11. Anything below is Win 10."

Fixes: https://github.com/libuv/libuv/issues/3381
Node Issue ref: https://github.com/nodejs/node/issues/40862

Suggestions are welcome if this is not the desired solution!