### PR TITLE
win: return `UV_EINVAL` from `uv_fs_readlink()` on a non-symlink file

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -102,7 +102,6 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_INSUFFICIENT_BUFFER:         return UV_EINVAL;
     case ERROR_INVALID_DATA:                return UV_EINVAL;
     case ERROR_INVALID_PARAMETER:           return UV_EINVAL;
-    case ERROR_NOT_A_REPARSE_POINT:         return UV_EINVAL;
     case ERROR_SYMLINK_NOT_SUPPORTED:       return UV_EINVAL;
     case WSAEINVAL:                         return UV_EINVAL;
     case WSAEPFNOSUPPORT:                   return UV_EINVAL;

--- a/src/win/error.c
+++ b/src/win/error.c
@@ -102,6 +102,7 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_INSUFFICIENT_BUFFER:         return UV_EINVAL;
     case ERROR_INVALID_DATA:                return UV_EINVAL;
     case ERROR_INVALID_PARAMETER:           return UV_EINVAL;
+    case ERROR_NOT_A_REPARSE_POINT:         return UV_EINVAL;
     case ERROR_SYMLINK_NOT_SUPPORTED:       return UV_EINVAL;
     case WSAEINVAL:                         return UV_EINVAL;
     case WSAEPFNOSUPPORT:                   return UV_EINVAL;

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2604,7 +2604,10 @@ static void fs__readlink(uv_fs_t* req) {
   }
 
   if (fs__readlink_handle(handle, (char**) &req->ptr, NULL) != 0) {
-    SET_REQ_WIN32_ERROR(req, GetLastError());
+    DWORD error = GetLastError();
+    SET_REQ_WIN32_ERROR(req, error);
+    if (error == ERROR_NOT_A_REPARSE_POINT)
+      req->result = UV_EINVAL;
     CloseHandle(handle);
     return;
   }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2040,19 +2040,19 @@ TEST_IMPL(fs_readlink) {
     /* Create a non-symlink file */
     r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
                    S_IWUSR | S_IRUSR, NULL);
-    ASSERT(r >= 0);
-    ASSERT(req.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(req.result, 0);
     file = req.result;
     uv_fs_req_cleanup(&req);
 
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT(r == 0);
-    ASSERT(req.result == 0);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(req.result, 0);
     uv_fs_req_cleanup(&req);
 
     /* Test */
     r = uv_fs_readlink(NULL, &req, "test_file", NULL);
-    ASSERT(r == UV_EINVAL);
+    ASSERT_EQ(r, UV_EINVAL);
     uv_fs_req_cleanup(&req);
 
     /* Cleanup */


### PR DESCRIPTION
In Node.js, `fs.readlink()` on a non-symlink file used to throw an `UNKNOWN`
error on Windows. This change maps `ERROR_NOT_A_REPARSE_POINT` to
`UV_EINVAL`, so that now it throws `EINVAL` just like all the other
platforms.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @vtjnash 