### PR TITLE
unix: fix uv_getrusage() ru_maxrss reporting

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -119,7 +119,10 @@ Data types
         } uv_rusage_t;
 
     Members marked with `(X)` are unsupported on Windows.
-    See :man:`getrusage(2)` for supported fields on Unix
+    See :man:`getrusage(2)` for supported fields on UNIX-like platforms.
+
+    The maximum resident set size is reported in kilobytes, the unit most
+    platforms use natively.
 
 .. c:type:: uv_cpu_info_t
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -986,6 +986,15 @@ int uv_getrusage(uv_rusage_t* rusage) {
   rusage->ru_nivcsw = usage.ru_nivcsw;
 #endif
 
+  /* Most platforms report ru_maxrss in kilobytes; macOS and Solaris are
+   * the outliers because of course they are.
+   */
+#if defined(__APPLE__) && !TARGET_OS_IPHONE
+  rusage->ru_maxrss /= 1024;                  /* macOS reports bytes. */
+#elif defined(__sun)
+  rusage->ru_maxrss /= getpagesize() / 1024;  /* Solaris reports pages. */
+#endif
+
   return 0;
 }
 


### PR DESCRIPTION
Most platforms report it in kilobytes but macOS and Solaris report it in
bytes and pages respectively.

Fixes: https://github.com/nodejs/node/issues/44332

<hr>

Windows, Linux and (Free|Net|Open)BSD all report kilobytes.