### PR TITLE
Add HIDE_UV_SYMBOLS to hide symbols when building static lib.

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -31,10 +31,7 @@ extern "C" {
 #error "Define either BUILDING_UV_SHARED or USING_UV_SHARED, not both."
 #endif
 
-#if defined(BUILDING_UV_SHARED)
-#undef HIDE_UV_SYMBOLS
-#endif
-  
+#ifndef UV_EXTERN
 #ifdef _WIN32
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
@@ -53,7 +50,8 @@ extern "C" {
 # define UV_EXTERN __global
 #else
 # define UV_EXTERN /* nothing */
-#endif
+#endif  
+#endif /* UV_EXTERN */
 
 #include "uv/errno.h"
 #include "uv/version.h"

--- a/include/uv.h
+++ b/include/uv.h
@@ -31,6 +31,10 @@ extern "C" {
 #error "Define either BUILDING_UV_SHARED or USING_UV_SHARED, not both."
 #endif
 
+#if defined(BUILDING_UV_SHARED)
+#undef HIDE_UV_SYMBOLS
+#endif
+  
 #ifdef _WIN32
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
@@ -43,7 +47,7 @@ extern "C" {
     /* Building static library. */
 #   define UV_EXTERN /* nothing */
 # endif
-#elif __GNUC__ >= 4
+#elif __GNUC__ >= 4 && !defined(HIDE_UV_SYMBOLS)
 # define UV_EXTERN __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550) /* Sun Studio >= 8 */
 # define UV_EXTERN __global


### PR DESCRIPTION
Lets say I have 2 shared libraries a.so and b.so
they link to different versions of libuv.
If they dont hide their uv symbols ( use `nm -D *.so` to check ), the symbols get mixed up when a excutable loads them both, which can lead to error.