### PR TITLE
test: fix musl libc.a dlerror() test expectation

### DIFF
--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -43,7 +43,9 @@ TEST_IMPL(dlerror) {
   msg = uv_dlerror(&lib);
   ASSERT_NOT_NULL(msg);
 #if !defined(__OpenBSD__) && !defined(__QNX__)
-  ASSERT_NOT_NULL(strstr(msg, path));
+  /* musl's libc.a does not support dlopen(), only libc.so does. */
+  if (NULL == strstr(msg, "Dynamic loading not supported"))
+    ASSERT_NOT_NULL(strstr(msg, path));
 #endif
   ASSERT_NULL(strstr(msg, dlerror_no_error));
 
@@ -51,7 +53,9 @@ TEST_IMPL(dlerror) {
   msg = uv_dlerror(&lib);
   ASSERT_NOT_NULL(msg);
 #if !defined(__OpenBSD__) && !defined(__QNX__)
-  ASSERT_NOT_NULL(strstr(msg, path));
+  /* musl's libc.a does not support dlopen(), only libc.so does. */
+  if (NULL == strstr(msg, "Dynamic loading not supported"))
+    ASSERT_NOT_NULL(strstr(msg, path));
 #endif
   ASSERT_NULL(strstr(msg, dlerror_no_error));
 


### PR DESCRIPTION
Dynamic loading with musl only works with libc.so because it is
is implemented in musl's dynamic linker, not in libc proper.

libc.a contains just a stub dlopen() that always fails with a "Dynamic
loading not supported" error message. Update the test to handle that.

Fix: https://github.com/libuv/libuv/issues/3706