### PR TITLE
unix,win: deal with handle read stop from alloc cb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-tcp-oob.c
        test/test-tcp-open.c
        test/test-tcp-read-stop.c
+       test/test-tcp-read-stop-alloc.c
        test/test-tcp-read-stop-start.c
        test/test-tcp-rst.c
        test/test-tcp-shutdown-after-write.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -266,6 +266,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-tcp-flags.c \
                          test/test-tcp-open.c \
                          test/test-tcp-read-stop.c \
+                         test/test-tcp-read-stop-alloc.c \
                          test/test-tcp-read-stop-start.c \
                          test/test-tcp-rst.c \
                          test/test-tcp-shutdown-after-write.c \

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -153,6 +153,10 @@ API
     In-progress requests, like uv_connect_t or uv_write_t, are cancelled and
     have their callbacks called asynchronously with status=UV_ECANCELED.
 
+    For stream-like handles where libuv still holds on to memory from an
+    earlier :c:type:`uv_alloc_cb` call, it calls c:type:`uv_read_cb` once
+    with `nread == 0` to indicate it is giving back the memory.
+
 .. c:function:: void uv_ref(uv_handle_t* handle)
 
     Reference the given handle. References are idempotent, that is, if a handle

--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -146,8 +146,11 @@ API
 
 .. c:function:: int uv_read_stop(uv_stream_t*)
 
-    Stop reading data from the stream. The :c:type:`uv_read_cb` callback will
-    no longer be called.
+    Stop reading data from the stream.
+
+    If libuv still owns memory from an earlier :c:type:`uv_alloc_cb` call, it
+    invokes the :c:type:`uv_read_cb` call once with `nread == 0` to give back
+    the memory. No further :c:type:`uv_read_cb` callbacks will be made.
 
     This function is idempotent and may be safely called on a stopped stream.
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1050,16 +1050,21 @@ static void uv__read(uv_stream_t* stream) {
 
   is_ipc = stream->type == UV_NAMED_PIPE && ((uv_pipe_t*) stream)->ipc;
 
-  /* XXX: Maybe instead of having UV_HANDLE_READING we just test if
-   * tcp->read_cb is NULL or not?
-   */
-  while (stream->read_cb
-      && (stream->flags & UV_HANDLE_READING)
-      && (count-- > 0)) {
-    assert(stream->alloc_cb != NULL);
+  while (count-- > 0) {
+    if (!(stream->flags & UV_HANDLE_READING))
+      return;
 
+    assert(stream->alloc_cb != NULL);
     buf = uv_buf_init(NULL, 0);
     stream->alloc_cb((uv_handle_t*)stream, 64 * 1024, &buf);
+
+    /* In case stream->alloc_cb called uv_read_stop(). */
+    if (!(stream->flags & UV_HANDLE_READING)) {
+      if (buf.len > 0)
+        stream->read_cb(stream, 0, &buf);  /* Give back buffer. */
+      return;
+    }
+
     if (buf.base == NULL || buf.len == 0) {
       /* User indicates it can't or won't handle the read. */
       stream->read_cb(stream, UV_ENOBUFS, &buf);
@@ -1488,9 +1493,12 @@ int uv_read_stop(uv_stream_t* stream) {
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
-
-  stream->read_cb = NULL;
   stream->alloc_cb = NULL;
+
+  /* Don't zero stream->read_cb in case we are being called
+   * from stream->alloc_cb and need to hand back the buffer.
+   */
+
   return 0;
 }
 

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -87,7 +87,8 @@ static void after_read(uv_stream_t* handle,
 
   if (nread < 0) {
     /* Error or EOF */
-    ASSERT_EQ(nread, UV_EOF);
+    if (nread != UV_ECONNRESET)
+      ASSERT_EQ(nread, UV_EOF);
 
     free(buf->base);
     sreq = malloc(sizeof* sreq);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -149,6 +149,8 @@ TEST_DECLARE   (tcp_write_to_half_open_connection)
 TEST_DECLARE   (tcp_unexpected_read)
 TEST_DECLARE   (tcp_read_stop)
 TEST_DECLARE   (tcp_read_stop_start)
+TEST_DECLARE   (tcp_read_stop_from_alloc)
+TEST_DECLARE   (tcp_close_from_alloc)
 TEST_DECLARE   (tcp_rst)
 TEST_DECLARE   (tcp_bind6_error_addrinuse)
 TEST_DECLARE   (tcp_bind6_error_addrnotavail)
@@ -730,6 +732,12 @@ TASK_LIST_START
   TEST_HELPER (tcp_read_stop, tcp4_echo_server)
 
   TEST_ENTRY  (tcp_read_stop_start)
+
+  TEST_ENTRY  (tcp_read_stop_from_alloc)
+  TEST_HELPER (tcp_read_stop_from_alloc, tcp4_echo_server)
+
+  TEST_ENTRY  (tcp_close_from_alloc)
+  TEST_HELPER (tcp_close_from_alloc, tcp4_echo_server)
 
   TEST_ENTRY  (tcp_rst)
   TEST_HELPER (tcp_rst, tcp4_echo_server)

--- a/test/test-tcp-read-stop-alloc.c
+++ b/test/test-tcp-read-stop-alloc.c
@@ -1,0 +1,102 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+enum { CLOSE, STOP };
+
+static int alloc_cb_called;
+static int read_cb_called;
+static int close_or_stop;
+
+static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
+  switch (close_or_stop) {
+    default:
+      ASSERT(0 && "unreachable");
+    case CLOSE:
+      uv_close(handle, NULL);
+      break;
+    case STOP:
+      ASSERT_EQ(0, uv_read_stop((uv_stream_t*) handle));
+      break;
+  }
+
+  static char c;
+  buf->base = &c;
+  buf->len = 1;
+  alloc_cb_called++;
+}
+
+static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
+  if (close_or_stop == STOP)
+    uv_close((uv_handle_t*) handle, NULL);
+
+  ASSERT_EQ(nread, 0);
+  read_cb_called++;
+}
+
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT_EQ(0, status);
+}
+
+static void connect_cb(uv_connect_t* req, int status) {
+  static uv_write_t write_req;
+  uv_buf_t buf;
+
+  buf.base = "OK";
+  buf.len = 2;
+
+  ASSERT_EQ(0, status);
+  ASSERT_EQ(0, uv_read_start(req->handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_write(&write_req, req->handle, &buf, 1, write_cb));
+}
+
+static int test(void) {
+  uv_connect_t connect_req;
+  struct sockaddr_in addr;
+  uv_tcp_t tcp_handle;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_handle));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &tcp_handle,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, alloc_cb_called);
+  ASSERT_EQ(1, read_cb_called);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+TEST_IMPL(tcp_read_stop_from_alloc) {
+  close_or_stop = STOP;
+  return test();
+}
+
+TEST_IMPL(tcp_close_from_alloc) {
+  close_or_stop = CLOSE;
+  return test();
+}

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -139,9 +139,8 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT(nread == 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
-  /* FIXME? `uv_udp_recv_stop` does what it says: recv_cb is not called
-    * anymore. That's problematic because the read buffer won't be returned
-    * either... Not sure I like that but it's consistent with `uv_read_stop`.
+  /* FIXME(bnoordhuis) `uv_udp_recv_stop` does what it says: recv_cb is not
+   * called anymore. Problematic because the read buffer won't be returned.
     */
   r = uv_udp_recv_stop(handle);
   ASSERT(r == 0);


### PR DESCRIPTION
The iron rule is that libuv always hands back memory that you gave it.

That means a call to `uv_alloc_cb` must always be followed by a
corresponding call to `uv_read_cb`, even when the former calls
`uv_close()` or `uv_read_stop()`, otherwise the program leaks memory.

Refs: https://github.com/libuv/libuv/discussions/3740

<hr>

Untested on Windows ~~but there is a chance it will do the right thing out of the box~~ (edit: okay, maybe not)

`uv_udp_recv_stop()` is up next.