### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ Make sure that you specify the architecture you wish to build for in the
 "ARCHS" flag. You can specify more than one by delimiting with a space
 (e.g. "x86_64 i386").
 
+### Install with vcpkg
+
+```bash
+$ git clone https://github.com/microsoft/vcpkg.git
+$ ./bootstrap-vcpkg.bat # for powershell
+$ ./bootstrap-vcpkg.sh # for bash
+$ ./vcpkg install libuv
+```
+
 ### Running tests
 
 Some tests are timing sensitive. Relaxing test timeouts may be necessary


### PR DESCRIPTION
`libuv` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `libuv` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `libuv`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libuv/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)