### PR TITLE
API for querying available memory + cgroup1 fixes

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -561,7 +561,7 @@ API
 
 .. c:function:: uint64_t uv_get_constrained_memory(void)
 
-    Gets the amount of memory available to the process (in bytes) based on
+    Gets the total amount of memory available to the process (in bytes) based on
     limits imposed by the OS. If there is no such constraint, or the constraint
     is unknown, `0` is returned. Note that it is not unusual for this value to
     be less than or greater than :c:func:`uv_get_total_memory`.
@@ -571,6 +571,20 @@ API
         on cgroups if it is present, and on z/OS based on RLIMIT_MEMLIMIT.
 
     .. versionadded:: 1.29.0
+
+.. c:function:: uint64_t uv_get_available_memory(void)
+
+    Gets the amount of free memory that is still available to the process (in bytes).
+    This differs from :c:func:`uv_get_free_memory` in that it takes into account any
+    limits imposed by the OS. If there is no such constraint, or the constraint
+    is unknown, the amount returned will be identical to :c:func:`uv_get_free_memory`.
+
+    .. note::
+        This function currently only returns a value that is different from
+        what :c:func:`uv_get_free_memory` reports on Linux, based
+        on cgroups if it is present.
+
+    .. versionadded:: 1.45.0
 
 .. c:function:: uint64_t uv_hrtime(void)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1718,6 +1718,7 @@ UV_EXTERN int uv_chdir(const char* dir);
 UV_EXTERN uint64_t uv_get_free_memory(void);
 UV_EXTERN uint64_t uv_get_total_memory(void);
 UV_EXTERN uint64_t uv_get_constrained_memory(void);
+UV_EXTERN uint64_t uv_get_available_memory(void);
 
 UV_EXTERN uint64_t uv_hrtime(void);
 UV_EXTERN void uv_sleep(unsigned int msec);

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -391,6 +391,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   perfstat_cpu_total_t ps_total;
   int result = perfstat_cpu_total(NULL, &ps_total, sizeof(ps_total), 1);

--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -51,3 +51,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 uint64_t uv_get_constrained_memory(void) {
   return 0;  /* Memory constraints are unknown. */
 }
+
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -131,6 +131,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/freebsd.c
+++ b/src/unix/freebsd.c
@@ -116,6 +116,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   struct loadavg info;
   size_t size = sizeof(info);

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -84,6 +84,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   area_info area;
   ssize_t cookie;

--- a/src/unix/hurd.c
+++ b/src/unix/hurd.c
@@ -165,3 +165,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 uint64_t uv_get_constrained_memory(void) {
   return 0;  /* Memory constraints are unknown. */
 }
+
+
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -249,6 +249,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   SSTS0200 rcvr;
 

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1342,11 +1342,13 @@ static uint64_t uv__read_uint64(const char* filename) {
   return rc;
 }
 
+
 /* Given a buffer with the contents of a cgroup1 /proc/self/cgroups,
  * finds the location and length of the memory controller mount path.
  * This disregards the leading / for easy concatenation of paths.
  * Returns NULL if the memory controller wasn't found. */
-static char* uv__cgroup1_find_memory_controller(char buf[static 1024], int* n) {
+static char* uv__cgroup1_find_memory_controller(char buf[static 1024],
+                                                int* n) {
   char* p;
 
   /* Seek to the memory controller line. */
@@ -1376,11 +1378,11 @@ static void uv__get_cgroup1_memory_limits(char buf[static 1024], uint64_t* high,
   p = uv__cgroup1_find_memory_controller(buf, &n);
   if (p != NULL) {
     snprintf(filename, sizeof(filename),
-            "/sys/fs/cgroup/memory/%.*s/memory.soft_limit_in_bytes", n, p);
+             "/sys/fs/cgroup/memory/%.*s/memory.soft_limit_in_bytes", n, p);
     *high = uv__read_uint64(filename);
 
     snprintf(filename, sizeof(filename),
-            "/sys/fs/cgroup/memory/%.*s/memory.limit_in_bytes", n, p);
+             "/sys/fs/cgroup/memory/%.*s/memory.limit_in_bytes", n, p);
     *max = uv__read_uint64(filename);
 
     /* If the controller wasn't mounted, the reads above will have failed,
@@ -1471,7 +1473,8 @@ static uint64_t uv__get_cgroup2_current_memory(char buf[static 1024]) {
   p = buf + strlen("0::/");
   n = (int) strcspn(p, "\n");
 
-  snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%.*s/memory.current", n, p);
+  snprintf(filename, sizeof(filename),
+           "/sys/fs/cgroup/%.*s/memory.current", n, p);
   return uv__read_uint64(filename);
 }
 

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1399,6 +1399,11 @@ static uint64_t uv__get_available_memory_fallback(void) {
     return uv_get_free_memory();
 
   current = uv__read_uint64("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+
+  /* usage_in_bytes can be higher than limit_in_bytes (for short bursts of time) */
+  if (constrained < current)
+    return 0;
+
   return constrained - current;
 }
 

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1351,8 +1351,6 @@ static void uv__get_cgroup1_memory_limits(char* buf, uint64_t* high,
   */
   *high = uv__read_uint64("/sys/fs/cgroup/memory/memory.soft_limit_in_bytes");
   *max = uv__read_uint64("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-
-  return;
 }
 
 static void uv__get_cgroup2_memory_limits(char* buf, uint64_t* high,
@@ -1371,8 +1369,6 @@ static void uv__get_cgroup2_memory_limits(char* buf, uint64_t* high,
 
   snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%s/memory.high", p);
   *high = uv__read_uint64(filename);
-
-  return;
 }
 
 static uint64_t uv__get_cgroup_constrained_memory(char* buf) {
@@ -1389,7 +1385,6 @@ static uint64_t uv__get_cgroup_constrained_memory(char* buf) {
     return 0;
 
   return high < max ? high : max;
-
 }
 
 uint64_t uv_get_constrained_memory(void) {
@@ -1438,11 +1433,10 @@ uint64_t uv_get_available_memory(void) {
     return uv_get_free_memory();
 
   /* In the case of cgroupv2, we'll only have a single entry. */
-  if (0 == memcmp(buf, "0::/", 4)) {
+  if (0 == memcmp(buf, "0::/", 4))
     current = uv__get_cgroup2_current_memory(buf);
-  } else {
+  else
     current = uv__get_cgroup1_current_memory(buf);
-  }
 
   /* memory usage can be higher than the limit (for short bursts of time) */
   if (constrained < current)

--- a/src/unix/netbsd.c
+++ b/src/unix/netbsd.c
@@ -131,6 +131,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   kvm_t *kd = NULL;
   struct kinfo_proc2 *kinfo = NULL;

--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -139,6 +139,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   struct kinfo_proc kinfo;
   size_t page_size = getpagesize();

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -198,6 +198,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   char* ascb;
   char* rax;

--- a/src/unix/qnx.c
+++ b/src/unix/qnx.c
@@ -88,6 +88,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 int uv_resident_set_memory(size_t* rss) {
   int fd;
   procfs_asinfo asinfo;

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -417,6 +417,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 void uv_loadavg(double avg[3]) {
   (void) getloadavg(avg, 3);
 }

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -362,6 +362,11 @@ uint64_t uv_get_constrained_memory(void) {
 }
 
 
+uint64_t uv_get_available_memory(void) {
+  return uv_get_free_memory();
+}
+
+
 uv_pid_t uv_os_getpid(void) {
   return GetCurrentProcessId();
 }

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -43,6 +43,11 @@ TEST_IMPL(get_memory) {
 #else
   ASSERT(total_mem > free_mem);
 #endif
-  ASSERT_LE(available_mem, free_mem);
+  ASSERT_LE(available_mem, total_mem);
+  /* we'd really want to test if available <= free, but that is fragile:
+   * with no limit set, get_available calls and returns get_free; so if
+   * any memory was freed between our calls to get_free and get_available
+   * we would fail such a test test (as observed on CI).
+   */
   return 0;
 }

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -26,11 +26,14 @@ TEST_IMPL(get_memory) {
   uint64_t free_mem = uv_get_free_memory();
   uint64_t total_mem = uv_get_total_memory();
   uint64_t constrained_mem = uv_get_constrained_memory();
+  uint64_t available_mem = uv_get_available_memory();
 
-  printf("free_mem=%llu, total_mem=%llu, constrained_mem=%llu\n",
+  printf("free_mem=%llu, total_mem=%llu, constrained_mem=%llu, "
+         "available_mem=%llu\n",
          (unsigned long long) free_mem,
          (unsigned long long) total_mem,
-         (unsigned long long) constrained_mem);
+         (unsigned long long) constrained_mem,
+         (unsigned long long) available_mem);
 
   ASSERT(free_mem > 0);
   ASSERT(total_mem > 0);
@@ -40,5 +43,6 @@ TEST_IMPL(get_memory) {
 #else
   ASSERT(total_mem > free_mem);
 #endif
+  ASSERT_LE(available_mem, free_mem);
   return 0;
 }


### PR DESCRIPTION
This PR mimicks https://github.com/libuv/libuv/pull/3744, accessing `memory.usage_in_bytes`/`memory.current` (cgroupv1/cgroupv2) and using it to implement a constraint-aware version of `uv_get_free_memory`.

Implements https://github.com/libuv/libuv/pull/3744#issuecomment-1249464780