### PR TITLE
Fix loop spinning forever when signal delivery races with uv_close()

### DIFF
--- a/test/test-list.h
+++ b/test/test-list.h
@@ -495,6 +495,7 @@ TEST_DECLARE   (we_get_signal_one_shot)
 TEST_DECLARE   (we_get_signals_mixed)
 TEST_DECLARE   (signal_multiple_loops)
 TEST_DECLARE   (signal_pending_on_close)
+TEST_DECLARE   (signal_delivered_in_handler)
 TEST_DECLARE   (signal_close_loop_alive)
 #endif
 #ifdef __APPLE__
@@ -995,6 +996,7 @@ TASK_LIST_START
   TEST_ENTRY  (we_get_signals_mixed)
   TEST_ENTRY  (signal_multiple_loops)
   TEST_ENTRY  (signal_pending_on_close)
+  TEST_ENTRY  (signal_delivered_in_handler)
   TEST_ENTRY  (signal_close_loop_alive)
 #endif
 

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -23,6 +23,7 @@
 #include "uv.h"
 #include "task.h"
 
+#include <signal.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -91,6 +92,143 @@ TEST_IMPL(signal_pending_on_close) {
   ASSERT(0 == uv_loop_close(&loop));
 
   ASSERT(2 == close_cb_called);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+static uv_sem_t wait_for_main_thread;
+static uv_sem_t wait_for_worker_thread;
+static unsigned main_thread_signal_count;
+
+static int signal_handler_is_default(int signum) {
+  struct sigaction oact;
+  ASSERT(0 == sigaction(signum, NULL, &oact));
+  return oact.sa_handler == SIG_DFL;
+}
+
+static void couting_singnal_handler(uv_signal_t* signal, int signum) {
+  ASSERT(signal == &signal_hdl);
+  ASSERT(signum == SIGUSR1);
+  main_thread_signal_count++;
+}
+
+/* Check that we don't end up triggering UAF invocations of signal handlers. */
+struct context_data {
+  unsigned num_calls;
+};
+void worker_signal_handler(uv_signal_t* handle, int signum) {
+  struct context_data* context = uv_handle_get_data((uv_handle_t*)handle);
+  ASSERT_EQ(signum, handle->signum);
+  ASSERT_EQ(1, handle->caught_signals);
+  ASSERT_EQ(0, handle->dispatched_signals);
+  ASSERT_EQ(0, context->num_calls); /* Should only be called once */
+  context->num_calls++;
+  uv_sem_post(&wait_for_worker_thread); /* Worker inside signal handler. */
+  uv_sem_wait(&wait_for_main_thread); /* Wait for main to raise() again. */
+  ASSERT_EQ(2, handle->caught_signals); /* Should have caught it again */
+  uv_close((uv_handle_t*)handle, close_cb);
+  /* after this signal handler caught_signals==1,dispatched_signals==2, which
+   * can cause the loop to end up in an infinite looping state */
+  free(context);
+  /* Should still have a libuv handler */
+  ASSERT(!signal_handler_is_default(SIGUSR1));
+}
+
+void worker_threadfunc(void* user_arg) {
+  uv_loop_t worker_loop;
+  uv_signal_t worker_sig;
+  (void)user_arg;
+
+  /* Create a signal handler with heap metadata to check we don't trigger UAF. */
+  struct context_data* context = malloc(sizeof(struct context_data));
+  ASSERT_NOT_NULL(context);
+  context->num_calls = 0;
+  uv_handle_set_data((uv_handle_t*)&worker_sig, context);
+  ASSERT_EQ(0, uv_loop_init(&worker_loop));
+  ASSERT_EQ(0, uv_signal_init(&worker_loop, &worker_sig));
+  ASSERT(signal_handler_is_default(SIGUSR1));
+  ASSERT_EQ(0, uv_signal_start(&worker_sig, worker_signal_handler, SIGUSR1));
+  ASSERT(!signal_handler_is_default(SIGUSR1));
+
+  uv_sem_post(&wait_for_worker_thread); /* Thread initialization done. */
+  uv_sem_wait(&wait_for_main_thread); /* Wait for raise(SIGUSR). */
+  ASSERT_EQ(0, close_cb_called);
+#ifdef SIGNAL_HANDLER_BUG_HAS_BEEN_FIXED
+  ASSERT_EQ(0, uv_run(&worker_loop, UV_RUN_ONCE));
+#else
+  ASSERT_EQ(1, uv_run(&worker_loop, UV_RUN_ONCE)); /* FIXME: this is wrong */
+#endif
+  uv_sem_post(&wait_for_worker_thread); /* Completed uv_run(). */
+
+  ASSERT(!uv_is_active((uv_handle_t*)&worker_sig));
+#ifdef SIGNAL_HANDLER_BUG_HAS_BEEN_FIXED
+  ASSERT_EQ(1, close_cb_called);
+  ASSERT_EQ(0, uv_loop_alive(&worker_loop));
+  ASSERT_EQ(2, worker_sig.caught_signals);
+  ASSERT_EQ(1, worker_sig.dispatched_signals);
+#else
+  /* FIXME: we have call uv_run once more to ensure close_cb was called. */
+  ASSERT_EQ(0, close_cb_called);
+  /* Check that we have fewer dispatched signals than caught signals. */
+  ASSERT_EQ(2, worker_sig.caught_signals);
+  ASSERT_EQ(1, worker_sig.dispatched_signals);
+  ASSERT_EQ(0, uv_run(&worker_loop, UV_RUN_ONCE));
+  ASSERT_EQ(2, worker_sig.caught_signals);
+  ASSERT_EQ(2, worker_sig.dispatched_signals); /* FIXME: this is wrong */
+#endif
+  ASSERT_EQ(1, close_cb_called);
+  ASSERT_EQ(0, uv_loop_alive(&worker_loop));
+  ASSERT_EQ(0, uv_loop_close(&worker_loop));
+}
+
+TEST_IMPL(signal_delivered_in_handler) {
+  uv_thread_t worker;
+
+  ASSERT_EQ(0, close_cb_called);
+  ASSERT_EQ(0, main_thread_signal_count);
+  ASSERT(signal_handler_is_default(SIGUSR1));
+  /* Set up semaphores for synchronization (to produce the race condition). */
+  ASSERT_EQ(0, uv_sem_init(&wait_for_main_thread, 0));
+  ASSERT_EQ(0, uv_sem_init(&wait_for_worker_thread, 0));
+  ASSERT_EQ(0, uv_thread_create(&worker, worker_threadfunc, 0));
+
+  uv_sem_wait(&wait_for_worker_thread); /* Wait for thread init */
+  /* We also register a signal handler in the main thread to ensure that
+   * we still have a signal handler registered with the kernel rather than
+   * just deregistering it on the last uv_signal_stop().
+   */
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_signal_init(&loop, &signal_hdl));
+  ASSERT_EQ(0, uv_signal_start(&signal_hdl, couting_singnal_handler, SIGUSR1));
+  ASSERT(!signal_handler_is_default(SIGUSR1));
+  /* Both signal handlers have been registered, we can raise() now */
+  raise(SIGUSR1);
+  ASSERT_EQ(0, main_thread_signal_count); /* Main thread should not see it yet */
+  uv_sem_post(&wait_for_main_thread); /* Worker can call uv_run() now. */
+  uv_sem_wait(&wait_for_worker_thread); /* Wait until worker is in handler. */
+  /* Worker is handling the signal, raise() again before it finishes. */
+  raise(SIGUSR1);
+  ASSERT_EQ(0, main_thread_signal_count); /* Main thread should not see it yet */
+  uv_sem_post(&wait_for_main_thread); /* Tell worker we raise()'d again. */
+
+  /* Wait for worker to finish. */
+  uv_sem_wait(&wait_for_worker_thread); /* Worker called uv_run(). */
+
+  uv_thread_join(&worker);
+
+  /* clean up main thread. */
+  ASSERT(!signal_handler_is_default(SIGUSR1));
+  ASSERT_EQ(0, main_thread_signal_count); /* Main thread should not see it yet */
+  ASSERT_EQ(1, uv_run(&loop, UV_RUN_ONCE));
+  ASSERT_EQ(2, main_thread_signal_count); /* Signals should be processed now */
+  ASSERT_EQ(1, uv_loop_alive(&loop));
+  uv_close((uv_handle_t*)&signal_hdl, close_cb);
+  ASSERT(signal_handler_is_default(SIGUSR1)); /* last handler deregistered. */
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_ONCE)); /* Process close callback. */
+  ASSERT_EQ(0, uv_loop_alive(&loop));
+  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
If we are closing a signal handler that has pending events, we have
two options: we can ignore the pending signal or we could invoke the
handler immediately now. We can't insert it back into the closing queue
to process it later since that could result in use-after-free (e.g. if
the handler uses handle->data and that is free()'d after calling
uv_signal_stop()). To avoid indefinitely retaining a handle in the
handle_queue, we simply ignore all further signals on this handle, since
otherwise we would end up with an event loop that is permanently spinning.

This fixes the behaviour of the newly added test signal_delivered_in_handler.