### PR TITLE
linux: add cpu affinity api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,6 +520,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-mutexes.c
        test/test-not-readable-nor-writable-on-read-error.c
        test/test-not-writable-after-shutdown.c
+       test/test-os-affinity.c
        test/test-osx-select.c
        test/test-pass-always.c
        test/test-ping-pong.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -207,6 +207,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-mutexes.c \
                          test/test-not-readable-nor-writable-on-read-error.c \
                          test/test-not-writable-after-shutdown.c \
+                         test/test-os-affinity.c \
                          test/test-osx-select.c \
                          test/test-pass-always.c \
                          test/test-ping-pong.c \

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -204,6 +204,10 @@ Data types
 
     Random data request type.
 
+.. c:type:: uv_cpuset_t
+
+    Data type for cpu affinity mask.
+
 API
 ---
 
@@ -779,3 +783,27 @@ API
     Causes the calling thread to sleep for `msec` milliseconds.
 
     .. versionadded:: 1.34.0
+
+.. c:function:: int uv_os_getcpu(void)
+
+    Get the CPU on which the calling thread is running.
+
+    :returns: non-negative value on success, or -1 on failure.
+
+    .. versionadded:: 1.44.3
+
+.. c:function:: int uv_os_setaffinity(uv_pid_t pid, const uv_cpuset_t* cpusets)
+
+    Set the cpu affinity mask for the process with pid.
+
+    :returns: 0 on success, or -1 on failure.
+
+    .. versionadded:: 1.44.3
+
+.. c:function:: int uv_os_getaffinity(uv_pid_t pid, uv_cpuset_t* cpusets)
+
+    Get the cpu affinity mask for the process with pid.
+
+    :returns: 0 on success, or -1 on failure.
+
+    .. versionadded:: 1.44.3

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -262,6 +262,9 @@ TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
+#ifdef __linux__
+TEST_DECLARE   (os_affinity)
+#endif
 TEST_DECLARE   (has_ref)
 TEST_DECLARE   (active)
 TEST_DECLARE   (embed)
@@ -857,6 +860,9 @@ TASK_LIST_START
   TEST_HELPER (pipe_ref4, pipe_echo_server)
   TEST_ENTRY  (process_ref)
   TEST_ENTRY  (process_priority)
+#ifdef __linux__
+  TEST_ENTRY  (os_affinity)
+#endif
   TEST_ENTRY  (has_ref)
 
   TEST_ENTRY  (loop_handles)

--- a/test/test-os-affinity.c
+++ b/test/test-os-affinity.c
@@ -1,0 +1,44 @@
+/* Copyright libuv contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef __linux__
+TEST_IMPL(os_affinity) {
+  uv_cpuset_t mask;
+  int r;
+  int c;
+
+  c = uv_os_getcpu();
+  ASSERT(c >= 0);
+
+  r = uv_os_getaffinity(0, &mask);
+  ASSERT(r == 0);
+
+  UV_CPU_ZERO(&mask);
+  UV_CPU_SET(c, &mask);
+  r = uv_os_setaffinity(0, &mask);
+  ASSERT(r == 0);
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
Add uv_os_setaffinity/uv_os_getaffinity api to set/get cpu affinity mask for the specific process. Add uv_os_getcpu api to get the cpu on which the calling thread is running.