### PR TITLE
build: restore qemu download logic

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -104,9 +104,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install QEMU
         # this ensure install latest qemu on ubuntu, apt get version is old
+        env:
+          QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
+          QEMU_VER: "qemu-user-static_7\\.0-.*_amd64.deb$"
         run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_7.0+dfsg-7ubuntu1_amd64.deb
-          sudo dpkg -i qemu-user-static_7.0+dfsg-7ubuntu1_amd64.deb
+          DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
+          wget $QEMU_SRC/$DEB
+          sudo dpkg -i $DEB
       - name: Install ${{ matrix.config.toolchain }}
         run: |
           sudo apt update

--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -106,7 +106,7 @@ jobs:
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:
           QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_7\\.0-.*_amd64.deb$"
+          QEMU_VER: "qemu-user-static_7\\.0+dfsg-.*_amd64.deb$"
         run: |
           DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
           wget $QEMU_SRC/$DEB


### PR DESCRIPTION
I recently changed it to download a fixed .deb but seems it's updated more frequently than I anticipated because the dfsg-7ubuntu1_package is already gone, replaced with dfsg-7ubuntu2.

Bring back the downloader logic that fetches the filename from the directory listing.