### PR TITLE
uv: move queue.h from src to include/uv

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,6 @@ libuv_la_SOURCES = src/fs-poll.c \
                    src/idna.h \
                    src/inet.c \
                    src/loop-watcher.c \
-                   src/queue.h \
                    src/random.c \
                    src/strscpy.c \
                    src/strscpy.h \
@@ -56,7 +55,9 @@ endif
 
 if WINNT
 
-uvinclude_HEADERS += include/uv/win.h include/uv/tree.h
+uvinclude_HEADERS += include/uv/win.h \
+                     include/uv/tree.h \
+                     include/uv/queue.h
 AM_CPPFLAGS += -I$(top_srcdir)/src/win \
                -DWIN32_LEAN_AND_MEAN \
                -D_WIN32_WINNT=0x0602

--- a/include/uv/queue.h
+++ b/include/uv/queue.h
@@ -13,8 +13,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef QUEUE_H_
-#define QUEUE_H_
+#ifndef  UV_QUEUE_H_
+#define  UV_QUEUE_H_
 
 #include <stddef.h>
 
@@ -105,4 +105,4 @@ typedef void *QUEUE[2];
   }                                                                           \
   while (0)
 
-#endif /* QUEUE_H_ */
+#endif  /* UV_QUEUE_H_ */

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -34,7 +34,7 @@
 
 #include "uv.h"
 #include "uv/tree.h"
-#include "queue.h"
+#include "uv/queue.h"
 #include "strscpy.h"
 
 #if EDOM > 0

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -24,8 +24,8 @@
 #include <stdlib.h>
 
 #include "uv.h"
+#include "uv/queue.h"
 #include "internal.h"
-#include "queue.h"
 #include "handle-inl.h"
 #include "heap-inl.h"
 #include "req-inl.h"


### PR DESCRIPTION
queue.h file name is frequently used accross many projects. Move queue.h from `src `to `include/uv` to avoid picking a wrong file while integrating libuv with third party code.