### PR TITLE
linux: remove unused or obsolete syscall wrappers

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -491,7 +491,7 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
 # if defined(__linux__)
     else {
       result = preadv(req->file,
-                      (struct iovec*)req->bufs,
+                      (struct iovec*) req->bufs,
                       req->nbufs,
                       req->off);
       if (result == -1 && errno == ENOSYS) {

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -490,10 +490,10 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
     }
 # if defined(__linux__)
     else {
-      result = uv__preadv(req->file,
-                          (struct iovec*)req->bufs,
-                          req->nbufs,
-                          req->off);
+      result = preadv(req->file,
+                      (struct iovec*)req->bufs,
+                      req->nbufs,
+                      req->off);
       if (result == -1 && errno == ENOSYS) {
         uv__store_relaxed(&no_preadv, 1);
         goto retry;
@@ -1234,10 +1234,10 @@ static ssize_t uv__fs_write(uv_fs_t* req) {
     }
 # if defined(__linux__)
     else {
-      r = uv__pwritev(req->file,
-                      (struct iovec*) req->bufs,
-                      req->nbufs,
-                      req->off);
+      r = pwritev(req->file,
+                  (struct iovec*) req->bufs,
+                  req->nbufs,
+                  req->off);
       if (r == -1 && errno == ENOSYS) {
         no_pwritev = 1;
         goto retry;

--- a/src/unix/linux-syscalls.c
+++ b/src/unix/linux-syscalls.c
@@ -50,46 +50,6 @@
 # endif
 #endif /* __NR_sendmmsg */
 
-#ifndef __NR_utimensat
-# if defined(__x86_64__)
-#  define __NR_utimensat 280
-# elif defined(__i386__)
-#  define __NR_utimensat 320
-# elif defined(__arm__)
-#  define __NR_utimensat (UV_SYSCALL_BASE + 348)
-# endif
-#endif /* __NR_utimensat */
-
-#ifndef __NR_preadv
-# if defined(__x86_64__)
-#  define __NR_preadv 295
-# elif defined(__i386__)
-#  define __NR_preadv 333
-# elif defined(__arm__)
-#  define __NR_preadv (UV_SYSCALL_BASE + 361)
-# endif
-#endif /* __NR_preadv */
-
-#ifndef __NR_pwritev
-# if defined(__x86_64__)
-#  define __NR_pwritev 296
-# elif defined(__i386__)
-#  define __NR_pwritev 334
-# elif defined(__arm__)
-#  define __NR_pwritev (UV_SYSCALL_BASE + 362)
-# endif
-#endif /* __NR_pwritev */
-
-#ifndef __NR_dup3
-# if defined(__x86_64__)
-#  define __NR_dup3 292
-# elif defined(__i386__)
-#  define __NR_dup3 330
-# elif defined(__arm__)
-#  define __NR_dup3 (UV_SYSCALL_BASE + 358)
-# endif
-#endif /* __NR_pwritev */
-
 #ifndef __NR_copy_file_range
 # if defined(__x86_64__)
 #  define __NR_copy_file_range 326
@@ -189,33 +149,6 @@ int uv__recvmmsg(int fd, struct uv__mmsghdr* mmsg, unsigned int vlen) {
   return syscall(__NR_recvmmsg, fd, mmsg, vlen, /* flags */ 0, /* timeout */ 0);
 #else
   return errno = ENOSYS, -1;
-#endif
-}
-
-
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, int64_t offset) {
-#if !defined(__NR_preadv) || defined(__ANDROID_API__) && __ANDROID_API__ < 24
-  return errno = ENOSYS, -1;
-#else
-  return syscall(__NR_preadv, fd, iov, iovcnt, (long)offset, (long)(offset >> 32));
-#endif
-}
-
-
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, int64_t offset) {
-#if !defined(__NR_pwritev) || defined(__ANDROID_API__) && __ANDROID_API__ < 24
-  return errno = ENOSYS, -1;
-#else
-  return syscall(__NR_pwritev, fd, iov, iovcnt, (long)offset, (long)(offset >> 32));
-#endif
-}
-
-
-int uv__dup3(int oldfd, int newfd, int flags) {
-#if !defined(__NR_dup3) || defined(__ANDROID_API__) && __ANDROID_API__ < 21
-  return errno = ENOSYS, -1;
-#else
-  return syscall(__NR_dup3, oldfd, newfd, flags);
 #endif
 }
 

--- a/src/unix/linux-syscalls.h
+++ b/src/unix/linux-syscalls.h
@@ -58,9 +58,6 @@ struct uv__statx {
   uint64_t unused1[14];
 };
 
-ssize_t uv__preadv(int fd, const struct iovec *iov, int iovcnt, int64_t offset);
-ssize_t uv__pwritev(int fd, const struct iovec *iov, int iovcnt, int64_t offset);
-int uv__dup3(int oldfd, int newfd, int flags);
 ssize_t
 uv__fs_copy_file_range(int fd_in,
                        off_t* off_in,


### PR DESCRIPTION
preadv, pwritev, dup3 and utimensat all exist in 2.6.32 kernels, libuv's minimum supported kernel.

The wrapper for utimensat was already gone, only the define remained.