### PR TITLE
unix,win: give thread pool threads an 8 MB stack

### DIFF
--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -14,6 +14,9 @@ is 1024).
 
 .. versionchanged:: 1.30.0 the maximum UV_THREADPOOL_SIZE allowed was increased from 128 to 1024.
 
+.. versionchanged:: 1.45.0 threads now have an 8 MB stack instead of the
+   (sometimes too low) platform default.
+
 The threadpool is global and shared across all event loops. When a particular
 function makes use of the threadpool (i.e. when using :c:func:`uv_queue_work`)
 libuv preallocates and initializes the maximum number of threads allowed by

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -191,6 +191,7 @@ void uv__threadpool_cleanup(void) {
 
 
 static void init_threads(void) {
+  uv_thread_options_t config;
   unsigned int i;
   const char* val;
   uv_sem_t sem;
@@ -226,8 +227,11 @@ static void init_threads(void) {
   if (uv_sem_init(&sem, 0))
     abort();
 
+  config.flags = UV_THREAD_HAS_STACK_SIZE;
+  config.stack_size = 8u << 20;  /* 8 MB */
+
   for (i = 0; i < nthreads; i++)
-    if (uv_thread_create(threads + i, worker, &sem))
+    if (uv_thread_create_ex(threads + i, &config, worker, &sem))
       abort();
 
   for (i = 0; i < nthreads; i++)


### PR DESCRIPTION
Give the threads in the thread pool a stack size that is consistent across platforms and architectures.

Fixes: https://github.com/libuv/libuv/issues/3786