### PR TITLE
Feature: added uv_allocator_t with opaque user-pointer support.

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -26,24 +26,24 @@ Data types
         .. note::
             On Windows this field is ULONG.
 
-.. c:type:: void* (*uv_malloc_func)(size_t size)
+.. c:type:: void* (*uv_malloc_func)(void* opaque, size_t size)
 
-        Replacement function for :man:`malloc(3)`.
+        Custom replacement function for :man:`malloc(3)`.
         See :c:func:`uv_replace_allocator`.
 
-.. c:type::  void* (*uv_realloc_func)(void* ptr, size_t size)
+.. c:type::  void* (*uv_realloc_func)(void* opaque, void* ptr, size_t size)
 
-        Replacement function for :man:`realloc(3)`.
+        Custom replacement function for :man:`realloc(3)`.
         See :c:func:`uv_replace_allocator`.
 
-.. c:type::  void* (*uv_calloc_func)(size_t count, size_t size)
+.. c:type::  void* (*uv_calloc_func)(void* opaque, size_t count, size_t size)
 
-        Replacement function for :man:`calloc(3)`.
+        Custom replacement  function for :man:`calloc(3)`.
         See :c:func:`uv_replace_allocator`.
 
-.. c:type:: void (*uv_free_func)(void* ptr)
+.. c:type:: void (*uv_free_func)(void* opaque, void* ptr)
 
-        Replacement function for :man:`free(3)`.
+        Custom replacement  function for :man:`free(3)`.
         See :c:func:`uv_replace_allocator`.
 
 .. c:type::  void (*uv_random_cb)(uv_random_t* req, int status, void* buf, size_t buflen)
@@ -195,6 +195,20 @@ Data types
             char* value;
         } uv_env_item_t;
 
+.. c:type:: uv_allocator_t
+
+    Data type for custom allocator.
+
+    ::
+
+        typedef struct uv_allocator_s {
+            uv_malloc_func malloc;
+            uv_realloc_func realloc;
+            uv_calloc_func calloc;
+            uv_free_func free;
+            void *opaque;
+        } uv_allocator_t;
+
 .. c:type:: uv_random_t
 
     Random data request type.
@@ -214,7 +228,7 @@ API
     STDIO file descriptor pseudo-handles ``UV_STDIN_FD``, ``UV_STDOUT_FD``, and ``UV_STDERR_FD``
     can be passed to any uv_os_fd_t field for cross-platform support of stdio.
 
-.. c:function:: int uv_replace_allocator(uv_malloc_func malloc_func, uv_realloc_func realloc_func, uv_calloc_func calloc_func, uv_free_func free_func)
+.. c:function:: int uv_replace_allocator(uv_allocator_t* allocator)
 
     .. versionadded:: 1.6.0
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -239,6 +239,7 @@ typedef struct uv_work_s uv_work_t;
 typedef struct uv_random_s uv_random_t;
 
 /* None of the above. */
+typedef struct uv_allocator_s uv_allocator_t;
 typedef struct uv_env_item_s uv_env_item_t;
 typedef struct uv_cpu_info_s uv_cpu_info_t;
 typedef struct uv_interface_address_s uv_interface_address_t;
@@ -262,17 +263,24 @@ typedef enum {
 UV_EXTERN unsigned int uv_version(void);
 UV_EXTERN const char* uv_version_string(void);
 
-typedef void* (*uv_malloc_func)(size_t size);
-typedef void* (*uv_realloc_func)(void* ptr, size_t size);
-typedef void* (*uv_calloc_func)(size_t count, size_t size);
-typedef void (*uv_free_func)(void* ptr);
+typedef void* (*uv_malloc_func)(void* opaque, size_t size);
+typedef void* (*uv_realloc_func)(void* opaque, void* ptr, size_t size);
+typedef void* (*uv_calloc_func)(void* opaque, size_t count, size_t size);
+typedef void (*uv_free_func)(void* opaque, void* ptr);
+
+struct uv_allocator_s {
+  uv_malloc_func malloc;
+  uv_realloc_func realloc;
+  uv_calloc_func calloc;
+  uv_free_func free;
+
+  /* User Opaque ptr */
+  void *opaque;
+};
 
 UV_EXTERN void uv_library_shutdown(void);
 
-UV_EXTERN int uv_replace_allocator(uv_malloc_func malloc_func,
-                                   uv_realloc_func realloc_func,
-                                   uv_calloc_func calloc_func,
-                                   uv_free_func free_func);
+UV_EXTERN int uv_replace_allocator(uv_allocator_t* allocator);
 
 UV_EXTERN uv_loop_t* uv_default_loop(void);
 UV_EXTERN int uv_loop_init(uv_loop_t* loop);


### PR DESCRIPTION
Added a public type `uv_allocator_t` with an opaque ptr in addition to the allocator functions.

Breaking API/ABI:
- uv allocator functions
- uv_replace_allocator function