### PR TITLE
test: Fixes warnings when compiling test suites

### DIFF
--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -104,13 +104,13 @@ TEST_IMPL(utf8_decode1_overrun) {
   p = b;
   b[0] = 0x7F;
   ASSERT_EQ(0x7F, uv__utf8_decode1(&p, b + 1));
-  ASSERT(p == b + 1);
+ ASSERT_PTR_EQ(p, b + 1);
 
   /* Multi-byte. */
   p = b;
   b[0] = 0xC0;
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + 1));
-  ASSERT(p == b + 1);
+  ASSERT_PTR_EQ(p, b + 1);
 
   return 0;
 }

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -104,13 +104,13 @@ TEST_IMPL(utf8_decode1_overrun) {
   p = b;
   b[0] = 0x7F;
   ASSERT_EQ(0x7F, uv__utf8_decode1(&p, b + 1));
-  ASSERT_EQ(p, b + 1);
+  ASSERT(p == b + 1);
 
   /* Multi-byte. */
   p = b;
   b[0] = 0xC0;
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + 1));
-  ASSERT_EQ(p, b + 1);
+  ASSERT(p == b + 1);
 
   return 0;
 }

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -104,7 +104,7 @@ TEST_IMPL(utf8_decode1_overrun) {
   p = b;
   b[0] = 0x7F;
   ASSERT_EQ(0x7F, uv__utf8_decode1(&p, b + 1));
- ASSERT_PTR_EQ(p, b + 1);
+  ASSERT_PTR_EQ(p, b + 1);
 
   /* Multi-byte. */
   p = b;

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -103,7 +103,7 @@ TEST_IMPL(ip6_addr_link_local) {
     fflush(stderr);
 
     ASSERT(0 == uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
-    fprintf(stderr, "Got scope_id 0x%02x\n", addr.sin6_scope_id);
+    fprintf(stderr, "Got scope_id 0x%2"PRIx32"\n", addr.sin6_scope_id);
     fflush(stderr);
     ASSERT(iface_index == addr.sin6_scope_id);
   }

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -103,7 +103,7 @@ TEST_IMPL(ip6_addr_link_local) {
     fflush(stderr);
 
     ASSERT(0 == uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
-    fprintf(stderr, "Got scope_id 0x%2"PRIx32"\n", addr.sin6_scope_id);
+    fprintf(stderr, "Got scope_id 0x%2x\n", (unsigned)addr.sin6_scope_id);
     fflush(stderr);
     ASSERT(iface_index == addr.sin6_scope_id);
   }


### PR DESCRIPTION
libuv/test/test-idna.c:107:3: note: in expansion of macro 'ASSERT_EQ'
libuv/test/task.h:119:26: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
libuv/test/test-ip6-addr.c:106:40: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]