### PR TITLE
unix: disable usage of ifaddrs.h on Solaris 10 from within configure.ac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+  if(CMAKE_SYSTEM_VERSION STREQUAL "5.10")
+    list(APPEND uv_defines SUNOS_NO_IFADDRS)
+    list(APPEND uv_libraries rt)
+  endif()
   list(APPEND uv_defines __EXTENSIONS__ _XOPEN_SOURCE=500 _REENTRANT)
   list(APPEND uv_libraries kstat nsl sendfile socket)
   list(APPEND uv_sources

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,9 @@ AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])
 AS_CASE([$host_os],[mingw*], [
     LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32"
 ])
+AS_CASE([$host_os], [solaris2.10], [
+    CFLAGS="$CFLAGS -DSUNOS_NO_IFADDRS"
+])
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AS_CASE([$host_os], [kfreebsd*], [
     LIBS="$LIBS -lfreebsd-glue"


### PR DESCRIPTION
Without this change, building for Solaris 10 fails since the SUNOS_NO_IFADDRS macro doesn't get set automatically, and ifaddrs.h was only introduced starting with Solaris 11.