### PR TITLE
unix: drop kfreebsd support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,11 +294,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "GNU")
        src/unix/hurd.c)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD")
-  list(APPEND uv_defines _GNU_SOURCE)
-  list(APPEND uv_libraries dl freebsd-glue)
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND uv_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
   list(APPEND uv_libraries dl rt)

--- a/Makefile.am
+++ b/Makefile.am
@@ -468,10 +468,6 @@ libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
                     src/unix/hurd.c
 endif
 
-if KFREEBSD
-libuv_la_CFLAGS += -D_GNU_SOURCE
-endif
-
 if LINUX
 uvinclude_HEADERS += include/uv/linux.h
 libuv_la_CFLAGS += -D_GNU_SOURCE

--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,7 @@ AM_CONDITIONAL([ANDROID],  [AS_CASE([$host_os],[linux-android*],[true], [false])
 AM_CONDITIONAL([CYGWIN],   [AS_CASE([$host_os],[cygwin*],       [true], [false])])
 AM_CONDITIONAL([DARWIN],   [AS_CASE([$host_os],[darwin*],       [true], [false])])
 AM_CONDITIONAL([DRAGONFLY],[AS_CASE([$host_os],[dragonfly*],    [true], [false])])
-AM_CONDITIONAL([FREEBSD],  [AS_CASE([$host_os],[*freebsd*],     [true], [false])])
-AM_CONDITIONAL([KFREEBSD], [AS_CASE([$host_os],[kfreebsd*],     [true], [false])])
+AM_CONDITIONAL([FREEBSD],  [AS_CASE([$host_os],[freebsd*],      [true], [false])])
 AM_CONDITIONAL([HAIKU],    [AS_CASE([$host_os],[haiku],         [true], [false])])
 AM_CONDITIONAL([HURD],     [AS_CASE([$host_os],[gnu*],          [true], [false])])
 AM_CONDITIONAL([LINUX],    [AS_CASE([$host_os],[linux*],        [true], [false])])
@@ -80,9 +79,6 @@ AS_CASE([$host_os], [solaris2.10], [
     CFLAGS="$CFLAGS -DSUNOS_NO_IFADDRS"
 ])
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
-AS_CASE([$host_os], [kfreebsd*], [
-    LIBS="$LIBS -lfreebsd-glue"
-])
 AS_CASE([$host_os], [haiku], [
     LIBS="$LIBS -lnetwork"
 ])

--- a/include/uv/errno.h
+++ b/include/uv/errno.h
@@ -413,7 +413,6 @@
 #elif defined(__APPLE__) || \
       defined(__DragonFly__) || \
       defined(__FreeBSD__) || \
-      defined(__FreeBSD_kernel__) || \
       defined(__NetBSD__) || \
       defined(__OpenBSD__)
 # define UV__EHOSTDOWN (-64)

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -59,7 +59,6 @@
 # include "uv/darwin.h"
 #elif defined(__DragonFly__)       || \
       defined(__FreeBSD__)         || \
-      defined(__FreeBSD_kernel__)  || \
       defined(__OpenBSD__)         || \
       defined(__NetBSD__)
 # include "uv/bsd.h"

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -66,7 +66,6 @@ extern char** environ;
 
 #if defined(__DragonFly__)      || \
     defined(__FreeBSD__)        || \
-    defined(__FreeBSD_kernel__) || \
     defined(__NetBSD__)         || \
     defined(__OpenBSD__)
 # include <sys/sysctl.h>

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -48,7 +48,6 @@
 
 #if defined(__DragonFly__)        ||                                      \
     defined(__FreeBSD__)          ||                                      \
-    defined(__FreeBSD_kernel__)   ||                                      \
     defined(__OpenBSD__)          ||                                      \
     defined(__NetBSD__)
 # define HAVE_PREADV 1
@@ -79,7 +78,6 @@
 #if defined(__APPLE__)            ||                                      \
     defined(__DragonFly__)        ||                                      \
     defined(__FreeBSD__)          ||                                      \
-    defined(__FreeBSD_kernel__)   ||                                      \
     defined(__OpenBSD__)          ||                                      \
     defined(__NetBSD__)
 # include <sys/param.h>
@@ -256,7 +254,6 @@ static ssize_t uv__fs_futime(uv_fs_t* req) {
 #elif defined(__APPLE__)                                                      \
     || defined(__DragonFly__)                                                 \
     || defined(__FreeBSD__)                                                   \
-    || defined(__FreeBSD_kernel__)                                            \
     || defined(__NetBSD__)                                                    \
     || defined(__OpenBSD__)                                                   \
     || defined(__sun)
@@ -1054,10 +1051,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
 
     return -1;
   }
-#elif defined(__APPLE__)           || \
-      defined(__DragonFly__)       || \
-      defined(__FreeBSD__)         || \
-      defined(__FreeBSD_kernel__)
+#elif defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__)
   {
     off_t len;
     ssize_t r;
@@ -1081,15 +1075,6 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
 #endif
     len = 0;
     r = sendfile(in_fd, out_fd, req->off, req->bufsml[0].len, NULL, &len, 0);
-#elif defined(__FreeBSD_kernel__)
-    len = 0;
-    r = bsd_sendfile(in_fd,
-                     out_fd,
-                     req->off,
-                     req->bufsml[0].len,
-                     NULL,
-                     &len,
-                     0);
 #else
     /* The darwin sendfile takes len as an input for the length to send,
      * so make sure to initialize it with the caller's value. */
@@ -1141,7 +1126,6 @@ static ssize_t uv__fs_utime(uv_fs_t* req) {
 #elif defined(__APPLE__)                                                      \
     || defined(__DragonFly__)                                                 \
     || defined(__FreeBSD__)                                                   \
-    || defined(__FreeBSD_kernel__)                                            \
     || defined(__NetBSD__)                                                    \
     || defined(__OpenBSD__)
   struct timeval tv[2];
@@ -1183,7 +1167,6 @@ static ssize_t uv__fs_lutime(uv_fs_t* req) {
 #elif defined(__APPLE__)          ||                                          \
       defined(__DragonFly__)      ||                                          \
       defined(__FreeBSD__)        ||                                          \
-      defined(__FreeBSD_kernel__) ||                                          \
       defined(__NetBSD__)
   struct timeval tv[2];
   tv[0] = uv__fs_to_timeval(req->atime);

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -207,7 +207,6 @@ struct uv__statx {
     defined(__APPLE__) || \
     defined(__DragonFly__) || \
     defined(__FreeBSD__) || \
-    defined(__FreeBSD_kernel__) || \
     defined(__linux__) || \
     defined(__OpenBSD__) || \
     defined(__NetBSD__)

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -55,7 +55,7 @@
 extern char **environ;
 #endif
 
-#if defined(__linux__) || defined(__GLIBC__)
+#if defined(__linux__)
 # include <grp.h>
 #endif
 

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -81,7 +81,7 @@ int uv__tcsetattr(int fd, int how, const struct termios *term) {
 
 static int uv__tty_is_slave(const int fd) {
   int result;
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD__)
   int dummy;
 
   result = ioctl(fd, TIOCGPTN, &dummy) != 0;

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -154,7 +154,7 @@ static void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int revents) {
 }
 
 static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD__)
   struct sockaddr_in6 peers[20];
   struct iovec iov[ARRAY_SIZE(peers)];
   struct mmsghdr msgs[ARRAY_SIZE(peers)];
@@ -210,9 +210,9 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
       handle->recv_cb(handle, 0, buf, NULL, UV_UDP_MMSG_FREE);
   }
   return nread;
-#else  /* __linux__ || ____FreeBSD__ || __FreeBSD_kernel__ */
+#else  /* __linux__ || ____FreeBSD__ */
   return UV_ENOSYS;
-#endif  /* __linux__ || ____FreeBSD__ || __FreeBSD_kernel__ */
+#endif  /* __linux__ || ____FreeBSD__ */
 }
 
 static void uv__udp_recvmsg(uv_udp_t* handle) {
@@ -282,7 +282,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
 }
 
 static void uv__udp_sendmsg(uv_udp_t* handle) {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD__)
   uv_udp_send_t* req;
   struct mmsghdr h[20];
   struct mmsghdr* p;
@@ -371,7 +371,7 @@ write_queue_drain:
   if (!QUEUE_EMPTY(&handle->write_queue))
     goto write_queue_drain;
   uv__io_feed(handle->loop, &handle->io_watcher);
-#else  /* __linux__ || ____FreeBSD__ || __FreeBSD_kernel__ */
+#else  /* __linux__ || ____FreeBSD__ */
   uv_udp_send_t* req;
   struct msghdr h;
   QUEUE* q;
@@ -424,7 +424,7 @@ write_queue_drain:
     QUEUE_INSERT_TAIL(&handle->write_completed_queue, &req->queue);
     uv__io_feed(handle->loop, &handle->io_watcher);
   }
-#endif  /* __linux__ || ____FreeBSD__ || __FreeBSD_kernel__ */
+#endif  /* __linux__ || ____FreeBSD__ */
 }
 
 /* On the BSDs, SO_REUSEPORT implies SO_REUSEADDR but with some additional
@@ -1020,7 +1020,7 @@ int uv__udp_init_ex(uv_loop_t* loop,
 
 
 int uv_udp_using_recvmmsg(const uv_udp_t* handle) {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD__)
   if (handle->flags & UV_HANDLE_UDP_RECVMMSG)
     return 1;
 #endif

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -33,7 +33,6 @@
 # if defined(__APPLE__) ||                                                    \
      defined(__DragonFly__) ||                                                \
      defined(__FreeBSD__) ||                                                  \
-     defined(__FreeBSD_kernel__) ||                                           \
      defined(__OpenBSD__) ||                                                  \
      defined(__NetBSD__)
 #  define HAVE_KQUEUE 1

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -631,7 +631,7 @@ TEST_IMPL(poll_unidirectional) {
  */
 TEST_IMPL(poll_bad_fdtype) {
 #if !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__sun) && \
-    !defined(_AIX) && !defined(__MVS__) && !defined(__FreeBSD_kernel__) && \
+    !defined(_AIX) && !defined(__MVS__) && \
     !defined(__OpenBSD__) && !defined(__CYGWIN__) && !defined(__MSYS__) && \
     !defined(__NetBSD__)
   uv_poll_t poll_handle;

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -28,7 +28,7 @@
 #else /*  Unix */
 # include <fcntl.h>
 # include <unistd.h>
-# if (defined(__linux__) || defined(__GLIBC__)) && !defined(__ANDROID__)
+# if defined(__linux__) && !defined(__ANDROID__)
 #  include <pty.h>
 # elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #  include <util.h>
@@ -433,7 +433,6 @@ TEST_IMPL(tty_pty) {
 #if defined(__APPLE__)                            || \
     defined(__DragonFly__)                        || \
     defined(__FreeBSD__)                          || \
-    defined(__FreeBSD_kernel__)                   || \
     (defined(__linux__) && !defined(__ANDROID__)) || \
     defined(__NetBSD__)                           || \
     defined(__OpenBSD__)

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
 #endif
 
@@ -49,7 +49,7 @@ static int recv_cb_called;
 static int close_cb_called;
 static uint16_t client_port;
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 static int can_ipv6_ipv4_dual(void) {
   int v6only;
   size_t size = sizeof(int);
@@ -220,7 +220,7 @@ TEST_IMPL(udp_dual_stack) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
   if (!can_ipv6_ipv4_dual())
     RETURN_SKIP("IPv6-IPv4 dual stack not supported");
 #elif defined(__OpenBSD__)

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -77,7 +77,7 @@ TEST_IMPL(udp_multicast_interface6) {
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
   ASSERT(r == 0);
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
   r = uv_udp_set_multicast_interface(&server, "::1%lo0");
 #else
   r = uv_udp_set_multicast_interface(&server, NULL);

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -33,7 +33,6 @@
 #if defined(__APPLE__)          || \
     defined(_AIX)               || \
     defined(__MVS__)            || \
-    defined(__FreeBSD_kernel__) || \
     defined(__NetBSD__)         || \
     defined(__OpenBSD__)
   #define MULTICAST_ADDR "ff02::1%lo0"


### PR DESCRIPTION
Because kFreeBSD is dead. RIP.

Fixes: https://github.com/libuv/libuv/issues/3833