### PR TITLE
build: drop qemu-alpha from ci matrix

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -94,7 +94,6 @@ jobs:
           - {target: mips64,  toolchain: gcc-mips64-linux-gnuabi64,   cc: mips64-linux-gnuabi64-gcc,  qemu: qemu-mips64-static   }
           - {target: mipsel,  toolchain: gcc-mipsel-linux-gnu,        cc: mipsel-linux-gnu-gcc,       qemu: qemu-mipsel-static   }
           - {target: mips64el,toolchain: gcc-mips64el-linux-gnuabi64, cc: mips64el-linux-gnuabi64-gcc,qemu: qemu-mips64el-static }
-          - {target: alpha,   toolchain: gcc-alpha-linux-gnu,       cc: alpha-linux-gnu-gcc,        qemu: qemu-alpha-static   }
           - {target: arm (u64 slots),     toolchain: gcc-arm-linux-gnueabi,     cc: arm-linux-gnueabi-gcc,      qemu: qemu-arm-static}
           - {target: aarch64 (u64 slots), toolchain: gcc-aarch64-linux-gnu,     cc: aarch64-linux-gnu-gcc,      qemu: qemu-aarch64-static}
           - {target: ppc (u64 slots),     toolchain: gcc-powerpc-linux-gnu,     cc: powerpc-linux-gnu-gcc,      qemu: qemu-ppc-static}


### PR DESCRIPTION
As of recent, the fs_partial_read and fs_partial_write tests reliably fail on that architecture.

An upgrade from Ubuntu 20.04 to 22.04 on the CI machines is suspected, not any changes in libuv itself.

Perhaps it's possible to work around it in the tests but as Alpha is a dead architecture, it doesn't seem worthwhile to sink time in that. Let's remove it from the CI matrix instead.

Fixes: https://github.com/libuv/libuv/issues/3843