### PR TITLE
Predefine UV_EXTERN to  ignore export

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -31,6 +31,7 @@ extern "C" {
 #error "Define either BUILDING_UV_SHARED or USING_UV_SHARED, not both."
 #endif
 
+#ifndef UV_EXTERN
 #ifdef _WIN32
   /* Windows - set up dll import/export decorators. */
 # if defined(BUILDING_UV_SHARED)
@@ -50,6 +51,7 @@ extern "C" {
 #else
 # define UV_EXTERN /* nothing */
 #endif
+#endif /* UV_EXTERN */
 
 #include "uv/errno.h"
 #include "uv/version.h"


### PR DESCRIPTION
reopen of #3730, which was accidentally closed