### PR TITLE
win: allow uv_spawn to limit inheritable handles

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1061,7 +1061,14 @@ enum uv_process_flags {
    * option is only meaningful on Windows systems. On Unix it is silently
    * ignored.
    */
-  UV_PROCESS_WINDOWS_HIDE_GUI = (1 << 6)
+  UV_PROCESS_WINDOWS_HIDE_GUI = (1 << 6),
+  /*
+   * Only inherit the inheritable handles configured in
+   * uv_process_options_t.stdio. By default all the handles marked as inheritable
+   * will be inherited by the child process. This option is only meaningful on Windows
+   * systems. On Unix it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_INHERIT_SPECIFIC_HANDLES = (1 << 7)
 };
 
 /*

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -287,14 +287,20 @@ int uv__random_rtlgenrandom(void* buf, size_t buflen);
 /*
  * Process stdio handles.
  */
+typedef struct {
+  BYTE* buffer;
+  HANDLE* handles;
+} uv__stdio_t;
+
 int uv__stdio_create(uv_loop_t* loop,
                      const uv_process_options_t* options,
-                     BYTE** buffer_ptr);
-void uv__stdio_destroy(BYTE* buffer);
+                     uv__stdio_t* stdio);
+void uv__stdio_destroy(uv__stdio_t* stdio);
 void uv__stdio_noinherit(BYTE* buffer);
 int uv__stdio_verify(BYTE* buffer, WORD size);
 WORD uv__stdio_size(BYTE* buffer);
 HANDLE uv__stdio_handle(BYTE* buffer, int fd);
+int uv__stdio_count(BYTE* buffer);
 
 
 /*

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -483,6 +483,7 @@ TEST_DECLARE   (poll_closesocket)
 TEST_DECLARE   (close_fd)
 TEST_DECLARE   (closed_fd_events)
 TEST_DECLARE   (spawn_fs_open)
+TEST_DECLARE   (spawn_fs_open_inheritable)
 #ifdef _WIN32
 TEST_DECLARE   (spawn_detect_pipe_name_collisions_on_windows)
 #if !defined(USING_UV_SHARED)
@@ -990,6 +991,7 @@ TASK_LIST_START
   TEST_ENTRY  (close_fd)
   TEST_ENTRY  (closed_fd_events)
   TEST_ENTRY  (spawn_fs_open)
+  TEST_ENTRY  (spawn_fs_open_inheritable)
 #ifdef _WIN32
   TEST_ENTRY  (spawn_detect_pipe_name_collisions_on_windows)
 #if !defined(USING_UV_SHARED)


### PR DESCRIPTION
Add `UV_PROCESS_WINDOWS_INHERIT_SPECIFIC_HANDLES` flag so the child process will only inherit the handles marked as inheritable in `uv_process_options_t.stdio`.

It tries to address #1490.

Documentation missing. I'd like to receive some feedback first.