### PR TITLE
test: try fixing flaky fs_event_watch_dir test

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -232,7 +232,8 @@ static void fs_event_create_files_in_subdir(uv_timer_t* handle) {
   if (++fs_event_created < fs_event_file_count) {
     /* Create another file on a different event loop tick.  We do it this way
      * to avoid fs events coalescing into one fs event. */
-    ASSERT(0 == uv_timer_start(&timer, fs_event_create_files_in_subdir, 1, 0));
+    ASSERT_EQ(0,
+              uv_timer_start(&timer, fs_event_create_files_in_subdir, 100, 0));
   }
 }
 

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -39,12 +39,6 @@
 # endif
 #endif
 
-#if defined(__arm__)/* Increase the timeout so the test passes on arm CI bots */
-# define CREATE_TIMEOUT 100
-#else
-# define CREATE_TIMEOUT 1
-#endif
-
 static uv_fs_event_t fs_event;
 static const char file_prefix[] = "fsevent-";
 static const int fs_event_file_count = 16;
@@ -162,10 +156,7 @@ static void fs_event_create_files(uv_timer_t* handle) {
   if (++fs_event_created < fs_event_file_count) {
     /* Create another file on a different event loop tick.  We do it this way
      * to avoid fs events coalescing into one fs event. */
-    ASSERT(0 == uv_timer_start(&timer,
-                               fs_event_create_files,
-                               CREATE_TIMEOUT,
-                               0));
+    ASSERT_EQ(0, uv_timer_start(&timer, fs_event_create_files, 100, 0));
   }
 }
 


### PR DESCRIPTION
Increase the timer interval. That hopefully ameliorates the problem of FSEvents.framework missing events on the macOS CI buildbot.

Not really a fix, more a mitigation.

Fixes: https://github.com/libuv/libuv/issues/3862