### PR TITLE
win: fix fs.stat for AppExecLink

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1891,19 +1891,14 @@ INLINE static DWORD fs__stat_impl_from_path(WCHAR* path,
                                             int do_lstat,
                                             uv_stat_t* statbuf) {
   HANDLE handle;
-  DWORD flags;
   DWORD ret;
-
-  flags = FILE_FLAG_BACKUP_SEMANTICS;
-  if (do_lstat)
-    flags |= FILE_FLAG_OPEN_REPARSE_POINT;
 
   handle = CreateFileW(path,
                        FILE_READ_ATTRIBUTES,
                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                        NULL,
                        OPEN_EXISTING,
-                       flags,
+                       FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
                        NULL);
 
   if (handle == INVALID_HANDLE_VALUE)

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -59,6 +59,10 @@ typedef struct {
   double mtime;
 } utime_check_t;
 
+typedef int (*fs_stat_func)(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* path,
+                            uv_fs_cb cb);
 
 static int dummy_cb_count;
 static int close_cb_count;
@@ -2509,7 +2513,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   return 0;
 }
 
-TEST_IMPL(fs_lstat_windows_store_apps) {
+void fs_windows_store_apps(fs_stat_func fs_stat_func) {
   uv_loop_t* loop;
   char localappdata[MAX_PATH];
   char windowsapps_path[MAX_PATH];
@@ -2554,10 +2558,18 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
                  dirent.name) < 0) {
       continue;
     }
-    ASSERT_EQ(uv_fs_lstat(loop, &stat_req, file_path, NULL), 0);
+    ASSERT_EQ(fs_stat_func(loop, &stat_req, file_path, NULL), 0);
   }
   MAKE_VALGRIND_HAPPY();
   return 0;
+}
+
+TEST_IMPL(fs_stat_windows_store_apps) {
+  fs_windows_store_apps(uv_fs_stat);
+}
+
+TEST_IMPL(fs_lstat_windows_store_apps) {
+  fs_windows_store_apps(uv_fs_lstat);
 }
 #endif
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -367,6 +367,7 @@ TEST_DECLARE   (fs_symlink_dir)
 #ifdef _WIN32
 TEST_DECLARE   (fs_symlink_junction)
 TEST_DECLARE   (fs_non_symlink_reparse_point)
+TEST_DECLARE   (fs_stat_windows_store_apps)
 TEST_DECLARE   (fs_lstat_windows_store_apps)
 TEST_DECLARE   (fs_open_flags)
 #endif
@@ -1051,6 +1052,7 @@ TASK_LIST_START
 #ifdef _WIN32
   TEST_ENTRY  (fs_symlink_junction)
   TEST_ENTRY  (fs_non_symlink_reparse_point)
+  TEST_ENTRY  (fs_stat_windows_store_apps)
   TEST_ENTRY  (fs_lstat_windows_store_apps)
   TEST_ENTRY  (fs_open_flags)
 #endif


### PR DESCRIPTION
Calling `uv_fs_stat` for AppExecLink reparse points (eg. `LOCALAPPDATA\Microsoft\\WindowsApps\MicrosoftEdge.exe` or any other application from that directory) was failing with EACCES code. Under the hood, what was failing was the `CreateFileW` function because `FILE_FLAG_OPEN_REPARSE_POINT` was not used in that case, unlike in the `uv_fs_lstat`.

Based on [documentation](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew) using the `FILE_FLAG_OPEN_REPARSE_POINT` flag is safe because "If the file is not a reparse point, then this flag is ignored". As a result, this change will not have a negative (nor any other) effect on all other cases when the file is not an AppExecLink reparse point.

This PR also adds a test covering this behavior.

Refs: https://github.com/nodejs/node/issues/36790
Refs: https://github.com/nodejs/node/issues/33024
Refs: https://github.com/libuv/libuv/pull/2812