### PR TITLE
build: enable platform_output test on qemu

### DIFF
--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -25,11 +25,6 @@
 
 
 TEST_IMPL(platform_output) {
-/* TODO(gengjiawen): Fix test on QEMU. */
-#if defined(__QEMU__)
-  RETURN_SKIP("Test does not currently work in QEMU");
-#endif
-
   char buffer[512];
   size_t rss;
   size_t size;


### PR DESCRIPTION
The test was disabled because of a qemu bug that is presumed to have since been fixed.

Refs: https://github.com/libuv/libuv/pull/3861