### PR TITLE
build,test: fix distcheck errors

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -24,12 +24,8 @@ jobs:
           mkdir build
           (cd build && ../configure)
       - name: distcheck
-        continue-on-error: true # XXX: allow failure
         run: |
           make -C build distcheck
-      - name: dist
-        run: |
-          make -C build dist
 
   build-android:
     runs-on: ubuntu-latest

--- a/configure.ac
+++ b/configure.ac
@@ -87,4 +87,5 @@ AC_CONFIG_FILES([Makefile libuv.pc])
 AC_CONFIG_LINKS([test/fixtures/empty_file:test/fixtures/empty_file])
 AC_CONFIG_LINKS([test/fixtures/load_error.node:test/fixtures/load_error.node])
 AC_CONFIG_LINKS([test/fixtures/lorem_ipsum.txt:test/fixtures/lorem_ipsum.txt])
+AC_CONFIG_LINKS([test/fixtures/one_file/one_file:test/fixtures/one_file/one_file])
 AC_OUTPUT

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -151,14 +151,18 @@ TEST_IMPL(fs_copyfile) {
   handle_result(&req);
 
   /* Fails to overwrites existing file. */
+  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  uv_fs_req_cleanup(&req);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_EXCL, NULL);
   ASSERT(r == UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
   /* Truncates when an existing destination is larger than the source file. */
+  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  uv_fs_req_cleanup(&req);
   touch_file(src, 1);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies a larger file. */
@@ -176,6 +180,9 @@ TEST_IMPL(fs_copyfile) {
   ASSERT(result_check_count == 5);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(result_check_count == 6);
+  /* Ensure file is user-writable (not copied from src). */
+  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  uv_fs_req_cleanup(&req);
 
   /* If the flags are invalid, the loop should not be kept open */
   unlink(dst);

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -51,6 +51,7 @@ static void connect_cb(uv_connect_t* connect_req, int status) {
 
 static void connect_cb_file(uv_connect_t* connect_req, int status) {
   if (status != UV_ENOTSOCK)
+    if (status != UV_EACCES)
       ASSERT_EQ(status, UV_ECONNREFUSED);
   uv_close((uv_handle_t*) connect_req->handle, close_cb);
   connect_cb_called++;

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -43,15 +43,16 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENOENT);
-  uv_close((uv_handle_t*)connect_req->handle, close_cb);
+  ASSERT_EQ(status, UV_ENOENT);
+  uv_close((uv_handle_t*) connect_req->handle, close_cb);
   connect_cb_called++;
 }
 
 
 static void connect_cb_file(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENOTSOCK || status == UV_ECONNREFUSED);
-  uv_close((uv_handle_t*)connect_req->handle, close_cb);
+  if (status != UV_ENOTSOCK)
+      ASSERT_EQ(status, UV_ECONNREFUSED);
+  uv_close((uv_handle_t*) connect_req->handle, close_cb);
   connect_cb_called++;
 }
 
@@ -62,13 +63,13 @@ TEST_IMPL(pipe_connect_bad_name) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&req, &client, BAD_PIPENAME, connect_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;
@@ -82,13 +83,13 @@ TEST_IMPL(pipe_connect_to_file) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&req, &client, path, connect_cb_file);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY();
   return 0;


### PR DESCRIPTION
When run under distcheck, the libuv source permissions are read-only, which makes this test copyfile fail without explicit correction to the permissions.

The undefined behavior that was previously failing here was now defined and fixed (https://github.com/libuv/libuv/issues/2199#issuecomment-466134438), so it is time we now promoted this to a mandatory test!