### PR TITLE
Win: add GetHostNameW fallback method

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4762,8 +4762,8 @@ extern sSetWinEventHook pSetWinEventHook;
 /* ws2_32.dll function pointer */
 /* mingw doesn't have this definition, so let's declare it here locally */
 typedef int (WINAPI *uv_sGetHostNameW)
-            (PWSTR,
-             int);
+            (PWSTR name,
+             int   namelen);
 extern uv_sGetHostNameW pGetHostNameW;
 
 #endif /* UV_WIN_WINAPI_H_ */


### PR DESCRIPTION
This is a simple, unobtrusive way to improve compatibility with legacy systems where GetHostNameW is not available.

p.s. It's totally fine to officially drop support for legacy systems.
But please don't refuse fixes that are still relevant to the community.

Related:
* https://github.com/libuv/libuv/issues/3260
* https://github.com/libuv/libuv/pull/3636