### PR TITLE
unix: abort on clock_gettime() error

### DIFF
--- a/src/unix/posix-hrtime.c
+++ b/src/unix/posix-hrtime.c
@@ -23,13 +23,14 @@
 #include "internal.h"
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 
-#undef NANOSEC
-#define NANOSEC ((uint64_t) 1e9)
-
 uint64_t uv__hrtime(uv_clocktype_t type) {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
+  struct timespec t;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &t))
+    abort();
+
+  return t.tv_sec * (uint64_t) 1e9 + t.tv_nsec;
 }


### PR DESCRIPTION
Per standard libuv operating procedures, abort on unexpected failure. Don't silently ignore the error and return garbage.