### PR TITLE
fix function definition for 'uv_udp_init_ex' not found.

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -342,7 +342,7 @@ int uv_tcp_bind(uv_tcp_t* handle,
 }
 
 
-int uv_udp_init_ex(uv_loop_t* loop, uv_udp_t* handle, unsigned flags) {
+int uv_udp_init_ex(uv_loop_t* loop, uv_udp_t* handle, unsigned int flags) {
   unsigned extra_flags;
   int domain;
   int rc;


### PR DESCRIPTION
fix visual studio warnings