### PR TITLE
test: make valgrind happy

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -4513,6 +4513,7 @@ TEST_IMPL(fs_statfs) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(statfs_cb_count == 2);
 
+  MAKE_VALGRIND_HAPPY();
   return 0;
 }
 


### PR DESCRIPTION
Missing a call to MAKE_VALGRIND_HAPPY() to silence valgrind output.