### PR TITLE
test: silence more valgrind warnings

### DIFF
--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -94,7 +94,7 @@ static int test_async_pummel(int nthreads) {
 
   free(tids);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -116,7 +116,7 @@ static int test_async(int nthreads) {
 
   free(threads);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/benchmark-fs-stat.c
+++ b/test/benchmark-fs-stat.c
@@ -131,6 +131,6 @@ BENCHMARK_IMPL(fs_stat) {
   warmup(path);
   sync_bench(path);
   async_bench(path);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -87,6 +87,6 @@ BENCHMARK_IMPL(getaddrinfo) {
           (double) calls_completed / (double) (end_time - start_time) * 1000.0);
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-loop-count.c
+++ b/test/benchmark-loop-count.c
@@ -68,7 +68,7 @@ BENCHMARK_IMPL(loop_count) {
           NUM_TICKS / (ns / 1e9));
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -87,6 +87,6 @@ BENCHMARK_IMPL(loop_count_timed) {
   fprintf(stderr, "loop_count: %lu ticks (%.0f ticks/s)\n", ticks, ticks / 5.0);
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -107,6 +107,6 @@ BENCHMARK_IMPL(million_async) {
           fmt(container->handles_seen));
   free(container);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -81,6 +81,6 @@ BENCHMARK_IMPL(million_timers) {
   fprintf(stderr, "%.2f seconds cleanup\n", (after_all - after_run) / 1e9);
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -431,7 +431,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   free(clients);
   free(servers);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -216,6 +216,6 @@ BENCHMARK_IMPL(ping_pongs) {
 
   ASSERT(completed_pingers == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-ping-udp.c
+++ b/test/benchmark-ping-udp.c
@@ -153,7 +153,7 @@ static int ping_udp(unsigned pingers) {
   fprintf(stderr, "ping_pongs: %d pingers, ~ %lu roundtrips/s\n",
           completed_pingers, completed_pings / (TIME/1000));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -306,7 +306,7 @@ static int pound_it(int concurrency,
           conns_failed);
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -415,7 +415,7 @@ HELPER_IMPL(pipe_pump_server) {
   notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -434,7 +434,7 @@ static void tcp_pump(int n) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 }
 
 
@@ -450,7 +450,7 @@ static void pipe_pump(int n) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 }
 
 

--- a/test/benchmark-queue-work.c
+++ b/test/benchmark-queue-work.c
@@ -63,6 +63,6 @@ BENCHMARK_IMPL(queue_work) {
   printf("%s async jobs in %.1f seconds (%s/s)\n", fmt(events), timeout / 1000.,
          fmt(events / (timeout / 1000.)));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -159,6 +159,6 @@ BENCHMARK_IMPL(spawn) {
           (double) N / (double) (end_time - start_time) * 1000.0);
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -139,6 +139,6 @@ BENCHMARK_IMPL(tcp_write_batch) {
          (long)NUM_WRITE_REQS,
          (stop - start) / 1e9);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -215,7 +215,7 @@ static int pummel(unsigned int n_senders,
          send_cb_called,
          duration / 1000.0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/task.h
+++ b/test/task.h
@@ -243,13 +243,13 @@ typedef enum {
 #define ASSERT_PTR_NE(a, b) \
   ASSERT_BASE(a, !=, b, void*, "p")
 
-/* This macro cleans up the main loop. This is used to avoid valgrind
- * warnings about memory being "leaked" by the main event loop.
+/* This macro cleans up the event loop. This is used to avoid valgrind
+ * warnings about memory being "leaked" by the event loop.
  */
-#define MAKE_VALGRIND_HAPPY()                       \
+#define MAKE_VALGRIND_HAPPY(loop)                   \
   do {                                              \
-    close_loop(uv_default_loop());                  \
-    ASSERT(0 == uv_loop_close(uv_default_loop()));  \
+    close_loop(loop);                               \
+    ASSERT(0 == uv_loop_close(loop));               \
     uv_library_shutdown();                          \
   } while (0)
 

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -79,6 +79,6 @@ TEST_IMPL(active) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -59,6 +59,6 @@ TEST_IMPL(async_null_cb) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(0 == uv_thread_join(&thread));
   ASSERT(1 == check_cb_called);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -129,6 +129,6 @@ TEST_IMPL(async) {
 
   ASSERT(0 == uv_thread_join(&thread));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -199,6 +199,6 @@ TEST_IMPL(callback_stack) {
   ASSERT(shutdown_cb_called == 1 && "shutdown_cb must be called exactly once");
   ASSERT(close_cb_called == 2 && "close_cb must be called exactly twice");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -79,6 +79,6 @@ TEST_IMPL(close_fd) {
   ASSERT(2 == read_cb_called);
   ASSERT(0 != uv_is_closing((const uv_handle_t *) &pipe_handle));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -75,6 +75,6 @@ TEST_IMPL(close_order) {
   ASSERT(close_cb_called == 3);
   ASSERT(timer_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-connect-unspecified.c
+++ b/test/test-connect-unspecified.c
@@ -59,5 +59,6 @@ TEST_IMPL(connect_unspecified) {
 
   ASSERT(uv_run(loop, UV_RUN_DEFAULT) == 0);
 
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -130,7 +130,7 @@ TEST_IMPL(connection_fail) {
   ASSERT(timer_close_cb_calls == 0);
   ASSERT(timer_cb_calls == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -156,6 +156,6 @@ TEST_IMPL(connection_fail_doesnt_auto_close) {
   ASSERT(timer_close_cb_calls == 1);
   ASSERT(timer_cb_calls == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -52,8 +52,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(2 == timer_cb_called);
-  ASSERT(0 == uv_loop_close(loop));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -184,6 +184,6 @@ TEST_IMPL(delayed_accept) {
   ASSERT(connect_cb_called == 2);
   ASSERT(close_cb_called == 7);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -89,7 +89,7 @@ TEST_IMPL(eintr_handling) {
 
   ASSERT_EQ(0, uv_thread_join(&thread));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -74,6 +74,6 @@ TEST_IMPL(embed) {
   ASSERT_EQ(0, uv_thread_join(&thread));
   uv_barrier_destroy(&barrier);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -94,7 +94,7 @@ TEST_IMPL(emfile) {
     first_fd += 1;
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -59,17 +59,18 @@ static void socket_cb(uv_poll_t* poll, int status, int events) {
 
 
 static void run_timer_loop_once(void) {
-  uv_loop_t* loop;
+  uv_loop_t loop;
   uv_timer_t timer_handle;
 
-  loop = uv_default_loop();
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   timer_cb_called = 0; /* Reset for the child. */
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
+  ASSERT(0 == uv_timer_init(&loop, &timer_handle));
   ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
   ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_loop_close(&loop));
 }
 
 
@@ -111,7 +112,7 @@ TEST_IMPL(fork_timer) {
     run_timer_loop_once();
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -148,7 +149,7 @@ TEST_IMPL(fork_socketpair) {
     ASSERT(1 == socket_cb_called);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -212,7 +213,7 @@ TEST_IMPL(fork_socketpair_started) {
     ASSERT(0 == strcmp("hi\n", socket_cb_read_buf));
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -269,7 +270,7 @@ TEST_IMPL(fork_signal_to_child) {
     ASSERT(SIGUSR1 == fork_signal_cb_called);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -342,7 +343,7 @@ TEST_IMPL(fork_signal_to_child_closed) {
     exit(0);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -500,7 +501,7 @@ static int _do_fork_fs_events_child(int file_or_dir) {
     printf("Exiting child \n");
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 
 }
@@ -597,7 +598,7 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
   }
 
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 #endif
 }
@@ -675,7 +676,7 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
   }
 
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif /* !__MVS__ */

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -220,5 +220,6 @@ TEST_IMPL(fs_copyfile) {
 #endif
 
   unlink(dst); /* Cleanup */
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -432,7 +432,7 @@ TEST_IMPL(fs_event_watch_dir) {
   remove("watch_dir/file1");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -494,7 +494,7 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
   remove("watch_dir/subdir");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 #else
   RETURN_SKIP("Recursive directory watching not supported on this platform.");
@@ -541,7 +541,7 @@ TEST_IMPL(fs_event_watch_dir_short_path) {
   remove("watch_dir/file1");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 
   if (!has_shortnames)
     RETURN_SKIP("Was not able to address files with 8.3 short name.");
@@ -587,7 +587,7 @@ TEST_IMPL(fs_event_watch_file) {
   remove("watch_dir/file1");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -640,7 +640,7 @@ TEST_IMPL(fs_event_watch_file_exact_path) {
   remove("watch_dir/file.jsx");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -664,7 +664,7 @@ TEST_IMPL(fs_event_watch_file_twice) {
   ASSERT(0 == uv_timer_start(&timer, timer_cb_watch_twice, 10, 0));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -719,7 +719,7 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
   /* Cleanup */
   remove("watch_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -745,7 +745,7 @@ TEST_IMPL(fs_event_watch_file_root_dir) {
 
   uv_close((uv_handle_t*) &fs_event, NULL);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 #endif
@@ -784,7 +784,7 @@ TEST_IMPL(fs_event_no_callback_after_close) {
   remove("watch_dir/file1");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -821,7 +821,7 @@ TEST_IMPL(fs_event_no_callback_on_close) {
   remove("watch_dir/file1");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -859,7 +859,7 @@ TEST_IMPL(fs_event_immediate_close) {
 
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -894,7 +894,7 @@ TEST_IMPL(fs_event_close_with_pending_event) {
   remove("watch_dir/file");
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -932,7 +932,7 @@ TEST_IMPL(fs_event_close_with_pending_delete_event) {
   /* Clean up */
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -973,7 +973,7 @@ TEST_IMPL(fs_event_close_in_callback) {
   fs_event_unlink_files(NULL);
   remove("watch_dir/");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1008,7 +1008,7 @@ TEST_IMPL(fs_event_start_and_close) {
   ASSERT(close_cb_called == 2);
 
   remove("watch_dir/");
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1061,7 +1061,7 @@ TEST_IMPL(fs_event_getpath) {
   }
 
   remove("watch_dir/");
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1150,7 +1150,7 @@ TEST_IMPL(fs_event_error_reporting) {
   } while (i-- != 0);
 
   remove("watch_dir/");
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1159,7 +1159,7 @@ TEST_IMPL(fs_event_error_reporting) {
 TEST_IMPL(fs_event_error_reporting) {
   /* No-op, needed only for FSEvents backend */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1182,7 +1182,7 @@ TEST_IMPL(fs_event_watch_invalid_path) {
   r = uv_fs_event_start(&fs_event, fs_event_cb_file, "", 0);
   ASSERT(r != 0);
   ASSERT(uv_is_active((uv_handle_t*) &fs_event) == 0);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1228,6 +1228,6 @@ TEST_IMPL(fs_event_stop_in_cb) {
 
   remove(path);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -424,7 +424,7 @@ TEST_IMPL(fs_open_flags) {
   /* Cleanup. */
   rmdir(empty_dir);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -164,7 +164,7 @@ TEST_IMPL(fs_poll) {
   ASSERT(timer_cb_called == 2);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -192,7 +192,7 @@ TEST_IMPL(fs_poll_getpath) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -212,9 +212,7 @@ TEST_IMPL(fs_poll_close_request) {
     uv_run(&loop, UV_RUN_ONCE);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(0 == uv_loop_close(&loop));
-
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 
@@ -238,9 +236,7 @@ TEST_IMPL(fs_poll_close_request_multi_start_stop) {
     uv_run(&loop, UV_RUN_ONCE);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(0 == uv_loop_close(&loop));
-
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 
@@ -264,9 +260,7 @@ TEST_IMPL(fs_poll_close_request_multi_stop_start) {
     uv_run(&loop, UV_RUN_ONCE);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(0 == uv_loop_close(&loop));
-
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 
@@ -293,8 +287,6 @@ TEST_IMPL(fs_poll_close_request_stop_when_active) {
   uv_run(&loop, UV_RUN_ONCE);
   ASSERT(close_cb_called == 1);
 
-  ASSERT(0 == uv_loop_close(&loop));
-
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -156,7 +156,7 @@ TEST_IMPL(fs_readdir_empty_dir) {
   ASSERT(empty_closedir_cb_count == 1);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
   uv_fs_req_cleanup(&rmdir_req);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -208,7 +208,7 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
   ASSERT(r == 0);
   ASSERT(non_existing_opendir_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -258,7 +258,7 @@ TEST_IMPL(fs_readdir_file) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
   ASSERT(file_opendir_cb_count == 1);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -457,6 +457,6 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   uv_fs_req_cleanup(&rmdir_req);
 
   cleanup_test_files();
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
  }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -723,7 +723,7 @@ TEST_IMPL(fs_file_noent) {
 
   /* TODO add EACCES test */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -749,7 +749,7 @@ TEST_IMPL(fs_file_nametoolong) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -791,7 +791,7 @@ TEST_IMPL(fs_file_loop) {
 
   unlink("test_symlink");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -958,7 +958,7 @@ TEST_IMPL(fs_file_async) {
   unlink("test_file");
   unlink("test_file2");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1048,7 +1048,7 @@ TEST_IMPL(fs_file_sync) {
   fs_file_sync(0);
   fs_file_sync(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1084,7 +1084,7 @@ TEST_IMPL(fs_file_write_null_buffer) {
   fs_file_write_null_buffer(0);
   fs_file_write_null_buffer(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1179,7 +1179,7 @@ TEST_IMPL(fs_async_dir) {
   unlink("test_dir/file2");
   rmdir("test_dir");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1259,7 +1259,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   unlink("test_file");
   unlink("test_file2");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1307,7 +1307,7 @@ TEST_IMPL(fs_mkdtemp) {
   uv_fs_req_cleanup(&mkdtemp_req1);
   uv_fs_req_cleanup(&mkdtemp_req2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1339,6 +1339,8 @@ TEST_IMPL(fs_mkstemp) {
 
   /* Make sure that path is empty string */
   ASSERT_EQ(0, strlen(mkstemp_req3.path));
+
+  uv_fs_req_cleanup(&mkstemp_req3);
 
   /* We can write to the opened file */
   iov = uv_buf_init(test_buf, sizeof(test_buf));
@@ -1373,7 +1375,7 @@ TEST_IMPL(fs_mkstemp) {
   uv_fs_req_cleanup(&mkstemp_req1);
   uv_fs_req_cleanup(&mkstemp_req2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1537,7 +1539,7 @@ TEST_IMPL(fs_fstat) {
   /* Cleanup. */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1574,7 +1576,7 @@ TEST_IMPL(fs_fstat_stdio) {
     uv_fs_req_cleanup(&req);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1650,7 +1652,7 @@ TEST_IMPL(fs_access) {
   unlink("test_file");
   rmdir("test_dir");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1748,7 +1750,7 @@ TEST_IMPL(fs_chmod) {
   /* Cleanup. */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1807,7 +1809,7 @@ TEST_IMPL(fs_unlink_readonly) {
   uv_fs_req_cleanup(&req);
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1865,7 +1867,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
   uv_fs_req_cleanup(&req);
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 #endif
@@ -1958,7 +1960,7 @@ TEST_IMPL(fs_chown) {
   unlink("test_file");
   unlink("test_file_link");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2044,7 +2046,7 @@ TEST_IMPL(fs_link) {
   unlink("test_file_link");
   unlink("test_file_link2");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2098,7 +2100,7 @@ TEST_IMPL(fs_readlink) {
     unlink("test_file");
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2119,7 +2121,7 @@ TEST_IMPL(fs_realpath) {
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2287,7 +2289,7 @@ TEST_IMPL(fs_symlink) {
   unlink("test_file_symlink2");
   unlink("test_file_symlink2_symlink");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2432,7 +2434,7 @@ int test_symlink_dir_impl(int type) {
   rmdir("test_dir");
   rmdir("test_dir_symlink");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2541,7 +2543,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   unlink("test_dir/test_file");
   rmdir("test_dir");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2561,7 +2563,7 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
   len = sizeof(localappdata);
   r = uv_os_getenv("LOCALAPPDATA", localappdata, &len);
   if (r == UV_ENOENT) {
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     return TEST_SKIP;
   }
   ASSERT_EQ(r, 0);
@@ -2572,11 +2574,11 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
   ASSERT_GT(r, 0);
   if (uv_fs_opendir(loop, &req, windowsapps_path, NULL) != 0) {
     /* If we cannot read the directory, skip the test. */
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     return TEST_SKIP;
   }
   if (uv_fs_scandir(loop, &req, windowsapps_path, 0, NULL) <= 0) {
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     return TEST_SKIP;
   }
   while (uv_fs_scandir_next(&req, &dirent) != UV_EOF) {
@@ -2592,7 +2594,7 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
     }
     ASSERT_EQ(uv_fs_lstat(loop, &stat_req, file_path, NULL), 0);
   }
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 #endif
@@ -2639,7 +2641,7 @@ TEST_IMPL(fs_utime) {
   /* Cleanup. */
   unlink(path);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2678,7 +2680,7 @@ TEST_IMPL(fs_utime_round) {
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   unlink(path);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2709,7 +2711,7 @@ TEST_IMPL(fs_stat_root) {
   r = uv_fs_stat(NULL, &stat_req, "\\\\?\\C:\\", NULL);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -2772,7 +2774,7 @@ TEST_IMPL(fs_futime) {
   /* Cleanup. */
   unlink(path);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2846,7 +2848,7 @@ TEST_IMPL(fs_lutime) {
   unlink(path);
   unlink(symlink_path);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2862,7 +2864,7 @@ TEST_IMPL(fs_stat_missing_path) {
   ASSERT(req.result == UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2899,7 +2901,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
   uv_fs_rmdir(NULL, &req, path, NULL);
   uv_fs_req_cleanup(&req);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2933,7 +2935,7 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2955,7 +2957,7 @@ TEST_IMPL(fs_scandir_file) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(scandir_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -2973,7 +2975,7 @@ TEST_IMPL(fs_scandir_early_exit) {
   ASSERT_NE(UV_EOF, uv_fs_scandir_next(&req, &d));
   uv_fs_req_cleanup(&req);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3003,7 +3005,7 @@ TEST_IMPL(fs_open_dir) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(open_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3078,7 +3080,7 @@ TEST_IMPL(fs_file_open_append) {
   fs_file_open_append(0);
   fs_file_open_append(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3147,7 +3149,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
   unlink("test_file");
   unlink("test_file2");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3205,7 +3207,7 @@ TEST_IMPL(fs_read_bufs) {
   fs_read_bufs(0);
   fs_read_bufs(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3271,7 +3273,7 @@ TEST_IMPL(fs_read_file_eof) {
   fs_read_file_eof(0);
   fs_read_file_eof(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3365,7 +3367,7 @@ TEST_IMPL(fs_write_multiple_bufs) {
   fs_write_multiple_bufs(0);
   fs_write_multiple_bufs(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3472,7 +3474,7 @@ TEST_IMPL(fs_write_alotof_bufs) {
   fs_write_alotof_bufs(0);
   fs_write_alotof_bufs(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3588,7 +3590,7 @@ TEST_IMPL(fs_write_alotof_bufs_with_offset) {
   fs_write_alotof_bufs_with_offset(0);
   fs_write_alotof_bufs_with_offset(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -3643,7 +3645,7 @@ TEST_IMPL(fs_read_dir) {
   /* Cleanup */
   rmdir("test_dir");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3802,7 +3804,7 @@ static void test_fs_partial(int doread) {
   free(buffer);
   free(ctx.data);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 }
 
 TEST_IMPL(fs_partial_read) {
@@ -3875,6 +3877,7 @@ TEST_IMPL(fs_read_write_null_arguments) {
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3913,7 +3916,7 @@ TEST_IMPL(get_osfhandle_valid_handle) {
   /* Cleanup. */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3959,7 +3962,7 @@ TEST_IMPL(open_osfhandle_valid_handle) {
   /* Cleanup. */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -3999,7 +4002,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
   /* Cleanup */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -4098,7 +4101,7 @@ TEST_IMPL(fs_file_pos_write) {
   fs_file_pos_write(0);
   fs_file_pos_write(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -4138,7 +4141,7 @@ TEST_IMPL(fs_file_pos_append) {
   fs_file_pos_append(0);
   fs_file_pos_append(UV_FS_O_FILEMAP);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -4298,7 +4301,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   /* Cleanup */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -4345,7 +4348,7 @@ TEST_IMPL(fs_file_flag_no_buffering) {
   /* Cleanup */
   unlink("test_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -4431,7 +4434,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     unlink("test_file_icacls");
     uv_os_free_passwd(&pwd);
     ASSERT(r == 0);
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     return 0;
 }
 #endif
@@ -4516,7 +4519,7 @@ TEST_IMPL(fs_statfs) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(statfs_cb_count == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -106,7 +106,7 @@ TEST_IMPL(getaddrinfo_fail) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(fail_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -127,7 +127,7 @@ TEST_IMPL(getaddrinfo_fail_sync) {
                             NULL));
   uv_freeaddrinfo(req.addrinfo);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -153,7 +153,7 @@ TEST_IMPL(getaddrinfo_basic) {
 
   ASSERT(getaddrinfo_cbs == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -173,7 +173,7 @@ TEST_IMPL(getaddrinfo_basic_sync) {
                              NULL));
   uv_freeaddrinfo(req.addrinfo);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -210,6 +210,6 @@ TEST_IMPL(getaddrinfo_concurrent) {
     ASSERT(callback_counts[i] == 1);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -65,7 +65,7 @@ TEST_IMPL(getnameinfo_basic_ip4) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -86,7 +86,7 @@ TEST_IMPL(getnameinfo_basic_ip4_sync) {
   ASSERT(req.host[0] != '\0');
   ASSERT(req.service[0] != '\0');
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -111,6 +111,6 @@ TEST_IMPL(getnameinfo_basic_ip6) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -337,7 +337,7 @@ TEST_IMPL(getsockname_tcp) {
   ASSERT(getsocknamecount_tcp == 3);
   ASSERT(getpeernamecount == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -357,6 +357,6 @@ TEST_IMPL(getsockname_udp) {
   ASSERT(udp.send_queue_size == 0);
   ASSERT(udpServer.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -120,6 +120,6 @@ TEST_IMPL(handle_fileno) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -94,7 +94,7 @@ TEST_IMPL(idle_starvation) {
   ASSERT(timer_cb_called == 1);
   ASSERT(close_cb_called == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -120,6 +120,6 @@ TEST_IMPL(idle_check) {
   ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(2, close_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-ip-name.c
+++ b/test/test-ip-name.c
@@ -51,7 +51,7 @@ TEST_IMPL(ip_name) {
     ASSERT_EQ(0, uv_ip6_addr("fe80::2acf:daff:fedd:342a", TEST_PORT, addr6));
     ASSERT_EQ(0, uv_ip6_name(addr6, dst, INET6_ADDRSTRLEN));
     ASSERT_EQ(0, strcmp("fe80::2acf:daff:fedd:342a", dst));
-    
+
     ASSERT_EQ(0, uv_ip_name(addr, dst, INET6_ADDRSTRLEN));
     ASSERT_EQ(0, strcmp("fe80::2acf:daff:fedd:342a", dst));
 
@@ -60,6 +60,6 @@ TEST_IMPL(ip_name) {
     /* size is not a concern here */
     ASSERT_EQ(UV_EAFNOSUPPORT, uv_ip_name(addr, dst, INET6_ADDRSTRLEN));
 
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(uv_default_loop());
     return 0;
 }

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -50,6 +50,6 @@ TEST_IMPL(ip4_addr) {
   ASSERT(UV_EAFNOSUPPORT == uv_inet_pton(42, "127.0.0.1",
     &addr.sin_addr.s_addr));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -113,7 +113,7 @@ TEST_IMPL(ip6_addr_link_local) {
   scoped_addr_len = sizeof(scoped_addr);
   ASSERT(0 != uv_if_indextoname((unsigned int)-1, scoped_addr, &scoped_addr_len));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -154,7 +154,7 @@ TEST_IMPL(ip6_pton) {
   GOOD_ADDR_LIST(TEST_GOOD)
   BAD_ADDR_LIST(TEST_BAD)
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -137,7 +137,7 @@ TEST_IMPL(ipc_heavy_traffic_deadlock_bug) {
   spawn_helper(&pipe, &process, "ipc_helper_heavy_traffic_deadlock_bug");
   do_writes_and_reads((uv_stream_t*) &pipe);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(pipe.loop);
   return 0;
 }
 
@@ -154,6 +154,6 @@ int ipc_helper_heavy_traffic_deadlock_bug(void) {
   do_writes_and_reads((uv_stream_t*) &pipe);
   uv_sleep(100);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -223,7 +223,7 @@ static int run_ipc_send_recv_pipe(int inprocess) {
   r = run_test(inprocess);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -264,7 +264,7 @@ static int run_ipc_send_recv_tcp(int inprocess) {
   r = run_test(inprocess);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -416,7 +416,7 @@ int ipc_send_recv_helper(void) {
   r = run_ipc_send_recv_helper(uv_default_loop(), 0);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -424,7 +424,7 @@ static int run_ipc_test(const char* helper, uv_read_cb read_cb) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -489,7 +489,7 @@ TEST_IMPL(listen_with_simultaneous_accepts) {
   ASSERT_EQ(r, 0);
   ASSERT_EQ(server.reqs_pending, 32);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -514,7 +514,7 @@ TEST_IMPL(listen_no_simultaneous_accepts) {
   ASSERT_EQ(r, 0);
   ASSERT_EQ(server.reqs_pending, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -721,7 +721,7 @@ int ipc_helper(int listen_after_write) {
   ASSERT_EQ(connection_accepted, 1);
   ASSERT_EQ(close_cb_called, 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -774,7 +774,7 @@ int ipc_helper_tcp_connection(void) {
   ASSERT_EQ(tcp_conn_write_cb_called, 1);
   ASSERT_EQ(close_cb_called, 4);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -820,7 +820,7 @@ int ipc_helper_bind_twice(void) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -852,6 +852,6 @@ int ipc_helper_send_zero(void) {
 
   ASSERT_EQ(send_zero_write, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -63,5 +63,6 @@ TEST_IMPL(loop_alive) {
   ASSERT(r == 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -62,6 +62,8 @@ static void loop_instant_close_work_cb(uv_work_t* req) {
 static void loop_instant_close_after_work_cb(uv_work_t* req, int status) {
 }
 
+/* It's impossible to properly cleanup after this test because loop can't be
+ * closed while work has been queued. */
 TEST_IMPL(loop_instant_close) {
   static uv_loop_t loop;
   static uv_work_t req;
@@ -70,6 +72,6 @@ TEST_IMPL(loop_instant_close) {
                             &req,
                             loop_instant_close_work_cb,
                             loop_instant_close_after_work_cb));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -332,6 +332,6 @@ TEST_IMPL(loop_handles) {
   ASSERT(idle_2_close_cb_called == idle_2_cb_started);
   ASSERT(idle_2_is_active == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -67,5 +67,6 @@ TEST_IMPL(loop_stop) {
   ASSERT(timer_called == 10);
   ASSERT(prepare_called == 10);
 
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -30,7 +30,7 @@ TEST_IMPL(loop_update_time) {
   while (uv_now(uv_default_loop()) - start < 1000)
     ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -64,6 +64,6 @@ TEST_IMPL(loop_backend_timeout) {
   ASSERT_EQ(r, 0);
   ASSERT_EQ(uv_backend_timeout(loop), 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-metrics.c
+++ b/test/test-metrics.c
@@ -71,7 +71,7 @@ TEST_IMPL(metrics_idle_time) {
   ASSERT_LE(idle_time, (timeout + 500) * UV_NS_TO_MS);
   ASSERT_GE(idle_time, (timeout - 500) * UV_NS_TO_MS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -147,7 +147,7 @@ TEST_IMPL(metrics_idle_time_zero) {
   ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
   ASSERT_UINT64_EQ(cntr, metrics.loop_count);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -236,6 +236,6 @@ TEST_IMPL(metrics_info_check) {
   uv_fs_unlink(NULL, &unlink_req, "test_file", NULL);
   uv_fs_req_cleanup(&unlink_req);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -104,6 +104,6 @@ TEST_IMPL(multiple_listen) {
   ASSERT(connect_cb_called == 1);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-not-readable-nor-writable-on-read-error.c
+++ b/test/test-not-readable-nor-writable-on-read-error.c
@@ -99,6 +99,6 @@ TEST_IMPL(not_readable_nor_writable_on_read_error) {
   ASSERT(write_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }

--- a/test/test-not-writable-after-shutdown.c
+++ b/test/test-not-writable-after-shutdown.c
@@ -61,9 +61,9 @@ TEST_IMPL(not_writable_after_shutdown) {
                      connect_cb);
   ASSERT(r == 0);
 
-  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -79,7 +79,7 @@ TEST_IMPL(osx_select) {
 
   ASSERT(read_count == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -133,7 +133,7 @@ TEST_IMPL(osx_select_many_fds) {
 
   ASSERT(read_count == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -378,7 +378,7 @@ static int run_ping_pong_test(void) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(completed_pingers, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -67,7 +67,7 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
 
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -88,7 +88,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -110,7 +110,7 @@ TEST_IMPL(pipe_bind_error_inval) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -134,7 +134,7 @@ TEST_IMPL(pipe_listen_without_bind) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -150,6 +150,6 @@ TEST_IMPL(pipe_bind_or_listen_error_after_close) {
 
   ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -101,7 +101,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
     ASSERT(WIFEXITED(status) && WEXITSTATUS(status) == 0);
   }
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -72,7 +72,7 @@ TEST_IMPL(pipe_connect_bad_name) {
   ASSERT_EQ(close_cb_called, 1);
   ASSERT_EQ(connect_cb_called, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -92,6 +92,6 @@ TEST_IMPL(pipe_connect_to_file) {
   ASSERT_EQ(close_cb_called, 1);
   ASSERT_EQ(connect_cb_called, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-pipe-connect-multiple.c
+++ b/test/test-pipe-connect-multiple.c
@@ -102,7 +102,7 @@ TEST_IMPL(pipe_connect_multiple) {
   ASSERT(connection_cb_called == NUM_CLIENTS);
   ASSERT(connect_cb_called == NUM_CLIENTS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -173,6 +173,6 @@ TEST_IMPL(pipe_connect_close_multiple) {
   ASSERT_EQ(connection_cb_called, NUM_CLIENTS);
   ASSERT_EQ(connect_cb_called, NUM_CLIENTS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -78,6 +78,6 @@ TEST_IMPL(pipe_connect_on_prepare) {
   ASSERT(close_cb_called == 2);
   ASSERT(connect_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -156,7 +156,7 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT(pipe_client_connect_cb_called == 1);
   ASSERT(pipe_close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -200,10 +200,10 @@ TEST_IMPL(pipe_getsockname_abstract) {
   close(sock);
 
   ASSERT(pipe_close_cb_called == 1);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #else
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }
@@ -265,6 +265,6 @@ TEST_IMPL(pipe_getsockname_blocking) {
   CloseHandle(writeh);
 #endif
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-pipe-pending-instances.c
+++ b/test/test-pipe-pending-instances.c
@@ -54,6 +54,6 @@ TEST_IMPL(pipe_pending_instances) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -158,14 +158,14 @@ TEST_IMPL(pipe_sendmsg) {
   ASSERT(ARRAY_SIZE(incoming) + 1 == close_called);
   close(fds[0]);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
 #else  /* !_WIN32 */
 
 TEST_IMPL(pipe_sendmsg) {
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -89,6 +89,6 @@ TEST_IMPL(pipe_server_close) {
   ASSERT(pipe_client_connect_cb_called == 1);
   ASSERT(pipe_close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -44,7 +44,7 @@ TEST_IMPL(pipe_set_chmod) {
    * successful. */
   r = uv_pipe_chmod(&pipe_handle, UV_READABLE);
   if (r == UV_EPERM) {
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");
   }
   ASSERT(r == 0);
@@ -87,6 +87,6 @@ TEST_IMPL(pipe_set_chmod) {
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
   ASSERT(r == UV_EBADF);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -122,6 +122,6 @@ TEST_IMPL(pipe_set_non_blocking) {
   fd[0] = -1;
   uv_barrier_destroy(&ctx.barrier);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-pipe-try-write.c
+++ b/test/test-pipe-try-write.c
@@ -136,7 +136,7 @@ static int pipe_try_write(void (*spammer)(uv_pipe_t*)) {
   uv_pipe_connect(&connect_req, &client.handle, TEST_PIPENAME, connect_cb);
   ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -108,7 +108,7 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -68,6 +68,6 @@ TEST_IMPL(poll_close) {
 
   ASSERT(close_cb_called == NUM_SOCKETS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -86,7 +86,7 @@ TEST_IMPL(poll_closesocket) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -94,6 +94,6 @@ TEST_IMPL(poll_multiple_handles) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -199,7 +199,7 @@ TEST_IMPL(poll_oob) {
    */
   ASSERT(srv_rd_check == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -589,7 +589,7 @@ static void start_poll_test(void) {
 #if !defined(__sun) && !defined(_AIX) && !defined(__MVS__)
   ASSERT(disconnects == NUM_CLIENTS * 2);
 #endif
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
 }
 
  
@@ -647,7 +647,7 @@ TEST_IMPL(poll_bad_fdtype) {
   ASSERT(0 == close(fd));
 #endif
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -668,7 +668,7 @@ TEST_IMPL(poll_nested_epoll) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(0 == close(fd));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif  /* __linux__ */
@@ -690,7 +690,7 @@ TEST_IMPL(poll_nested_kqueue) {
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(0 == close(fd));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif  /* UV_HAVE_KQUEUE */

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -120,7 +120,7 @@ TEST_IMPL(process_title_big_argv) {
   ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -198,7 +198,7 @@ TEST_IMPL(queue_foreach_delete) {
   ASSERT(helper_timer_cb_calls == 1);
 #endif
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 
   return 0;
 }

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -70,7 +70,7 @@ TEST_IMPL(random_async) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(2 == random_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -89,6 +89,6 @@ TEST_IMPL(random_sync) {
   memset(zero, 0, sizeof(zero));
   ASSERT(0 != memcmp(buf, zero, sizeof(zero)));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-readable-on-eof.c
+++ b/test/test-readable-on-eof.c
@@ -106,6 +106,6 @@ TEST_IMPL(readable_on_eof) {
   ASSERT_EQ(write_cb_called, 1);
   ASSERT_EQ(close_cb_called, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -101,7 +101,7 @@ static void connect_and_shutdown(uv_connect_t* req, int status) {
 
 TEST_IMPL(ref) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -113,7 +113,7 @@ TEST_IMPL(idle_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -124,7 +124,7 @@ TEST_IMPL(async_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -136,7 +136,7 @@ TEST_IMPL(prepare_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -148,7 +148,7 @@ TEST_IMPL(check_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -165,7 +165,7 @@ TEST_IMPL(unref_in_prepare_cb) {
   uv_prepare_start(&h, prepare_cb);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -176,7 +176,7 @@ TEST_IMPL(timer_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -188,7 +188,7 @@ TEST_IMPL(timer_ref2) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -203,7 +203,7 @@ TEST_IMPL(fs_event_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -215,7 +215,7 @@ TEST_IMPL(fs_poll_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -226,7 +226,7 @@ TEST_IMPL(tcp_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -238,7 +238,7 @@ TEST_IMPL(tcp_ref2) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -251,7 +251,7 @@ TEST_IMPL(tcp_ref2b) {
   uv_close((uv_handle_t*)&h, close_cb);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(close_cb_called == 1);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -270,7 +270,7 @@ TEST_IMPL(tcp_ref3) {
   ASSERT(connect_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -290,7 +290,7 @@ TEST_IMPL(tcp_ref4) {
   ASSERT(write_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -301,7 +301,7 @@ TEST_IMPL(udp_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -316,7 +316,7 @@ TEST_IMPL(udp_ref2) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -340,7 +340,7 @@ TEST_IMPL(udp_ref3) {
   ASSERT(req_cb_called == 1);
   do_close(&h);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -351,7 +351,7 @@ TEST_IMPL(pipe_ref) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -363,7 +363,7 @@ TEST_IMPL(pipe_ref2) {
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -377,7 +377,7 @@ TEST_IMPL(pipe_ref3) {
   ASSERT(connect_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -392,7 +392,7 @@ TEST_IMPL(pipe_ref4) {
   ASSERT(write_cb_called == 1);
   ASSERT(shutdown_cb_called == 1);
   do_close(&h);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -428,7 +428,7 @@ TEST_IMPL(process_ref) {
 
   do_close(&h);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -440,6 +440,6 @@ TEST_IMPL(has_ref) {
   ASSERT(uv_has_ref((uv_handle_t*)&h) == 1);
   uv_unref((uv_handle_t*)&h);
   ASSERT(uv_has_ref((uv_handle_t*)&h) == 0);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -41,5 +41,6 @@ TEST_IMPL(run_nowait) {
   ASSERT(r != 0);
   ASSERT(timer_called == 0);
 
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-run-once.c
+++ b/test/test-run-once.c
@@ -43,6 +43,6 @@ TEST_IMPL(run_once) {
   while (uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT(idle_counter == NUM_TICKS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -84,7 +84,7 @@ TEST_IMPL(shutdown_close_tcp) {
   ASSERT(shutdown_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -103,6 +103,6 @@ TEST_IMPL(shutdown_close_pipe) {
   ASSERT(shutdown_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -182,7 +182,7 @@ TEST_IMPL(shutdown_eof) {
   ASSERT(called_timer_close_cb == 1);
   ASSERT(called_timer_cb == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-shutdown-simultaneous.c
+++ b/test/test-shutdown-simultaneous.c
@@ -130,6 +130,6 @@ TEST_IMPL(shutdown_simultaneous) {
   ASSERT_EQ(got_eof, 1);
   ASSERT_EQ(got_q, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -75,11 +75,11 @@ TEST_IMPL(shutdown_twice) {
                      connect_cb);
   ASSERT(r == 0);
 
-  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
   ASSERT(shutdown_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -310,7 +310,7 @@ TEST_IMPL(signal_multiple_loops) {
    */
   ASSERT(loop_creation_counter >= NUM_LOOP_CREATING_THREADS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -88,11 +88,9 @@ TEST_IMPL(signal_pending_on_close) {
 
   ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT(0 == uv_loop_close(&loop));
-
   ASSERT(2 == close_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 
@@ -109,10 +107,9 @@ TEST_IMPL(signal_close_loop_alive) {
   ASSERT(1 == uv_loop_alive(&loop));
 
   ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(0 == uv_loop_close(&loop));
   ASSERT(1 == close_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -38,7 +38,7 @@ TEST_IMPL(kill_invalid_signum) {
 #endif
   ASSERT(uv_kill(pid, 4096) == UV_EINVAL);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -69,7 +69,7 @@ TEST_IMPL(win32_signum_number) {
   ASSERT(uv_signal_start(&signal, signum_test_cb, -1) == UV_EINVAL);
   ASSERT(uv_signal_start(&signal, signum_test_cb, NSIG) == UV_EINVAL);
   ASSERT(uv_signal_start(&signal, signum_test_cb, 1024) == UV_EINVAL);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 #else
@@ -180,7 +180,7 @@ TEST_IMPL(we_get_signal) {
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT(sc.ncalls == NSIGNALS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -206,7 +206,7 @@ TEST_IMPL(we_get_signals) {
   for (i = 0; i < ARRAY_SIZE(tc); i++)
     ASSERT(tc[i].ncalls == NSIGNALS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -235,7 +235,7 @@ TEST_IMPL(we_get_signal_one_shot) {
   ASSERT(tc.ncalls == NSIGNALS);
   ASSERT(sc.ncalls == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -318,7 +318,7 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT(sc[2].ncalls == 0);
   ASSERT(sc[3].ncalls == NSIGNALS);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -72,6 +72,6 @@ TEST_IMPL(socket_buffer_size) {
 
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -193,7 +193,7 @@ TEST_IMPL(spawn_fails) {
   uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -223,7 +223,7 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
   uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -253,7 +253,7 @@ TEST_IMPL(spawn_empty_env) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -272,7 +272,7 @@ TEST_IMPL(spawn_exit_code) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -305,7 +305,7 @@ TEST_IMPL(spawn_stdout) {
   printf("output is: %s", output);
   ASSERT(strcmp("hello world\n", output) == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -359,7 +359,7 @@ TEST_IMPL(spawn_stdout_to_file) {
   /* Cleanup. */
   unlink("stdout_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -415,7 +415,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   /* Cleanup. */
   unlink("stdout_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -477,7 +477,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   /* Cleanup. */
   unlink("stdout_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #else
   RETURN_SKIP("Unix only test");
@@ -569,7 +569,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   unlink("stdout_file");
   unlink("stderr_file");
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #else
   RETURN_SKIP("Unix only test");
@@ -615,7 +615,7 @@ TEST_IMPL(spawn_stdin) {
   ASSERT(close_cb_called == 3); /* Once for process twice for the pipe. */
   ASSERT(strcmp(buffer, output) == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -650,7 +650,7 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   printf("output from stdio[3] is: %s", output);
   ASSERT(strcmp("fourth stdio!\n", output) == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -728,7 +728,7 @@ TEST_IMPL(spawn_tcp_server) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -750,7 +750,7 @@ TEST_IMPL(spawn_ignored_stdio) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -775,7 +775,7 @@ TEST_IMPL(spawn_and_kill) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* Once for process and once for timer. */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -815,7 +815,7 @@ TEST_IMPL(spawn_preserve_env) {
   printf("output is: %s", output);
   ASSERT(strcmp("testval", output) == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -845,7 +845,7 @@ TEST_IMPL(spawn_detached) {
   r = uv_kill(process.pid, SIGTERM);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -903,7 +903,7 @@ TEST_IMPL(spawn_and_kill_with_std) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 5); /* process x 1, timer x 1, stdio x 3. */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -950,7 +950,7 @@ TEST_IMPL(spawn_and_ping) {
   ASSERT(exit_cb_called == 1);
   ASSERT(strcmp(output, "TEST") == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -997,7 +997,7 @@ TEST_IMPL(spawn_same_stdout_stderr) {
   ASSERT(exit_cb_called == 1);
   ASSERT(strcmp(output, "TEST") == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1029,7 +1029,7 @@ TEST_IMPL(spawn_closed_process_io) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2); /* process, child stdin */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1083,7 +1083,7 @@ TEST_IMPL(kill) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1135,7 +1135,7 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   printf("output is: %s", output);
   ASSERT(strcmp("hello world\n", output) == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1363,7 +1363,7 @@ TEST_IMPL(spawn_with_an_odd_path) {
   uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -1406,7 +1406,7 @@ TEST_IMPL(spawn_setuid_setgid) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -1459,7 +1459,7 @@ TEST_IMPL(spawn_setuid_fails) {
 
   ASSERT(close_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1504,7 +1504,7 @@ TEST_IMPL(spawn_setgid_fails) {
 
   ASSERT(close_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -1535,7 +1535,7 @@ TEST_IMPL(spawn_setuid_fails) {
 
   ASSERT(close_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1556,7 +1556,7 @@ TEST_IMPL(spawn_setgid_fails) {
 
   ASSERT(close_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -1570,7 +1570,7 @@ TEST_IMPL(spawn_auto_unref) {
   uv_close((uv_handle_t*) &process, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT(1 == uv_is_closing((uv_handle_t*) &process));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1633,7 +1633,7 @@ TEST_IMPL(spawn_fs_open) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 2);  /* One for `in`, one for process */
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1705,7 +1705,7 @@ TEST_IMPL(closed_fd_events) {
   ASSERT(0 == close(fd[1]));
 #endif
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1775,7 +1775,7 @@ TEST_IMPL(spawn_reads_child_path) {
   ASSERT(exit_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -1859,7 +1859,7 @@ TEST_IMPL(spawn_inherit_streams) {
   r = memcmp(ubuf, output, sizeof ubuf);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1883,7 +1883,7 @@ TEST_IMPL(spawn_quoted_path) {
   /* We test if libuv will not segfault. */
   uv_spawn(uv_default_loop(), &process, &options);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }
@@ -1922,7 +1922,7 @@ TEST_IMPL(spawn_exercise_sigchld_issue) {
   ASSERT_EQ(exit_cb_called, 1);
   ASSERT_EQ(close_cb_called, 101);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -2009,6 +2009,6 @@ TEST_IMPL(spawn_relative_path) {
   ASSERT_EQ(1, exit_cb_called);
   ASSERT_EQ(1, close_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -145,7 +145,7 @@ static void test_stdio_over_pipes(int overlapped) {
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
   ASSERT(r == 0);
 
-  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
   ASSERT(on_read_cb_called > 1);
@@ -155,7 +155,7 @@ static void test_stdio_over_pipes(int overlapped) {
   ASSERT(memcmp("hello world\nhello world\n", output, 24) == 0);
   ASSERT(output_used == 24);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 }
 
 TEST_IMPL(stdio_over_pipes) {
@@ -294,6 +294,6 @@ int stdio_over_pipes_helper(void) {
   ASSERT(on_pipe_read_called == 2);
   ASSERT(close_cb_called == 4);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -118,6 +118,6 @@ TEST_IMPL(tcp_alloc_cb_fail) {
   ASSERT(connection_cb_called == 1);
   ASSERT(close_cb_called == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -72,7 +72,7 @@ TEST_IMPL(tcp_bind_error_addrinuse_connect) {
   ASSERT(connect_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -105,7 +105,7 @@ TEST_IMPL(tcp_bind_error_addrinuse_listen) {
 
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -130,7 +130,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -153,7 +153,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -178,7 +178,7 @@ TEST_IMPL(tcp_bind_error_fault) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -206,7 +206,7 @@ TEST_IMPL(tcp_bind_error_inval) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -223,7 +223,7 @@ TEST_IMPL(tcp_bind_localhost_ok) {
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -240,7 +240,7 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, UV_TCP_IPV6ONLY);
   ASSERT(r == UV_EINVAL);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -254,7 +254,7 @@ TEST_IMPL(tcp_listen_without_bind) {
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -294,7 +294,7 @@ TEST_IMPL(tcp_bind_writable_flags) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -312,6 +312,6 @@ TEST_IMPL(tcp_bind_or_listen_error_after_close) {
   ASSERT_EQ(uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0), UV_EINVAL);
   ASSERT_EQ(uv_listen((uv_stream_t*) &tcp, 5, NULL), UV_EINVAL);
   ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -66,7 +66,7 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
 
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -92,7 +92,7 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -120,7 +120,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -151,7 +151,7 @@ TEST_IMPL(tcp_bind6_error_inval) {
 
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -171,6 +171,6 @@ TEST_IMPL(tcp_bind6_localhost_ok) {
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -187,7 +187,7 @@ TEST_IMPL(tcp_close_accept) {
   ASSERT(ARRAY_SIZE(tcp_outgoing) == write_cb_called);
   ASSERT(1 == read_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-tcp-close-after-read-timeout.c
+++ b/test/test-tcp-close-after-read-timeout.c
@@ -178,6 +178,6 @@ TEST_IMPL(tcp_close_after_read_timeout) {
   ASSERT_EQ(read_cb_called, 1);
   ASSERT_EQ(on_close_called, 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -223,7 +223,7 @@ TEST_IMPL(tcp_close_reset_client) {
   ASSERT(close_cb_called == 1);
   ASSERT(shutdown_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -250,7 +250,7 @@ TEST_IMPL(tcp_close_reset_client_after_shutdown) {
   ASSERT(close_cb_called == 0);
   ASSERT(shutdown_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -277,7 +277,7 @@ TEST_IMPL(tcp_close_reset_accepted) {
   ASSERT(close_cb_called == 1);
   ASSERT(shutdown_cb_called == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -304,7 +304,7 @@ TEST_IMPL(tcp_close_reset_accepted_after_shutdown) {
   ASSERT(close_cb_called == 0);
   ASSERT(shutdown_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -331,6 +331,6 @@ TEST_IMPL(tcp_close_reset_accepted_after_socket_shutdown) {
   ASSERT_EQ(close_cb_called, 1);
   ASSERT_EQ(shutdown_cb_called, 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -88,7 +88,7 @@ TEST_IMPL(tcp_close_while_connecting) {
   ASSERT(timer1_cb_called == 1);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
 
   if (netunreach_errors > 0)
     RETURN_SKIP("Network unreachable.");

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -131,6 +131,6 @@ TEST_IMPL(tcp_close) {
   ASSERT(write_cb_called == NUM_WRITE_REQS);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -92,7 +92,7 @@ TEST_IMPL(tcp_connect_error_after_write) {
   ASSERT(write_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -68,6 +68,6 @@ TEST_IMPL(tcp_connect_error_fault) {
   ASSERT(connect_cb_called == 0);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -86,7 +86,7 @@ TEST_IMPL(tcp_connect_timeout) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -153,7 +153,7 @@ TEST_IMPL(tcp_local_connect_timeout) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -191,6 +191,6 @@ TEST_IMPL(tcp6_local_connect_timeout) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(r, 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -66,6 +66,6 @@ TEST_IMPL(tcp_connect6_error_fault) {
   ASSERT(connect_cb_called == 0);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -128,7 +128,7 @@ TEST_IMPL(tcp_create_early) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -173,7 +173,7 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -190,7 +190,7 @@ TEST_IMPL(tcp_create_early_bad_domain) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -204,6 +204,6 @@ TEST_IMPL(tcp_create_early_accept) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -47,6 +47,6 @@ TEST_IMPL(tcp_flags) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -135,7 +135,7 @@ TEST_IMPL(tcp_oob) {
 
   ASSERT(ticks == kMaxTicks);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -277,7 +277,7 @@ TEST_IMPL(tcp_open) {
   ASSERT(write_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -304,7 +304,7 @@ TEST_IMPL(tcp_open_twice) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -327,7 +327,7 @@ TEST_IMPL(tcp_open_bound) {
 
   ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, NULL));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -361,7 +361,7 @@ TEST_IMPL(tcp_open_connected) {
   ASSERT(write_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -396,6 +396,6 @@ TEST_IMPL(tcp_write_ready) {
   ASSERT(write_cb_called > 0);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-read-stop-start.c
+++ b/test/test-tcp-read-stop-start.c
@@ -131,6 +131,6 @@ TEST_IMPL(tcp_read_stop_start) {
 
   ASSERT(read_cb_called >= 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -70,7 +70,7 @@ TEST_IMPL(tcp_read_stop) {
                              (const struct sockaddr*) &addr,
                              connect_cb));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
 
   return 0;
 }

--- a/test/test-tcp-rst.c
+++ b/test/test-tcp-rst.c
@@ -102,7 +102,7 @@ TEST_IMPL(tcp_rst) {
   ASSERT_EQ(called_connect_cb, 1);
   ASSERT_EQ(called_close_cb, 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #else
   RETURN_SKIP("Unix only test");

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -133,6 +133,6 @@ TEST_IMPL(tcp_shutdown_after_write) {
   ASSERT(conn_close_cb_called == 1);
   ASSERT(timer_close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -104,6 +104,6 @@ TEST_IMPL(tcp_try_write_error) {
   ASSERT(close_cb_called == 3);
   ASSERT(connection_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -130,6 +130,6 @@ TEST_IMPL(tcp_try_write) {
   ASSERT(bytes_read == bytes_written);
   ASSERT(bytes_written > 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -112,6 +112,6 @@ TEST_IMPL(tcp_unexpected_read) {
    */
   ASSERT(ticks <= 20);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -66,7 +66,7 @@ TEST_IMPL(tcp_write_after_connect) {
 
   uv_run(&loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
   return 0;
 }
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -110,6 +110,6 @@ TEST_IMPL(tcp_write_fail) {
   ASSERT(write_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-write-in-a-row.c
+++ b/test/test-tcp-write-in-a-row.c
@@ -136,7 +136,7 @@ TEST_IMPL(tcp_write_in_a_row) {
   ASSERT_EQ(1, connection_cb_called);
   ASSERT_EQ(2, write_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 #endif
 }

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -134,6 +134,6 @@ TEST_IMPL(tcp_write_queue_order) {
          write_cancelled_callbacks == REQ_COUNT);
   ASSERT(close_cb_called == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -136,6 +136,6 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   ASSERT(write_cb_called > 0);
   ASSERT(read_cb_called > 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -179,6 +179,6 @@ TEST_IMPL(tcp_writealot) {
 
   free(send_buffer);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -189,7 +189,7 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == timer_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -225,7 +225,7 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == timer_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -248,7 +248,7 @@ TEST_IMPL(threadpool_cancel_random) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == done_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -272,7 +272,7 @@ TEST_IMPL(threadpool_cancel_work) {
   ASSERT(1 == timer_cb_called);
   ASSERT(ARRAY_SIZE(reqs) == done2_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -326,7 +326,7 @@ TEST_IMPL(threadpool_cancel_fs) {
   ASSERT(1 == timer_cb_called);
 
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -344,6 +344,6 @@ TEST_IMPL(threadpool_cancel_single) {
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   ASSERT(1 == done_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -54,7 +54,7 @@ TEST_IMPL(threadpool_queue_work_simple) {
   ASSERT(work_cb_count == 1);
   ASSERT(after_work_cb_count == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -71,6 +71,6 @@ TEST_IMPL(threadpool_queue_work_einval) {
   ASSERT(work_cb_count == 0);
   ASSERT(after_work_cb_count == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -136,6 +136,6 @@ TEST_IMPL(timer_again) {
           (long int)(uv_now(uv_default_loop()) - start_time));
   fflush(stderr);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -75,6 +75,6 @@ TEST_IMPL(timer_from_check) {
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -154,7 +154,7 @@ TEST_IMPL(timer) {
 
   ASSERT(500 <= uv_now(uv_default_loop()) - start_time);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -174,7 +174,7 @@ TEST_IMPL(timer_start_twice) {
 
   ASSERT(twice_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -187,7 +187,7 @@ TEST_IMPL(timer_init) {
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&handle));
   ASSERT(0 == uv_is_active((uv_handle_t*) &handle));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -236,7 +236,7 @@ TEST_IMPL(timer_order) {
 
   ASSERT(order_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -260,7 +260,7 @@ TEST_IMPL(timer_huge_timeout) {
   ASSERT_UINT64_EQ(281474976710655, uv_timer_get_due_in(&huge_timer1));
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&huge_timer2));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -286,7 +286,7 @@ TEST_IMPL(timer_huge_repeat) {
   ASSERT(0 == uv_timer_start(&tiny_timer, huge_repeat_cb, 2, 2));
   ASSERT(0 == uv_timer_start(&huge_timer1, huge_repeat_cb, 1, (uint64_t) -1));
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -314,7 +314,7 @@ TEST_IMPL(timer_run_once) {
   uv_close((uv_handle_t*) &timer_handle, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -327,7 +327,7 @@ TEST_IMPL(timer_is_closing) {
 
   ASSERT(UV_EINVAL == uv_timer_start(&handle, never_cb, 100, 100));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -338,7 +338,7 @@ TEST_IMPL(timer_null_callback) {
   ASSERT(0 == uv_timer_init(uv_default_loop(), &handle));
   ASSERT(UV_EINVAL == uv_timer_start(&handle, NULL, 100, 100));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -365,6 +365,6 @@ TEST_IMPL(timer_early_check) {
   uv_close((uv_handle_t*) &timer_handle, NULL);
   ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -180,7 +180,7 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -246,7 +246,7 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -310,7 +310,7 @@ TEST_IMPL(tty_composing_character) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -420,7 +420,7 @@ TEST_IMPL(tty_cursor_up) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -471,7 +471,7 @@ TEST_IMPL(tty_cursor_down) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -532,7 +532,7 @@ TEST_IMPL(tty_cursor_forward) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -593,7 +593,7 @@ TEST_IMPL(tty_cursor_back) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -644,7 +644,7 @@ TEST_IMPL(tty_cursor_next_line) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -695,7 +695,7 @@ TEST_IMPL(tty_cursor_previous_line) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -741,7 +741,7 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -797,7 +797,7 @@ TEST_IMPL(tty_cursor_move_absolute) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -831,7 +831,7 @@ TEST_IMPL(tty_hide_show_cursor) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -905,7 +905,7 @@ TEST_IMPL(tty_erase) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -979,7 +979,7 @@ TEST_IMPL(tty_erase_line) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1037,7 +1037,7 @@ TEST_IMPL(tty_set_cursor_shape) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1237,7 +1237,7 @@ TEST_IMPL(tty_set_style) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 #endif
 }
@@ -1297,7 +1297,7 @@ TEST_IMPL(tty_save_restore_cursor_position) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1340,7 +1340,7 @@ TEST_IMPL(tty_full_reset) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -1620,7 +1620,7 @@ TEST_IMPL(tty_escape_sequence_processing) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 #endif
 }

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -94,12 +94,12 @@ TEST_IMPL(tty) {
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
-  r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
+  r = uv_tty_init(loop, &tty_in, ttyin_fd, 1);  /* Readable. */
   ASSERT(r == 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
-  r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
+  r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
   ASSERT(r == 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
@@ -112,7 +112,7 @@ TEST_IMPL(tty) {
   if (width == 0 && height == 0) {
    /* Some environments such as containers or Jenkins behave like this
     * sometimes */
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(loop);
     return TEST_SKIP;
   }
 
@@ -141,7 +141,7 @@ TEST_IMPL(tty) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -184,7 +184,7 @@ TEST_IMPL(tty_raw) {
   ASSERT(ttyin_fd >= 0);
   ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
 
-  r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
+  r = uv_tty_init(loop, &tty_in, ttyin_fd, 1);  /* Readable. */
   ASSERT(r == 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
@@ -211,7 +211,7 @@ TEST_IMPL(tty_raw) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -242,7 +242,7 @@ TEST_IMPL(tty_empty_write) {
 
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
-  r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
+  r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
   ASSERT(r == 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
@@ -257,7 +257,7 @@ TEST_IMPL(tty_empty_write) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -288,7 +288,7 @@ TEST_IMPL(tty_large_write) {
 
   ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
 
-  r = uv_tty_init(uv_default_loop(), &tty_out, ttyout_fd, 0);  /* Writable. */
+  r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
   ASSERT(r == 0);
 
   memset(dummy, '.', sizeof(dummy) - 1);
@@ -303,7 +303,7 @@ TEST_IMPL(tty_large_write) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -336,7 +336,7 @@ TEST_IMPL(tty_raw_cancel) {
   r = uv_read_stop((uv_stream_t*) &tty_in);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 #endif
@@ -410,9 +410,8 @@ TEST_IMPL(tty_file) {
 
 
   ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(0 == uv_loop_close(&loop));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
 #endif
   return 0;
 }
@@ -463,7 +462,7 @@ TEST_IMPL(tty_pty) {
 
   ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(&loop);
 #endif
   return 0;
 }

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -191,6 +191,6 @@ TEST_IMPL(udp_alloc_cb_fail) {
   ASSERT(sv_recv_cb_called == 1);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-bind.c
+++ b/test/test-udp-bind.c
@@ -55,7 +55,7 @@ TEST_IMPL(udp_bind) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -88,6 +88,6 @@ TEST_IMPL(udp_bind_reuseaddr) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -191,6 +191,6 @@ TEST_IMPL(udp_connect) {
   ASSERT(client.send_queue_size == 0);
   ASSERT(server.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-connect6.c
+++ b/test/test-udp-connect6.c
@@ -194,6 +194,6 @@ TEST_IMPL(udp_connect6) {
   ASSERT_EQ(client.send_queue_size, 0);
   ASSERT_EQ(server.send_queue_size, 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -68,7 +68,7 @@ TEST_IMPL(udp_create_early) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -113,7 +113,7 @@ TEST_IMPL(udp_create_early_bad_bind) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -130,6 +130,6 @@ TEST_IMPL(udp_create_early_bad_domain) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -86,6 +86,6 @@ TEST_IMPL(udp_dgram_too_big) {
   ASSERT(send_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -207,7 +207,7 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
 
   ASSERT(close_cb_called == 3);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
 }
 
 

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -144,6 +144,6 @@ TEST_IMPL(udp_mmsg) {
   else
     ASSERT_EQ(alloc_cb_called, recv_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -99,6 +99,6 @@ TEST_IMPL(udp_multicast_interface) {
   ASSERT(client.send_queue_size == 0);
   ASSERT(server.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -103,6 +103,6 @@ TEST_IMPL(udp_multicast_interface6) {
   ASSERT(sv_send_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -179,6 +179,6 @@ TEST_IMPL(udp_multicast_join) {
   ASSERT(sv_send_cb_called == 2);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -186,7 +186,7 @@ TEST_IMPL(udp_multicast_join6) {
 
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, UV_JOIN_GROUP);
   if (r == UV_ENODEV) {
-    MAKE_VALGRIND_HAPPY();
+    MAKE_VALGRIND_HAPPY(uv_default_loop());
     RETURN_SKIP("No ipv6 multicast route");
   }
 
@@ -213,6 +213,6 @@ TEST_IMPL(udp_multicast_join6) {
   ASSERT(sv_send_cb_called == 2);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -89,6 +89,6 @@ TEST_IMPL(udp_multicast_ttl) {
   ASSERT(sv_send_cb_called == 1);
   ASSERT(close_cb_called == 1);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -188,7 +188,7 @@ TEST_IMPL(udp_open) {
 
   ASSERT(client.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -215,7 +215,7 @@ TEST_IMPL(udp_open_twice) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -245,7 +245,7 @@ TEST_IMPL(udp_open_bound) {
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -295,7 +295,7 @@ TEST_IMPL(udp_open_connect) {
 
   ASSERT(client.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
@@ -344,7 +344,7 @@ TEST_IMPL(udp_send_unix) {
   close(fd);
   unlink(TEST_PIPENAME);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 #endif

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -87,7 +87,7 @@ static int udp_options_test(const struct sockaddr* addr) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(r == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 
@@ -155,6 +155,6 @@ TEST_IMPL(udp_no_autobind) {
 
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-udp-recv-in-a-row.c
+++ b/test/test-udp-recv-in-a-row.c
@@ -116,6 +116,6 @@ TEST_IMPL(udp_recv_in_a_row) {
 
   ASSERT(check_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -207,6 +207,6 @@ TEST_IMPL(udp_send_and_recv) {
   ASSERT(client.send_queue_size == 0);
   ASSERT(server.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -94,6 +94,6 @@ TEST_IMPL(udp_send_hang_loop) {
 
   ASSERT(loop_hang_called > 1000);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -143,6 +143,6 @@ TEST_IMPL(udp_send_immediate) {
   ASSERT(sv_recv_cb_called == 2);
   ASSERT(close_cb_called == 2);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -196,6 +196,6 @@ TEST_IMPL(udp_send_unreachable) {
   ASSERT_EQ(timer_cb_called, 1);
   ASSERT_EQ(close_cb_called, (long)(can_recverr ? 3 : 2));
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-sendmmsg-error.c
+++ b/test/test-udp-sendmmsg-error.c
@@ -70,6 +70,6 @@ TEST_IMPL(udp_sendmmsg_error) {
 
   ASSERT_EQ(0, client.send_queue_size);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -116,6 +116,6 @@ TEST_IMPL(udp_try_send) {
   ASSERT(client.send_queue_size == 0);
   ASSERT(server.send_queue_size == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -72,6 +72,6 @@ TEST_IMPL(walk_handles) {
   uv_walk(loop, walk_cb, magic_cookie);
   ASSERT(seen_timer_handle == 0);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -107,6 +107,6 @@ TEST_IMPL(watcher_cross_stop) {
   ASSERT(ARRAY_SIZE(sockets) == send_cb_called);
   ASSERT(ARRAY_SIZE(sockets) == close_cb_called);
 
-  MAKE_VALGRIND_HAPPY();
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }


### PR DESCRIPTION
Pass the loop to `MAKE_VALGRIND_HAPPY()` so it's explicit on which loop needs to be cleaned up. Since it asserts on `uv_loop_close()`, need to remove a couple of those that were being done before the call.

Cleanup where loop was assigned, so the entire test either uses `loop` or `uv_default_loop()`. Not both.

Also take care of any reqs that may have been left uncleaned.