### PR TITLE
doc: note misleading error code in `uv_os_get_passwd`

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -541,6 +541,10 @@ API
     memory allocated to `pwd` needs to be freed with
     :c:func:`uv_os_free_passwd`.
 
+    .. note::
+        If the effective uid does not have an entry in the password file this
+        function will return ENOENT even if the file exists.
+
     .. versionadded:: 1.9.0
 
 .. c:function:: void uv_os_free_passwd(uv_passwd_t* pwd)


### PR DESCRIPTION
If an effective uid does not have an entry in the passwd file, the `uv_os_get_passwd` function will return `ENOENT` which has misled our debugging efforts to look for missing files even if they were present. I've added a short note to the documentation to help others encountering similar issues in the future.