### PR TITLE
linux: replace unsafe macro with inline function

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -393,7 +393,6 @@ UV_UNUSED(static int uv__stat(const char* path, struct stat* s)) {
 }
 
 #if defined(__linux__)
-int uv__inotify_fork(uv_loop_t* loop, void* old_watchers);
 ssize_t
 uv__fs_copy_file_range(int fd_in,
                        off_t* off_in,


### PR DESCRIPTION
Replace the throw-type-safety-to-the-wind CAST() macro with an inline function that is hopefully harder to misuse. It should make the inotify code slightly more legible if nothing else.

<hr>

I flattened some code. Should be easier to read with ?w=1 (no whitespace changes)