### PR TITLE
New API uv_set_socket_create_cb to support Android VPN app

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -430,6 +430,9 @@ struct uv_shutdown_s {
 };
 
 
+typedef void (*uv_socket_create_cb)(uv_handle_t* handle, void* p);
+UV_EXTERN void uv_set_socket_create_cb(uv_handle_t* handle, uv_socket_create_cb cb, void* p);
+
 #define UV_HANDLE_FIELDS                                                      \
   /* public */                                                                \
   void* data;                                                                 \
@@ -441,6 +444,10 @@ struct uv_shutdown_s {
   void* handle_queue[2];                                                      \
   union {                                                                     \
     int fd;                                                                   \
+    struct {                                                                  \
+      uv_socket_create_cb cb;                                                 \
+      void* p;                                                                \
+    } socket_create;                                                          \
     void* reserved[4];                                                        \
   } u;                                                                        \
   UV_HANDLE_PRIVATE_FIELDS                                                    \

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -505,6 +505,10 @@ int uv__udp_bind(uv_udp_t* handle,
       return err;
     fd = err;
     handle->io_watcher.fd = fd;
+
+    if (handle->u.socket_create.cb) {
+      handle->u.socket_create.cb((uv_handle_t*)handle, handle->u.socket_create.p);
+    }
   }
 
   if (flags & UV_UDP_LINUX_RECVERR) {
@@ -1008,6 +1012,9 @@ int uv__udp_init_ex(uv_loop_t* loop,
   uv__io_init(&handle->io_watcher, uv__udp_io, fd);
   QUEUE_INIT(&handle->write_queue);
   QUEUE_INIT(&handle->write_completed_queue);
+
+  handle->u.socket_create.cb = NULL;
+  handle->u.socket_create.p = NULL;
 
   return 0;
 }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -342,6 +342,23 @@ int uv_tcp_bind(uv_tcp_t* handle,
 }
 
 
+void uv_set_socket_create_cb(uv_handle_t* handle,
+                             uv_socket_create_cb cb,
+                             void* p) {
+  if (handle) {
+    uv_os_fd_t fd = (uv_os_fd_t)-1;
+    if (uv_fileno((uv_handle_t*)handle, &fd) == 0) {
+      if (cb) {
+        cb(handle, p);
+      }
+    } else {
+      handle->u.socket_create.cb = cb;
+      handle->u.socket_create.p = p;
+    }
+  }
+}
+
+
 int uv_udp_init_ex(uv_loop_t* loop, uv_udp_t* handle, unsigned flags) {
   unsigned extra_flags;
   int domain;

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -139,6 +139,10 @@ static int uv__tcp_set_socket(uv_loop_t* loop,
     assert(!(handle->flags & UV_HANDLE_IPV6));
   }
 
+  if (handle->u.socket_create.cb) {
+    handle->u.socket_create.cb((uv_handle_t*)handle, handle->u.socket_create.p);
+  }
+
   return 0;
 }
 
@@ -163,6 +167,9 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* handle, unsigned int flags) {
   handle->tcp.conn.func_connectex = NULL;
   handle->tcp.serv.processed_accepts = 0;
   handle->delayed_error = 0;
+
+  handle->u.socket_create.cb = NULL;
+  handle->u.socket_create.p = NULL;
 
   /* If anything fails beyond this point we need to remove the handle from
    * the handle queue, since it was added by uv__handle_init in uv__stream_init.

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -116,6 +116,10 @@ static int uv__udp_set_socket(uv_loop_t* loop, uv_udp_t* handle, SOCKET socket,
     assert(!(handle->flags & UV_HANDLE_IPV6));
   }
 
+  if (handle->u.socket_create.cb) {
+    handle->u.socket_create.cb((uv_handle_t*)handle, handle->u.socket_create.p);
+  }
+
   return 0;
 }
 
@@ -134,6 +138,9 @@ int uv__udp_init_ex(uv_loop_t* loop,
   handle->send_queue_count = 0;
   UV_REQ_INIT(&handle->recv_req, UV_UDP_RECV);
   handle->recv_req.data = handle;
+
+  handle->u.socket_create.cb = NULL;
+  handle->u.socket_create.p = NULL;
 
   /* If anything fails beyond this point we need to remove the handle from
    * the handle queue, since it was added by uv__handle_init.


### PR DESCRIPTION
Hi @bnoordhuis and @vtjnash, 
After a year, I re-make a PR for my patch #3616 , because this is the only solution on making VPN app on Android with libuv.

I searched for methods in other languages on the internet to do this, without exception, they all have to do the same work. 
Unless we give up supporting the development of VPN applications using libuv library on Android platform. 

Of course, if you still refuse to merge it, then let this PR stay here so that other developers who have the same needs can find the solution that troubles them.

This patch will not break ABI and will not break backward compatibility. see [this](https://github.com/libuv/libuv/pull/3616#issuecomment-1132433891)

Some reference links.
-  [VpnService.protect(int socket)](https://developer.android.com/reference/android/net/VpnService#protect(int)) 
- An example [toyvpn](https://android.googlesource.com/platform/development/+/refs/tags/android-platform-12.1.0_r3/samples/ToyVpn/src/com/example/android/toyvpn/ToyVpnConnection.java#169)
