### PR TITLE
unix,sunos: SO_REUSEPORT not valid on all sockets

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -495,7 +495,8 @@ static int uv__set_reuse(int fd) {
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
        return UV__ERR(errno);
   }
-#elif defined(SO_REUSEPORT) && !defined(__linux__) && !defined(__GNU__)
+#elif defined(SO_REUSEPORT) && !defined(__linux__) && !defined(__GNU__) && \
+	!defined(__sun__)
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
     return UV__ERR(errno);
 #else


### PR DESCRIPTION
Issue observed on Solaris with ISC BIND 9.18 which reported
"unable to open route socket: unexpected error". illumos did
not hit it because it does not have SO_REUSEPORT (open RFE
https://www.illumos.org/issues/12455)