### PR TITLE
Fix atomics to use C11 where possible

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -233,10 +233,10 @@ int uv__getiovmax(void) {
 #if defined(IOV_MAX)
   return IOV_MAX;
 #elif defined(_SC_IOV_MAX)
-  static int iovmax_cached = -1;
+  static _Atomic int iovmax_cached = -1;
   int iovmax;
 
-  iovmax = uv__load_relaxed(&iovmax_cached);
+  iovmax = atomic_load_explicit(&iovmax_cached, memory_order_relaxed);
   if (iovmax != -1)
     return iovmax;
 
@@ -248,7 +248,7 @@ int uv__getiovmax(void) {
   if (iovmax == -1)
     iovmax = 1;
 
-  uv__store_relaxed(&iovmax_cached, iovmax);
+  atomic_store_explicit(&iovmax_cached, iovmax, memory_order_relaxed);
 
   return iovmax;
 #else

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -579,7 +579,7 @@ update_timeout:
 }
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
-  static clock_t fast_clock_id = -1;
+  static _Atomic clock_t fast_clock_id = -1;
   struct timespec t;
   clock_t clock_id;
 
@@ -595,7 +595,7 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
   if (type != UV_CLOCK_FAST)
     goto done;
 
-  clock_id = uv__load_relaxed(&fast_clock_id);
+  clock_id = atomic_load_explicit(&fast_clock_id, memory_order_relaxed);
   if (clock_id != -1)
     goto done;
 
@@ -604,7 +604,7 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
     if (t.tv_nsec <= 1 * 1000 * 1000)
       clock_id = CLOCK_MONOTONIC_COARSE;
 
-  uv__store_relaxed(&fast_clock_id, clock_id);
+  atomic_store_explicit(&fast_clock_id, clock_id, memory_order_relaxed);
 
 done:
 

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -944,7 +944,7 @@ __attribute__((destructor))
 void uv_library_shutdown(void) {
   static int was_shutdown;
 
-  if (uv__load_relaxed(&was_shutdown))
+  if (uv__exchange_int_relaxed(&was_shutdown, 1))
     return;
 
   uv__process_title_cleanup();
@@ -955,7 +955,6 @@ void uv_library_shutdown(void) {
 #else
   uv__threadpool_cleanup();
 #endif
-  uv__store_relaxed(&was_shutdown, 1);
 }
 
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -37,6 +37,10 @@
 #include "queue.h"
 #include "strscpy.h"
 
+#ifndef _MSC_VER
+# include <stdatomic.h>
+#endif
+
 #if EDOM > 0
 # define UV__ERR(x) (-(x))
 #else
@@ -61,12 +65,12 @@ extern int snprintf(char*, size_t, const char*, ...);
   void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 7)
-#define uv__load_relaxed(p) __atomic_load_n(p, __ATOMIC_RELAXED)
-#define uv__store_relaxed(p, v) __atomic_store_n(p, v, __ATOMIC_RELAXED)
+#ifdef _MSC_VER
+#define uv__exchange_int_relaxed(p, v)                                        \
+  InterlockedExchangeNoFence((LONG volatile*)(p), v)
 #else
-#define uv__load_relaxed(p) (*p)
-#define uv__store_relaxed(p, v) do *p = v; while (0)
+#define uv__exchange_int_relaxed(p, v)                                        \
+  atomic_exchange_explicit((_Atomic int*)(p), v, memory_order_relaxed)
 #endif
 
 #define UV__UDP_DGRAM_MAXSIZE (64 * 1024)


### PR DESCRIPTION
Unfortunately MSVC only started supporting C11 atomics in VS2022 version
17.5 Preview 2 as experimental. So resort to using the Interlocked API
if possible. There is no Interlocked API for storing a value. The best
method I could find is to cast it as a `volatile` and store it directly.

Ref: https://devblogs.microsoft.com/cppblog/c11-atomics-in-visual-studio-2022-version-17-5-preview-2/
Fixes: https://github.com/libuv/libuv/issues/3948