### PR TITLE
test: don't use static buffer for formatting

### DIFF
--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -62,6 +62,7 @@ static void pummel(void* arg) {
 
 
 static int test_async_pummel(int nthreads) {
+  char fmtbuf[2][32];
   uv_thread_t* tids;
   uv_async_t handle;
   uint64_t time;
@@ -88,9 +89,9 @@ static int test_async_pummel(int nthreads) {
 
   printf("async_pummel_%d: %s callbacks in %.2f seconds (%s/sec)\n",
          nthreads,
-         fmt(callbacks),
+         fmt(&fmtbuf[0], callbacks),
          time / 1e9,
-         fmt(callbacks / (time / 1e9)));
+         fmt(&fmtbuf[1], callbacks / (time / 1e9)));
 
   free(tids);
 

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -73,6 +73,7 @@ static void worker(void* arg) {
 
 
 static int test_async(int nthreads) {
+  char fmtbuf[32];
   struct ctx* threads;
   struct ctx* ctx;
   uint64_t time;
@@ -112,7 +113,7 @@ static int test_async(int nthreads) {
   printf("async%d: %.2f sec (%s/sec)\n",
          nthreads,
          time / 1e9,
-         fmt(NUM_PINGS / (time / 1e9)));
+         fmt(&fmtbuf, NUM_PINGS / (time / 1e9)));
 
   free(threads);
 

--- a/test/benchmark-fs-stat.c
+++ b/test/benchmark-fs-stat.c
@@ -60,6 +60,7 @@ static void warmup(const char* path) {
 
 
 static void sync_bench(const char* path) {
+  char fmtbuf[2][32];
   uint64_t before;
   uint64_t after;
   uv_fs_t req;
@@ -74,9 +75,9 @@ static void sync_bench(const char* path) {
   after = uv_hrtime();
 
   printf("%s stats (sync): %.2fs (%s/s)\n",
-         fmt(1.0 * NUM_SYNC_REQS),
+         fmt(&fmtbuf[0], 1.0 * NUM_SYNC_REQS),
          (after - before) / 1e9,
-         fmt((1.0 * NUM_SYNC_REQS) / ((after - before) / 1e9)));
+         fmt(&fmtbuf[1], (1.0 * NUM_SYNC_REQS) / ((after - before) / 1e9)));
   fflush(stdout);
 }
 
@@ -93,6 +94,7 @@ static void stat_cb(uv_fs_t* fs_req) {
 static void async_bench(const char* path) {
   struct async_req reqs[MAX_CONCURRENT_REQS];
   struct async_req* req;
+  char fmtbuf[2][32];
   uint64_t before;
   uint64_t after;
   int count;
@@ -112,10 +114,10 @@ static void async_bench(const char* path) {
     after = uv_hrtime();
 
     printf("%s stats (%d concurrent): %.2fs (%s/s)\n",
-           fmt(1.0 * NUM_ASYNC_REQS),
+           fmt(&fmtbuf[0], 1.0 * NUM_ASYNC_REQS),
            i,
            (after - before) / 1e9,
-           fmt((1.0 * NUM_ASYNC_REQS) / ((after - before) / 1e9)));
+           fmt(&fmtbuf[1], (1.0 * NUM_ASYNC_REQS) / ((after - before) / 1e9)));
     fflush(stdout);
   }
 }

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -76,6 +76,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 BENCHMARK_IMPL(million_async) {
+  char fmtbuf[3][32];
   uv_timer_t timer_handle;
   uv_async_t* handle;
   uv_loop_t* loop;
@@ -101,10 +102,10 @@ BENCHMARK_IMPL(million_async) {
   ASSERT(0 == uv_thread_create(&thread_id, thread_cb, NULL));
   ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
   printf("%s async events in %.1f seconds (%s/s, %s unique handles seen)\n",
-          fmt(container->async_events),
+          fmt(&fmtbuf[0], container->async_events),
           timeout / 1000.,
-          fmt(container->async_events / (timeout / 1000.)),
-          fmt(container->handles_seen));
+          fmt(&fmtbuf[1], container->async_events / (timeout / 1000.)),
+          fmt(&fmtbuf[2], container->handles_seen));
   free(container);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/benchmark-queue-work.c
+++ b/test/benchmark-queue-work.c
@@ -46,6 +46,7 @@ static void after_work_cb(uv_work_t* req, int status) {
 static void timer_cb(uv_timer_t* handle) { done = 1; }
 
 BENCHMARK_IMPL(queue_work) {
+  char fmtbuf[2][32];
   uv_timer_t timer_handle;
   uv_work_t work;
   uv_loop_t* loop;
@@ -60,8 +61,10 @@ BENCHMARK_IMPL(queue_work) {
   ASSERT_EQ(0, uv_queue_work(loop, &work, work_cb, after_work_cb));
   ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  printf("%s async jobs in %.1f seconds (%s/s)\n", fmt(events), timeout / 1000.,
-         fmt(events / (timeout / 1000.)));
+  printf("%s async jobs in %.1f seconds (%s/s)\n",
+         fmt(&fmtbuf[0], events),
+         timeout / 1000.,
+         fmt(&fmtbuf[1], events / (timeout / 1000.)));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/runner.c
+++ b/test/runner.c
@@ -37,28 +37,14 @@ static int compare_task(const void* va, const void* vb) {
 }
 
 
-const char* fmt(double d) {
-  static char buf[1024];
-  static char* p;
+char* fmt(char (*buf)[32], double d) {
   uint64_t v;
+  char* p;
 
-  if (p == NULL)
-    p = buf;
-
-  p += 31;
-
-  if (p >= buf + sizeof(buf))
-    return "<buffer too small>";
-
+  p = &(*buf)[32];
   v = (uint64_t) d;
 
-#if 0 /* works but we don't care about fractional precision */
-  if (d - v >= 0.01) {
-    *--p = '0' + (uint64_t) (d * 100) % 10;
-    *--p = '0' + (uint64_t) (d * 10) % 10;
-    *--p = '.';
-  }
-#endif
+  *--p = '\0';
 
   if (v == 0)
     *--p = '0';

--- a/test/task.h
+++ b/test/task.h
@@ -266,8 +266,8 @@ typedef enum {
   int run_helper_##name(void);                                                \
   int run_helper_##name(void)
 
-/* Format big numbers nicely. WARNING: leaks memory. */
-const char* fmt(double d);
+/* Format big numbers nicely. */
+char* fmt(char (*buf)[32], double d);
 
 /* Reserved test exit codes. */
 enum test_status {


### PR DESCRIPTION
Don't use a static buffer to hold human-readable "big" numbers.

The buffer isn't big enough for benchmarks like fs_stat that print a large number of them. Have the caller pass in a buffer instead.