### PR TITLE
linux: fix academic valgrind warning

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -348,7 +348,13 @@ int uv__io_uring_enter(int fd,
    * in newer kernels unless IORING_ENTER_EXT_ARG is set,
    * in which case it takes a struct io_uring_getevents_arg.
    */
-  return syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags, 0, 0);
+  return syscall(__NR_io_uring_enter,
+                 fd,
+                 to_submit,
+                 min_complete,
+                 flags,
+                 NULL,
+                 0L);
 }
 
 


### PR DESCRIPTION
Fix a valgrind warning that only manifested with clang (not gcc!) by explicitly passing 0L instead of plain 0 as the |sigsz| argument to io_uring_enter(). That is, pass a long instead of an int.

On x86_64, |sigsz| is passed on the stack (the other arguments are passed in registers) but where gcc emits a `push $0` that zeroes the entire stack slot, clang emits a `movl $0,(%rsp)` that leaves the upper 32 bits untouched.

It's academic though since we don't pass IORING_ENTER_EXT_ARG and the kernel therefore completely ignores the argument.

Refs: https://github.com/libuv/libuv/pull/3952