### PR TITLE
test: disable signal test under ASan and MSan

### DIFF
--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -208,8 +208,12 @@ TEST_IMPL(signal_multiple_loops) {
 #endif
 /* TODO(gengjiawen): Fix test on QEMU. */
 #if defined(__QEMU__)
-  // See https://github.com/libuv/libuv/issues/2859
+  /* See https://github.com/libuv/libuv/issues/2859 */
   RETURN_SKIP("QEMU's signal emulation code is notoriously tricky");
+#endif
+#if defined(__ASAN__) || defined(__MSAN__)
+  /* See https://github.com/libuv/libuv/issues/3956 */
+  RETURN_SKIP("Test is too slow to run under ASan or MSan");
 #endif
 #if defined(__TSAN__)
   /* ThreadSanitizer complains - likely legitimately - about data races


### PR DESCRIPTION
The signal_multiple_loops test is flaky when run under AddressSanitizer and MemorySanitizer. Sometimes thread creation fails, other times it simply times out.

Fixes: https://github.com/libuv/libuv/issues/3956