### PR TITLE
Fix race condition in uv__init_console

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2423,7 +2423,6 @@ static void uv__tty_console_signal_resize(void) {
   height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
 
   uv_mutex_lock(&uv__tty_console_resize_mutex);
-  assert(uv__tty_console_width != -1 && uv__tty_console_height != -1);
   if (width != uv__tty_console_width || height != uv__tty_console_height) {
     uv__tty_console_width = width;
     uv__tty_console_height = height;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -170,14 +170,14 @@ void uv__console_init(void) {
                                        0);
   if (uv__tty_console_handle != INVALID_HANDLE_VALUE) {
     CONSOLE_SCREEN_BUFFER_INFO sb_info;
-    QueueUserWorkItem(uv__tty_console_resize_message_loop_thread,
-                      NULL,
-                      WT_EXECUTELONGFUNCTION);
     uv_mutex_init(&uv__tty_console_resize_mutex);
     if (GetConsoleScreenBufferInfo(uv__tty_console_handle, &sb_info)) {
       uv__tty_console_width = sb_info.dwSize.X;
       uv__tty_console_height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
     }
+    QueueUserWorkItem(uv__tty_console_resize_message_loop_thread,
+                      NULL,
+                      WT_EXECUTELONGFUNCTION);
   }
 }
 


### PR DESCRIPTION
This fixes #3970. It moves the initialization of two things to the point before where a thread task is spawned.

The existing code has a race condition. Calling `QueueUserWorkItem` queues a work item on a thread pool.  It's possible for that work item to begin executing even before the `QueueUserWorkItem` function returns.

On heavily-loaded systems, especially VMs where scheduling can be unpredictable due to hypervisor interrupts, it is possible for the worker function that is queued by `QueueUserWorkItem` to query the console size and attempt to acquire `uv__tty_console_resize_mutex` before it is initialized.  That's undefined behavior, and in practice, it can cause a crash.  Separately, the worker code also asserts that the `uv_tty_console_width` (and height) variables have been initialized, but they are not guaranteed to be.

The fix is simple.  Only queue the worker task after initializing the mutex and querying the initial values of the console buffer size.

I represent a team at Microsoft that is using Node.js heavily.  We found that this bug really does trigger on heavily-loaded build machines.  The repro takes hours and requires a lot of machine setup, so it's not an easy repro.  I was able to reproduce it much more easily by adding `Sleep(1000);` immediately after the call to `QueueUserWorkItem`, and repeatedly spawning Node with a test binary that printed messages to the console.  With this change, the crash no longer reproduces.
