### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ was primarily developed for use by [Node.js][], but it's also
 used by [Luvit](http://luvit.io/), [Julia](http://julialang.org/),
 [uvloop](https://github.com/MagicStack/uvloop), and [others](https://github.com/libuv/libuv/blob/v1.x/LINKS.md).
 
+libuv's name and logo stand for "Unicorn Velociraptor", where:
+
+* U or Unicorn is a reference to universal and multi-platform.
+
+* V or Velociraptor is a reference to velocity and high-performance.
+
 ## Feature highlights
 
  * Full-featured event loop backed by epoll, kqueue, IOCP, event ports.


### PR DESCRIPTION
In my company's recent project, we could not use `libuv` or `uv` as folder name (in our `3rd-party` directory). Because UV stands for something already in our project (namely, 3D models use UV for textures).

Hence, we would like to use `lib-unicorn-velociraptor` or `unicorn-velociraptor` as folder name, but because there is no such name in your `README.md`, that may cause confusion later.

Whenever a letter **or logo** means something, then that something spelled out is both more human-readable and more search-engine-friendly.

It would be better if `libuv`'s devs would explain themselves,
but here is how I would explain it:
```
libuv's name and logo stand for "Unicorn Velociraptor", where:

* U or Unicorn is a reference to universal and multi-platform.

* V or Velociraptor is a reference to velocity and high-performance.
```

**Note** that for now in our docs, we simply added a [link to discussion](https://github.com/libuv/libuv/discussions/3283):

> No, the logo is not a good hint, because T-rex ≠ Velociraptor:
> ![](https://user-images.githubusercontent.com/31405473/234839323-1a6a4552-e2aa-456b-99f1-48a957e81b6f.png)

---

Any thoughts?
Where would you put such explanation if NOT in `README.md` file?
Any reason why this should NOT be merged?
