### PR TITLE
macos: update minimum supported version

### DIFF
--- a/SUPPORTED_PLATFORMS.md
+++ b/SUPPORTED_PLATFORMS.md
@@ -3,7 +3,7 @@
 |  System | Support type | Supported versions | Notes |
 |---|---|---|---|
 | GNU/Linux | Tier 1 | Linux >= 3.10 with glibc >= 2.17 | |
-| macOS | Tier 1 | macOS >= 10.15 | Current and previous macOS release |
+| macOS | Tier 1 | macOS >= 11 | Currently supported macOS releases |
 | Windows | Tier 1 | >= Windows 8 | VS 2015 and later are supported |
 | FreeBSD | Tier 2 | >= 12 | |
 | AIX | Tier 2 | >= 6 | Maintainers: @libuv/aix |


### PR DESCRIPTION
Only support the versions still maintained by Apple.

`fs_copyfile` already fails in `10.15`.