### PR TITLE
build: set libtool min version to 2.4.6

### DIFF
--- a/m4/libuv-check-versions.m4
+++ b/m4/libuv-check-versions.m4
@@ -2,6 +2,6 @@
 AC_PREREQ(2.71)
 AC_INIT([libuv-release-check], [0.0])
 AM_INIT_AUTOMAKE([1.16.5])
-LT_PREREQ(2.4.7)
+LT_PREREQ(2.4.6)
 AC_OUTPUT
 


### PR DESCRIPTION
As it's the one used in Ubuntu 22.04 LTS.

Got hit by this while preparing `v1.45.0`.