### PR TITLE
build: add autoconf option for disable-maintainer-mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ m4_include([m4/libuv-extra-automake-flags.m4])
 m4_include([m4/as_case.m4])
 m4_include([m4/libuv-check-flags.m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects] UV_EXTRA_AUTOMAKE_FLAGS)
+AM_MAINTAINER_MODE([enable]) # pass --disable-maintainer-mode if autotools may be unavailable
 AC_CANONICAL_HOST
 AC_ENABLE_SHARED
 AC_ENABLE_STATIC


### PR DESCRIPTION
This was requested, to make it easier to use our `make dist` packages. There is significant debate online regarding whether this flag is "not cool"[^1] to include, including by the flag's original author and the documentation for the flag itself[^2]. But this setting means that nothing changes by default, except that libuv gains support for the `--disable-maintainer-mode` command line flag. So it seems quite reasonable to include here, despite some blogs arguing that this makes libuv "less cool".

[^1]: https://blogs.gnome.org/desrt/2011/09/08/am_maintainer_mode-is-not-cool/
[^2]: https://www.gnu.org/software/automake/manual/automake.html#maintainer_002dmode