### PR TITLE
linux: work around EOWNERDEAD io_uring kernel bug

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -705,7 +705,8 @@ static void uv__iou_submit(struct uv__iou* iou) {
 
   if (flags & UV__IORING_SQ_NEED_WAKEUP)
     if (uv__io_uring_enter(iou->ringfd, 0, 0, UV__IORING_ENTER_SQ_WAKEUP))
-      perror("libuv: io_uring_enter(wakeup)");  /* Can't happen. */
+      if (errno != EOWNERDEAD)  /* Kernel bug. Harmless, ignore. */
+        perror("libuv: io_uring_enter(wakeup)");  /* Can't happen. */
 }
 
 


### PR DESCRIPTION
io_uring sometimes erroneously returns EOWNERDEAD when the intention was to return 0. It's harmless and fixed in linux 5.14 so just ignore the error.

Fixes: https://github.com/libuv/libuv/issues/4001
Refs: https://github.com/torvalds/linux/commit/21f965221e