### PR TITLE
linux: fix WRITEV with lots of bufs using io_uring

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -782,6 +782,11 @@ int uv__iou_fs_read_or_write(uv_loop_t* loop,
   struct uv__io_uring_sqe* sqe;
   struct uv__iou* iou;
 
+  /* For the moment, if iovcnt is greater than IOV_MAX, fallback to the
+   * threadpool. In the future we might take advantage of IOSQE_IO_LINK. */
+  if (req->nbufs > IOV_MAX)
+    return 0;
+
   iou = &uv__get_internal_fields(loop)->iou;
 
   sqe = uv__iou_get_sqe(iou, loop, req);


### PR DESCRIPTION
In the case of trying to write more than `IOV_MAX` buffers, the `IORING_OP_WRITEV` operation will return `EINVAL`. As a temporal fix, fallback to the old ways. In the future we might implement this by linking multiple `IORING_OP_WRITEV` requests using `IOSQE_IO_LINK`.