### PR TITLE
test: remove erroneous RETURN_SKIP

### DIFF
--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -78,10 +78,6 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
 static void getaddrinfo_cb(uv_getaddrinfo_t* handle,
                            int status,
                            struct addrinfo* res) {
-/* TODO(gengjiawen): Fix test on QEMU. */
-#if defined(__QEMU__)
-  RETURN_SKIP("Test does not currently work in QEMU");
-#endif
   struct getaddrinfo_req* req;
 
   ASSERT(status == 0);


### PR DESCRIPTION
The threadpool_multiple_event_loops test already calls RETURN_SKIP when needed. Remove it from the callback function where it isn't needed work (nor works) and generates a build warning when compiling for qemu.

Fixes: https://github.com/libuv/libuv/issues/4014