### PR TITLE
Fix compile warnings from GCC 12

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -897,6 +897,10 @@ error:
 }
 
 
+#if defined(__GNUC__) && __GNUC__ >= 12
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
 static void uv__write_callbacks(uv_stream_t* stream) {
   uv_write_t* req;
   QUEUE* q;
@@ -926,7 +930,9 @@ static void uv__write_callbacks(uv_stream_t* stream) {
       req->cb(req, req->error);
   }
 }
-
+#if defined(__GNUC__) && __GNUC__ >= 12
+# pragma GCC diagnostic pop
+#endif
 
 static void uv__stream_eof(uv_stream_t* stream, const uv_buf_t* buf) {
   stream->flags |= UV_HANDLE_READ_EOF;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -531,7 +531,10 @@ int uv_udp_recv_stop(uv_udp_t* handle) {
     return uv__udp_recv_stop(handle);
 }
 
-
+#if defined(__GNUC__) && __GNUC__ >= 12
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
 void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
   QUEUE queue;
   QUEUE* q;
@@ -549,7 +552,9 @@ void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
     walk_cb(h, arg);
   }
 }
-
+#if defined(__GNUC__) && __GNUC__ >= 12
+# pragma GCC diagnostic pop
+#endif
 
 static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
   const char* type;


### PR DESCRIPTION
It was apparently false positives. The fix is just to suppress the warnings.

Closes #4019.