### PR TITLE
unix,win: replace QUEUE with struct uv__queue

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -59,6 +59,12 @@ extern "C" {
 #include <stdio.h>
 #include <stdint.h>
 
+/* Internal type, do not use. */
+struct uv__queue {
+  struct uv__queue* next;
+  struct uv__queue* prev;
+};
+
 #if defined(_WIN32)
 # include "uv/win.h"
 #else
@@ -459,7 +465,7 @@ struct uv_shutdown_s {
   uv_handle_type type;                                                        \
   /* private */                                                               \
   uv_close_cb close_cb;                                                       \
-  void* handle_queue[2];                                                      \
+  struct uv__queue handle_queue;                                              \
   union {                                                                     \
     int fd;                                                                   \
     void* reserved[4];                                                        \
@@ -1849,7 +1855,7 @@ struct uv_loop_s {
   void* data;
   /* Loop reference counting. */
   unsigned int active_handles;
-  void* handle_queue[2];
+  struct uv__queue handle_queue;
   union {
     void* unused;
     unsigned int count;

--- a/include/uv/darwin.h
+++ b/include/uv/darwin.h
@@ -40,7 +40,7 @@
   void* cf_state;                                                             \
   uv_mutex_t cf_mutex;                                                        \
   uv_sem_t cf_sem;                                                            \
-  void* cf_signals[2];                                                        \
+  struct uv__queue cf_signals;                                                \
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
   uv__io_t event_watcher;                                                     \
@@ -48,8 +48,8 @@
   int realpath_len;                                                           \
   int cf_flags;                                                               \
   uv_async_t* cf_cb;                                                          \
-  void* cf_events[2];                                                         \
-  void* cf_member[2];                                                         \
+  struct uv__queue cf_events;                                                 \
+  struct uv__queue cf_member;                                                 \
   int cf_error;                                                               \
   uv_mutex_t cf_mutex;                                                        \
 

--- a/include/uv/linux.h
+++ b/include/uv/linux.h
@@ -28,7 +28,7 @@
   int inotify_fd;                                                             \
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
-  void* watchers[2];                                                          \
+  struct uv__queue watchers;                                                  \
   int wd;                                                                     \
 
 #endif /* UV_LINUX_H */

--- a/include/uv/threadpool.h
+++ b/include/uv/threadpool.h
@@ -31,7 +31,7 @@ struct uv__work {
   void (*work)(struct uv__work *w);
   void (*done)(struct uv__work *w, int status);
   struct uv_loop_s* loop;
-  void* wq[2];
+  struct uv__queue wq;
 };
 
 #endif /* UV_THREADPOOL_H_ */

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -92,8 +92,8 @@ typedef struct uv__io_s uv__io_t;
 
 struct uv__io_s {
   uv__io_cb cb;
-  void* pending_queue[2];
-  void* watcher_queue[2];
+  struct uv__queue pending_queue;
+  struct uv__queue watcher_queue;
   unsigned int pevents; /* Pending event mask i.e. mask at next tick. */
   unsigned int events;  /* Current event mask. */
   int fd;
@@ -220,21 +220,21 @@ typedef struct {
 #define UV_LOOP_PRIVATE_FIELDS                                                \
   unsigned long flags;                                                        \
   int backend_fd;                                                             \
-  void* pending_queue[2];                                                     \
-  void* watcher_queue[2];                                                     \
+  struct uv__queue pending_queue;                                             \
+  struct uv__queue watcher_queue;                                             \
   uv__io_t** watchers;                                                        \
   unsigned int nwatchers;                                                     \
   unsigned int nfds;                                                          \
-  void* wq[2];                                                                \
+  struct uv__queue wq;                                                        \
   uv_mutex_t wq_mutex;                                                        \
   uv_async_t wq_async;                                                        \
   uv_rwlock_t cloexec_lock;                                                   \
   uv_handle_t* closing_handles;                                               \
-  void* process_handles[2];                                                   \
-  void* prepare_handles[2];                                                   \
-  void* check_handles[2];                                                     \
-  void* idle_handles[2];                                                      \
-  void* async_handles[2];                                                     \
+  struct uv__queue process_handles;                                           \
+  struct uv__queue prepare_handles;                                           \
+  struct uv__queue check_handles;                                             \
+  struct uv__queue idle_handles;                                              \
+  struct uv__queue async_handles;                                             \
   void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
   uv__io_t async_io_watcher;                                                  \
   int async_wfd;                                                              \
@@ -257,7 +257,7 @@ typedef struct {
 #define UV_PRIVATE_REQ_TYPES /* empty */
 
 #define UV_WRITE_PRIVATE_FIELDS                                               \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
   unsigned int write_index;                                                   \
   uv_buf_t* bufs;                                                             \
   unsigned int nbufs;                                                         \
@@ -265,12 +265,12 @@ typedef struct {
   uv_buf_t bufsml[4];                                                         \
 
 #define UV_CONNECT_PRIVATE_FIELDS                                             \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
 
 #define UV_SHUTDOWN_PRIVATE_FIELDS /* empty */
 
 #define UV_UDP_SEND_PRIVATE_FIELDS                                            \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
   struct sockaddr_storage addr;                                               \
   unsigned int nbufs;                                                         \
   uv_buf_t* bufs;                                                             \
@@ -286,8 +286,8 @@ typedef struct {
   uv_connect_t *connect_req;                                                  \
   uv_shutdown_t *shutdown_req;                                                \
   uv__io_t io_watcher;                                                        \
-  void* write_queue[2];                                                       \
-  void* write_completed_queue[2];                                             \
+  struct uv__queue write_queue;                                               \
+  struct uv__queue write_completed_queue;                                     \
   uv_connection_cb connection_cb;                                             \
   int delayed_error;                                                          \
   int accepted_fd;                                                            \
@@ -300,8 +300,8 @@ typedef struct {
   uv_alloc_cb alloc_cb;                                                       \
   uv_udp_recv_cb recv_cb;                                                     \
   uv__io_t io_watcher;                                                        \
-  void* write_queue[2];                                                       \
-  void* write_completed_queue[2];                                             \
+  struct uv__queue write_queue;                                               \
+  struct uv__queue write_completed_queue;                                     \
 
 #define UV_PIPE_PRIVATE_FIELDS                                                \
   const char* pipe_fname; /* strdup'ed */
@@ -311,19 +311,19 @@ typedef struct {
 
 #define UV_PREPARE_PRIVATE_FIELDS                                             \
   uv_prepare_cb prepare_cb;                                                   \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
 
 #define UV_CHECK_PRIVATE_FIELDS                                               \
   uv_check_cb check_cb;                                                       \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
 
 #define UV_IDLE_PRIVATE_FIELDS                                                \
   uv_idle_cb idle_cb;                                                         \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
 
 #define UV_ASYNC_PRIVATE_FIELDS                                               \
   uv_async_cb async_cb;                                                       \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
   int pending;                                                                \
 
 #define UV_TIMER_PRIVATE_FIELDS                                               \
@@ -352,7 +352,7 @@ typedef struct {
   int retcode;
 
 #define UV_PROCESS_PRIVATE_FIELDS                                             \
-  void* queue[2];                                                             \
+  struct uv__queue queue;                                                     \
   int status;                                                                 \
 
 #define UV_FS_PRIVATE_FIELDS                                                  \

--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -357,7 +357,7 @@ typedef struct {
   /* Counter to started timer */                                              \
   uint64_t timer_counter;                                                     \
   /* Threadpool */                                                            \
-  void* wq[2];                                                                \
+  struct uv__queue wq;                                                        \
   uv_mutex_t wq_mutex;                                                        \
   uv_async_t wq_async;
 
@@ -486,7 +486,7 @@ typedef struct {
     uint32_t payload_remaining;                                               \
     uint64_t dummy; /* TODO: retained for ABI compat; remove this in v2.x. */ \
   } ipc_data_frame;                                                           \
-  void* ipc_xfer_queue[2];                                                    \
+  struct uv__queue ipc_xfer_queue;                                            \
   int ipc_xfer_queue_length;                                                  \
   uv_write_t* non_overlapped_writes_tail;                                     \
   CRITICAL_SECTION readfile_thread_lock;                                      \

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -37,10 +37,10 @@ static unsigned int slow_io_work_running;
 static unsigned int nthreads;
 static uv_thread_t* threads;
 static uv_thread_t default_threads[4];
-static QUEUE exit_message;
-static QUEUE wq;
-static QUEUE run_slow_work_message;
-static QUEUE slow_io_pending_wq;
+static struct uv__queue exit_message;
+static struct uv__queue wq;
+static struct uv__queue run_slow_work_message;
+static struct uv__queue slow_io_pending_wq;
 
 static unsigned int slow_work_thread_threshold(void) {
   return (nthreads + 1) / 2;
@@ -56,7 +56,7 @@ static void uv__cancelled(struct uv__work* w) {
  */
 static void worker(void* arg) {
   struct uv__work* w;
-  QUEUE* q;
+  struct uv__queue* q;
   int is_slow_work;
 
   uv_sem_post((uv_sem_t*) arg);
@@ -68,49 +68,49 @@ static void worker(void* arg) {
 
     /* Keep waiting while either no work is present or only slow I/O
        and we're at the threshold for that. */
-    while (QUEUE_EMPTY(&wq) ||
-           (QUEUE_HEAD(&wq) == &run_slow_work_message &&
-            QUEUE_NEXT(&run_slow_work_message) == &wq &&
+    while (uv__queue_empty(&wq) ||
+           (uv__queue_head(&wq) == &run_slow_work_message &&
+            uv__queue_next(&run_slow_work_message) == &wq &&
             slow_io_work_running >= slow_work_thread_threshold())) {
       idle_threads += 1;
       uv_cond_wait(&cond, &mutex);
       idle_threads -= 1;
     }
 
-    q = QUEUE_HEAD(&wq);
+    q = uv__queue_head(&wq);
     if (q == &exit_message) {
       uv_cond_signal(&cond);
       uv_mutex_unlock(&mutex);
       break;
     }
 
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);  /* Signal uv_cancel() that the work req is executing. */
+    uv__queue_remove(q);
+    uv__queue_init(q);  /* Signal uv_cancel() that the work req is executing. */
 
     is_slow_work = 0;
     if (q == &run_slow_work_message) {
       /* If we're at the slow I/O threshold, re-schedule until after all
          other work in the queue is done. */
       if (slow_io_work_running >= slow_work_thread_threshold()) {
-        QUEUE_INSERT_TAIL(&wq, q);
+        uv__queue_insert_tail(&wq, q);
         continue;
       }
 
       /* If we encountered a request to run slow I/O work but there is none
          to run, that means it's cancelled => Start over. */
-      if (QUEUE_EMPTY(&slow_io_pending_wq))
+      if (uv__queue_empty(&slow_io_pending_wq))
         continue;
 
       is_slow_work = 1;
       slow_io_work_running++;
 
-      q = QUEUE_HEAD(&slow_io_pending_wq);
-      QUEUE_REMOVE(q);
-      QUEUE_INIT(q);
+      q = uv__queue_head(&slow_io_pending_wq);
+      uv__queue_remove(q);
+      uv__queue_init(q);
 
       /* If there is more slow I/O work, schedule it to be run as well. */
-      if (!QUEUE_EMPTY(&slow_io_pending_wq)) {
-        QUEUE_INSERT_TAIL(&wq, &run_slow_work_message);
+      if (!uv__queue_empty(&slow_io_pending_wq)) {
+        uv__queue_insert_tail(&wq, &run_slow_work_message);
         if (idle_threads > 0)
           uv_cond_signal(&cond);
       }
@@ -118,13 +118,13 @@ static void worker(void* arg) {
 
     uv_mutex_unlock(&mutex);
 
-    w = QUEUE_DATA(q, struct uv__work, wq);
+    w = uv__queue_data(q, struct uv__work, wq);
     w->work(w);
 
     uv_mutex_lock(&w->loop->wq_mutex);
     w->work = NULL;  /* Signal uv_cancel() that the work req is done
                         executing. */
-    QUEUE_INSERT_TAIL(&w->loop->wq, &w->wq);
+    uv__queue_insert_tail(&w->loop->wq, &w->wq);
     uv_async_send(&w->loop->wq_async);
     uv_mutex_unlock(&w->loop->wq_mutex);
 
@@ -139,12 +139,12 @@ static void worker(void* arg) {
 }
 
 
-static void post(QUEUE* q, enum uv__work_kind kind) {
+static void post(struct uv__queue* q, enum uv__work_kind kind) {
   uv_mutex_lock(&mutex);
   if (kind == UV__WORK_SLOW_IO) {
     /* Insert into a separate queue. */
-    QUEUE_INSERT_TAIL(&slow_io_pending_wq, q);
-    if (!QUEUE_EMPTY(&run_slow_work_message)) {
+    uv__queue_insert_tail(&slow_io_pending_wq, q);
+    if (!uv__queue_empty(&run_slow_work_message)) {
       /* Running slow I/O tasks is already scheduled => Nothing to do here.
          The worker that runs said other task will schedule this one as well. */
       uv_mutex_unlock(&mutex);
@@ -153,7 +153,7 @@ static void post(QUEUE* q, enum uv__work_kind kind) {
     q = &run_slow_work_message;
   }
 
-  QUEUE_INSERT_TAIL(&wq, q);
+  uv__queue_insert_tail(&wq, q);
   if (idle_threads > 0)
     uv_cond_signal(&cond);
   uv_mutex_unlock(&mutex);
@@ -220,9 +220,9 @@ static void init_threads(void) {
   if (uv_mutex_init(&mutex))
     abort();
 
-  QUEUE_INIT(&wq);
-  QUEUE_INIT(&slow_io_pending_wq);
-  QUEUE_INIT(&run_slow_work_message);
+  uv__queue_init(&wq);
+  uv__queue_init(&slow_io_pending_wq);
+  uv__queue_init(&run_slow_work_message);
 
   if (uv_sem_init(&sem, 0))
     abort();
@@ -285,9 +285,9 @@ static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
   uv_mutex_lock(&mutex);
   uv_mutex_lock(&w->loop->wq_mutex);
 
-  cancelled = !QUEUE_EMPTY(&w->wq) && w->work != NULL;
+  cancelled = !uv__queue_empty(&w->wq) && w->work != NULL;
   if (cancelled)
-    QUEUE_REMOVE(&w->wq);
+    uv__queue_remove(&w->wq);
 
   uv_mutex_unlock(&w->loop->wq_mutex);
   uv_mutex_unlock(&mutex);
@@ -297,7 +297,7 @@ static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
 
   w->work = uv__cancelled;
   uv_mutex_lock(&loop->wq_mutex);
-  QUEUE_INSERT_TAIL(&loop->wq, &w->wq);
+  uv__queue_insert_tail(&loop->wq, &w->wq);
   uv_async_send(&loop->wq_async);
   uv_mutex_unlock(&loop->wq_mutex);
 
@@ -308,21 +308,21 @@ static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
 void uv__work_done(uv_async_t* handle) {
   struct uv__work* w;
   uv_loop_t* loop;
-  QUEUE* q;
-  QUEUE wq;
+  struct uv__queue* q;
+  struct uv__queue wq;
   int err;
   int nevents;
 
   loop = container_of(handle, uv_loop_t, wq_async);
   uv_mutex_lock(&loop->wq_mutex);
-  QUEUE_MOVE(&loop->wq, &wq);
+  uv__queue_move(&loop->wq, &wq);
   uv_mutex_unlock(&loop->wq_mutex);
 
   nevents = 0;
 
-  while (!QUEUE_EMPTY(&wq)) {
-    q = QUEUE_HEAD(&wq);
-    QUEUE_REMOVE(q);
+  while (!uv__queue_empty(&wq)) {
+    q = uv__queue_head(&wq);
+    uv__queue_remove(q);
 
     w = container_of(q, struct uv__work, wq);
     err = (w->work == uv__cancelled) ? UV_ECANCELED : 0;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -136,7 +136,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct pollfd pqry;
   struct pollfd* pe;
   struct poll_ctl pc;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__io_t* w;
   uint64_t base;
   uint64_t diff;
@@ -151,18 +151,18 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int reset_timeout;
 
   if (loop->nfds == 0) {
-    assert(QUEUE_EMPTY(&loop->watcher_queue));
+    assert(uv__queue_empty(&loop->watcher_queue));
     return;
   }
 
   lfields = uv__get_internal_fields(loop);
 
-  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
-    q = QUEUE_HEAD(&loop->watcher_queue);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
+  while (!uv__queue_empty(&loop->watcher_queue)) {
+    q = uv__queue_head(&loop->watcher_queue);
+    uv__queue_remove(q);
+    uv__queue_init(q);
 
-    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
+    w = uv__queue_data(q, uv__io_t, watcher_queue);
     assert(w->pevents != 0);
     assert(w->fd >= 0);
     assert(w->fd < (int) loop->nwatchers);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -344,7 +344,7 @@ static void uv__finish_close(uv_handle_t* handle) {
   }
 
   uv__handle_unref(handle);
-  QUEUE_REMOVE(&handle->handle_queue);
+  uv__queue_remove(&handle->handle_queue);
 
   if (handle->close_cb) {
     handle->close_cb(handle);
@@ -380,7 +380,7 @@ int uv_backend_fd(const uv_loop_t* loop) {
 static int uv__loop_alive(const uv_loop_t* loop) {
   return uv__has_active_handles(loop) ||
          uv__has_active_reqs(loop) ||
-         !QUEUE_EMPTY(&loop->pending_queue) ||
+         !uv__queue_empty(&loop->pending_queue) ||
          loop->closing_handles != NULL;
 }
 
@@ -389,8 +389,8 @@ static int uv__backend_timeout(const uv_loop_t* loop) {
   if (loop->stop_flag == 0 &&
       /* uv__loop_alive(loop) && */
       (uv__has_active_handles(loop) || uv__has_active_reqs(loop)) &&
-      QUEUE_EMPTY(&loop->pending_queue) &&
-      QUEUE_EMPTY(&loop->idle_handles) &&
+      uv__queue_empty(&loop->pending_queue) &&
+      uv__queue_empty(&loop->idle_handles) &&
       (loop->flags & UV_LOOP_REAP_CHILDREN) == 0 &&
       loop->closing_handles == NULL)
     return uv__next_timeout(loop);
@@ -399,7 +399,7 @@ static int uv__backend_timeout(const uv_loop_t* loop) {
 
 
 int uv_backend_timeout(const uv_loop_t* loop) {
-  if (QUEUE_EMPTY(&loop->watcher_queue))
+  if (uv__queue_empty(&loop->watcher_queue))
     return uv__backend_timeout(loop);
   /* Need to call uv_run to update the backend fd state. */
   return 0;
@@ -432,7 +432,8 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
   while (r != 0 && loop->stop_flag == 0) {
     can_sleep =
-        QUEUE_EMPTY(&loop->pending_queue) && QUEUE_EMPTY(&loop->idle_handles);
+        uv__queue_empty(&loop->pending_queue) &&
+        uv__queue_empty(&loop->idle_handles);
 
     uv__run_pending(loop);
     uv__run_idle(loop);
@@ -448,7 +449,7 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
     /* Process immediate callbacks (e.g. write_cb) a small fixed number of
      * times to avoid loop starvation.*/
-    for (r = 0; r < 8 && !QUEUE_EMPTY(&loop->pending_queue); r++)
+    for (r = 0; r < 8 && !uv__queue_empty(&loop->pending_queue); r++)
       uv__run_pending(loop);
 
     /* Run one final update on the provider_idle_time in case uv__io_poll
@@ -827,17 +828,17 @@ int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
 
 
 static void uv__run_pending(uv_loop_t* loop) {
-  QUEUE* q;
-  QUEUE pq;
+  struct uv__queue* q;
+  struct uv__queue pq;
   uv__io_t* w;
 
-  QUEUE_MOVE(&loop->pending_queue, &pq);
+  uv__queue_move(&loop->pending_queue, &pq);
 
-  while (!QUEUE_EMPTY(&pq)) {
-    q = QUEUE_HEAD(&pq);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
-    w = QUEUE_DATA(q, uv__io_t, pending_queue);
+  while (!uv__queue_empty(&pq)) {
+    q = uv__queue_head(&pq);
+    uv__queue_remove(q);
+    uv__queue_init(q);
+    w = uv__queue_data(q, uv__io_t, pending_queue);
     w->cb(loop, w, POLLOUT);
   }
 }
@@ -892,8 +893,8 @@ static void maybe_resize(uv_loop_t* loop, unsigned int len) {
 void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
   assert(cb != NULL);
   assert(fd >= -1);
-  QUEUE_INIT(&w->pending_queue);
-  QUEUE_INIT(&w->watcher_queue);
+  uv__queue_init(&w->pending_queue);
+  uv__queue_init(&w->watcher_queue);
   w->cb = cb;
   w->fd = fd;
   w->events = 0;
@@ -919,8 +920,8 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     return;
 #endif
 
-  if (QUEUE_EMPTY(&w->watcher_queue))
-    QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+  if (uv__queue_empty(&w->watcher_queue))
+    uv__queue_insert_tail(&loop->watcher_queue, &w->watcher_queue);
 
   if (loop->watchers[w->fd] == NULL) {
     loop->watchers[w->fd] = w;
@@ -945,8 +946,8 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   w->pevents &= ~events;
 
   if (w->pevents == 0) {
-    QUEUE_REMOVE(&w->watcher_queue);
-    QUEUE_INIT(&w->watcher_queue);
+    uv__queue_remove(&w->watcher_queue);
+    uv__queue_init(&w->watcher_queue);
     w->events = 0;
 
     if (w == loop->watchers[w->fd]) {
@@ -955,14 +956,14 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
       loop->nfds--;
     }
   }
-  else if (QUEUE_EMPTY(&w->watcher_queue))
-    QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+  else if (uv__queue_empty(&w->watcher_queue))
+    uv__queue_insert_tail(&loop->watcher_queue, &w->watcher_queue);
 }
 
 
 void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
   uv__io_stop(loop, w, POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI);
-  QUEUE_REMOVE(&w->pending_queue);
+  uv__queue_remove(&w->pending_queue);
 
   /* Remove stale events for this file descriptor */
   if (w->fd != -1)
@@ -971,8 +972,8 @@ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
 
 
 void uv__io_feed(uv_loop_t* loop, uv__io_t* w) {
-  if (QUEUE_EMPTY(&w->pending_queue))
-    QUEUE_INSERT_TAIL(&loop->pending_queue, &w->pending_queue);
+  if (uv__queue_empty(&w->pending_queue))
+    uv__queue_insert_tail(&loop->pending_queue, &w->pending_queue);
 }
 
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -133,7 +133,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct timespec spec;
   unsigned int nevents;
   unsigned int revents;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__io_t* w;
   uv_process_t* process;
   sigset_t* pset;
@@ -152,19 +152,19 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int reset_timeout;
 
   if (loop->nfds == 0) {
-    assert(QUEUE_EMPTY(&loop->watcher_queue));
+    assert(uv__queue_empty(&loop->watcher_queue));
     return;
   }
 
   lfields = uv__get_internal_fields(loop);
   nevents = 0;
 
-  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
-    q = QUEUE_HEAD(&loop->watcher_queue);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
+  while (!uv__queue_empty(&loop->watcher_queue)) {
+    q = uv__queue_head(&loop->watcher_queue);
+    uv__queue_remove(q);
+    uv__queue_init(q);
 
-    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
+    w = uv__queue_data(q, uv__io_t, watcher_queue);
     assert(w->pevents != 0);
     assert(w->fd >= 0);
     assert(w->fd < (int) loop->nwatchers);
@@ -307,8 +307,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
       /* Handle kevent NOTE_EXIT results */
       if (ev->filter == EVFILT_PROC) {
-        QUEUE_FOREACH(q, &loop->process_handles) {
-          process = QUEUE_DATA(q, uv_process_t, queue);
+        uv__queue_foreach(q, &loop->process_handles) {
+          process = uv__queue_data(q, uv_process_t, queue);
           if (process->pid == fd) {
             process->flags |= UV_HANDLE_REAP;
             loop->flags |= UV_LOOP_REAP_CHILDREN;

--- a/src/unix/loop-watcher.c
+++ b/src/unix/loop-watcher.c
@@ -32,7 +32,7 @@
   int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
     if (uv__is_active(handle)) return 0;                                      \
     if (cb == NULL) return UV_EINVAL;                                         \
-    QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
+    uv__queue_insert_head(&handle->loop->name##_handles, &handle->queue);     \
     handle->name##_cb = cb;                                                   \
     uv__handle_start(handle);                                                 \
     return 0;                                                                 \
@@ -40,21 +40,21 @@
                                                                               \
   int uv_##name##_stop(uv_##name##_t* handle) {                               \
     if (!uv__is_active(handle)) return 0;                                     \
-    QUEUE_REMOVE(&handle->queue);                                             \
+    uv__queue_remove(&handle->queue);                                         \
     uv__handle_stop(handle);                                                  \
     return 0;                                                                 \
   }                                                                           \
                                                                               \
   void uv__run_##name(uv_loop_t* loop) {                                      \
     uv_##name##_t* h;                                                         \
-    QUEUE queue;                                                              \
-    QUEUE* q;                                                                 \
-    QUEUE_MOVE(&loop->name##_handles, &queue);                                \
-    while (!QUEUE_EMPTY(&queue)) {                                            \
-      q = QUEUE_HEAD(&queue);                                                 \
-      h = QUEUE_DATA(q, uv_##name##_t, queue);                                \
-      QUEUE_REMOVE(q);                                                        \
-      QUEUE_INSERT_TAIL(&loop->name##_handles, q);                            \
+    struct uv__queue queue;                                                   \
+    struct uv__queue* q;                                                      \
+    uv__queue_move(&loop->name##_handles, &queue);                            \
+    while (!uv__queue_empty(&queue)) {                                        \
+      q = uv__queue_head(&queue);                                             \
+      h = uv__queue_data(q, uv_##name##_t, queue);                            \
+      uv__queue_remove(q);                                                    \
+      uv__queue_insert_tail(&loop->name##_handles, q);                        \
       h->name##_cb(h);                                                        \
     }                                                                         \
   }                                                                           \

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -27,7 +27,7 @@
 #include <termios.h>
 #include <sys/msg.h>
 
-static QUEUE global_epoll_queue;
+static struct uv__queue global_epoll_queue;
 static uv_mutex_t global_epoll_lock;
 static uv_once_t once = UV_ONCE_INIT;
 
@@ -178,18 +178,18 @@ static void after_fork(void) {
 
 
 static void child_fork(void) {
-  QUEUE* q;
+  struct uv__queue* q;
   uv_once_t child_once = UV_ONCE_INIT;
 
   /* reset once */
   memcpy(&once, &child_once, sizeof(child_once));
 
   /* reset epoll list */
-  while (!QUEUE_EMPTY(&global_epoll_queue)) {
+  while (!uv__queue_empty(&global_epoll_queue)) {
     uv__os390_epoll* lst;
-    q = QUEUE_HEAD(&global_epoll_queue);
-    QUEUE_REMOVE(q);
-    lst = QUEUE_DATA(q, uv__os390_epoll, member);
+    q = uv__queue_head(&global_epoll_queue);
+    uv__queue_remove(q);
+    lst = uv__queue_data(q, uv__os390_epoll, member);
     uv__free(lst->items);
     lst->items = NULL;
     lst->size = 0;
@@ -201,7 +201,7 @@ static void child_fork(void) {
 
 
 static void epoll_init(void) {
-  QUEUE_INIT(&global_epoll_queue);
+  uv__queue_init(&global_epoll_queue);
   if (uv_mutex_init(&global_epoll_lock))
     abort();
 
@@ -225,7 +225,7 @@ uv__os390_epoll* epoll_create1(int flags) {
     lst->items[lst->size - 1].revents = 0;
     uv_once(&once, epoll_init);
     uv_mutex_lock(&global_epoll_lock);
-    QUEUE_INSERT_TAIL(&global_epoll_queue, &lst->member);
+    uv__queue_insert_tail(&global_epoll_queue, &lst->member);
     uv_mutex_unlock(&global_epoll_lock);
   }
 
@@ -352,14 +352,14 @@ int epoll_wait(uv__os390_epoll* lst, struct epoll_event* events,
 
 
 int epoll_file_close(int fd) {
-  QUEUE* q;
+  struct uv__queue* q;
 
   uv_once(&once, epoll_init);
   uv_mutex_lock(&global_epoll_lock);
-  QUEUE_FOREACH(q, &global_epoll_queue) {
+  uv__queue_foreach(q, &global_epoll_queue) {
     uv__os390_epoll* lst;
 
-    lst = QUEUE_DATA(q, uv__os390_epoll, member);
+    lst = uv__queue_data(q, uv__os390_epoll, member);
     if (fd < lst->size && lst->items != NULL && lst->items[fd].fd != -1)
       lst->items[fd].fd = -1;
   }
@@ -371,7 +371,7 @@ int epoll_file_close(int fd) {
 void epoll_queue_close(uv__os390_epoll* lst) {
   /* Remove epoll instance from global queue */
   uv_mutex_lock(&global_epoll_lock);
-  QUEUE_REMOVE(&lst->member);
+  uv__queue_remove(&lst->member);
   uv_mutex_unlock(&global_epoll_lock);
 
   /* Free resources */

--- a/src/unix/os390-syscalls.h
+++ b/src/unix/os390-syscalls.h
@@ -45,7 +45,7 @@ struct epoll_event {
 };
 
 typedef struct {
-  QUEUE member;
+  struct uv__queue member;
   struct pollfd* items;
   unsigned long size;
   int msg_queue;

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -815,7 +815,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   uv__os390_epoll* ep;
   int have_signals;
   int real_timeout;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__io_t* w;
   uint64_t base;
   int count;
@@ -827,19 +827,19 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int reset_timeout;
 
   if (loop->nfds == 0) {
-    assert(QUEUE_EMPTY(&loop->watcher_queue));
+    assert(uv__queue_empty(&loop->watcher_queue));
     return;
   }
 
   lfields = uv__get_internal_fields(loop);
 
-  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
+  while (!uv__queue_empty(&loop->watcher_queue)) {
     uv_stream_t* stream;
 
-    q = QUEUE_HEAD(&loop->watcher_queue);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
-    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
+    q = uv__queue_head(&loop->watcher_queue);
+    uv__queue_remove(q);
+    uv__queue_init(q);
+    w = uv__queue_data(q, uv__io_t, watcher_queue);
 
     assert(w->pevents != 0);
     assert(w->fd >= 0);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -230,7 +230,7 @@ out:
   uv__req_init(handle->loop, req, UV_CONNECT);
   req->handle = (uv_stream_t*)handle;
   req->cb = cb;
-  QUEUE_INIT(&req->queue);
+  uv__queue_init(&req->queue);
 
   /* Force callback to run on next tick in case of error. */
   if (err)

--- a/src/unix/posix-poll.c
+++ b/src/unix/posix-poll.c
@@ -137,7 +137,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   sigset_t set;
   uint64_t time_base;
   uint64_t time_diff;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__io_t* w;
   size_t i;
   unsigned int nevents;
@@ -149,19 +149,19 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int reset_timeout;
 
   if (loop->nfds == 0) {
-    assert(QUEUE_EMPTY(&loop->watcher_queue));
+    assert(uv__queue_empty(&loop->watcher_queue));
     return;
   }
 
   lfields = uv__get_internal_fields(loop);
 
   /* Take queued watchers and add their fds to our poll fds array.  */
-  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
-    q = QUEUE_HEAD(&loop->watcher_queue);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
+  while (!uv__queue_empty(&loop->watcher_queue)) {
+    q = uv__queue_head(&loop->watcher_queue);
+    uv__queue_remove(q);
+    uv__queue_init(q);
 
-    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
+    w = uv__queue_data(q, uv__io_t, watcher_queue);
     assert(w->pevents != 0);
     assert(w->fd >= 0);
     assert(w->fd < (int) loop->nwatchers);

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -108,17 +108,17 @@ void uv__wait_children(uv_loop_t* loop) {
   int status;
   int options;
   pid_t pid;
-  QUEUE pending;
-  QUEUE* q;
-  QUEUE* h;
+  struct uv__queue pending;
+  struct uv__queue* q;
+  struct uv__queue* h;
 
-  QUEUE_INIT(&pending);
+  uv__queue_init(&pending);
 
   h = &loop->process_handles;
-  q = QUEUE_HEAD(h);
+  q = uv__queue_head(h);
   while (q != h) {
-    process = QUEUE_DATA(q, uv_process_t, queue);
-    q = QUEUE_NEXT(q);
+    process = uv__queue_data(q, uv_process_t, queue);
+    q = uv__queue_next(q);
 
 #ifndef UV_USE_SIGCHLD
     if ((process->flags & UV_HANDLE_REAP) == 0)
@@ -149,18 +149,18 @@ void uv__wait_children(uv_loop_t* loop) {
 
     assert(pid == process->pid);
     process->status = status;
-    QUEUE_REMOVE(&process->queue);
-    QUEUE_INSERT_TAIL(&pending, &process->queue);
+    uv__queue_remove(&process->queue);
+    uv__queue_insert_tail(&pending, &process->queue);
   }
 
   h = &pending;
-  q = QUEUE_HEAD(h);
+  q = uv__queue_head(h);
   while (q != h) {
-    process = QUEUE_DATA(q, uv_process_t, queue);
-    q = QUEUE_NEXT(q);
+    process = uv__queue_data(q, uv_process_t, queue);
+    q = uv__queue_next(q);
 
-    QUEUE_REMOVE(&process->queue);
-    QUEUE_INIT(&process->queue);
+    uv__queue_remove(&process->queue);
+    uv__queue_init(&process->queue);
     uv__handle_stop(process);
 
     if (process->exit_cb == NULL)
@@ -176,7 +176,7 @@ void uv__wait_children(uv_loop_t* loop) {
 
     process->exit_cb(process, exit_status, term_signal);
   }
-  assert(QUEUE_EMPTY(&pending));
+  assert(uv__queue_empty(&pending));
 }
 
 /*
@@ -978,7 +978,7 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
 
   uv__handle_init(loop, (uv_handle_t*)process, UV_PROCESS);
-  QUEUE_INIT(&process->queue);
+  uv__queue_init(&process->queue);
   process->status = 0;
 
   stdio_count = options->stdio_count;
@@ -1041,7 +1041,7 @@ int uv_spawn(uv_loop_t* loop,
 
     process->pid = pid;
     process->exit_cb = options->exit_cb;
-    QUEUE_INSERT_TAIL(&loop->process_handles, &process->queue);
+    uv__queue_insert_tail(&loop->process_handles, &process->queue);
     uv__handle_start(process);
   }
 
@@ -1103,10 +1103,10 @@ int uv_kill(int pid, int signum) {
 
 
 void uv__process_close(uv_process_t* handle) {
-  QUEUE_REMOVE(&handle->queue);
+  uv__queue_remove(&handle->queue);
   uv__handle_stop(handle);
 #ifdef UV_USE_SIGCHLD
-  if (QUEUE_EMPTY(&handle->loop->process_handles))
+  if (uv__queue_empty(&handle->loop->process_handles))
     uv_signal_stop(&handle->loop->child_watcher);
 #endif
 }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -291,16 +291,16 @@ int uv__signal_loop_fork(uv_loop_t* loop) {
 
 
 void uv__signal_loop_cleanup(uv_loop_t* loop) {
-  QUEUE* q;
+  struct uv__queue* q;
 
   /* Stop all the signal watchers that are still attached to this loop. This
    * ensures that the (shared) signal tree doesn't contain any invalid entries
    * entries, and that signal handlers are removed when appropriate.
-   * It's safe to use QUEUE_FOREACH here because the handles and the handle
+   * It's safe to use uv__queue_foreach here because the handles and the handle
    * queue are not modified by uv__signal_stop().
    */
-  QUEUE_FOREACH(q, &loop->handle_queue) {
-    uv_handle_t* handle = QUEUE_DATA(q, uv_handle_t, handle_queue);
+  uv__queue_foreach(q, &loop->handle_queue) {
+    uv_handle_t* handle = uv__queue_data(q, uv_handle_t, handle_queue);
 
     if (handle->type == UV_SIGNAL)
       uv__signal_stop((uv_signal_t*) handle);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -94,8 +94,8 @@ void uv__stream_init(uv_loop_t* loop,
   stream->accepted_fd = -1;
   stream->queued_fds = NULL;
   stream->delayed_error = 0;
-  QUEUE_INIT(&stream->write_queue);
-  QUEUE_INIT(&stream->write_completed_queue);
+  uv__queue_init(&stream->write_queue);
+  uv__queue_init(&stream->write_completed_queue);
   stream->write_queue_size = 0;
 
   if (loop->emfile_fd == -1) {
@@ -439,15 +439,15 @@ int uv__stream_open(uv_stream_t* stream, int fd, int flags) {
 
 void uv__stream_flush_write_queue(uv_stream_t* stream, int error) {
   uv_write_t* req;
-  QUEUE* q;
-  while (!QUEUE_EMPTY(&stream->write_queue)) {
-    q = QUEUE_HEAD(&stream->write_queue);
-    QUEUE_REMOVE(q);
+  struct uv__queue* q;
+  while (!uv__queue_empty(&stream->write_queue)) {
+    q = uv__queue_head(&stream->write_queue);
+    uv__queue_remove(q);
 
-    req = QUEUE_DATA(q, uv_write_t, queue);
+    req = uv__queue_data(q, uv_write_t, queue);
     req->error = error;
 
-    QUEUE_INSERT_TAIL(&stream->write_completed_queue, &req->queue);
+    uv__queue_insert_tail(&stream->write_completed_queue, &req->queue);
   }
 }
 
@@ -627,7 +627,7 @@ static void uv__drain(uv_stream_t* stream) {
   uv_shutdown_t* req;
   int err;
 
-  assert(QUEUE_EMPTY(&stream->write_queue));
+  assert(uv__queue_empty(&stream->write_queue));
   if (!(stream->flags & UV_HANDLE_CLOSING)) {
     uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);
     uv__stream_osx_interrupt_select(stream);
@@ -714,7 +714,7 @@ static void uv__write_req_finish(uv_write_t* req) {
   uv_stream_t* stream = req->handle;
 
   /* Pop the req off tcp->write_queue. */
-  QUEUE_REMOVE(&req->queue);
+  uv__queue_remove(&req->queue);
 
   /* Only free when there was no error. On error, we touch up write_queue_size
    * right before making the callback. The reason we don't do that right away
@@ -731,7 +731,7 @@ static void uv__write_req_finish(uv_write_t* req) {
   /* Add it to the write_completed_queue where it will have its
    * callback called in the near future.
    */
-  QUEUE_INSERT_TAIL(&stream->write_completed_queue, &req->queue);
+  uv__queue_insert_tail(&stream->write_completed_queue, &req->queue);
   uv__io_feed(stream->loop, &stream->io_watcher);
 }
 
@@ -837,7 +837,7 @@ static int uv__try_write(uv_stream_t* stream,
 }
 
 static void uv__write(uv_stream_t* stream) {
-  QUEUE* q;
+  struct uv__queue* q;
   uv_write_t* req;
   ssize_t n;
   int count;
@@ -851,11 +851,11 @@ static void uv__write(uv_stream_t* stream) {
   count = 32;
 
   for (;;) {
-    if (QUEUE_EMPTY(&stream->write_queue))
+    if (uv__queue_empty(&stream->write_queue))
       return;
 
-    q = QUEUE_HEAD(&stream->write_queue);
-    req = QUEUE_DATA(q, uv_write_t, queue);
+    q = uv__queue_head(&stream->write_queue);
+    req = uv__queue_data(q, uv_write_t, queue);
     assert(req->handle == stream);
 
     n = uv__try_write(stream,
@@ -899,19 +899,19 @@ error:
 
 static void uv__write_callbacks(uv_stream_t* stream) {
   uv_write_t* req;
-  QUEUE* q;
-  QUEUE pq;
+  struct uv__queue* q;
+  struct uv__queue pq;
 
-  if (QUEUE_EMPTY(&stream->write_completed_queue))
+  if (uv__queue_empty(&stream->write_completed_queue))
     return;
 
-  QUEUE_MOVE(&stream->write_completed_queue, &pq);
+  uv__queue_move(&stream->write_completed_queue, &pq);
 
-  while (!QUEUE_EMPTY(&pq)) {
+  while (!uv__queue_empty(&pq)) {
     /* Pop a req off write_completed_queue. */
-    q = QUEUE_HEAD(&pq);
-    req = QUEUE_DATA(q, uv_write_t, queue);
-    QUEUE_REMOVE(q);
+    q = uv__queue_head(&pq);
+    req = uv__queue_data(q, uv_write_t, queue);
+    uv__queue_remove(q);
     uv__req_unregister(stream->loop, req);
 
     if (req->bufs != NULL) {
@@ -1174,7 +1174,7 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* stream, uv_shutdown_cb cb) {
   stream->shutdown_req = req;
   stream->flags &= ~UV_HANDLE_WRITABLE;
 
-  if (QUEUE_EMPTY(&stream->write_queue))
+  if (uv__queue_empty(&stream->write_queue))
     uv__io_feed(stream->loop, &stream->io_watcher);
 
   return 0;
@@ -1227,7 +1227,7 @@ static void uv__stream_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     uv__write_callbacks(stream);
 
     /* Write queue drained. */
-    if (QUEUE_EMPTY(&stream->write_queue))
+    if (uv__queue_empty(&stream->write_queue))
       uv__drain(stream);
   }
 }
@@ -1270,7 +1270,7 @@ static void uv__stream_connect(uv_stream_t* stream) {
   stream->connect_req = NULL;
   uv__req_unregister(stream->loop, req);
 
-  if (error < 0 || QUEUE_EMPTY(&stream->write_queue)) {
+  if (error < 0 || uv__queue_empty(&stream->write_queue)) {
     uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);
   }
 
@@ -1352,7 +1352,7 @@ int uv_write2(uv_write_t* req,
   req->handle = stream;
   req->error = 0;
   req->send_handle = send_handle;
-  QUEUE_INIT(&req->queue);
+  uv__queue_init(&req->queue);
 
   req->bufs = req->bufsml;
   if (nbufs > ARRAY_SIZE(req->bufsml))
@@ -1367,7 +1367,7 @@ int uv_write2(uv_write_t* req,
   stream->write_queue_size += uv__count_bufs(bufs, nbufs);
 
   /* Append the request to write_queue. */
-  QUEUE_INSERT_TAIL(&stream->write_queue, &req->queue);
+  uv__queue_insert_tail(&stream->write_queue, &req->queue);
 
   /* If the queue was empty when this function began, we should attempt to
    * do the write immediately. Otherwise start the write_watcher and wait

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -148,7 +148,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct port_event events[1024];
   struct port_event* pe;
   struct timespec spec;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__io_t* w;
   sigset_t* pset;
   sigset_t set;
@@ -166,16 +166,16 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int reset_timeout;
 
   if (loop->nfds == 0) {
-    assert(QUEUE_EMPTY(&loop->watcher_queue));
+    assert(uv__queue_empty(&loop->watcher_queue));
     return;
   }
 
-  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
-    q = QUEUE_HEAD(&loop->watcher_queue);
-    QUEUE_REMOVE(q);
-    QUEUE_INIT(q);
+  while (!uv__queue_empty(&loop->watcher_queue)) {
+    q = uv__queue_head(&loop->watcher_queue);
+    uv__queue_remove(q);
+    uv__queue_init(q);
 
-    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
+    w = uv__queue_data(q, uv__io_t, watcher_queue);
     assert(w->pevents != 0);
 
     if (port_associate(loop->backend_fd,
@@ -316,8 +316,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;  /* Disabled by callback. */
 
       /* Events Ports operates in oneshot mode, rearm timer on next run. */
-      if (w->pevents != 0 && QUEUE_EMPTY(&w->watcher_queue))
-        QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+      if (w->pevents != 0 && uv__queue_empty(&w->watcher_queue))
+        uv__queue_insert_tail(&loop->watcher_queue, &w->watcher_queue);
     }
 
     uv__metrics_inc_events(loop, nevents);

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -124,7 +124,7 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* tcp, unsigned int flags) {
   if (domain != AF_UNSPEC) {
     err = new_socket(tcp, domain, 0);
     if (err) {
-      QUEUE_REMOVE(&tcp->handle_queue);
+      uv__queue_remove(&tcp->handle_queue);
       if (tcp->io_watcher.fd != -1)
         uv__close(tcp->io_watcher.fd);
       tcp->io_watcher.fd = -1;
@@ -252,7 +252,7 @@ out:
   uv__req_init(handle->loop, req, UV_CONNECT);
   req->cb = cb;
   req->handle = (uv_stream_t*) handle;
-  QUEUE_INIT(&req->queue);
+  uv__queue_init(&req->queue);
   handle->connect_req = req;
 
   uv__io_start(handle->loop, &handle->io_watcher, POLLOUT);

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -222,7 +222,7 @@ skip:
     int rc = r;
     if (newfd != -1)
       uv__close(newfd);
-    QUEUE_REMOVE(&tty->handle_queue);
+    uv__queue_remove(&tty->handle_queue);
     do
       r = fcntl(fd, F_SETFL, saved_flags);
     while (r == -1 && errno == EINTR);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -533,17 +533,17 @@ int uv_udp_recv_stop(uv_udp_t* handle) {
 
 
 void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
-  QUEUE queue;
-  QUEUE* q;
+  struct uv__queue queue;
+  struct uv__queue* q;
   uv_handle_t* h;
 
-  QUEUE_MOVE(&loop->handle_queue, &queue);
-  while (!QUEUE_EMPTY(&queue)) {
-    q = QUEUE_HEAD(&queue);
-    h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+  uv__queue_move(&loop->handle_queue, &queue);
+  while (!uv__queue_empty(&queue)) {
+    q = uv__queue_head(&queue);
+    h = uv__queue_data(q, uv_handle_t, handle_queue);
 
-    QUEUE_REMOVE(q);
-    QUEUE_INSERT_TAIL(&loop->handle_queue, q);
+    uv__queue_remove(q);
+    uv__queue_insert_tail(&loop->handle_queue, q);
 
     if (h->flags & UV_HANDLE_INTERNAL) continue;
     walk_cb(h, arg);
@@ -553,14 +553,14 @@ void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
 
 static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
   const char* type;
-  QUEUE* q;
+  struct uv__queue* q;
   uv_handle_t* h;
 
   if (loop == NULL)
     loop = uv_default_loop();
 
-  QUEUE_FOREACH(q, &loop->handle_queue) {
-    h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+  uv__queue_foreach(q, &loop->handle_queue) {
+    h = uv__queue_data(q, uv_handle_t, handle_queue);
 
     if (only_active && !uv__is_active(h))
       continue;
@@ -846,7 +846,7 @@ uv_loop_t* uv_loop_new(void) {
 
 
 int uv_loop_close(uv_loop_t* loop) {
-  QUEUE* q;
+  struct uv__queue* q;
   uv_handle_t* h;
 #ifndef NDEBUG
   void* saved_data;
@@ -855,8 +855,8 @@ int uv_loop_close(uv_loop_t* loop) {
   if (uv__has_active_reqs(loop))
     return UV_EBUSY;
 
-  QUEUE_FOREACH(q, &loop->handle_queue) {
-    h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+  uv__queue_foreach(q, &loop->handle_queue) {
+    h = uv__queue_data(q, uv_handle_t, handle_queue);
     if (!(h->flags & UV_HANDLE_INTERNAL))
       return UV_EBUSY;
   }

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -323,7 +323,7 @@ void uv__threadpool_cleanup(void);
     (h)->loop = (loop_);                                                      \
     (h)->type = (type_);                                                      \
     (h)->flags = UV_HANDLE_REF;  /* Ref the loop when active. */              \
-    QUEUE_INSERT_TAIL(&(loop_)->handle_queue, &(h)->handle_queue);            \
+    uv__queue_insert_tail(&(loop_)->handle_queue, &(h)->handle_queue);        \
     uv__handle_platform_init(h);                                              \
   }                                                                           \
   while (0)

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -255,8 +255,8 @@ int uv_loop_init(uv_loop_t* loop) {
   loop->time = 0;
   uv_update_time(loop);
 
-  QUEUE_INIT(&loop->wq);
-  QUEUE_INIT(&loop->handle_queue);
+  uv__queue_init(&loop->wq);
+  uv__queue_init(&loop->handle_queue);
   loop->active_reqs.count = 0;
   loop->active_handles = 0;
 
@@ -358,7 +358,7 @@ void uv__loop_close(uv_loop_t* loop) {
   }
 
   uv_mutex_lock(&loop->wq_mutex);
-  assert(QUEUE_EMPTY(&loop->wq) && "thread pool work queue not empty!");
+  assert(uv__queue_empty(&loop->wq) && "thread pool work queue not empty!");
   assert(!uv__has_active_reqs(loop));
   uv_mutex_unlock(&loop->wq_mutex);
   uv_mutex_destroy(&loop->wq_mutex);

--- a/src/win/handle-inl.h
+++ b/src/win/handle-inl.h
@@ -75,7 +75,7 @@
 
 #define uv__handle_close(handle)                                        \
   do {                                                                  \
-    QUEUE_REMOVE(&(handle)->handle_queue);                              \
+    uv__queue_remove(&(handle)->handle_queue);                          \
     uv__active_handle_rm((uv_handle_t*) (handle));                      \
                                                                         \
     (handle)->flags |= UV_HANDLE_CLOSED;                                \

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -55,7 +55,7 @@ static const int pipe_prefix_len = sizeof(pipe_prefix) - 1;
 typedef struct {
   uv__ipc_socket_xfer_type_t xfer_type;
   uv__ipc_socket_xfer_info_t xfer_info;
-  QUEUE member;
+  struct uv__queue member;
 } uv__ipc_xfer_queue_item_t;
 
 /* IPC frame header flags. */
@@ -111,7 +111,7 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int ipc) {
   handle->name = NULL;
   handle->pipe.conn.ipc_remote_pid = 0;
   handle->pipe.conn.ipc_data_frame.payload_remaining = 0;
-  QUEUE_INIT(&handle->pipe.conn.ipc_xfer_queue);
+  uv__queue_init(&handle->pipe.conn.ipc_xfer_queue);
   handle->pipe.conn.ipc_xfer_queue_length = 0;
   handle->ipc = ipc;
   handle->pipe.conn.non_overlapped_writes_tail = NULL;
@@ -637,13 +637,13 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
 
   if (handle->flags & UV_HANDLE_CONNECTION) {
     /* Free pending sockets */
-    while (!QUEUE_EMPTY(&handle->pipe.conn.ipc_xfer_queue)) {
-      QUEUE* q;
+    while (!uv__queue_empty(&handle->pipe.conn.ipc_xfer_queue)) {
+      struct uv__queue* q;
       SOCKET socket;
 
-      q = QUEUE_HEAD(&handle->pipe.conn.ipc_xfer_queue);
-      QUEUE_REMOVE(q);
-      xfer_queue_item = QUEUE_DATA(q, uv__ipc_xfer_queue_item_t, member);
+      q = uv__queue_head(&handle->pipe.conn.ipc_xfer_queue);
+      uv__queue_remove(q);
+      xfer_queue_item = uv__queue_data(q, uv__ipc_xfer_queue_item_t, member);
 
       /* Materialize socket and close it */
       socket = WSASocketW(FROM_PROTOCOL_INFO,
@@ -1062,20 +1062,20 @@ int uv__pipe_accept(uv_pipe_t* server, uv_stream_t* client) {
   uv_loop_t* loop = server->loop;
   uv_pipe_t* pipe_client;
   uv_pipe_accept_t* req;
-  QUEUE* q;
+  struct uv__queue* q;
   uv__ipc_xfer_queue_item_t* item;
   int err;
 
   if (server->ipc) {
-    if (QUEUE_EMPTY(&server->pipe.conn.ipc_xfer_queue)) {
+    if (uv__queue_empty(&server->pipe.conn.ipc_xfer_queue)) {
       /* No valid pending sockets. */
       return WSAEWOULDBLOCK;
     }
 
-    q = QUEUE_HEAD(&server->pipe.conn.ipc_xfer_queue);
-    QUEUE_REMOVE(q);
+    q = uv__queue_head(&server->pipe.conn.ipc_xfer_queue);
+    uv__queue_remove(q);
     server->pipe.conn.ipc_xfer_queue_length--;
-    item = QUEUE_DATA(q, uv__ipc_xfer_queue_item_t, member);
+    item = uv__queue_data(q, uv__ipc_xfer_queue_item_t, member);
 
     err = uv__tcp_xfer_import(
         (uv_tcp_t*) client, item->xfer_type, &item->xfer_info);
@@ -1829,7 +1829,7 @@ static void uv__pipe_queue_ipc_xfer_info(
   item->xfer_type = xfer_type;
   item->xfer_info = *xfer_info;
 
-  QUEUE_INSERT_TAIL(&handle->pipe.conn.ipc_xfer_queue, &item->member);
+  uv__queue_insert_tail(&handle->pipe.conn.ipc_xfer_queue, &item->member);
   handle->pipe.conn.ipc_xfer_queue_length++;
 }
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -175,14 +175,14 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* handle, unsigned int flags) {
     sock = socket(domain, SOCK_STREAM, 0);
     if (sock == INVALID_SOCKET) {
       err = WSAGetLastError();
-      QUEUE_REMOVE(&handle->handle_queue);
+      uv__queue_remove(&handle->handle_queue);
       return uv_translate_sys_error(err);
     }
 
     err = uv__tcp_set_socket(handle->loop, handle, sock, domain, 0);
     if (err) {
       closesocket(sock);
-      QUEUE_REMOVE(&handle->handle_queue);
+      uv__queue_remove(&handle->handle_queue);
       return uv_translate_sys_error(err);
     }
 

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -146,14 +146,14 @@ int uv__udp_init_ex(uv_loop_t* loop,
     sock = socket(domain, SOCK_DGRAM, 0);
     if (sock == INVALID_SOCKET) {
       err = WSAGetLastError();
-      QUEUE_REMOVE(&handle->handle_queue);
+      uv__queue_remove(&handle->handle_queue);
       return uv_translate_sys_error(err);
     }
 
     err = uv__udp_set_socket(handle->loop, handle, sock, domain);
     if (err) {
       closesocket(sock);
-      QUEUE_REMOVE(&handle->handle_queue);
+      uv__queue_remove(&handle->handle_queue);
       return uv_translate_sys_error(err);
     }
   }

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -29,7 +29,7 @@
  * The idea behind the test is as follows.
  * Certain handle types are stored in a queue internally.
  * Extra care should be taken for removal of a handle from the queue while iterating over the queue.
- * (i.e., QUEUE_REMOVE() called within QUEUE_FOREACH())
+ * (i.e., uv__queue_remove() called within uv__queue_foreach())
  * This usually happens when someone closes or stops a handle from within its callback.
  * So we need to check that we haven't screwed the queue on close/stop.
  * To do so we do the following (for each handle type):
@@ -54,7 +54,8 @@
  *                  wrong foreach "next"  |
  *
  *  4. The callback for handle #1 shouldn't be called because the handle #1 is stopped in the previous step.
- *     However, if QUEUE_REMOVE() is not handled properly within QUEUE_FOREACH(), the callback _will_ be called.
+ *     However, if uv__queue_remove() is not handled properly within uv__queue_foreach(), the callback _will_
+ *     be called.
  */
 
 static const unsigned first_handle_number_idle     = 2;


### PR DESCRIPTION
Recent versions of gcc have started emitting warnings about the liberal type casting inside the QUEUE macros. Although the warnings are false positives, let's use them as the impetus to switch to a type-safer and arguably cleaner approach.

Fixes: https://github.com/libuv/libuv/issues/4019