### PR TITLE
ios: fix uv_getrusage() ru_maxrss calculation

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1021,8 +1021,8 @@ int uv_getrusage(uv_rusage_t* rusage) {
   /* Most platforms report ru_maxrss in kilobytes; macOS and Solaris are
    * the outliers because of course they are.
    */
-#if defined(__APPLE__) && !TARGET_OS_IPHONE
-  rusage->ru_maxrss /= 1024;                  /* macOS reports bytes. */
+#if defined(__APPLE__)
+  rusage->ru_maxrss /= 1024;                  /* macOS and iOS report bytes. */
 #elif defined(__sun)
   rusage->ru_maxrss /= getpagesize() / 1024;  /* Solaris reports pages. */
 #endif


### PR DESCRIPTION
Apple's documentation claims ru_maxrss is reported in kilobytes but the XNU source code suggests the actual unit is bytes, like macOS.

Fixes: https://github.com/libuv/libuv/issues/4025