### PR TITLE
linux: add UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -259,7 +259,11 @@ typedef struct uv_metrics_s uv_metrics_t;
 
 typedef enum {
   UV_LOOP_BLOCK_SIGNAL = 0,
-  UV_METRICS_IDLE_TIME
+  UV_METRICS_IDLE_TIME,
+  /* This flag is going away again. Use at your own risk. */
+#define UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING \
+    UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING
+  UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING = 1 << 30
 } uv_loop_option;
 
 typedef enum {

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -801,8 +801,15 @@ void uv__fs_readdir_cleanup(uv_fs_t* req) {
 
 
 int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
+  uv__loop_internal_fields_t* lfields;
   va_list ap;
   int err;
+
+  if (option == UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING) {
+    lfields = uv__get_internal_fields(loop);
+    lfields->flags |= UV_LOOP_EXPERIMENTAL_LINUX_ONLY_ERROR_UNLESS_IOURING;
+    return 0;
+  }
 
   va_start(ap, option);
   /* Any platform-agnostic options should be handled here. */


### PR DESCRIPTION
Add a uv_loop_configure() flag that tells libuv to return UV_EBUSY instead of falling back to the thread pool when io_uring is not available for operations that would otherwise be handed off to it.

Refs: https://github.com/libuv/libuv/discussions/4034

<hr>

Not intended for review or merge, I just want to see the outcome of the CI.

cc @cole-miller