### PR TITLE
test,win: enable tcp_connect_error_after_write

### DIFF
--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -55,11 +55,6 @@ static void write_cb(uv_write_t* req, int status) {
  * Related issue: https://github.com/joyent/libuv/issues/443
  */
 TEST_IMPL(tcp_connect_error_after_write) {
-#ifdef _WIN32
-  RETURN_SKIP("This test is disabled on Windows for now. "
-              "See https://github.com/joyent/libuv/issues/444\n");
-#else
-
   uv_connect_t connect_req;
   struct sockaddr_in addr;
   uv_write_t write_req;
@@ -74,7 +69,11 @@ TEST_IMPL(tcp_connect_error_after_write) {
   ASSERT_OK(r);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
+#ifdef _WIN32
+  ASSERT_EQ(r, UV_EPIPE);
+#else
   ASSERT_EQ(r, UV_EBADF);
+#endif
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -94,5 +93,4 @@ TEST_IMPL(tcp_connect_error_after_write) {
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
-#endif
 }


### PR DESCRIPTION
The test was added in 2012 but never enabled on Windows. Let's see how it fares anno 2023.