### PR TITLE
linux: work around io_uring IORING_OP_CLOSE bug

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -57,7 +57,6 @@
 
 #if defined(__linux__)
 # include <sys/sendfile.h>
-# include <sys/utsname.h>
 #endif
 
 #if defined(__sun)
@@ -899,31 +898,6 @@ out:
 
 
 #ifdef __linux__
-unsigned uv__kernel_version(void) {
-  static _Atomic unsigned cached_version;
-  struct utsname u;
-  unsigned version;
-  unsigned major;
-  unsigned minor;
-  unsigned patch;
-
-  version = atomic_load_explicit(&cached_version, memory_order_relaxed);
-  if (version != 0)
-    return version;
-
-  if (-1 == uname(&u))
-    return 0;
-
-  if (3 != sscanf(u.release, "%u.%u.%u", &major, &minor, &patch))
-    return 0;
-
-  version = major * 65536 + minor * 256 + patch;
-  atomic_store_explicit(&cached_version, version, memory_order_relaxed);
-
-  return version;
-}
-
-
 /* Pre-4.20 kernels have a bug where CephFS uses the RADOS copy-from command
  * in copy_file_range() when it shouldn't. There is no workaround except to
  * fall back to a regular copy.


### PR DESCRIPTION
Work around a poorly understood bug in older kernels where closing a file descriptor pointing to /foo/bar results in ETXTBSY errors when trying to execve("/foo/bar") later on.

The bug seems to have been fixed somewhere between 5.15.78 and 5.15.98. I couldn't pinpoint the responsible commit but good candidates are the several data race fixes.

Interestingly, it seems to manifest only when running under Docker so the possibility of Docker bug can't be completely ruled out either.

This commit moves uv__kernel_version() from fs.c to linux.c because the latter now uses it more than the former.

Fixes: https://github.com/nodejs/node/issues/48444