### PR TITLE
fs:  no malloc buffer for sync read/write on unix.

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -2164,7 +2164,6 @@ int uv_fs_write(uv_loop_t* loop,
     return UV_EINVAL;
 
   req->file = file;
-
   req->off = off;
   req->nbufs = nbufs;
 
@@ -2180,9 +2179,9 @@ int uv_fs_write(uv_loop_t* loop,
 
     if (uv__iou_fs_read_or_write(loop, req, /* is_read */ 0))
       return 0;
-	} else {
-		req->bufs = (uv_buf_t*)bufs;
-	}
+  } else {
+    req->bufs = (uv_buf_t*)bufs;
+  }
 
   POST;
 }


### PR DESCRIPTION
Closes #4038. 
Modified uv_fs_read and uv_fs_write to malloc and copy the buffer only when cb != NULL.
Lastly, added checks for cb == NULL in uv__fs_read and uv__fs_write_all to avoid
freeing automatically allocated buffer when synchronous.