### PR TITLE
Release v1.46.0 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -542,3 +542,9 @@ Lewis Russell <me@lewisr.dev>
 sivadeilra <arlie.davis@gmail.com>
 cui fliter <imcusg@gmail.com>
 Mohammed Keyvanzadeh <mohammadkeyvanzade94@gmail.com>
+Niklas Mischkulnig <4586894+mischnic@users.noreply.github.com>
+Stefan Karpinski <stefan@karpinski.org>
+liuxiang88 <94350585+liuxiang88@users.noreply.github.com>
+Jeffrey H. Johnson <trnsz@pobox.com>
+Abdirahim Musse <33973272+abmusse@users.noreply.github.com>
+小明 <7737673+caobug@users.noreply.github.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2023.06.30, Version 1.46.0 (Stable)
+2023.06.30, Version 1.46.0 (Stable), f0bb7e40f0508bedf6fad33769b3f87bb8aedfa6
 
 Changes since version 1.45.0:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,62 @@
+2023.06.30, Version 1.46.0 (Stable)
+
+Changes since version 1.45.0:
+
+* Add SHA to ChangeLog (Santiago Gimeno)
+
+* misc: update readthedocs config (Jameson Nash)
+
+* test: remove erroneous RETURN_SKIP (Ben Noordhuis)
+
+* android: disable io_uring support (Ben Noordhuis)
+
+* linux: add some more iouring backed fs ops (Santiago Gimeno)
+
+* build: add autoconf option for disable-maintainer-mode (Jameson Nash)
+
+* fs: use WTF-8 on Windows (Stefan Karpinski)
+
+* unix,win: replace QUEUE with struct uv__queue (Ben Noordhuis)
+
+* linux: fs_read to use io_uring if iovcnt > IOV_MAX (Santiago Gimeno)
+
+* ios: fix uv_getrusage() ru_maxrss calculation (Ben Noordhuis)
+
+* include: update outdated code comment (Ben Noordhuis)
+
+* linux: support abstract unix sockets (Ben Noordhuis)
+
+* unix,win: add UV_PIPE_NO_TRUNCATE flag (Ben Noordhuis)
+
+* unix: add loongarch support (liuxiang88)
+
+* doc: add DPS8M to LINKS.md (Jeffrey H. Johnson)
+
+* include: add EUNATCH errno mapping (Abdirahim Musse)
+
+* src: don't run timers if loop is stopped/unref'd (Trevor Norris)
+
+* win: fix -Wpointer-to-int-cast warning (Ben Noordhuis)
+
+* test,win: fix -Wunused-variable warning (Ben Noordhuis)
+
+* test,win: fix -Wformat warning (Ben Noordhuis)
+
+* linux: work around io_uring IORING_OP_CLOSE bug (Ben Noordhuis)
+
+* win: remove unused functions (Ben Noordhuis)
+
+* bench: add bench to check uv_loop_alive (Trevor Norris)
+
+* test: add uv_cancel test for threadpool (Trevor Norris)
+
+* unix: skip prohibited syscalls on tvOS and watchOS (小明)
+
+* unix,fs: make no_pwritev access thread-safe (Santiago Gimeno)
+
+* unix: fix build for lower versions of Android (小明)
+
+
 2023.05.19, Version 1.45.0 (Stable), 96e05543f53b19d9642b4b0dd73b86ad3cea313e
 
 Changes since version 1.44.2:

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 AC_PREREQ(2.57)
-AC_INIT([libuv], [1.45.1-dev], [https://github.com/libuv/libuv/issues])
+AC_INIT([libuv], [1.46.0], [https://github.com/libuv/libuv/issues])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/libuv-extra-automake-flags.m4])
 m4_include([m4/as_case.m4])

--- a/include/uv/version.h
+++ b/include/uv/version.h
@@ -31,10 +31,10 @@
  */
 
 #define UV_VERSION_MAJOR 1
-#define UV_VERSION_MINOR 45
-#define UV_VERSION_PATCH 1
-#define UV_VERSION_IS_RELEASE 0
-#define UV_VERSION_SUFFIX "dev"
+#define UV_VERSION_MINOR 46
+#define UV_VERSION_PATCH 0
+#define UV_VERSION_IS_RELEASE 1
+#define UV_VERSION_SUFFIX ""
 
 #define UV_VERSION_HEX  ((UV_VERSION_MAJOR << 16) | \
                          (UV_VERSION_MINOR <<  8) | \


### PR DESCRIPTION
Finalize `v1.46.0`. Already tagged, pushed and artifacts published, but the `v1.x` branch is protected so I need a PR for this.