### PR TITLE
test: fix out-of-bounds access

### DIFF
--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -41,7 +41,7 @@ TEST_IMPL(cwd_and_chdir) {
   err = uv_cwd(buffer_orig, &size1);
   ASSERT(err == 0);
   ASSERT(size1 > 0);
-  ASSERT(buffer_orig[size1] != '/');
+  ASSERT(buffer_orig[size1 - 1] != '/');
 
   err = uv_chdir(buffer_orig);
   ASSERT(err == 0);


### PR DESCRIPTION
The `size1` variable is reassigned to the size of `buffer_orig` which is 4096 but tries to access index 4096 using the size which overruns the array, subtract by 1 to correctly access the last element.