### PR TITLE
unix: match kqueue and epoll code

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -262,6 +262,9 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     if (nfds == -1)
       assert(errno == EINTR);
+    else if (nfds == 0)
+      /* Unlimited timeout should only return with events or signal. */
+      assert(timeout != -1);
 
     if (pset != NULL)
       pthread_sigmask(SIG_UNBLOCK, pset, NULL);
@@ -286,8 +289,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         timeout = user_timeout;
         reset_timeout = 0;
       } else if (nfds == 0) {
-        /* Reached the user timeout value. */
-        assert(timeout != -1);
         return;
       }
 


### PR DESCRIPTION
Made this PR more for discussion about the kqueue and epoll implementations. They're very similar, but the ~~addition~~ changed location of a check in 42cc412c ~~has caused a~~ is crashing as reported in  https://github.com/nodejs/node/issues/48490. It's unknown why this is happening, and the `assert()` has been moved to be directly after `kevent()` to make reasoning easier while debugging the crash. Instead of making the `assert()` conditional on the state of `reset_timeout`.

I'm currently trying to replicate the crash in the linked node issue. So far have been unsuccessful. Also, by removing the early return we enforce updating the timestamp. Not sure if that would have been considered a bug.

Then main question is, should `timeout` never be `-1` if `nfds == 0`?