### PR TITLE
doc: switch to Furo, a more modern Sphinx theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,27 +1,36 @@
 # primary
-sphinx==6.1.3
+furo==2023.5.20
+Sphinx==6.1.3
 
 # dependencies
 alabaster==0.7.13
 Babel==2.11.0
+beautifulsoup4==4.12.2
 certifi==2022.12.7
 charset-normalizer==3.0.1
+colorama==0.4.6
 docutils==0.19
 idna==3.4
 imagesize==1.4.1
 importlib-metadata==6.0.0
 Jinja2==3.1.2
+livereload==2.6.3
 MarkupSafe==2.1.2
 packaging==23.0
 Pygments==2.14.0
 pytz==2022.7.1
 requests==2.28.2
+six==1.16.0
 snowballstemmer==2.2.0
-sphinxcontrib-applehelp==1.0.3
+soupsieve==2.4.1
+sphinx-autobuild==2021.3.14
+sphinx-basic-ng==1.0.0b2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib.applehelp==1.0.3
+tornado==6.3.2
 urllib3==1.26.14
 zipp==3.11.0

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -118,7 +118,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
It's responsive and the content is centered on the screen. Also, dark mode!

<img width="2672" alt="Screen Shot 2023-07-13 at 22 50 19" src="https://github.com/libuv/libuv/assets/317464/0bf4ffa2-b172-46ec-b404-8c86894b2f06">
<img width="2672" alt="Screen Shot 2023-07-13 at 22 49 49" src="https://github.com/libuv/libuv/assets/317464/cee653fa-c76a-46f1-9924-61bd41942099">
<img width="2672" alt="Screen Shot 2023-07-13 at 22 49 34" src="https://github.com/libuv/libuv/assets/317464/97b11ed2-4293-447f-988c-d5506959ee92">
<img width="2672" alt="Screen Shot 2023-07-13 at 22 48 56" src="https://github.com/libuv/libuv/assets/317464/49abe8a9-1213-4b0b-a920-ba47d36281d3">
<img width="2672" alt="Screen Shot 2023-07-13 at 22 48 47" src="https://github.com/libuv/libuv/assets/317464/1ba460d2-4449-4ee7-a48d-db728415fdce">
