### PR TITLE
build: upgrade qemu-user-static package

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -125,7 +125,7 @@ jobs:
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:
           QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_7\\.2+dfsg-.*_amd64.deb$"
+          QEMU_VER: "qemu-user-static_8\\.0\\.4+dfsg-.*_amd64.deb$"
         run: |
           DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
           wget $QEMU_SRC/$DEB


### PR DESCRIPTION
qemu 8 contains a bug fix that is needed to make an upcoming libuv feature work on systems where the host endianness differs from the target endianness. Without it, the regression test fails on such systems.

Refs: https://github.com/libuv/libuv/pull/4107
Refs: https://github.com/qemu/qemu/commit/44cf6731d6b