### PR TITLE
build: silence CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.9)
 
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW) # Enable MSVC_RUNTIME_LIBRARY setting


### PR DESCRIPTION
CMake 3.27 now warns that "Compatibility with CMake < 3.5 will be removed from a future version of CMake." (https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features)

This PR adds 3.5 as an allowable minimum CMake version, keeping the "minimum minimum" at 3.4.

Background: GitHub recently upgraded the version of CMake on their Ubuntu 22.04 container image to 3.27 (https://github.com/actions/runner-images/commit/79252fad3a14bc2c1893881d39d51905c4d2d50d), and this broke the build for some projects that include libuv with `-Werror=dev` (e.g. https://github.com/WebAssembly/wabt/pull/2273).

Could also just bump the minimum up to 3.5 (or higher) if you prefer. It was last updated in https://github.com/libuv/libuv/pull/2495