### PR TITLE
doc: minor clarification about safe memory access

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1394,7 +1394,7 @@ int uv_write2(uv_write_t* req,
 }
 
 
-/* The buffers to be written must remain valid until the callback is called.
+/* The buffers to be written must not be accessed until the callback is called.
  * This is not required for the uv_buf_t array.
  */
 int uv_write(uv_write_t* req,


### PR DESCRIPTION
Regarding Windows the documentation for `uv_write` is incorrect. 

From the `WSASend` documentation on [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasend)
>[in] lpBuffers
A pointer to an array of [WSABUF](https://learn.microsoft.com/en-us/windows/desktop/api/ws2def/ns-ws2def-wsabuf) structures. Each WSABUF structure contains a pointer to a buffer and the length, in bytes, of the buffer. For a Winsock application, once the WSASend function is called, the system owns these buffers and the application may not access them. This array must remain valid for the duration of the send operation.

The problem is `uv_write` invokes WSASend asynchronously so in the meantime you can't access the buffers you give it. `uv_write` says they must "remain valid" which is kind of ambiguous and sounds like they shouldn't be freed or something.

This made a data race out of what I thought was a benign race condition in my code. I only realized this after looking through the implementation of `uv_write`.

Also I realize this is from the unix implementation file and things might be different on POSIX systems, but this is the documentation that's part of the autodocs for all platforms.

Feel free to change the wording of the documentation however you like, I'd just like it to get the point across.