### PR TITLE
doc: fix broken "Shared library" Wikipedia link which is causing `linkcheck`/`CI-docs` to fail

### DIFF
--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -363,7 +363,7 @@ to get the error message.
 argument. ``init_plugin_function`` is a function pointer to the sort of
 function we are looking for in the application's plugins.
 
-.. _shared libraries: https://en.wikipedia.org/wiki/Shared_library#Shared_libraries
+.. _shared libraries: https://en.wikipedia.org/wiki/Shared_library
 
 TTY
 ---


### PR DESCRIPTION
`linkcheck` is printing the following error:

```
( guide/utilities: line  311) broken    https://en.wikipedia.org/wiki/Shared_library#Shared_libraries - Anchor 'Shared_libraries' not found
```

We can see this error when running the [`CI-docs` GitHub Action](https://github.com/libuv/libuv/actions/workflows/CI-docs.yml), see https://github.com/libuv/libuv/actions/runs/5714962859/job/15483307862 on PR https://github.com/libuv/libuv/pull/4113.


It looks like the Wikipedia page changed on `13:03, 28 July 2023`, see https://en.wikipedia.org/w/index.php?title=Shared_library&oldid=1167554761.

---

FYI, I wasn't sure whether the word-wrap the `linkcheck` error message in my commit to 72 chars or not, but most projects I've seen generally don't line-wrap errors in commit messages, so I haven't either.