### PR TITLE
[v2] docs: fix bad reStructuredText directive

### DIFF
--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -59,7 +59,7 @@ API
         If a path on Unix exceeds ``sizeof(sockaddr_un.sun_path)`` bytes, typically between
         92 and 108 bytes, ``uv_pipe_bind`` will fail with ``UV_ENAMETOOLONG``.
 
-    .. versionchanged: 2.0.0 long filenames will lead to an error rather than being truncated
+    .. versionchanged:: 2.0.0 long filenames will lead to an error rather than being truncated
 
 .. c:function:: void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle, const char* name, uv_connect_cb cb)
 
@@ -69,7 +69,7 @@ API
         If a path on Unix exceeds ``sizeof(sockaddr_un.sun_path)`` bytes, typically between
         92 and 108 bytes, ``uv_pipe_bind`` will fail with ``UV_ENAMETOOLONG``.
 
-    .. versionchanged: 2.0.0 long filenames will lead to an error rather than being truncated
+    .. versionchanged:: 2.0.0 long filenames will lead to an error rather than being truncated
 
 .. c:function:: int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size)
 


### PR DESCRIPTION
reStructuredText requires a `::` (double-colon) to read something as a valid directive. Otherwise, it assumes that the text is just a comment.

Fixes: 66319cf494d7875a6ffc8653928d31ffbd07187f

### Before

_Changed in version 2.0.0: long filenames will lead to an error rather than being truncated_ isn't shown.

![screenshot of HTML website showing that the RST directions aren't working](https://github.com/libuv/libuv/assets/19716675/6180c95d-74bd-46d0-87fd-5d9ff75b33d5)

### After

_Changed in version 2.0.0: long filenames will lead to an error rather than being truncated_ is shown.

![screenshot of HTML website showing that the RST directions work after using a double-colon](https://github.com/libuv/libuv/assets/19716675/59508349-cc0b-49d6-bc69-07515cb87cb5)
