### PR TITLE
[v2] misc: make `uv_ip4_addr()`/`uv_ip6_addr()` accept an `unsigned short` port instead of `int`

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -406,16 +406,20 @@ API
     .. note::
         Returns [0,0,0] on Windows (i.e., it's not implemented).
 
-.. c:function:: int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr)
+.. c:function:: int uv_ip4_addr(const char* ip, unsigned short port, struct sockaddr_in* addr)
 
     Convert a string containing an IPv4 addresses to a binary structure.
 
-.. c:function:: int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr)
+    .. versionchanged:: 2.0.0 now `port` is a `unsigned short` instead
+                        of an `int`.
+
+.. c:function:: int uv_ip6_addr(const char* ip, unsigned short port, struct sockaddr_in6* addr)
 
     Convert a string containing an IPv6 addresses to a binary structure.
 
     .. versionchanged:: 2.0.0: :man:`if_nametoindex(3)` errors are no longer
                         ignored on Unix platforms.
+                        `port` is a `unsigned short` instead of an `int`.
 
 .. c:function:: int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size)
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1763,8 +1763,8 @@ UV_EXTERN int uv_fs_event_getpath(uv_fs_event_t* handle,
                                   char* buffer,
                                   size_t* size);
 
-UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr);
-UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr);
+UV_EXTERN int uv_ip4_addr(const char* ip, unsigned short port, struct sockaddr_in* addr);
+UV_EXTERN int uv_ip6_addr(const char* ip, unsigned short port, struct sockaddr_in6* addr);
 
 UV_EXTERN int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size);
 UV_EXTERN int uv_ip6_name(const struct sockaddr_in6* src, char* dst, size_t size);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -252,7 +252,7 @@ const char* uv_strerror(int err) {
 #undef UV_STRERROR_GEN
 
 
-int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr) {
+int uv_ip4_addr(const char* ip, unsigned short port, struct sockaddr_in* addr) {
   memset(addr, 0, sizeof(*addr));
   addr->sin_family = AF_INET;
   addr->sin_port = htons(port);
@@ -263,7 +263,7 @@ int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr) {
 }
 
 
-int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
+int uv_ip6_addr(const char* ip, unsigned short port, struct sockaddr_in6* addr) {
   char address_part[40];
   size_t address_part_size;
   const char* zone_index;

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -248,7 +248,7 @@ static void on_recv(uv_udp_t* handle,
   ASSERT(0 <= uv_udp_send(req, handle, &sndbuf, 1, addr, on_send));
 }
 
-static int tcp4_echo_start(int port) {
+static int tcp4_echo_start(unsigned short port) {
   struct sockaddr_in addr;
   int r;
 
@@ -282,7 +282,7 @@ static int tcp4_echo_start(int port) {
 }
 
 
-static int tcp6_echo_start(int port) {
+static int tcp6_echo_start(unsigned short port) {
   struct sockaddr_in6 addr6;
   int r;
 
@@ -317,7 +317,7 @@ static int tcp6_echo_start(int port) {
 }
 
 
-static int udp4_echo_start(int port) {
+static int udp4_echo_start(unsigned short port) {
   struct sockaddr_in addr;
   int r;
 

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -28,7 +28,7 @@
 
 static const char* address_ip4 = "127.0.0.1";
 static const char* address_ip6 = "::1";
-static const int port = 80;
+static const unsigned short port = 80;
 
 static struct sockaddr_in addr4;
 static struct sockaddr_in6 addr6;


### PR DESCRIPTION
Change the `port` parameter of `uv_ip4_addr()` and `uv_ip6_addr()` from an `int` to an `unsigned short`.

Currently, the `uv_ip4_addr()` and `uv_ip6_addr()` functions cast the `port` to a `uint16_t` internally anyway, when calling [`htons()`][1].

Making the function accept `unsigned short` instead has two benefits:
  - Very slight performance increase, since we can avoid a `unsigned short` -> `int` -> `unsigned short` conversion.
  - Compilers can warn users of `libuv` if their `port` parameter to `uv_ip4_addr()` might be truncated.

**ABI BREAKING CHANGE**: This PR targets the `master`/v2 branch, as this change breaks the ABI. Although, it does not break the API (other than potentially causing some compiler warnings if the user calls this function with overflowing types), so I haven't bothered putting a message into the [libuv v1 -> v2 migration guide](https://github.com/libuv/libuv/blob/a877ca2435134ef86315326ef4ef0c16bdbabf17/docs/src/migration_100_200.rst).

[1]: https://linux.die.net/man/3/htons

---

The `CI-docs` CI will probably fail due to a broken link that's unrelated to this PR.

It's already been fixed in the `v1.x` branch thanks to PR https://github.com/libuv/libuv/pull/4128, but this PR targets the `master` branch, which doesn't yet have this fix.