### PR TITLE
feat: visibility under control by -fvisibility flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,9 @@ AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AS_CASE([$host_os], [haiku], [
     LIBS="$LIBS -lnetwork"
 ])
+AS_IF([test "x$enable_shared" = xyes],
+    [AC_DEFINE([BUILDING_UV_SHARED], [1], [Define if building a shared library])
+])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])
 AC_CONFIG_LINKS([test/fixtures/empty_file:test/fixtures/empty_file])

--- a/include/uv.h
+++ b/include/uv.h
@@ -45,7 +45,11 @@ extern "C" {
 #   define UV_EXTERN /* nothing */
 # endif
 #elif __GNUC__ >= 4
+# if defined(BUILDING_UV_SHARED)
 # define UV_EXTERN __attribute__((visibility("default")))
+# else
+# define UV_EXTERN /* nothing */
+# endif
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550) /* Sun Studio >= 8 */
 # define UV_EXTERN __global
 #else


### PR DESCRIPTION
On Unix-like systems, if the `UV_EXTERN` macro is not manually defined, `UV_EXTERN` will always make the symbol visible when `__GNUC__ >= 4`, which will result in compilation that is not controlled by the compile option `-fvisibility=hidden`.

In historical PR #3855, there is a submission that determines whether `UV_EXTERN` is artificially defined. If it is defined, the user-defined one will prevail. But once this macro is defined, the `__declspec` related options under Windows will be affected, and you have to decide whether to define the `UV_EXTERN` macro before compilation based on the platform.

This is not a reasonable usage scenario, so submit this PR to modify if `__GNUC__ >= 4` is compiled as a dynamic library, use `__attribute__((visibility("default")))`, otherwise use the default compilation option `-fvisibility=hidden` determines.