### PR TITLE
test: fix get_passwd2 on IBM i

### DIFF
--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -142,8 +142,9 @@ TEST_IMPL(get_passwd2) {
   ASSERT_STR_EQ(pwd2.username, "root");
 #endif
   len = strlen(pwd2.homedir);
+# ifndef __PASE__
   ASSERT_GT(len, 0);
-
+#endif
   len = strlen(pwd2.shell);
 # ifndef __PASE__
   ASSERT_GT(len, 0);

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -135,8 +135,12 @@ TEST_IMPL(get_passwd2) {
 
   len = strlen(pwd2.username);
   ASSERT_GT(len, 0);
+#if defined(__PASE__)
+  // uid 0 is qsecofr on IBM i
+  ASSERT_STR_EQ(pwd2.username, "qsecofr");
+#else
   ASSERT_STR_EQ(pwd2.username, "root");
-
+#endif
   len = strlen(pwd2.homedir);
   ASSERT_GT(len, 0);
 


### PR DESCRIPTION
Part of https://github.com/libuv/libuv/issues/4143

uid 0 is qsecofr on IBM i