### PR TITLE
test: switch from old-style ASSERT macro to new-style ASSERT_EQ,... macros #2974

### DIFF
--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -71,21 +71,21 @@ static int test_async_pummel(int nthreads) {
   tids = calloc(nthreads, sizeof(tids[0]));
   ASSERT_NOT_NULL(tids);
 
-  ASSERT(0 == uv_async_init(uv_default_loop(), &handle, async_cb));
+  ASSERT_EQ(0, uv_async_init(uv_default_loop(), &handle, async_cb));
   ACCESS_ONCE(const char*, handle.data) = running;
 
   for (i = 0; i < nthreads; i++)
-    ASSERT(0 == uv_thread_create(tids + i, pummel, &handle));
+    ASSERT_EQ(0, uv_thread_create(tids + i, pummel, &handle));
 
   time = uv_hrtime();
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   time = uv_hrtime() - time;
   done = 1;
 
   for (i = 0; i < nthreads; i++)
-    ASSERT(0 == uv_thread_join(tids + i));
+    ASSERT_EQ(0, uv_thread_join(tids + i));
 
   printf("async_pummel_%d: %s callbacks in %.2f seconds (%s/sec)\n",
          nthreads,

--- a/test/benchmark-async-pummel.c
+++ b/test/benchmark-async-pummel.c
@@ -71,21 +71,21 @@ static int test_async_pummel(int nthreads) {
   tids = calloc(nthreads, sizeof(tids[0]));
   ASSERT_NOT_NULL(tids);
 
-  ASSERT_EQ(0, uv_async_init(uv_default_loop(), &handle, async_cb));
+  ASSERT_OK(uv_async_init(uv_default_loop(), &handle, async_cb));
   ACCESS_ONCE(const char*, handle.data) = running;
 
   for (i = 0; i < nthreads; i++)
-    ASSERT_EQ(0, uv_thread_create(tids + i, pummel, &handle));
+    ASSERT_OK(uv_thread_create(tids + i, pummel, &handle));
 
   time = uv_hrtime();
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   time = uv_hrtime() - time;
   done = 1;
 
   for (i = 0; i < nthreads; i++)
-    ASSERT_EQ(0, uv_thread_join(tids + i));
+    ASSERT_OK(uv_thread_join(tids + i));
 
   printf("async_pummel_%d: %s callbacks in %.2f seconds (%s/sec)\n",
          nthreads,

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -43,7 +43,7 @@ struct ctx {
 static void worker_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, worker_async);
 
-  ASSERT(0 == uv_async_send(&ctx->main_async));
+  ASSERT_EQ(0, uv_async_send(&ctx->main_async));
   ctx->worker_sent++;
   ctx->worker_seen++;
 
@@ -55,7 +55,7 @@ static void worker_async_cb(uv_async_t* handle) {
 static void main_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, main_async);
 
-  ASSERT(0 == uv_async_send(&ctx->worker_async));
+  ASSERT_EQ(0, uv_async_send(&ctx->worker_async));
   ctx->main_sent++;
   ctx->main_seen++;
 
@@ -66,8 +66,8 @@ static void main_async_cb(uv_async_t* handle) {
 
 static void worker(void* arg) {
   struct ctx* ctx = arg;
-  ASSERT(0 == uv_async_send(&ctx->main_async));
-  ASSERT(0 == uv_run(&ctx->loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_async_send(&ctx->main_async));
+  ASSERT_EQ(0, uv_run(&ctx->loop, UV_RUN_DEFAULT));
   uv_loop_close(&ctx->loop);
 }
 
@@ -85,29 +85,29 @@ static int test_async(int nthreads) {
   for (i = 0; i < nthreads; i++) {
     ctx = threads + i;
     ctx->nthreads = nthreads;
-    ASSERT(0 == uv_loop_init(&ctx->loop));
-    ASSERT(0 == uv_async_init(&ctx->loop, &ctx->worker_async, worker_async_cb));
-    ASSERT(0 == uv_async_init(uv_default_loop(),
-                              &ctx->main_async,
-                              main_async_cb));
-    ASSERT(0 == uv_thread_create(&ctx->thread, worker, ctx));
+    ASSERT_EQ(0, uv_loop_init(&ctx->loop));
+    ASSERT_EQ(0, uv_async_init(&ctx->loop, &ctx->worker_async, worker_async_cb));
+    ASSERT_EQ(0, uv_async_init(uv_default_loop(),
+                               &ctx->main_async,
+                               main_async_cb));
+    ASSERT_EQ(0, uv_thread_create(&ctx->thread, worker, ctx));
   }
 
   time = uv_hrtime();
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   for (i = 0; i < nthreads; i++)
-    ASSERT(0 == uv_thread_join(&threads[i].thread));
+    ASSERT_EQ(0, uv_thread_join(&threads[i].thread));
 
   time = uv_hrtime() - time;
 
   for (i = 0; i < nthreads; i++) {
     ctx = threads + i;
-    ASSERT(ctx->worker_sent == NUM_PINGS);
-    ASSERT(ctx->worker_seen == NUM_PINGS);
-    ASSERT(ctx->main_sent == (unsigned int) NUM_PINGS);
-    ASSERT(ctx->main_seen == (unsigned int) NUM_PINGS);
+    ASSERT_EQ(ctx->worker_sent, NUM_PINGS);
+    ASSERT_EQ(ctx->worker_seen, NUM_PINGS);
+    ASSERT_EQ(ctx->main_sent, (unsigned int) NUM_PINGS);
+    ASSERT_EQ(ctx->main_seen, (unsigned int) NUM_PINGS);
   }
 
   printf("async%d: %.2f sec (%s/sec)\n",

--- a/test/benchmark-async.c
+++ b/test/benchmark-async.c
@@ -43,7 +43,7 @@ struct ctx {
 static void worker_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, worker_async);
 
-  ASSERT_EQ(0, uv_async_send(&ctx->main_async));
+  ASSERT_OK(uv_async_send(&ctx->main_async));
   ctx->worker_sent++;
   ctx->worker_seen++;
 
@@ -55,7 +55,7 @@ static void worker_async_cb(uv_async_t* handle) {
 static void main_async_cb(uv_async_t* handle) {
   struct ctx* ctx = container_of(handle, struct ctx, main_async);
 
-  ASSERT_EQ(0, uv_async_send(&ctx->worker_async));
+  ASSERT_OK(uv_async_send(&ctx->worker_async));
   ctx->main_sent++;
   ctx->main_seen++;
 
@@ -66,8 +66,8 @@ static void main_async_cb(uv_async_t* handle) {
 
 static void worker(void* arg) {
   struct ctx* ctx = arg;
-  ASSERT_EQ(0, uv_async_send(&ctx->main_async));
-  ASSERT_EQ(0, uv_run(&ctx->loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_async_send(&ctx->main_async));
+  ASSERT_OK(uv_run(&ctx->loop, UV_RUN_DEFAULT));
   uv_loop_close(&ctx->loop);
 }
 
@@ -85,20 +85,20 @@ static int test_async(int nthreads) {
   for (i = 0; i < nthreads; i++) {
     ctx = threads + i;
     ctx->nthreads = nthreads;
-    ASSERT_EQ(0, uv_loop_init(&ctx->loop));
-    ASSERT_EQ(0, uv_async_init(&ctx->loop, &ctx->worker_async, worker_async_cb));
-    ASSERT_EQ(0, uv_async_init(uv_default_loop(),
-                               &ctx->main_async,
-                               main_async_cb));
-    ASSERT_EQ(0, uv_thread_create(&ctx->thread, worker, ctx));
+    ASSERT_OK(uv_loop_init(&ctx->loop));
+    ASSERT_OK(uv_async_init(&ctx->loop, &ctx->worker_async, worker_async_cb));
+    ASSERT_OK(uv_async_init(uv_default_loop(),
+                            &ctx->main_async,
+                            main_async_cb));
+    ASSERT_OK(uv_thread_create(&ctx->thread, worker, ctx));
   }
 
   time = uv_hrtime();
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   for (i = 0; i < nthreads; i++)
-    ASSERT_EQ(0, uv_thread_join(&threads[i].thread));
+    ASSERT_OK(uv_thread_join(&threads[i].thread));
 
   time = uv_hrtime() - time;
 

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -43,7 +43,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle);
 
 static void getaddrinfo_cb(uv_getaddrinfo_t* handle, int status,
     struct addrinfo* res) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   calls_completed++;
   if (calls_initiated < TOTAL_CALLS) {
     getaddrinfo_initiate(handle);
@@ -59,7 +59,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle) {
   calls_initiated++;
 
   r = uv_getaddrinfo(loop, handle, &getaddrinfo_cb, name, NULL, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 

--- a/test/benchmark-getaddrinfo.c
+++ b/test/benchmark-getaddrinfo.c
@@ -43,7 +43,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle);
 
 static void getaddrinfo_cb(uv_getaddrinfo_t* handle, int status,
     struct addrinfo* res) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   calls_completed++;
   if (calls_initiated < TOTAL_CALLS) {
     getaddrinfo_initiate(handle);
@@ -59,7 +59,7 @@ static void getaddrinfo_initiate(uv_getaddrinfo_t* handle) {
   calls_initiated++;
 
   r = uv_getaddrinfo(loop, handle, &getaddrinfo_cb, name, NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -80,8 +80,8 @@ BENCHMARK_IMPL(getaddrinfo) {
   uv_update_time(loop);
   end_time = uv_now(loop);
 
-  ASSERT(calls_initiated == TOTAL_CALLS);
-  ASSERT(calls_completed == TOTAL_CALLS);
+  ASSERT_EQ(calls_initiated, TOTAL_CALLS);
+  ASSERT_EQ(calls_completed, TOTAL_CALLS);
 
   fprintf(stderr, "getaddrinfo: %.0f req/s\n",
           (double) calls_completed / (double) (end_time - start_time) * 1000.0);

--- a/test/benchmark-loop-count.c
+++ b/test/benchmark-loop-count.c
@@ -74,7 +74,7 @@ BENCHMARK_IMPL(loop_count) {
   uv_run(loop, UV_RUN_DEFAULT);
   ns = uv_hrtime() - ns;
 
-  ASSERT(ticks == NUM_TICKS);
+  ASSERT_UINT64_EQ(ticks, NUM_TICKS);
 
   fprintf(stderr, "loop_count: %d ticks in %.2fs (%.0f/s)\n",
           NUM_TICKS,

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -60,7 +60,7 @@ static void timer_cb(uv_timer_t* handle) {
   unsigned i;
 
   done = 1;
-  ASSERT_EQ(0, uv_thread_join(&thread_id));
+  ASSERT_OK(uv_thread_join(&thread_id));
 
   for (i = 0; i < ARRAY_SIZE(container->async_handles); i++) {
     uv_async_t* handle = container->async_handles + i;
@@ -93,14 +93,14 @@ BENCHMARK_IMPL(million_async) {
 
   for (i = 0; i < ARRAY_SIZE(container->async_handles); i++) {
     handle = container->async_handles + i;
-    ASSERT_EQ(0, uv_async_init(loop, handle, async_cb));
+    ASSERT_OK(uv_async_init(loop, handle, async_cb));
     handle->data = NULL;
   }
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, timeout, 0));
-  ASSERT_EQ(0, uv_thread_create(&thread_id, thread_cb, NULL));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, timeout, 0));
+  ASSERT_OK(uv_thread_create(&thread_id, thread_cb, NULL));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   printf("%s async events in %.1f seconds (%s/s, %s unique handles seen)\n",
           fmt(&fmtbuf[0], container->async_events),
           timeout / 1000.,

--- a/test/benchmark-million-async.c
+++ b/test/benchmark-million-async.c
@@ -60,7 +60,7 @@ static void timer_cb(uv_timer_t* handle) {
   unsigned i;
 
   done = 1;
-  ASSERT(0 == uv_thread_join(&thread_id));
+  ASSERT_EQ(0, uv_thread_join(&thread_id));
 
   for (i = 0; i < ARRAY_SIZE(container->async_handles); i++) {
     uv_async_t* handle = container->async_handles + i;
@@ -93,14 +93,14 @@ BENCHMARK_IMPL(million_async) {
 
   for (i = 0; i < ARRAY_SIZE(container->async_handles); i++) {
     handle = container->async_handles + i;
-    ASSERT(0 == uv_async_init(loop, handle, async_cb));
+    ASSERT_EQ(0, uv_async_init(loop, handle, async_cb));
     handle->data = NULL;
   }
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, timeout, 0));
-  ASSERT(0 == uv_thread_create(&thread_id, thread_cb, NULL));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, timeout, 0));
+  ASSERT_EQ(0, uv_thread_create(&thread_id, thread_cb, NULL));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
   printf("%s async events in %.1f seconds (%s/s, %s unique handles seen)\n",
           fmt(&fmtbuf[0], container->async_events),
           timeout / 1000.,

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -57,22 +57,22 @@ BENCHMARK_IMPL(million_timers) {
   before_all = uv_hrtime();
   for (i = 0; i < NUM_TIMERS; i++) {
     if (i % 1000 == 0) timeout++;
-    ASSERT(0 == uv_timer_init(loop, timers + i));
-    ASSERT(0 == uv_timer_start(timers + i, timer_cb, timeout, 0));
+    ASSERT_EQ(uv_timer_init(loop, timers + i), 0);
+    ASSERT_EQ(uv_timer_start(timers + i, timer_cb, timeout, 0), 0);
   }
 
   before_run = uv_hrtime();
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(uv_run(loop, UV_RUN_DEFAULT), 0);
   after_run = uv_hrtime();
 
   for (i = 0; i < NUM_TIMERS; i++)
     uv_close((uv_handle_t*) (timers + i), close_cb);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
   after_all = uv_hrtime();
 
-  ASSERT(timer_cb_called == NUM_TIMERS);
-  ASSERT(close_cb_called == NUM_TIMERS);
+  ASSERT_EQ(timer_cb_called, NUM_TIMERS);
+  ASSERT_EQ(close_cb_called, NUM_TIMERS);
   free(timers);
 
   fprintf(stderr, "%.2f seconds total\n", (after_all - before_all) / 1e9);

--- a/test/benchmark-million-timers.c
+++ b/test/benchmark-million-timers.c
@@ -57,18 +57,18 @@ BENCHMARK_IMPL(million_timers) {
   before_all = uv_hrtime();
   for (i = 0; i < NUM_TIMERS; i++) {
     if (i % 1000 == 0) timeout++;
-    ASSERT_EQ(uv_timer_init(loop, timers + i), 0);
-    ASSERT_EQ(uv_timer_start(timers + i, timer_cb, timeout, 0), 0);
+    ASSERT_OK(uv_timer_init(loop, timers + i));
+    ASSERT_OK(uv_timer_start(timers + i, timer_cb, timeout, 0));
   }
 
   before_run = uv_hrtime();
-  ASSERT_EQ(uv_run(loop, UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   after_run = uv_hrtime();
 
   for (i = 0; i < NUM_TIMERS; i++)
     uv_close((uv_handle_t*) (timers + i), close_cb);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   after_all = uv_hrtime();
 
   ASSERT_EQ(timer_cb_called, NUM_TIMERS);

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -117,19 +117,19 @@ static void ipc_connection_cb(uv_stream_t* ipc_pipe, int status) {
   ASSERT_NOT_NULL(pc);
 
   if (ipc_pipe->type == UV_TCP)
-    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) &pc->peer_handle));
+    ASSERT_OK(uv_tcp_init(loop, (uv_tcp_t*) &pc->peer_handle));
   else if (ipc_pipe->type == UV_NAMED_PIPE)
-    ASSERT_EQ(0, uv_pipe_init(loop, (uv_pipe_t*) &pc->peer_handle, 1));
+    ASSERT_OK(uv_pipe_init(loop, (uv_pipe_t*) &pc->peer_handle, 1));
   else
     ASSERT(0);
 
-  ASSERT_EQ(0, uv_accept(ipc_pipe, (uv_stream_t*) &pc->peer_handle));
-  ASSERT_EQ(0, uv_write2(&pc->write_req,
-                         (uv_stream_t*) &pc->peer_handle,
-                         &buf,
-                         1,
-                         (uv_stream_t*) &sc->server_handle,
-                         ipc_write_cb));
+  ASSERT_OK(uv_accept(ipc_pipe, (uv_stream_t*) &pc->peer_handle));
+  ASSERT_OK(uv_write2(&pc->write_req,
+                      (uv_stream_t*) &pc->peer_handle,
+                      &buf,
+                      1,
+                      (uv_stream_t*) &sc->server_handle,
+                      ipc_write_cb));
 
   if (--sc->num_connects == 0)
     uv_close((uv_handle_t*) ipc_pipe, NULL);
@@ -153,10 +153,10 @@ static void ipc_close_cb(uv_handle_t* handle) {
 static void ipc_connect_cb(uv_connect_t* req, int status) {
   struct ipc_client_ctx* ctx;
   ctx = container_of(req, struct ipc_client_ctx, connect_req);
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &ctx->ipc_pipe,
-                             ipc_alloc_cb,
-                             ipc_read_cb));
+  ASSERT_OK(status);
+  ASSERT_OK(uv_read_start((uv_stream_t*) &ctx->ipc_pipe,
+                          ipc_alloc_cb,
+                          ipc_read_cb));
 }
 
 
@@ -185,13 +185,13 @@ static void ipc_read_cb(uv_stream_t* handle,
   ASSERT_EQ(1, uv_pipe_pending_count(ipc_pipe));
   type = uv_pipe_pending_type(ipc_pipe);
   if (type == UV_TCP)
-    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) ctx->server_handle));
+    ASSERT_OK(uv_tcp_init(loop, (uv_tcp_t*) ctx->server_handle));
   else if (type == UV_NAMED_PIPE)
-    ASSERT_EQ(0, uv_pipe_init(loop, (uv_pipe_t*) ctx->server_handle, 0));
+    ASSERT_OK(uv_pipe_init(loop, (uv_pipe_t*) ctx->server_handle, 0));
   else
     ASSERT(0);
 
-  ASSERT_EQ(0, uv_accept(handle, ctx->server_handle));
+  ASSERT_OK(uv_accept(handle, ctx->server_handle));
   uv_close((uv_handle_t*) &ctx->ipc_pipe, NULL);
 }
 
@@ -211,10 +211,10 @@ static void send_listen_handles(uv_handle_type type,
   ctx.num_connects = num_servers;
 
   if (type == UV_TCP) {
-    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) &ctx.server_handle));
-    ASSERT_EQ(0, uv_tcp_bind((uv_tcp_t*) &ctx.server_handle,
-                             (const struct sockaddr*) &listen_addr,
-                             0));
+    ASSERT_OK(uv_tcp_init(loop, (uv_tcp_t*) &ctx.server_handle));
+    ASSERT_OK(uv_tcp_bind((uv_tcp_t*) &ctx.server_handle,
+                          (const struct sockaddr*) &listen_addr,
+                          0));
   }
   else
     ASSERT(0);
@@ -223,16 +223,16 @@ static void send_listen_handles(uv_handle_type type,
    * If we accept a connection then the connected pipe must be initialized
    * with ipc=1.
    */
-  ASSERT_EQ(0, uv_pipe_init(loop, &ctx.ipc_pipe, 0));
-  ASSERT_EQ(0, uv_pipe_bind(&ctx.ipc_pipe, IPC_PIPE_NAME));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb));
+  ASSERT_OK(uv_pipe_init(loop, &ctx.ipc_pipe, 0));
+  ASSERT_OK(uv_pipe_bind(&ctx.ipc_pipe, IPC_PIPE_NAME));
+  ASSERT_OK(uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb));
 
   for (i = 0; i < num_servers; i++)
     uv_sem_post(&servers[i].semaphore);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &ctx.server_handle, NULL);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   for (i = 0; i < num_servers; i++)
     uv_sem_wait(&servers[i].semaphore);
@@ -245,12 +245,12 @@ static void get_listen_handle(uv_loop_t* loop, uv_stream_t* server_handle) {
   ctx.server_handle = server_handle;
   ctx.server_handle->data = "server handle";
 
-  ASSERT_EQ(0, uv_pipe_init(loop, &ctx.ipc_pipe, 1));
+  ASSERT_OK(uv_pipe_init(loop, &ctx.ipc_pipe, 1));
   uv_pipe_connect(&ctx.connect_req,
                   &ctx.ipc_pipe,
                   IPC_PIPE_NAME,
                   ipc_connect_cb);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 }
 
 
@@ -259,9 +259,9 @@ static void server_cb(void *arg) {
   uv_loop_t loop;
 
   ctx = arg;
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
-  ASSERT_EQ(0, uv_async_init(&loop, &ctx->async_handle, sv_async_cb));
+  ASSERT_OK(uv_async_init(&loop, &ctx->async_handle, sv_async_cb));
   uv_unref((uv_handle_t*) &ctx->async_handle);
 
   /* Wait until the main thread is ready. */
@@ -270,10 +270,10 @@ static void server_cb(void *arg) {
   uv_sem_post(&ctx->semaphore);
 
   /* Now start the actual benchmark. */
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &ctx->server_handle,
-                         128,
-                         sv_connection_cb));
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_listen((uv_stream_t*) &ctx->server_handle,
+                      128,
+                      sv_connection_cb));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
   uv_loop_close(&loop);
 }
@@ -292,20 +292,20 @@ static void sv_connection_cb(uv_stream_t* server_handle, int status) {
   struct server_ctx* ctx;
 
   ctx = container_of(server_handle, struct server_ctx, server_handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   storage = malloc(sizeof(*storage));
   ASSERT_NOT_NULL(storage);
 
   if (server_handle->type == UV_TCP)
-    ASSERT_EQ(0, uv_tcp_init(server_handle->loop, (uv_tcp_t*) storage));
+    ASSERT_OK(uv_tcp_init(server_handle->loop, (uv_tcp_t*) storage));
   else if (server_handle->type == UV_NAMED_PIPE)
-    ASSERT_EQ(0, uv_pipe_init(server_handle->loop, (uv_pipe_t*) storage, 0));
+    ASSERT_OK(uv_pipe_init(server_handle->loop, (uv_pipe_t*) storage, 0));
   else
     ASSERT(0);
 
-  ASSERT_EQ(0, uv_accept(server_handle, (uv_stream_t*) storage));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) storage, sv_alloc_cb, sv_read_cb));
+  ASSERT_OK(uv_accept(server_handle, (uv_stream_t*) storage));
+  ASSERT_OK(uv_read_start((uv_stream_t*) storage, sv_alloc_cb, sv_read_cb));
   ctx->num_connects++;
 }
 
@@ -330,7 +330,7 @@ static void sv_read_cb(uv_stream_t* handle,
 static void cl_connect_cb(uv_connect_t* req, int status) {
   struct client_ctx* ctx = container_of(req, struct client_ctx, connect_req);
   uv_idle_start(&ctx->idle_handle, cl_idle_cb);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -351,11 +351,11 @@ static void cl_close_cb(uv_handle_t* handle) {
     return;
   }
 
-  ASSERT_EQ(0, uv_tcp_init(handle->loop, (uv_tcp_t*) &ctx->client_handle));
-  ASSERT_EQ(0, uv_tcp_connect(&ctx->connect_req,
-                              (uv_tcp_t*) &ctx->client_handle,
-                              (const struct sockaddr*) &listen_addr,
-                              cl_connect_cb));
+  ASSERT_OK(uv_tcp_init(handle->loop, (uv_tcp_t*) &ctx->client_handle));
+  ASSERT_OK(uv_tcp_connect(&ctx->connect_req,
+                           (uv_tcp_t*) &ctx->client_handle,
+                           (const struct sockaddr*) &listen_addr,
+                           cl_connect_cb));
 }
 
 
@@ -367,7 +367,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   unsigned int i;
   double time;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &listen_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &listen_addr));
   loop = uv_default_loop();
 
   servers = calloc(num_servers, sizeof(servers[0]));
@@ -381,8 +381,8 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
    */
   for (i = 0; i < num_servers; i++) {
     struct server_ctx* ctx = servers + i;
-    ASSERT_EQ(0, uv_sem_init(&ctx->semaphore, 0));
-    ASSERT_EQ(0, uv_thread_create(&ctx->thread_id, server_cb, ctx));
+    ASSERT_OK(uv_sem_init(&ctx->semaphore, 0));
+    ASSERT_OK(uv_thread_create(&ctx->thread_id, server_cb, ctx));
   }
 
   send_listen_handles(UV_TCP, num_servers, servers);
@@ -392,17 +392,17 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
     ctx->num_connects = NUM_CONNECTS / num_clients;
     handle = (uv_tcp_t*) &ctx->client_handle;
     handle->data = "client handle";
-    ASSERT_EQ(0, uv_tcp_init(loop, handle));
-    ASSERT_EQ(0, uv_tcp_connect(&ctx->connect_req,
-                                handle,
-                                (const struct sockaddr*) &listen_addr,
-                                cl_connect_cb));
-    ASSERT_EQ(0, uv_idle_init(loop, &ctx->idle_handle));
+    ASSERT_OK(uv_tcp_init(loop, handle));
+    ASSERT_OK(uv_tcp_connect(&ctx->connect_req,
+                             handle,
+                             (const struct sockaddr*) &listen_addr,
+                             cl_connect_cb));
+    ASSERT_OK(uv_idle_init(loop, &ctx->idle_handle));
   }
 
   {
     uint64_t t = uv_hrtime();
-    ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+    ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
     t = uv_hrtime() - t;
     time = t / 1e9;
   }
@@ -410,7 +410,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   for (i = 0; i < num_servers; i++) {
     struct server_ctx* ctx = servers + i;
     uv_async_send(&ctx->async_handle);
-    ASSERT_EQ(0, uv_thread_join(&ctx->thread_id));
+    ASSERT_OK(uv_thread_join(&ctx->thread_id));
     uv_sem_destroy(&ctx->semaphore);
   }
 

--- a/test/benchmark-multi-accept.c
+++ b/test/benchmark-multi-accept.c
@@ -117,19 +117,19 @@ static void ipc_connection_cb(uv_stream_t* ipc_pipe, int status) {
   ASSERT_NOT_NULL(pc);
 
   if (ipc_pipe->type == UV_TCP)
-    ASSERT(0 == uv_tcp_init(loop, (uv_tcp_t*) &pc->peer_handle));
+    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) &pc->peer_handle));
   else if (ipc_pipe->type == UV_NAMED_PIPE)
-    ASSERT(0 == uv_pipe_init(loop, (uv_pipe_t*) &pc->peer_handle, 1));
+    ASSERT_EQ(0, uv_pipe_init(loop, (uv_pipe_t*) &pc->peer_handle, 1));
   else
     ASSERT(0);
 
-  ASSERT(0 == uv_accept(ipc_pipe, (uv_stream_t*) &pc->peer_handle));
-  ASSERT(0 == uv_write2(&pc->write_req,
-                        (uv_stream_t*) &pc->peer_handle,
-                        &buf,
-                        1,
-                        (uv_stream_t*) &sc->server_handle,
-                        ipc_write_cb));
+  ASSERT_EQ(0, uv_accept(ipc_pipe, (uv_stream_t*) &pc->peer_handle));
+  ASSERT_EQ(0, uv_write2(&pc->write_req,
+                         (uv_stream_t*) &pc->peer_handle,
+                         &buf,
+                         1,
+                         (uv_stream_t*) &sc->server_handle,
+                         ipc_write_cb));
 
   if (--sc->num_connects == 0)
     uv_close((uv_handle_t*) ipc_pipe, NULL);
@@ -153,10 +153,10 @@ static void ipc_close_cb(uv_handle_t* handle) {
 static void ipc_connect_cb(uv_connect_t* req, int status) {
   struct ipc_client_ctx* ctx;
   ctx = container_of(req, struct ipc_client_ctx, connect_req);
-  ASSERT(0 == status);
-  ASSERT(0 == uv_read_start((uv_stream_t*) &ctx->ipc_pipe,
-                            ipc_alloc_cb,
-                            ipc_read_cb));
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &ctx->ipc_pipe,
+                             ipc_alloc_cb,
+                             ipc_read_cb));
 }
 
 
@@ -182,16 +182,16 @@ static void ipc_read_cb(uv_stream_t* handle,
   ctx = container_of(ipc_pipe, struct ipc_client_ctx, ipc_pipe);
   loop = ipc_pipe->loop;
 
-  ASSERT(1 == uv_pipe_pending_count(ipc_pipe));
+  ASSERT_EQ(1, uv_pipe_pending_count(ipc_pipe));
   type = uv_pipe_pending_type(ipc_pipe);
   if (type == UV_TCP)
-    ASSERT(0 == uv_tcp_init(loop, (uv_tcp_t*) ctx->server_handle));
+    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) ctx->server_handle));
   else if (type == UV_NAMED_PIPE)
-    ASSERT(0 == uv_pipe_init(loop, (uv_pipe_t*) ctx->server_handle, 0));
+    ASSERT_EQ(0, uv_pipe_init(loop, (uv_pipe_t*) ctx->server_handle, 0));
   else
     ASSERT(0);
 
-  ASSERT(0 == uv_accept(handle, ctx->server_handle));
+  ASSERT_EQ(0, uv_accept(handle, ctx->server_handle));
   uv_close((uv_handle_t*) &ctx->ipc_pipe, NULL);
 }
 
@@ -211,10 +211,10 @@ static void send_listen_handles(uv_handle_type type,
   ctx.num_connects = num_servers;
 
   if (type == UV_TCP) {
-    ASSERT(0 == uv_tcp_init(loop, (uv_tcp_t*) &ctx.server_handle));
-    ASSERT(0 == uv_tcp_bind((uv_tcp_t*) &ctx.server_handle,
-                            (const struct sockaddr*) &listen_addr,
-                            0));
+    ASSERT_EQ(0, uv_tcp_init(loop, (uv_tcp_t*) &ctx.server_handle));
+    ASSERT_EQ(0, uv_tcp_bind((uv_tcp_t*) &ctx.server_handle,
+                             (const struct sockaddr*) &listen_addr,
+                             0));
   }
   else
     ASSERT(0);
@@ -223,16 +223,16 @@ static void send_listen_handles(uv_handle_type type,
    * If we accept a connection then the connected pipe must be initialized
    * with ipc=1.
    */
-  ASSERT(0 == uv_pipe_init(loop, &ctx.ipc_pipe, 0));
-  ASSERT(0 == uv_pipe_bind(&ctx.ipc_pipe, IPC_PIPE_NAME));
-  ASSERT(0 == uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb));
+  ASSERT_EQ(0, uv_pipe_init(loop, &ctx.ipc_pipe, 0));
+  ASSERT_EQ(0, uv_pipe_bind(&ctx.ipc_pipe, IPC_PIPE_NAME));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &ctx.ipc_pipe, 128, ipc_connection_cb));
 
   for (i = 0; i < num_servers; i++)
     uv_sem_post(&servers[i].semaphore);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &ctx.server_handle, NULL);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
   for (i = 0; i < num_servers; i++)
     uv_sem_wait(&servers[i].semaphore);
@@ -245,12 +245,12 @@ static void get_listen_handle(uv_loop_t* loop, uv_stream_t* server_handle) {
   ctx.server_handle = server_handle;
   ctx.server_handle->data = "server handle";
 
-  ASSERT(0 == uv_pipe_init(loop, &ctx.ipc_pipe, 1));
+  ASSERT_EQ(0, uv_pipe_init(loop, &ctx.ipc_pipe, 1));
   uv_pipe_connect(&ctx.connect_req,
                   &ctx.ipc_pipe,
                   IPC_PIPE_NAME,
                   ipc_connect_cb);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 }
 
 
@@ -259,9 +259,9 @@ static void server_cb(void *arg) {
   uv_loop_t loop;
 
   ctx = arg;
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
-  ASSERT(0 == uv_async_init(&loop, &ctx->async_handle, sv_async_cb));
+  ASSERT_EQ(0, uv_async_init(&loop, &ctx->async_handle, sv_async_cb));
   uv_unref((uv_handle_t*) &ctx->async_handle);
 
   /* Wait until the main thread is ready. */
@@ -270,10 +270,10 @@ static void server_cb(void *arg) {
   uv_sem_post(&ctx->semaphore);
 
   /* Now start the actual benchmark. */
-  ASSERT(0 == uv_listen((uv_stream_t*) &ctx->server_handle,
-                        128,
-                        sv_connection_cb));
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &ctx->server_handle,
+                         128,
+                         sv_connection_cb));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
 
   uv_loop_close(&loop);
 }
@@ -292,20 +292,20 @@ static void sv_connection_cb(uv_stream_t* server_handle, int status) {
   struct server_ctx* ctx;
 
   ctx = container_of(server_handle, struct server_ctx, server_handle);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   storage = malloc(sizeof(*storage));
   ASSERT_NOT_NULL(storage);
 
   if (server_handle->type == UV_TCP)
-    ASSERT(0 == uv_tcp_init(server_handle->loop, (uv_tcp_t*) storage));
+    ASSERT_EQ(0, uv_tcp_init(server_handle->loop, (uv_tcp_t*) storage));
   else if (server_handle->type == UV_NAMED_PIPE)
-    ASSERT(0 == uv_pipe_init(server_handle->loop, (uv_pipe_t*) storage, 0));
+    ASSERT_EQ(0, uv_pipe_init(server_handle->loop, (uv_pipe_t*) storage, 0));
   else
     ASSERT(0);
 
-  ASSERT(0 == uv_accept(server_handle, (uv_stream_t*) storage));
-  ASSERT(0 == uv_read_start((uv_stream_t*) storage, sv_alloc_cb, sv_read_cb));
+  ASSERT_EQ(0, uv_accept(server_handle, (uv_stream_t*) storage));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) storage, sv_alloc_cb, sv_read_cb));
   ctx->num_connects++;
 }
 
@@ -322,7 +322,7 @@ static void sv_alloc_cb(uv_handle_t* handle,
 static void sv_read_cb(uv_stream_t* handle,
                        ssize_t nread,
                        const uv_buf_t* buf) {
-  ASSERT(nread == UV_EOF);
+  ASSERT_EQ(nread, UV_EOF);
   uv_close((uv_handle_t*) handle, (uv_close_cb) free);
 }
 
@@ -330,7 +330,7 @@ static void sv_read_cb(uv_stream_t* handle,
 static void cl_connect_cb(uv_connect_t* req, int status) {
   struct client_ctx* ctx = container_of(req, struct client_ctx, connect_req);
   uv_idle_start(&ctx->idle_handle, cl_idle_cb);
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -351,11 +351,11 @@ static void cl_close_cb(uv_handle_t* handle) {
     return;
   }
 
-  ASSERT(0 == uv_tcp_init(handle->loop, (uv_tcp_t*) &ctx->client_handle));
-  ASSERT(0 == uv_tcp_connect(&ctx->connect_req,
-                             (uv_tcp_t*) &ctx->client_handle,
-                             (const struct sockaddr*) &listen_addr,
-                             cl_connect_cb));
+  ASSERT_EQ(0, uv_tcp_init(handle->loop, (uv_tcp_t*) &ctx->client_handle));
+  ASSERT_EQ(0, uv_tcp_connect(&ctx->connect_req,
+                              (uv_tcp_t*) &ctx->client_handle,
+                              (const struct sockaddr*) &listen_addr,
+                              cl_connect_cb));
 }
 
 
@@ -367,7 +367,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   unsigned int i;
   double time;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &listen_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &listen_addr));
   loop = uv_default_loop();
 
   servers = calloc(num_servers, sizeof(servers[0]));
@@ -381,8 +381,8 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
    */
   for (i = 0; i < num_servers; i++) {
     struct server_ctx* ctx = servers + i;
-    ASSERT(0 == uv_sem_init(&ctx->semaphore, 0));
-    ASSERT(0 == uv_thread_create(&ctx->thread_id, server_cb, ctx));
+    ASSERT_EQ(0, uv_sem_init(&ctx->semaphore, 0));
+    ASSERT_EQ(0, uv_thread_create(&ctx->thread_id, server_cb, ctx));
   }
 
   send_listen_handles(UV_TCP, num_servers, servers);
@@ -392,17 +392,17 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
     ctx->num_connects = NUM_CONNECTS / num_clients;
     handle = (uv_tcp_t*) &ctx->client_handle;
     handle->data = "client handle";
-    ASSERT(0 == uv_tcp_init(loop, handle));
-    ASSERT(0 == uv_tcp_connect(&ctx->connect_req,
-                               handle,
-                               (const struct sockaddr*) &listen_addr,
-                               cl_connect_cb));
-    ASSERT(0 == uv_idle_init(loop, &ctx->idle_handle));
+    ASSERT_EQ(0, uv_tcp_init(loop, handle));
+    ASSERT_EQ(0, uv_tcp_connect(&ctx->connect_req,
+                                handle,
+                                (const struct sockaddr*) &listen_addr,
+                                cl_connect_cb));
+    ASSERT_EQ(0, uv_idle_init(loop, &ctx->idle_handle));
   }
 
   {
     uint64_t t = uv_hrtime();
-    ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+    ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
     t = uv_hrtime() - t;
     time = t / 1e9;
   }
@@ -410,7 +410,7 @@ static int test_tcp(unsigned int num_servers, unsigned int num_clients) {
   for (i = 0; i < num_servers; i++) {
     struct server_ctx* ctx = servers + i;
     uv_async_send(&ctx->async_handle);
-    ASSERT(0 == uv_thread_join(&ctx->thread_id));
+    ASSERT_EQ(0, uv_thread_join(&ctx->thread_id));
     uv_sem_destroy(&ctx->semaphore);
   }
 

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -90,7 +90,7 @@ static void pinger_close_cb(uv_handle_t* handle) {
 
 
 static void pinger_write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   free(req);
 }
@@ -110,14 +110,14 @@ static void pinger_write_ping(pinger_t* pinger) {
 
 
 static void pinger_shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   pinger_shutdown_cb_called++;
 
   /*
    * The close callback has not been triggered yet. We must wait for EOF
    * until we close the connection.
    */
-  ASSERT_EQ(completed_pingers, 0);
+  ASSERT_OK(completed_pingers);
 }
 
 
@@ -166,7 +166,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
 static void pinger_connect_cb(uv_connect_t* req, int status) {
   pinger_t *pinger = (pinger_t*)req->handle->data;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   pinger_write_ping(pinger);
 
@@ -182,8 +182,8 @@ static void pinger_new(void) {
   pinger_t *pinger;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &client_addr));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &client_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   pinger->state = 0;
   pinger->pongs = 0;
@@ -194,9 +194,9 @@ static void pinger_new(void) {
 
   pinger->tcp.data = pinger;
 
-  ASSERT_EQ(0, uv_tcp_bind(&pinger->tcp,
-                           (const struct sockaddr*) &client_addr,
-                           0));
+  ASSERT_OK(uv_tcp_bind(&pinger->tcp,
+                        (const struct sockaddr*) &client_addr,
+                        0));
 
   r = uv_tcp_connect(&pinger->connect_req,
                      &pinger->tcp,

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -136,7 +136,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
       buf_free(buf);
     }
 
-    ASSERT_EQ(pinger_shutdown_cb_called, 1);
+    ASSERT_EQ(1, pinger_shutdown_cb_called);
     uv_close((uv_handle_t*)tcp, pinger_close_cb);
 
     return;
@@ -214,7 +214,7 @@ BENCHMARK_IMPL(ping_pongs) {
   pinger_new();
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(completed_pingers, 1);
+  ASSERT_EQ(1, completed_pingers);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/benchmark-ping-pongs.c
+++ b/test/benchmark-ping-pongs.c
@@ -90,7 +90,7 @@ static void pinger_close_cb(uv_handle_t* handle) {
 
 
 static void pinger_write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   free(req);
 }
@@ -110,14 +110,14 @@ static void pinger_write_ping(pinger_t* pinger) {
 
 
 static void pinger_shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   pinger_shutdown_cb_called++;
 
   /*
    * The close callback has not been triggered yet. We must wait for EOF
    * until we close the connection.
    */
-  ASSERT(completed_pingers == 0);
+  ASSERT_EQ(completed_pingers, 0);
 }
 
 
@@ -130,13 +130,13 @@ static void pinger_read_cb(uv_stream_t* tcp,
   pinger = (pinger_t*)tcp->data;
 
   if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     if (buf->base) {
       buf_free(buf);
     }
 
-    ASSERT(pinger_shutdown_cb_called == 1);
+    ASSERT_EQ(pinger_shutdown_cb_called, 1);
     uv_close((uv_handle_t*)tcp, pinger_close_cb);
 
     return;
@@ -144,7 +144,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
 
   /* Now we count the pings */
   for (i = 0; i < nread; i++) {
-    ASSERT(buf->base[i] == PING[pinger->state]);
+    ASSERT_EQ(buf->base[i], PING[pinger->state]);
     pinger->state = (pinger->state + 1) % (sizeof(PING) - 1);
     if (pinger->state == 0) {
       pinger->pongs++;
@@ -166,7 +166,7 @@ static void pinger_read_cb(uv_stream_t* tcp,
 static void pinger_connect_cb(uv_connect_t* req, int status) {
   pinger_t *pinger = (pinger_t*)req->handle->data;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   pinger_write_ping(pinger);
 
@@ -182,8 +182,8 @@ static void pinger_new(void) {
   pinger_t *pinger;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &client_addr));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &client_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   pinger->state = 0;
   pinger->pongs = 0;
@@ -194,9 +194,9 @@ static void pinger_new(void) {
 
   pinger->tcp.data = pinger;
 
-  ASSERT(0 == uv_tcp_bind(&pinger->tcp,
-                          (const struct sockaddr*) &client_addr,
-                          0));
+  ASSERT_EQ(0, uv_tcp_bind(&pinger->tcp,
+                           (const struct sockaddr*) &client_addr,
+                           0));
 
   r = uv_tcp_connect(&pinger->connect_req,
                      &pinger->tcp,
@@ -214,7 +214,7 @@ BENCHMARK_IMPL(ping_pongs) {
   pinger_new();
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(completed_pingers == 1);
+  ASSERT_EQ(completed_pingers, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/benchmark-ping-udp.c
+++ b/test/benchmark-ping-udp.c
@@ -119,15 +119,15 @@ static void udp_pinger_new(void) {
   pinger_t* pinger = malloc(sizeof(*pinger));
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &pinger->server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &pinger->server_addr));
   pinger->state = 0;
   pinger->pongs = 0;
 
   /* Try to do NUM_PINGS ping-pongs (connection-less). */
   r = uv_udp_init(loop, &pinger->udp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_bind(&pinger->udp, (const struct sockaddr*) &pinger->server_addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   pinger->udp.data = pinger;
 

--- a/test/benchmark-ping-udp.c
+++ b/test/benchmark-ping-udp.c
@@ -95,11 +95,11 @@ static void pinger_read_cb(uv_udp_t* udp,
   pinger = (pinger_t*)udp->data;
 
   /* No data here means something went wrong */
-  ASSERT(nread > 0);
+  ASSERT_GT(nread, 0);
 
   /* Now we count the pings */
   for (i = 0; i < nread; i++) {
-    ASSERT(buf->base[i] == PING[pinger->state]);
+    ASSERT_EQ(buf->base[i], PING[pinger->state]);
     pinger->state = (pinger->state + 1) % (sizeof(PING) - 1);
     if (pinger->state == 0) {
       pinger->pongs++;
@@ -119,15 +119,15 @@ static void udp_pinger_new(void) {
   pinger_t* pinger = malloc(sizeof(*pinger));
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &pinger->server_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &pinger->server_addr));
   pinger->state = 0;
   pinger->pongs = 0;
 
   /* Try to do NUM_PINGS ping-pongs (connection-less). */
   r = uv_udp_init(loop, &pinger->udp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_bind(&pinger->udp, (const struct sockaddr*) &pinger->server_addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   pinger->udp.data = pinger;
 
@@ -148,7 +148,7 @@ static int ping_udp(unsigned pingers) {
     udp_pinger_new();
   }
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(completed_pingers >= 1);
+  ASSERT_GE(completed_pingers, 1);
 
   fprintf(stderr, "ping_pongs: %d pingers, ~ %lu roundtrips/s\n",
           completed_pingers, completed_pings / (TIME/1000));

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -115,7 +115,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   }
 
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   conn = (conn_rec*)req->data;
   ASSERT_NOT_NULL(conn);
@@ -125,13 +125,13 @@ static void connect_cb(uv_connect_t* req, int status) {
 #endif
 
   r = uv_read_start(&conn->stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = buffer;
   buf.len = sizeof(buffer) - 1;
 
   r = uv_write(&conn->write_req, &conn->stream, &buf, 1, after_write);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -200,9 +200,9 @@ static void tcp_make_connect(conn_rec* p) {
   tp = (tcp_conn_rec*) p;
 
   r = uv_tcp_init(loop, (uv_tcp_t*)&p->stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_connect(&tp->conn_req,
                      (uv_tcp_t*) &p->stream,
@@ -227,7 +227,7 @@ static void pipe_make_connect(conn_rec* p) {
   int r;
 
   r = uv_pipe_init(loop, (uv_pipe_t*)&p->stream, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_connect(&((pipe_conn_rec*) p)->conn_req,
                   (uv_pipe_t*) &p->stream,

--- a/test/benchmark-pound.c
+++ b/test/benchmark-pound.c
@@ -115,7 +115,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   }
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   conn = (conn_rec*)req->data;
   ASSERT_NOT_NULL(conn);
@@ -125,13 +125,13 @@ static void connect_cb(uv_connect_t* req, int status) {
 #endif
 
   r = uv_read_start(&conn->stream, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf.base = buffer;
   buf.len = sizeof(buffer) - 1;
 
   r = uv_write(&conn->write_req, &conn->stream, &buf, 1, after_write);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -200,9 +200,9 @@ static void tcp_make_connect(conn_rec* p) {
   tp = (tcp_conn_rec*) p;
 
   r = uv_tcp_init(loop, (uv_tcp_t*)&p->stream);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_connect(&tp->conn_req,
                      (uv_tcp_t*) &p->stream,
@@ -227,7 +227,7 @@ static void pipe_make_connect(conn_rec* p) {
   int r;
 
   r = uv_pipe_init(loop, (uv_pipe_t*)&p->stream, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_connect(&((pipe_conn_rec*) p)->conn_req,
                   (uv_pipe_t*) &p->stream,

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -159,9 +159,9 @@ static void start_stats_collection(void) {
   /* Show-stats timer */
   stats_left = STATS_COUNT;
   r = uv_timer_init(loop, &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, show_stats, STATS_INTERVAL, STATS_INTERVAL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_update_time(loop);
   start_time = uv_now(loop);
@@ -170,7 +170,7 @@ static void start_stats_collection(void) {
 
 static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
   if (nrecv_total == 0) {
-    ASSERT(start_time == 0);
+    ASSERT_EQ(start_time, 0);
     uv_update_time(loop);
     start_time = uv_now(loop);
   }
@@ -188,7 +188,7 @@ static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   req_free((uv_req_t*) req);
 
@@ -209,7 +209,7 @@ static void do_write(uv_stream_t* stream) {
 
   req = (uv_write_t*) req_alloc();
   r = uv_write(req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -220,7 +220,7 @@ static void connect_cb(uv_connect_t* req, int status) {
     fprintf(stderr, "%s", uv_strerror(status));
     fflush(stderr);
   }
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   write_sockets++;
   req_free((uv_req_t*) req);
@@ -253,19 +253,19 @@ static void maybe_connect_some(void) {
       tcp = &tcp_write_handles[max_connect_socket++];
 
       r = uv_tcp_init(loop, tcp);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       req = (uv_connect_t*) req_alloc();
       r = uv_tcp_connect(req,
                          tcp,
                          (const struct sockaddr*) &connect_addr,
                          connect_cb);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     } else {
       pipe = &pipe_write_handles[max_connect_socket++];
 
       r = uv_pipe_init(loop, pipe, 0);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       req = (uv_connect_t*) req_alloc();
       uv_pipe_connect(req, pipe, TEST_PIPENAME, connect_cb);
@@ -278,24 +278,24 @@ static void connection_cb(uv_stream_t* s, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(server == s);
-  ASSERT(status == 0);
+  ASSERT_EQ(server, s);
+  ASSERT_EQ(status, 0);
 
   if (type == TCP) {
     stream = (uv_stream_t*)malloc(sizeof(uv_tcp_t));
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   } else {
     stream = (uv_stream_t*)malloc(sizeof(uv_pipe_t));
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   r = uv_accept(s, stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start(stream, buf_alloc, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   read_sockets++;
   max_read_sockets++;
@@ -379,16 +379,16 @@ HELPER_IMPL(tcp_pump_server) {
   type = TCP;
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &listen_addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &listen_addr));
 
   /* Server */
   server = (uv_stream_t*)&tcpServer;
   r = uv_tcp_init(loop, &tcpServer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&tcpServer, (const struct sockaddr*) &listen_addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&tcpServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
@@ -406,11 +406,11 @@ HELPER_IMPL(pipe_pump_server) {
   /* Server */
   server = (uv_stream_t*)&pipeServer;
   r = uv_pipe_init(loop, &pipeServer, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&pipeServer, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&pipeServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
@@ -421,13 +421,13 @@ HELPER_IMPL(pipe_pump_server) {
 
 
 static void tcp_pump(int n) {
-  ASSERT(n <= MAX_WRITE_HANDLES);
+  ASSERT_LE(n, MAX_WRITE_HANDLES);
   TARGET_CONNECTIONS = n;
   type = TCP;
 
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &connect_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &connect_addr));
 
   /* Start making connections */
   maybe_connect_some();
@@ -439,7 +439,7 @@ static void tcp_pump(int n) {
 
 
 static void pipe_pump(int n) {
-  ASSERT(n <= MAX_WRITE_HANDLES);
+  ASSERT_LE(n, MAX_WRITE_HANDLES);
   TARGET_CONNECTIONS = n;
   type = PIPE;
 

--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -159,9 +159,9 @@ static void start_stats_collection(void) {
   /* Show-stats timer */
   stats_left = STATS_COUNT;
   r = uv_timer_init(loop, &timer_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&timer_handle, show_stats, STATS_INTERVAL, STATS_INTERVAL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_update_time(loop);
   start_time = uv_now(loop);
@@ -170,7 +170,7 @@ static void start_stats_collection(void) {
 
 static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
   if (nrecv_total == 0) {
-    ASSERT_EQ(start_time, 0);
+    ASSERT_OK(start_time);
     uv_update_time(loop);
     start_time = uv_now(loop);
   }
@@ -188,7 +188,7 @@ static void read_cb(uv_stream_t* stream, ssize_t bytes, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   req_free((uv_req_t*) req);
 
@@ -209,7 +209,7 @@ static void do_write(uv_stream_t* stream) {
 
   req = (uv_write_t*) req_alloc();
   r = uv_write(req, stream, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -220,7 +220,7 @@ static void connect_cb(uv_connect_t* req, int status) {
     fprintf(stderr, "%s", uv_strerror(status));
     fflush(stderr);
   }
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   write_sockets++;
   req_free((uv_req_t*) req);
@@ -253,19 +253,19 @@ static void maybe_connect_some(void) {
       tcp = &tcp_write_handles[max_connect_socket++];
 
       r = uv_tcp_init(loop, tcp);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
 
       req = (uv_connect_t*) req_alloc();
       r = uv_tcp_connect(req,
                          tcp,
                          (const struct sockaddr*) &connect_addr,
                          connect_cb);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
     } else {
       pipe = &pipe_write_handles[max_connect_socket++];
 
       r = uv_pipe_init(loop, pipe, 0);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
 
       req = (uv_connect_t*) req_alloc();
       uv_pipe_connect(req, pipe, TEST_PIPENAME, connect_cb);
@@ -279,23 +279,23 @@ static void connection_cb(uv_stream_t* s, int status) {
   int r;
 
   ASSERT_EQ(server, s);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   if (type == TCP) {
     stream = (uv_stream_t*)malloc(sizeof(uv_tcp_t));
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   } else {
     stream = (uv_stream_t*)malloc(sizeof(uv_pipe_t));
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   r = uv_accept(s, stream);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start(stream, buf_alloc, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   read_sockets++;
   max_read_sockets++;
@@ -379,16 +379,16 @@ HELPER_IMPL(tcp_pump_server) {
   type = TCP;
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &listen_addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &listen_addr));
 
   /* Server */
   server = (uv_stream_t*)&tcpServer;
   r = uv_tcp_init(loop, &tcpServer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&tcpServer, (const struct sockaddr*) &listen_addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&tcpServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
@@ -406,11 +406,11 @@ HELPER_IMPL(pipe_pump_server) {
   /* Server */
   server = (uv_stream_t*)&pipeServer;
   r = uv_pipe_init(loop, &pipeServer, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_bind(&pipeServer, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&pipeServer, MAX_WRITE_HANDLES, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   notify_parent_process();
   uv_run(loop, UV_RUN_DEFAULT);
@@ -427,7 +427,7 @@ static void tcp_pump(int n) {
 
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &connect_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &connect_addr));
 
   /* Start making connections */
   maybe_connect_some();

--- a/test/benchmark-queue-work.c
+++ b/test/benchmark-queue-work.c
@@ -40,7 +40,7 @@ static void work_cb(uv_work_t* req) {
 static void after_work_cb(uv_work_t* req, int status) {
   events++;
   if (!done)
-    ASSERT_EQ(0, uv_queue_work(req->loop, req, work_cb, after_work_cb));
+    ASSERT_OK(uv_queue_work(req->loop, req, work_cb, after_work_cb));
 }
 
 static void timer_cb(uv_timer_t* handle) { done = 1; }
@@ -55,11 +55,11 @@ BENCHMARK_IMPL(queue_work) {
   loop = uv_default_loop();
   timeout = 5000;
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, timeout, 0));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, timeout, 0));
 
-  ASSERT_EQ(0, uv_queue_work(loop, &work, work_cb, after_work_cb));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_queue_work(loop, &work, work_cb, after_work_cb));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   printf("%s async jobs in %.1f seconds (%s/s)\n",
          fmt(&fmtbuf[0], events),

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -58,7 +58,7 @@ static void maybe_spawn(void) {
 
 
 static void process_close_cb(uv_handle_t* handle) {
-  ASSERT_EQ(process_open, 1);
+  ASSERT_EQ(1, process_open);
   process_open = 0;
   maybe_spawn();
 }
@@ -67,7 +67,7 @@ static void process_close_cb(uv_handle_t* handle) {
 static void exit_cb(uv_process_t* process,
                     int64_t exit_status,
                     int term_signal) {
-  ASSERT_EQ(exit_status, 42);
+  ASSERT_EQ(42, exit_status);
   ASSERT_OK(term_signal);
   uv_close((uv_handle_t*)process, process_close_cb);
 }
@@ -82,7 +82,7 @@ static void on_alloc(uv_handle_t* handle,
 
 
 static void pipe_close_cb(uv_handle_t* pipe) {
-  ASSERT_EQ(pipe_open, 1);
+  ASSERT_EQ(1, pipe_open);
   pipe_open = 0;
   maybe_spawn();
 }
@@ -90,7 +90,7 @@ static void pipe_close_cb(uv_handle_t* pipe) {
 
 static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT_EQ(pipe_open, 1);
+    ASSERT_EQ(1, pipe_open);
     output_used += nread;
   } else if (nread < 0) {
     if (nread == UV_EOF) {

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -68,7 +68,7 @@ static void exit_cb(uv_process_t* process,
                     int64_t exit_status,
                     int term_signal) {
   ASSERT_EQ(exit_status, 42);
-  ASSERT_EQ(term_signal, 0);
+  ASSERT_OK(term_signal);
   uv_close((uv_handle_t*)process, process_close_cb);
 }
 
@@ -104,8 +104,8 @@ static void spawn(void) {
   uv_stdio_container_t stdio[2];
   int r;
 
-  ASSERT_EQ(process_open, 0);
-  ASSERT_EQ(pipe_open, 0);
+  ASSERT_OK(process_open);
+  ASSERT_OK(pipe_open);
 
   args[0] = exepath;
   args[1] = "spawn_helper";
@@ -123,14 +123,14 @@ static void spawn(void) {
   options.stdio[1].data.stream = (uv_stream_t*)&out;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   process_open = 1;
   pipe_open = 1;
   output_used = 0;
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -141,7 +141,7 @@ BENCHMARK_IMPL(spawn) {
   loop = uv_default_loop();
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   exepath[exepath_size] = '\0';
 
   uv_update_time(loop);
@@ -150,7 +150,7 @@ BENCHMARK_IMPL(spawn) {
   spawn();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_update_time(loop);
   end_time = uv_now(loop);

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -58,7 +58,7 @@ static void maybe_spawn(void) {
 
 
 static void process_close_cb(uv_handle_t* handle) {
-  ASSERT(process_open == 1);
+  ASSERT_EQ(process_open, 1);
   process_open = 0;
   maybe_spawn();
 }
@@ -67,8 +67,8 @@ static void process_close_cb(uv_handle_t* handle) {
 static void exit_cb(uv_process_t* process,
                     int64_t exit_status,
                     int term_signal) {
-  ASSERT(exit_status == 42);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(exit_status, 42);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*)process, process_close_cb);
 }
 
@@ -82,7 +82,7 @@ static void on_alloc(uv_handle_t* handle,
 
 
 static void pipe_close_cb(uv_handle_t* pipe) {
-  ASSERT(pipe_open == 1);
+  ASSERT_EQ(pipe_open, 1);
   pipe_open = 0;
   maybe_spawn();
 }
@@ -90,7 +90,7 @@ static void pipe_close_cb(uv_handle_t* pipe) {
 
 static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT(pipe_open == 1);
+    ASSERT_EQ(pipe_open, 1);
     output_used += nread;
   } else if (nread < 0) {
     if (nread == UV_EOF) {
@@ -104,8 +104,8 @@ static void spawn(void) {
   uv_stdio_container_t stdio[2];
   int r;
 
-  ASSERT(process_open == 0);
-  ASSERT(pipe_open == 0);
+  ASSERT_EQ(process_open, 0);
+  ASSERT_EQ(pipe_open, 0);
 
   args[0] = exepath;
   args[1] = "spawn_helper";
@@ -123,14 +123,14 @@ static void spawn(void) {
   options.stdio[1].data.stream = (uv_stream_t*)&out;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   process_open = 1;
   pipe_open = 1;
   output_used = 0;
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -141,7 +141,7 @@ BENCHMARK_IMPL(spawn) {
   loop = uv_default_loop();
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
 
   uv_update_time(loop);
@@ -150,7 +150,7 @@ BENCHMARK_IMPL(spawn) {
   spawn();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_update_time(loop);
   end_time = uv_now(loop);

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -60,11 +60,11 @@ static void connect_cb(uv_connect_t* req, int status) {
   for (i = 0; i < NUM_WRITE_REQS; i++) {
     w = &write_reqs[i];
     r = uv_write(&w->req, req->handle, &w->buf, 1, write_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   connect_cb_called++;
 }
@@ -72,14 +72,14 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   write_cb_called++;
 }
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_client);
-  ASSERT_EQ(req->handle->write_queue_size, 0);
+  ASSERT_OK(req->handle->write_queue_size);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
   free(write_reqs);
@@ -112,21 +112,21 @@ BENCHMARK_IMPL(tcp_write_batch) {
   }
 
   loop = uv_default_loop();
-  ASSERT_EQ(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr), 0);
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   start = uv_hrtime();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   stop = uv_hrtime();
 

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -130,10 +130,10 @@ BENCHMARK_IMPL(tcp_write_batch) {
 
   stop = uv_hrtime();
 
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
   ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   printf("%ld write requests in %.2fs.\n",
          (long)NUM_WRITE_REQS,

--- a/test/benchmark-tcp-write-batch.c
+++ b/test/benchmark-tcp-write-batch.c
@@ -55,16 +55,16 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i;
   int r;
 
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_client);
 
   for (i = 0; i < NUM_WRITE_REQS; i++) {
     w = &write_reqs[i];
     r = uv_write(&w->req, req->handle, &w->buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connect_cb_called++;
 }
@@ -72,14 +72,14 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
-  ASSERT(req->handle->write_queue_size == 0);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_client);
+  ASSERT_EQ(req->handle->write_queue_size, 0);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
   free(write_reqs);
@@ -89,7 +89,7 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*)&tcp_client);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&tcp_client);
   close_cb_called++;
 }
 
@@ -112,28 +112,28 @@ BENCHMARK_IMPL(tcp_write_batch) {
   }
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr), 0);
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   start = uv_hrtime();
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   stop = uv_hrtime();
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == NUM_WRITE_REQS);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   printf("%ld write requests in %.2fs.\n",
          (long)NUM_WRITE_REQS,

--- a/test/benchmark-thread.c
+++ b/test/benchmark-thread.c
@@ -47,10 +47,10 @@ BENCHMARK_IMPL(thread_create) {
 
   for (i = 0; i < NUM_THREADS; i++) {
     r = uv_thread_create(&tid, thread_entry, (void *) 42);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_thread_join(&tid);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   duration = (uv_hrtime() - start_time) / 1e9;

--- a/test/benchmark-thread.c
+++ b/test/benchmark-thread.c
@@ -31,7 +31,7 @@ static volatile int num_threads;
 
 
 static void thread_entry(void* arg) {
-  ASSERT(arg == (void *) 42);
+  ASSERT_PTR_EQ(arg, (void *) 42);
   num_threads++;
   /* FIXME write barrier? */
 }
@@ -47,15 +47,15 @@ BENCHMARK_IMPL(thread_create) {
 
   for (i = 0; i < NUM_THREADS; i++) {
     r = uv_thread_create(&tid, thread_entry, (void *) 42);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_thread_join(&tid);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   duration = (uv_hrtime() - start_time) / 1e9;
 
-  ASSERT(num_threads == NUM_THREADS);
+  ASSERT_EQ(num_threads, NUM_THREADS);
 
   printf("%d threads created in %.2f seconds (%.0f/s)\n",
       NUM_THREADS, duration, NUM_THREADS / duration);

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -63,7 +63,7 @@ static void alloc_cb(uv_handle_t* handle,
                      size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -75,7 +75,7 @@ static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
 
   if (status != 0) {
-    ASSERT(status == UV_ECANCELED);
+    ASSERT_EQ(status, UV_ECANCELED);
     return;
   }
 
@@ -83,7 +83,7 @@ static void send_cb(uv_udp_send_t* req, int status) {
     return;
 
   s = container_of(req, struct sender_state, send_req);
-  ASSERT(req->handle == &s->udp_handle);
+  ASSERT_PTR_EQ(req->handle, &s->udp_handle);
 
   if (timed)
     goto send;
@@ -96,12 +96,12 @@ static void send_cb(uv_udp_send_t* req, int status) {
   packet_counter--;
 
 send:
-  ASSERT(0 == uv_udp_send(&s->send_req,
-                          &s->udp_handle,
-                          bufs,
-                          ARRAY_SIZE(bufs),
-                          (const struct sockaddr*) &s->addr,
-                          send_cb));
+  ASSERT_EQ(0, uv_udp_send(&s->send_req,
+                           &s->udp_handle,
+                           bufs,
+                           ARRAY_SIZE(bufs),
+                           (const struct sockaddr*) &s->addr,
+                           send_cb));
   send_cb_called++;
 }
 
@@ -115,11 +115,11 @@ static void recv_cb(uv_udp_t* handle,
     return;
 
   if (nread < 0) {
-    ASSERT(nread == UV_ECANCELED);
+    ASSERT_EQ(nread, UV_ECANCELED);
     return;
   }
 
-  ASSERT(addr->sa_family == AF_INET);
+  ASSERT_EQ(addr->sa_family, AF_INET);
   ASSERT(!memcmp(buf->base, EXPECTED, nread));
 
   recv_cb_called++;
@@ -153,8 +153,8 @@ static int pummel(unsigned int n_senders,
   uv_loop_t* loop;
   unsigned int i;
 
-  ASSERT(n_senders <= ARRAY_SIZE(senders));
-  ASSERT(n_receivers <= ARRAY_SIZE(receivers));
+  ASSERT_LE(n_senders, ARRAY_SIZE(senders));
+  ASSERT_LE(n_receivers, ARRAY_SIZE(receivers));
 
   loop = uv_default_loop();
 
@@ -162,8 +162,8 @@ static int pummel(unsigned int n_senders,
   n_receivers_ = n_receivers;
 
   if (timeout) {
-    ASSERT(0 == uv_timer_init(loop, &timer_handle));
-    ASSERT(0 == uv_timer_start(&timer_handle, timeout_cb, timeout, 0));
+    ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+    ASSERT_EQ(0, uv_timer_start(&timer_handle, timeout_cb, timeout, 0));
     /* Timer should not keep loop alive. */
     uv_unref((uv_handle_t*)&timer_handle);
     timed = 1;
@@ -172,10 +172,10 @@ static int pummel(unsigned int n_senders,
   for (i = 0; i < n_receivers; i++) {
     struct receiver_state* s = receivers + i;
     struct sockaddr_in addr;
-    ASSERT(0 == uv_ip4_addr("0.0.0.0", BASE_PORT + i, &addr));
-    ASSERT(0 == uv_udp_init(loop, &s->udp_handle));
-    ASSERT(0 == uv_udp_bind(&s->udp_handle, (const struct sockaddr*) &addr, 0));
-    ASSERT(0 == uv_udp_recv_start(&s->udp_handle, alloc_cb, recv_cb));
+    ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", BASE_PORT + i, &addr));
+    ASSERT_EQ(0, uv_udp_init(loop, &s->udp_handle));
+    ASSERT_EQ(0, uv_udp_bind(&s->udp_handle, (const struct sockaddr*) &addr, 0));
+    ASSERT_EQ(0, uv_udp_recv_start(&s->udp_handle, alloc_cb, recv_cb));
     uv_unref((uv_handle_t*)&s->udp_handle);
   }
 
@@ -187,20 +187,20 @@ static int pummel(unsigned int n_senders,
 
   for (i = 0; i < n_senders; i++) {
     struct sender_state* s = senders + i;
-    ASSERT(0 == uv_ip4_addr("127.0.0.1",
-                            BASE_PORT + (i % n_receivers),
-                            &s->addr));
-    ASSERT(0 == uv_udp_init(loop, &s->udp_handle));
-    ASSERT(0 == uv_udp_send(&s->send_req,
-                            &s->udp_handle,
-                            bufs,
-                            ARRAY_SIZE(bufs),
-                            (const struct sockaddr*) &s->addr,
-                            send_cb));
+    ASSERT_EQ(0, uv_ip4_addr("127.0.0.1",
+                             BASE_PORT + (i % n_receivers),
+                             &s->addr));
+    ASSERT_EQ(0, uv_udp_init(loop, &s->udp_handle));
+    ASSERT_EQ(0, uv_udp_send(&s->send_req,
+                             &s->udp_handle,
+                             bufs,
+                             ARRAY_SIZE(bufs),
+                             (const struct sockaddr*) &s->addr,
+                             send_cb));
   }
 
   duration = uv_hrtime();
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
   duration = uv_hrtime() - duration;
   /* convert from nanoseconds to milliseconds */
   duration = duration / (uint64_t) 1e6;

--- a/test/benchmark-udp-pummel.c
+++ b/test/benchmark-udp-pummel.c
@@ -96,12 +96,12 @@ static void send_cb(uv_udp_send_t* req, int status) {
   packet_counter--;
 
 send:
-  ASSERT_EQ(0, uv_udp_send(&s->send_req,
-                           &s->udp_handle,
-                           bufs,
-                           ARRAY_SIZE(bufs),
-                           (const struct sockaddr*) &s->addr,
-                           send_cb));
+  ASSERT_OK(uv_udp_send(&s->send_req,
+                        &s->udp_handle,
+                        bufs,
+                        ARRAY_SIZE(bufs),
+                        (const struct sockaddr*) &s->addr,
+                        send_cb));
   send_cb_called++;
 }
 
@@ -162,8 +162,8 @@ static int pummel(unsigned int n_senders,
   n_receivers_ = n_receivers;
 
   if (timeout) {
-    ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-    ASSERT_EQ(0, uv_timer_start(&timer_handle, timeout_cb, timeout, 0));
+    ASSERT_OK(uv_timer_init(loop, &timer_handle));
+    ASSERT_OK(uv_timer_start(&timer_handle, timeout_cb, timeout, 0));
     /* Timer should not keep loop alive. */
     uv_unref((uv_handle_t*)&timer_handle);
     timed = 1;
@@ -172,10 +172,10 @@ static int pummel(unsigned int n_senders,
   for (i = 0; i < n_receivers; i++) {
     struct receiver_state* s = receivers + i;
     struct sockaddr_in addr;
-    ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", BASE_PORT + i, &addr));
-    ASSERT_EQ(0, uv_udp_init(loop, &s->udp_handle));
-    ASSERT_EQ(0, uv_udp_bind(&s->udp_handle, (const struct sockaddr*) &addr, 0));
-    ASSERT_EQ(0, uv_udp_recv_start(&s->udp_handle, alloc_cb, recv_cb));
+    ASSERT_OK(uv_ip4_addr("0.0.0.0", BASE_PORT + i, &addr));
+    ASSERT_OK(uv_udp_init(loop, &s->udp_handle));
+    ASSERT_OK(uv_udp_bind(&s->udp_handle, (const struct sockaddr*) &addr, 0));
+    ASSERT_OK(uv_udp_recv_start(&s->udp_handle, alloc_cb, recv_cb));
     uv_unref((uv_handle_t*)&s->udp_handle);
   }
 
@@ -187,20 +187,20 @@ static int pummel(unsigned int n_senders,
 
   for (i = 0; i < n_senders; i++) {
     struct sender_state* s = senders + i;
-    ASSERT_EQ(0, uv_ip4_addr("127.0.0.1",
-                             BASE_PORT + (i % n_receivers),
-                             &s->addr));
-    ASSERT_EQ(0, uv_udp_init(loop, &s->udp_handle));
-    ASSERT_EQ(0, uv_udp_send(&s->send_req,
-                             &s->udp_handle,
-                             bufs,
-                             ARRAY_SIZE(bufs),
-                             (const struct sockaddr*) &s->addr,
-                             send_cb));
+    ASSERT_OK(uv_ip4_addr("127.0.0.1",
+                          BASE_PORT + (i % n_receivers),
+                          &s->addr));
+    ASSERT_OK(uv_udp_init(loop, &s->udp_handle));
+    ASSERT_OK(uv_udp_send(&s->send_req,
+                          &s->udp_handle,
+                          bufs,
+                          ARRAY_SIZE(bufs),
+                          (const struct sockaddr*) &s->addr,
+                          send_cb));
   }
 
   duration = uv_hrtime();
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   duration = uv_hrtime() - duration;
   /* convert from nanoseconds to milliseconds */
   duration = duration / (uint64_t) 1e6;

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -43,20 +43,20 @@ static void connection_cb(uv_stream_t* stream, int status) {
   conn_rec* conn;
   int r;
 
-  ASSERT(status == 0);
-  ASSERT(stream == (uv_stream_t*)&tcp_server);
+  ASSERT_EQ(status, 0);
+  ASSERT_PTR_EQ(stream, (uv_stream_t*)&tcp_server);
 
   conn = malloc(sizeof *conn);
   ASSERT_NOT_NULL(conn);
 
   r = uv_tcp_init(stream->loop, &conn->handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(stream, (uv_stream_t*)&conn->handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&conn->handle, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -76,12 +76,12 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   if (nread >= 0)
     return;
 
-  ASSERT(nread == UV_EOF);
+  ASSERT_EQ(nread, UV_EOF);
 
   conn = container_of(stream, conn_rec, handle);
 
   r = uv_shutdown(&conn->shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -103,20 +103,20 @@ HELPER_IMPL(tcp4_blackhole_server) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(0 && "Blackhole server dropped out of event loop.");
+  ASSERT_NE(0 && "Blackhole server dropped out of event loop.", 0);
 
   return 0;
 }

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -43,20 +43,20 @@ static void connection_cb(uv_stream_t* stream, int status) {
   conn_rec* conn;
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(stream, (uv_stream_t*)&tcp_server);
 
   conn = malloc(sizeof *conn);
   ASSERT_NOT_NULL(conn);
 
   r = uv_tcp_init(stream->loop, &conn->handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(stream, (uv_stream_t*)&conn->handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*)&conn->handle, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -81,7 +81,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   conn = container_of(stream, conn_rec, handle);
 
   r = uv_shutdown(&conn->shutdown_req, stream, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -103,16 +103,16 @@ HELPER_IMPL(tcp4_blackhole_server) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);

--- a/test/blackhole-server.c
+++ b/test/blackhole-server.c
@@ -116,7 +116,7 @@ HELPER_IMPL(tcp4_blackhole_server) {
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_NE(0 && "Blackhole server dropped out of event loop.", 0);
+  ASSERT(0 && "Blackhole server dropped out of event loop.");
 
   return 0;
 }

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -65,14 +65,14 @@ static void after_write(uv_write_t* req, int status) {
 
 
 static void after_shutdown(uv_shutdown_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   uv_close((uv_handle_t*) req->handle, on_close);
   free(req);
 }
 
 
 static void on_shutdown(uv_shutdown_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   free(req);
 }
 
@@ -92,7 +92,7 @@ static void after_read(uv_stream_t* handle,
     free(buf->base);
     sreq = malloc(sizeof* sreq);
     if (uv_is_writable(handle)) {
-      ASSERT_EQ(0, uv_shutdown(sreq, handle, after_shutdown));
+      ASSERT_OK(uv_shutdown(sreq, handle, after_shutdown));
     }
     return;
   }
@@ -118,7 +118,7 @@ static void after_read(uv_stream_t* handle,
         if (i + 2 < nread && buf->base[i + 2] == 'H')
           reset = 1;
         if (reset && handle->type == UV_TCP)
-          ASSERT_EQ(0, uv_tcp_close_reset((uv_tcp_t*) handle, on_close));
+          ASSERT_OK(uv_tcp_close_reset((uv_tcp_t*) handle, on_close));
         else if (shutdown)
           break;
         else
@@ -141,7 +141,7 @@ static void after_read(uv_stream_t* handle,
   }
 
   if (shutdown)
-    ASSERT_EQ(0, uv_shutdown(malloc(sizeof* sreq), handle, on_shutdown));
+    ASSERT_OK(uv_shutdown(malloc(sizeof* sreq), handle, on_shutdown));
 }
 
 
@@ -173,21 +173,21 @@ static void on_connection(uv_stream_t* server, int status) {
   if (status != 0) {
     fprintf(stderr, "Connect error %s\n", uv_err_name(status));
   }
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   switch (serverType) {
   case TCP:
     stream = malloc(sizeof(uv_tcp_t));
     ASSERT_NOT_NULL(stream);
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     break;
 
   case PIPE:
     stream = malloc(sizeof(uv_pipe_t));
     ASSERT_NOT_NULL(stream);
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     break;
 
   default:
@@ -199,10 +199,10 @@ static void on_connection(uv_stream_t* server, int status) {
   stream->data = server;
 
   r = uv_accept(server, stream);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start(stream, echo_alloc, after_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -221,7 +221,7 @@ static uv_udp_send_t* send_alloc(void) {
 
 static void on_send(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   req->data = send_freelist;
   send_freelist = req;
 }
@@ -252,7 +252,7 @@ static int tcp4_echo_start(int port) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", port, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", port, &addr));
 
   server = (uv_handle_t*)&tcpServer;
   serverType = TCP;
@@ -286,7 +286,7 @@ static int tcp6_echo_start(int port) {
   struct sockaddr_in6 addr6;
   int r;
 
-  ASSERT_EQ(0, uv_ip6_addr("::1", port, &addr6));
+  ASSERT_OK(uv_ip6_addr("::1", port, &addr6));
 
   server = (uv_handle_t*)&tcpServer;
   serverType = TCP;
@@ -321,7 +321,7 @@ static int udp4_echo_start(int port) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", port, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", port, &addr));
   server = (uv_handle_t*)&udpServer;
   serverType = UDP;
 

--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -173,21 +173,21 @@ static void on_connection(uv_stream_t* server, int status) {
   if (status != 0) {
     fprintf(stderr, "Connect error %s\n", uv_err_name(status));
   }
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   switch (serverType) {
   case TCP:
     stream = malloc(sizeof(uv_tcp_t));
     ASSERT_NOT_NULL(stream);
     r = uv_tcp_init(loop, (uv_tcp_t*)stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     break;
 
   case PIPE:
     stream = malloc(sizeof(uv_pipe_t));
     ASSERT_NOT_NULL(stream);
     r = uv_pipe_init(loop, (uv_pipe_t*)stream, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     break;
 
   default:
@@ -199,15 +199,15 @@ static void on_connection(uv_stream_t* server, int status) {
   stream->data = server;
 
   r = uv_accept(server, stream);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start(stream, echo_alloc, after_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void on_server_close(uv_handle_t* handle) {
-  ASSERT(handle == server);
+  ASSERT_PTR_EQ(handle, server);
 }
 
 static uv_udp_send_t* send_alloc(void) {
@@ -221,7 +221,7 @@ static uv_udp_send_t* send_alloc(void) {
 
 static void on_send(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   req->data = send_freelist;
   send_freelist = req;
 }
@@ -239,20 +239,20 @@ static void on_recv(uv_udp_t* handle,
     return;
   }
 
-  ASSERT(nread > 0);
-  ASSERT(addr->sa_family == AF_INET);
+  ASSERT_GT(nread, 0);
+  ASSERT_EQ(addr->sa_family, AF_INET);
 
   req = send_alloc();
   ASSERT_NOT_NULL(req);
   sndbuf = uv_buf_init(rcvbuf->base, nread);
-  ASSERT(0 <= uv_udp_send(req, handle, &sndbuf, 1, addr, on_send));
+  ASSERT_LE(0, uv_udp_send(req, handle, &sndbuf, 1, addr, on_send));
 }
 
 static int tcp4_echo_start(int port) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", port, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", port, &addr));
 
   server = (uv_handle_t*)&tcpServer;
   serverType = TCP;
@@ -286,7 +286,7 @@ static int tcp6_echo_start(int port) {
   struct sockaddr_in6 addr6;
   int r;
 
-  ASSERT(0 == uv_ip6_addr("::1", port, &addr6));
+  ASSERT_EQ(0, uv_ip6_addr("::1", port, &addr6));
 
   server = (uv_handle_t*)&tcpServer;
   serverType = TCP;
@@ -321,7 +321,7 @@ static int udp4_echo_start(int port) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", port, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", port, &addr));
   server = (uv_handle_t*)&udpServer;
   serverType = UDP;
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -145,7 +145,7 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper3") == 0) {
     char buffer[256];
     notify_parent_process();
-    ASSERT(buffer == fgets(buffer, sizeof(buffer) - 1, stdin));
+    ASSERT_EQ(buffer, fgets(buffer, sizeof(buffer) - 1, stdin));
     buffer[sizeof(buffer) - 1] = '\0';
     fputs(buffer, stdout);
     return 1;
@@ -183,10 +183,10 @@ static int maybe_run_test(int argc, char **argv) {
     notify_parent_process();
 
     r = fprintf(stdout, "hello world\n");
-    ASSERT(r > 0);
+    ASSERT_GT(r, 0);
 
     r = fprintf(stderr, "hello errworld\n");
-    ASSERT(r > 0);
+    ASSERT_GT(r, 0);
 
     return 1;
   }
@@ -202,7 +202,7 @@ static int maybe_run_test(int argc, char **argv) {
     ASSERT_NOT_NULL(test);
 
     r = fprintf(stdout, "%s", test);
-    ASSERT(r > 0);
+    ASSERT_GT(r, 0);
 
     return 1;
   }
@@ -216,23 +216,24 @@ static int maybe_run_test(int argc, char **argv) {
     sCompareObjectHandles pCompareObjectHandles; /* function introduced in Windows 10 */
 #endif
     notify_parent_process();
-    ASSERT(sizeof(closed_fd) == read(0, &closed_fd, sizeof(closed_fd)));
-    ASSERT(sizeof(open_fd) == read(0, &open_fd, sizeof(open_fd)));
+    ASSERT_EQ(sizeof(closed_fd), read(0, &closed_fd, sizeof(closed_fd)));
+    ASSERT_EQ(sizeof(open_fd), read(0, &open_fd, sizeof(open_fd)));
 #ifdef _WIN32
-    ASSERT((intptr_t) closed_fd > 0);
-    ASSERT((intptr_t) open_fd > 0);
-    ASSERT(0 != GetHandleInformation(open_fd, &flags));
+    ASSERT_GT((intptr_t) closed_fd, 0);
+    ASSERT_GT((intptr_t) open_fd, 0);
+    ASSERT_NE(0, GetHandleInformation(open_fd, &flags));
     kernelbase_module = GetModuleHandleA("kernelbase.dll");
     pCompareObjectHandles = (sCompareObjectHandles)
         GetProcAddress(kernelbase_module, "CompareObjectHandles");
-    ASSERT(pCompareObjectHandles == NULL || !pCompareObjectHandles(open_fd, closed_fd));
+    ASSERT_NE(pCompareObjectHandles == NULL || \
+              !pCompareObjectHandles(open_fd, closed_fd), 0);
 #else
-    ASSERT(open_fd > 2);
-    ASSERT(closed_fd > 2);
+    ASSERT_GT(open_fd, 2);
+    ASSERT_GT(closed_fd, 2);
 # if defined(__PASE__)  /* On IBMi PASE, write() returns 1 */
-    ASSERT(1 == write(closed_fd, "x", 1));
+    ASSERT_EQ(1, write(closed_fd, "x", 1));
 # else
-    ASSERT(-1 == write(closed_fd, "x", 1));
+    ASSERT_EQ(-1, write(closed_fd, "x", 1));
 # endif  /* !__PASE__ */
 #endif
     return 1;
@@ -249,8 +250,8 @@ static int maybe_run_test(int argc, char **argv) {
     uv_uid_t uid = atoi(argv[2]);
     uv_gid_t gid = atoi(argv[3]);
 
-    ASSERT(uid == getuid());
-    ASSERT(gid == getgid());
+    ASSERT_EQ(uid, getuid());
+    ASSERT_EQ(gid, getgid());
     notify_parent_process();
 
     return 1;

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -185,7 +185,7 @@ int process_wait(process_info_t *vec, int n, int timeout) {
   if (n == 0)
     return 0;
 
-  ASSERT(n <= MAXIMUM_WAIT_OBJECTS);
+  ASSERT_LE(n, MAXIMUM_WAIT_OBJECTS);
 
   for (i = 0; i < n; i++)
     handles[i] = vec[i].process;
@@ -245,7 +245,7 @@ int process_read_last_line(process_info_t *p,
   DWORD start;
   OVERLAPPED overlapped;
 
-  ASSERT(buffer_len > 0);
+  ASSERT_GT(buffer_len, 0);
 
   size = GetFileSize(p->stdio_out, NULL);
   if (size == INVALID_FILE_SIZE)

--- a/test/task.h
+++ b/test/task.h
@@ -250,7 +250,7 @@ typedef enum {
 #define MAKE_VALGRIND_HAPPY(loop)                   \
   do {                                              \
     close_loop(loop);                               \
-    ASSERT(0 == uv_loop_close(loop));               \
+    ASSERT_EQ(0, uv_loop_close(loop));              \
     uv_library_shutdown();                          \
   } while (0)
 

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -45,37 +45,37 @@ TEST_IMPL(active) {
   uv_timer_t timer;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* uv_is_active() and uv_is_closing() should always return either 0 or 1. */
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_active((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(1, uv_is_active((uv_handle_t*) &timer));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_stop(&timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_active((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(1, uv_is_active((uv_handle_t*) &timer));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &timer));
 
   uv_close((uv_handle_t*) &timer, close_cb);
 
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_OK(uv_is_active((uv_handle_t*) &timer));
   ASSERT_EQ(1, uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(close_cb_called, 1);
 

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -45,39 +45,39 @@ TEST_IMPL(active) {
   uv_timer_t timer;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* uv_is_active() and uv_is_closing() should always return either 0 or 1. */
-  ASSERT(0 == uv_is_active((uv_handle_t*) &timer));
-  ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(1 == uv_is_active((uv_handle_t*) &timer));
-  ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_EQ(1, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_stop(&timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_is_active((uv_handle_t*) &timer));
-  ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(1 == uv_is_active((uv_handle_t*) &timer));
-  ASSERT(0 == uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_EQ(1, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &timer));
 
   uv_close((uv_handle_t*) &timer, close_cb);
 
-  ASSERT(0 == uv_is_active((uv_handle_t*) &timer));
-  ASSERT(1 == uv_is_closing((uv_handle_t*) &timer));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &timer));
+  ASSERT_EQ(1, uv_is_closing((uv_handle_t*) &timer));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-active.c
+++ b/test/test-active.c
@@ -77,7 +77,7 @@ TEST_IMPL(active) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -36,7 +36,7 @@ static void thread_cb(void* dummy) {
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_OK(check_cb_called);
   uv_close((uv_handle_t*) &async_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   check_cb_called++;
@@ -52,12 +52,12 @@ TEST_IMPL(async_null_cb) {
    */
   memset(&async_handle, 0xff, sizeof(async_handle));
 
-  ASSERT_EQ(0, uv_async_init(uv_default_loop(), &async_handle, NULL));
-  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_cb, NULL));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_async_init(uv_default_loop(), &async_handle, NULL));
+  ASSERT_OK(uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_OK(uv_check_start(&check_handle, check_cb));
+  ASSERT_OK(uv_thread_create(&thread, thread_cb, NULL));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_thread_join(&thread));
   ASSERT_EQ(check_cb_called, 1);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -36,7 +36,7 @@ static void thread_cb(void* dummy) {
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT(check_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
   uv_close((uv_handle_t*) &async_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   check_cb_called++;
@@ -52,13 +52,13 @@ TEST_IMPL(async_null_cb) {
    */
   memset(&async_handle, 0xff, sizeof(async_handle));
 
-  ASSERT(0 == uv_async_init(uv_default_loop(), &async_handle, NULL));
-  ASSERT(0 == uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT(0 == uv_check_start(&check_handle, check_cb));
-  ASSERT(0 == uv_thread_create(&thread, thread_cb, NULL));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == uv_thread_join(&thread));
-  ASSERT(1 == check_cb_called);
+  ASSERT_EQ(0, uv_async_init(uv_default_loop(), &async_handle, NULL));
+  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_cb, NULL));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_EQ(check_cb_called, 1);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-async-null-cb.c
+++ b/test/test-async-null-cb.c
@@ -58,7 +58,7 @@ TEST_IMPL(async_null_cb) {
   ASSERT_OK(uv_thread_create(&thread, thread_cb, NULL));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_OK(uv_thread_join(&thread));
-  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(1, check_cb_called);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -124,8 +124,8 @@ TEST_IMPL(async) {
   ASSERT_OK(r);
 
   ASSERT_GT(prepare_cb_called, 0);
-  ASSERT_EQ(async_cb_called, 3);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(3, async_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   ASSERT_OK(uv_thread_join(&thread));
 

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -49,7 +49,7 @@ static void thread_cb(void *arg) {
     }
 
     r = uv_async_send(&async);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     /* Work around a bug in Valgrind.
      *
@@ -100,7 +100,7 @@ static void prepare_cb(uv_prepare_t* handle) {
     return;
 
   r = uv_thread_create(&thread, thread_cb, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_mutex_unlock(&mutex);
 }
 
@@ -109,25 +109,25 @@ TEST_IMPL(async) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_mutex_lock(&mutex);
 
   r = uv_prepare_init(uv_default_loop(), &prepare);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_prepare_start(&prepare, prepare_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_async_init(uv_default_loop(), &async, async_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_GT(prepare_cb_called, 0);
   ASSERT_EQ(async_cb_called, 3);
   ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-async.c
+++ b/test/test-async.c
@@ -49,7 +49,7 @@ static void thread_cb(void *arg) {
     }
 
     r = uv_async_send(&async);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     /* Work around a bug in Valgrind.
      *
@@ -78,7 +78,7 @@ static void close_cb(uv_handle_t* handle) {
 static void async_cb(uv_async_t* handle) {
   int n;
 
-  ASSERT(handle == &async);
+  ASSERT_PTR_EQ(handle, &async);
 
   uv_mutex_lock(&mutex);
   n = ++async_cb_called;
@@ -94,13 +94,13 @@ static void async_cb(uv_async_t* handle) {
 static void prepare_cb(uv_prepare_t* handle) {
   int r;
 
-  ASSERT(handle == &prepare);
+  ASSERT_PTR_EQ(handle, &prepare);
 
   if (prepare_cb_called++)
     return;
 
   r = uv_thread_create(&thread, thread_cb, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_mutex_unlock(&mutex);
 }
 
@@ -109,25 +109,25 @@ TEST_IMPL(async) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_mutex_lock(&mutex);
 
   r = uv_prepare_init(uv_default_loop(), &prepare);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare, prepare_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_async_init(uv_default_loop(), &async, async_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(prepare_cb_called > 0);
-  ASSERT(async_cb_called == 3);
-  ASSERT(close_cb_called == 2);
+  ASSERT_GT(prepare_cb_called, 0);
+  ASSERT_EQ(async_cb_called, 3);
+  ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-barrier.c
+++ b/test/test-barrier.c
@@ -53,13 +53,13 @@ TEST_IMPL(barrier_1) {
   memset(&wc, 0, sizeof(wc));
   wc.niter = 1;
 
-  ASSERT_EQ(0, uv_barrier_init(&wc.barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_barrier_init(&wc.barrier, 2));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   uv_sleep(100);
   wc.main_barrier_wait_rval = uv_barrier_wait(&wc.barrier);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_barrier_destroy(&wc.barrier);
 
   ASSERT_EQ(1, (wc.main_barrier_wait_rval ^ wc.worker_barrier_wait_rval));
@@ -76,12 +76,12 @@ TEST_IMPL(barrier_2) {
   wc.delay = 100;
   wc.niter = 1;
 
-  ASSERT_EQ(0, uv_barrier_init(&wc.barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_barrier_init(&wc.barrier, 2));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   wc.main_barrier_wait_rval = uv_barrier_wait(&wc.barrier);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_barrier_destroy(&wc.barrier);
 
   ASSERT_EQ(1, (wc.main_barrier_wait_rval ^ wc.worker_barrier_wait_rval));
@@ -98,13 +98,13 @@ TEST_IMPL(barrier_3) {
   memset(&wc, 0, sizeof(wc));
   wc.niter = 5;
 
-  ASSERT_EQ(0, uv_barrier_init(&wc.barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_barrier_init(&wc.barrier, 2));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   for (i = 0; i < wc.niter; i++)
     wc.main_barrier_wait_rval += uv_barrier_wait(&wc.barrier);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_barrier_destroy(&wc.barrier);
 
   ASSERT_EQ(wc.niter, wc.main_barrier_wait_rval + wc.worker_barrier_wait_rval);
@@ -133,10 +133,10 @@ TEST_IMPL(barrier_serial_thread) {
   uv_barrier_t barrier;
   unsigned i;
 
-  ASSERT_EQ(0, uv_barrier_init(&barrier, ARRAY_SIZE(threads) + 1));
+  ASSERT_OK(uv_barrier_init(&barrier, ARRAY_SIZE(threads) + 1));
 
   for (i = 0; i < ARRAY_SIZE(threads); ++i)
-    ASSERT_EQ(0, uv_thread_create(&threads[i], serial_worker, &barrier));
+    ASSERT_OK(uv_thread_create(&threads[i], serial_worker, &barrier));
 
   for (i = 0; i < 5; i++)
     uv_barrier_wait(&barrier);
@@ -144,7 +144,7 @@ TEST_IMPL(barrier_serial_thread) {
     uv_barrier_destroy(&barrier);
 
   for (i = 0; i < ARRAY_SIZE(threads); ++i)
-    ASSERT_EQ(0, uv_thread_join(&threads[i]));
+    ASSERT_OK(uv_thread_join(&threads[i]));
 
   return 0;
 }
@@ -153,7 +153,7 @@ TEST_IMPL(barrier_serial_thread) {
 TEST_IMPL(barrier_serial_thread_single) {
   uv_barrier_t barrier;
 
-  ASSERT_EQ(0, uv_barrier_init(&barrier, 1));
+  ASSERT_OK(uv_barrier_init(&barrier, 1));
   ASSERT_LT(0, uv_barrier_wait(&barrier));
   uv_barrier_destroy(&barrier);
   return 0;

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -60,7 +60,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "shutdown_cb must be called from a fresh stack");
 
   shutdown_cb_called++;
@@ -77,7 +77,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     return;
 
   } else if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
 
     nested++;
     uv_close((uv_handle_t*)tcp, close_cb);
@@ -105,7 +105,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_PTR_EQ(handle, &timer);
   ASSERT(nested == 0 && "timer_cb must be called from a fresh stack");
 
   puts("Timeout complete. Now read data...");
@@ -125,7 +125,7 @@ static void timer_cb(uv_timer_t* handle) {
 static void write_cb(uv_write_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "write_cb must be called from a fresh stack");
 
   puts("Data written. 500ms timeout...");
@@ -136,9 +136,9 @@ static void write_cb(uv_write_t* req, int status) {
    * for the backend to use dirty stack for calling read_cb. */
   nested++;
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   nested--;
 
   write_cb_called++;
@@ -150,7 +150,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   puts("Connected. Write some data to echo server...");
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(nested == 0 && "connect_cb must be called from a fresh stack");
 
   nested++;
@@ -171,7 +171,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 TEST_IMPL(callback_stack) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   if (uv_tcp_init(uv_default_loop(), &client)) {
     FATAL("uv_tcp_init failed");
@@ -191,13 +191,18 @@ TEST_IMPL(callback_stack) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(nested == 0);
-  ASSERT(connect_cb_called == 1 && "connect_cb must be called exactly once");
-  ASSERT(write_cb_called == 1 && "write_cb must be called exactly once");
-  ASSERT(timer_cb_called == 1 && "timer_cb must be called exactly once");
-  ASSERT(bytes_received == sizeof MESSAGE);
-  ASSERT(shutdown_cb_called == 1 && "shutdown_cb must be called exactly once");
-  ASSERT(close_cb_called == 2 && "close_cb must be called exactly twice");
+  ASSERT_EQ(nested, 0);
+  ASSERT_NE(connect_cb_called == 1 && \
+            "connect_cb must be called exactly once", 0);
+  ASSERT_NE(write_cb_called == 1 && "write_cb must be called exactly once",
+            0);
+  ASSERT_NE(timer_cb_called == 1 && "timer_cb must be called exactly once",
+            0);
+  ASSERT_EQ(bytes_received, sizeof MESSAGE);
+  ASSERT_NE(shutdown_cb_called == 1 && \
+            "shutdown_cb must be called exactly once", 0);
+  ASSERT_NE(close_cb_called == 2 && "close_cb must be called exactly twice",
+            0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-callback-stack.c
+++ b/test/test-callback-stack.c
@@ -60,7 +60,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT(nested == 0 && "shutdown_cb must be called from a fresh stack");
 
   shutdown_cb_called++;
@@ -125,7 +125,7 @@ static void timer_cb(uv_timer_t* handle) {
 static void write_cb(uv_write_t* req, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT(nested == 0 && "write_cb must be called from a fresh stack");
 
   puts("Data written. 500ms timeout...");
@@ -136,9 +136,9 @@ static void write_cb(uv_write_t* req, int status) {
    * for the backend to use dirty stack for calling read_cb. */
   nested++;
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   nested--;
 
   write_cb_called++;
@@ -150,7 +150,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   puts("Connected. Write some data to echo server...");
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT(nested == 0 && "connect_cb must be called from a fresh stack");
 
   nested++;
@@ -171,7 +171,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 TEST_IMPL(callback_stack) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   if (uv_tcp_init(uv_default_loop(), &client)) {
     FATAL("uv_tcp_init failed");
@@ -191,7 +191,7 @@ TEST_IMPL(callback_stack) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(nested, 0);
+  ASSERT_OK(nested);
   ASSERT_NE(connect_cb_called == 1 && \
             "connect_cb must be called exactly once", 0);
   ASSERT_NE(write_cb_called == 1 && "write_cb must be called exactly once",

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -36,7 +36,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   switch (++read_cb_called) {
   case 1:
-    ASSERT_EQ(nread, 1);
+    ASSERT_EQ(1, nread);
     uv_read_stop(handle);
     break;
   case 2:
@@ -62,7 +62,7 @@ TEST_IMPL(close_fd) {
   fd[0] = -1;
 
   ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT_EQ(req.result, 1);
+  ASSERT_EQ(1, req.result);
   uv_fs_req_cleanup(&req);
 #ifdef _WIN32
   ASSERT_OK(_close(fd[1]));
@@ -72,11 +72,11 @@ TEST_IMPL(close_fd) {
   fd[1] = -1;
   ASSERT_OK(uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(read_cb_called, 1);
+  ASSERT_EQ(1, read_cb_called);
   ASSERT_OK(uv_is_active((const uv_handle_t *) &pipe_handle));
   ASSERT_OK(uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(read_cb_called, 2);
+  ASSERT_EQ(2, read_cb_called);
   ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &pipe_handle));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -55,9 +55,9 @@ TEST_IMPL(close_fd) {
   uv_file fd[2];
   bufs[0] = uv_buf_init("", 1);
 
-  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
-  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[0]));
+  ASSERT_OK(uv_pipe(fd, 0, 0));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_OK(uv_pipe_open(&pipe_handle, fd[0]));
   /* uv_pipe_open() takes ownership of the file descriptor. */
   fd[0] = -1;
 
@@ -65,17 +65,17 @@ TEST_IMPL(close_fd) {
   ASSERT_EQ(req.result, 1);
   uv_fs_req_cleanup(&req);
 #ifdef _WIN32
-  ASSERT_EQ(0, _close(fd[1]));
+  ASSERT_OK(_close(fd[1]));
 #else
-  ASSERT_EQ(0, close(fd[1]));
+  ASSERT_OK(close(fd[1]));
 #endif
   fd[1] = -1;
-  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(0, uv_is_active((const uv_handle_t *) &pipe_handle));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_is_active((const uv_handle_t *) &pipe_handle));
+  ASSERT_OK(uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(read_cb_called, 2);
   ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &pipe_handle));
 

--- a/test/test-close-fd.c
+++ b/test/test-close-fd.c
@@ -36,11 +36,11 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   switch (++read_cb_called) {
   case 1:
-    ASSERT(nread == 1);
+    ASSERT_EQ(nread, 1);
     uv_read_stop(handle);
     break;
   case 2:
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t *) handle, NULL);
     break;
   default:
@@ -55,29 +55,29 @@ TEST_IMPL(close_fd) {
   uv_file fd[2];
   bufs[0] = uv_buf_init("", 1);
 
-  ASSERT(0 == uv_pipe(fd, 0, 0));
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT(0 == uv_pipe_open(&pipe_handle, fd[0]));
+  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[0]));
   /* uv_pipe_open() takes ownership of the file descriptor. */
   fd[0] = -1;
 
-  ASSERT(1 == uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT(1 == req.result);
+  ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
+  ASSERT_EQ(req.result, 1);
   uv_fs_req_cleanup(&req);
 #ifdef _WIN32
-  ASSERT(0 == _close(fd[1]));
+  ASSERT_EQ(0, _close(fd[1]));
 #else
-  ASSERT(0 == close(fd[1]));
+  ASSERT_EQ(0, close(fd[1]));
 #endif
   fd[1] = -1;
-  ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == read_cb_called);
-  ASSERT(0 == uv_is_active((const uv_handle_t *) &pipe_handle));
-  ASSERT(0 == uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(2 == read_cb_called);
-  ASSERT(0 != uv_is_closing((const uv_handle_t *) &pipe_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(read_cb_called, 1);
+  ASSERT_EQ(0, uv_is_active((const uv_handle_t *) &pipe_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t *) &pipe_handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(read_cb_called, 2);
+  ASSERT_NE(0, uv_is_closing((const uv_handle_t *) &pipe_handle));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -39,9 +39,9 @@ static void close_cb(uv_handle_t* handle) {
 
 /* check_cb should run before any close_cb */
 static void check_cb(uv_check_t* handle) {
-  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_OK(check_cb_called);
   ASSERT_EQ(timer_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_OK(close_cb_called);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &timer_handle2, close_cb);
   check_cb_called++;
@@ -65,9 +65,9 @@ TEST_IMPL(close_order) {
   uv_timer_init(loop, &timer_handle2);
   uv_timer_start(&timer_handle2, timer_cb, 100000, 0);
 
-  ASSERT_EQ(check_cb_called, 0);
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(timer_cb_called, 0);
+  ASSERT_OK(check_cb_called);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(timer_cb_called);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -40,7 +40,7 @@ static void close_cb(uv_handle_t* handle) {
 /* check_cb should run before any close_cb */
 static void check_cb(uv_check_t* handle) {
   ASSERT_OK(check_cb_called);
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, timer_cb_called);
   ASSERT_OK(close_cb_called);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &timer_handle2, close_cb);
@@ -71,9 +71,9 @@ TEST_IMPL(close_order) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(check_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, check_cb_called);
+  ASSERT_EQ(3, close_cb_called);
+  ASSERT_EQ(1, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-close-order.c
+++ b/test/test-close-order.c
@@ -39,9 +39,9 @@ static void close_cb(uv_handle_t* handle) {
 
 /* check_cb should run before any close_cb */
 static void check_cb(uv_check_t* handle) {
-  ASSERT(check_cb_called == 0);
-  ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 0);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &timer_handle2, close_cb);
   check_cb_called++;
@@ -65,15 +65,15 @@ TEST_IMPL(close_order) {
   uv_timer_init(loop, &timer_handle2);
   uv_timer_start(&timer_handle2, timer_cb, 100000, 0);
 
-  ASSERT(check_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(timer_cb_called == 0);
+  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(check_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(timer_cb_called == 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(timer_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -55,10 +55,10 @@ void worker_config_init(worker_config* wc,
   wc->use_broadcast = use_broadcast;
 
   /* Init. */
-  ASSERT_EQ(0, uv_sem_init(&wc->sem_waiting, 0));
-  ASSERT_EQ(0, uv_sem_init(&wc->sem_signaled, 0));
-  ASSERT_EQ(0, uv_cond_init(&wc->cond));
-  ASSERT_EQ(0, uv_mutex_init(&wc->mutex));
+  ASSERT_OK(uv_sem_init(&wc->sem_waiting, 0));
+  ASSERT_OK(uv_sem_init(&wc->sem_signaled, 0));
+  ASSERT_OK(uv_cond_init(&wc->cond));
+  ASSERT_OK(uv_mutex_init(&wc->mutex));
 }
 
 void worker_config_destroy(worker_config* wc) {
@@ -87,7 +87,7 @@ static void condvar_signal(worker_config* c, int* flag) {
   uv_mutex_lock(&c->mutex);
 
   /* Help waiter differentiate between spurious and legitimate wakeup. */
-  ASSERT_EQ(*flag, 0);
+  ASSERT_OK(*flag);
   *flag = 1;
 
   if (c->use_broadcast)
@@ -130,13 +130,13 @@ TEST_IMPL(condvar_1) {
 
   /* Helper signal-then-wait. */
   worker_config_init(&wc, 0, condvar_signal, condvar_wait);
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
-  ASSERT_EQ(0, wc.wait_cond(&wc, &wc.posted_1));
+  ASSERT_OK(wc.wait_cond(&wc, &wc.posted_1));
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -149,13 +149,13 @@ TEST_IMPL(condvar_2) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 1, condvar_signal, condvar_wait);
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
-  ASSERT_EQ(0, wc.wait_cond(&wc, &wc.posted_1));
+  ASSERT_OK(wc.wait_cond(&wc, &wc.posted_1));
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -176,7 +176,7 @@ static int condvar_timedwait(worker_config* c, const int* flag) {
   /* Wait until I get a non-spurious signal. */
   do {
     r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(1 * 1e9)); /* 1 s */
-    ASSERT_EQ(r, 0); /* Should not time out. */
+    ASSERT_OK(r); /* Should not time out. */
   } while (*flag == 0);
   ASSERT_EQ(*flag, 1);
 
@@ -194,13 +194,13 @@ TEST_IMPL(condvar_3) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 0, condvar_signal, condvar_timedwait);
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
   wc.wait_cond(&wc, &wc.posted_1);
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -213,13 +213,13 @@ TEST_IMPL(condvar_4) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 1, condvar_signal, condvar_timedwait);
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
   wc.wait_cond(&wc, &wc.posted_1);
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -113,7 +113,7 @@ static int condvar_wait(worker_config* c, const int* flag) {
   do {
     uv_cond_wait(&c->cond, &c->mutex);
   } while (*flag == 0);
-  ASSERT_EQ(*flag, 1);
+  ASSERT_EQ(1, *flag);
 
   uv_mutex_unlock(&c->mutex);
 
@@ -178,7 +178,7 @@ static int condvar_timedwait(worker_config* c, const int* flag) {
     r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(1 * 1e9)); /* 1 s */
     ASSERT_OK(r); /* Should not time out. */
   } while (*flag == 0);
-  ASSERT_EQ(*flag, 1);
+  ASSERT_EQ(1, *flag);
 
   uv_mutex_unlock(&c->mutex);
 

--- a/test/test-condvar.c
+++ b/test/test-condvar.c
@@ -55,10 +55,10 @@ void worker_config_init(worker_config* wc,
   wc->use_broadcast = use_broadcast;
 
   /* Init. */
-  ASSERT(0 == uv_sem_init(&wc->sem_waiting, 0));
-  ASSERT(0 == uv_sem_init(&wc->sem_signaled, 0));
-  ASSERT(0 == uv_cond_init(&wc->cond));
-  ASSERT(0 == uv_mutex_init(&wc->mutex));
+  ASSERT_EQ(0, uv_sem_init(&wc->sem_waiting, 0));
+  ASSERT_EQ(0, uv_sem_init(&wc->sem_signaled, 0));
+  ASSERT_EQ(0, uv_cond_init(&wc->cond));
+  ASSERT_EQ(0, uv_mutex_init(&wc->mutex));
 }
 
 void worker_config_destroy(worker_config* wc) {
@@ -87,7 +87,7 @@ static void condvar_signal(worker_config* c, int* flag) {
   uv_mutex_lock(&c->mutex);
 
   /* Help waiter differentiate between spurious and legitimate wakeup. */
-  ASSERT(*flag == 0);
+  ASSERT_EQ(*flag, 0);
   *flag = 1;
 
   if (c->use_broadcast)
@@ -113,7 +113,7 @@ static int condvar_wait(worker_config* c, const int* flag) {
   do {
     uv_cond_wait(&c->cond, &c->mutex);
   } while (*flag == 0);
-  ASSERT(*flag == 1);
+  ASSERT_EQ(*flag, 1);
 
   uv_mutex_unlock(&c->mutex);
 
@@ -130,13 +130,13 @@ TEST_IMPL(condvar_1) {
 
   /* Helper signal-then-wait. */
   worker_config_init(&wc, 0, condvar_signal, condvar_wait);
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
-  ASSERT(0 == wc.wait_cond(&wc, &wc.posted_1));
+  ASSERT_EQ(0, wc.wait_cond(&wc, &wc.posted_1));
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -149,13 +149,13 @@ TEST_IMPL(condvar_2) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 1, condvar_signal, condvar_wait);
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
-  ASSERT(0 == wc.wait_cond(&wc, &wc.posted_1));
+  ASSERT_EQ(0, wc.wait_cond(&wc, &wc.posted_1));
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -176,9 +176,9 @@ static int condvar_timedwait(worker_config* c, const int* flag) {
   /* Wait until I get a non-spurious signal. */
   do {
     r = uv_cond_timedwait(&c->cond, &c->mutex, (uint64_t)(1 * 1e9)); /* 1 s */
-    ASSERT(r == 0); /* Should not time out. */
+    ASSERT_EQ(r, 0); /* Should not time out. */
   } while (*flag == 0);
-  ASSERT(*flag == 1);
+  ASSERT_EQ(*flag, 1);
 
   uv_mutex_unlock(&c->mutex);
 
@@ -194,13 +194,13 @@ TEST_IMPL(condvar_3) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 0, condvar_signal, condvar_timedwait);
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
   wc.wait_cond(&wc, &wc.posted_1);
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;
@@ -213,13 +213,13 @@ TEST_IMPL(condvar_4) {
 
   /* Helper to signal-then-wait. */
   worker_config_init(&wc, 1, condvar_signal, condvar_timedwait);
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   /* We wait-then-signal. */
   wc.wait_cond(&wc, &wc.posted_1);
   wc.signal_cond(&wc, &wc.posted_2);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   worker_config_destroy(&wc);
 
   return 0;

--- a/test/test-connect-unspecified.c
+++ b/test/test-connect-unspecified.c
@@ -41,23 +41,23 @@ TEST_IMPL(connect_unspecified) {
 
   loop = uv_default_loop();
 
-  ASSERT_EQ(uv_tcp_init(loop, &socket4), 0);
-  ASSERT_EQ(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr4), 0);
-  ASSERT_EQ(uv_tcp_connect(&connect4,
+  ASSERT_OK(uv_tcp_init(loop, &socket4));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr4));
+  ASSERT_OK(uv_tcp_connect(&connect4,
                            &socket4,
                            (const struct sockaddr*) &addr4,
-                           connect_4), 0);
+                           connect_4));
 
   if (can_ipv6()) {
-    ASSERT_EQ(uv_tcp_init(loop, &socket6), 0);
-    ASSERT_EQ(uv_ip6_addr("::", TEST_PORT, &addr6), 0);
-    ASSERT_EQ(uv_tcp_connect(&connect6,
+    ASSERT_OK(uv_tcp_init(loop, &socket6));
+    ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &addr6));
+    ASSERT_OK(uv_tcp_connect(&connect6,
                              &socket6,
                              (const struct sockaddr*) &addr6,
-                             connect_6), 0);
+                             connect_6));
   }
 
-  ASSERT_EQ(uv_run(loop, UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-connect-unspecified.c
+++ b/test/test-connect-unspecified.c
@@ -23,11 +23,11 @@
 #include "task.h"
 
 static void connect_4(uv_connect_t* req, int status) {
-  ASSERT(status != UV_EADDRNOTAVAIL);
+  ASSERT_NE(status, UV_EADDRNOTAVAIL);
 }
 
 static void connect_6(uv_connect_t* req, int status) {
-  ASSERT(status != UV_EADDRNOTAVAIL);
+  ASSERT_NE(status, UV_EADDRNOTAVAIL);
 }
 
 TEST_IMPL(connect_unspecified) {
@@ -41,23 +41,23 @@ TEST_IMPL(connect_unspecified) {
 
   loop = uv_default_loop();
 
-  ASSERT(uv_tcp_init(loop, &socket4) == 0);
-  ASSERT(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr4) == 0);
-  ASSERT(uv_tcp_connect(&connect4,
-                        &socket4,
-                        (const struct sockaddr*) &addr4,
-                        connect_4) == 0);
+  ASSERT_EQ(uv_tcp_init(loop, &socket4), 0);
+  ASSERT_EQ(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr4), 0);
+  ASSERT_EQ(uv_tcp_connect(&connect4,
+                           &socket4,
+                           (const struct sockaddr*) &addr4,
+                           connect_4), 0);
 
   if (can_ipv6()) {
-    ASSERT(uv_tcp_init(loop, &socket6) == 0);
-    ASSERT(uv_ip6_addr("::", TEST_PORT, &addr6) == 0);
-    ASSERT(uv_tcp_connect(&connect6,
-                          &socket6,
-                          (const struct sockaddr*) &addr6,
-                          connect_6) == 0);
+    ASSERT_EQ(uv_tcp_init(loop, &socket6), 0);
+    ASSERT_EQ(uv_ip6_addr("::", TEST_PORT, &addr6), 0);
+    ASSERT_EQ(uv_tcp_connect(&connect6,
+                             &socket6,
+                             (const struct sockaddr*) &addr6,
+                             connect_6), 0);
   }
 
-  ASSERT(uv_run(loop, UV_RUN_DEFAULT) == 0);
+  ASSERT_EQ(uv_run(loop, UV_RUN_DEFAULT), 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -55,7 +55,7 @@ static void timer_cb(uv_timer_t* handle) {
    * uv_close the handle manually.
    */
   ASSERT_OK(close_cb_calls);
-  ASSERT_EQ(connect_cb_calls, 1);
+  ASSERT_EQ(1, connect_cb_calls);
 
   /* Close the tcp handle. */
   uv_close((uv_handle_t*)&tcp, on_close);
@@ -110,8 +110,8 @@ static void connection_fail(uv_connect_cb connect_cb) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connect_cb_calls, 1);
-  ASSERT_EQ(close_cb_calls, 1);
+  ASSERT_EQ(1, connect_cb_calls);
+  ASSERT_EQ(1, close_cb_calls);
 }
 
 
@@ -153,8 +153,8 @@ TEST_IMPL(connection_fail_doesnt_auto_close) {
 
   connection_fail(on_connect_without_close);
 
-  ASSERT_EQ(timer_close_cb_calls, 1);
-  ASSERT_EQ(timer_cb_calls, 1);
+  ASSERT_EQ(1, timer_close_cb_calls);
+  ASSERT_EQ(1, timer_cb_calls);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-connection-fail.c
+++ b/test/test-connection-fail.c
@@ -54,7 +54,7 @@ static void timer_cb(uv_timer_t* handle) {
    * but libuv hasn't automatically closed the socket. The user must
    * uv_close the handle manually.
    */
-  ASSERT_EQ(close_cb_calls, 0);
+  ASSERT_OK(close_cb_calls);
   ASSERT_EQ(connect_cb_calls, 1);
 
   /* Close the tcp handle. */
@@ -70,7 +70,7 @@ static void on_connect_with_close(uv_connect_t *req, int status) {
   ASSERT_EQ(status, UV_ECONNREFUSED);
   connect_cb_calls++;
 
-  ASSERT_EQ(close_cb_calls, 0);
+  ASSERT_OK(close_cb_calls);
   uv_close((uv_handle_t*)req->handle, on_close);
 }
 
@@ -81,7 +81,7 @@ static void on_connect_without_close(uv_connect_t *req, int status) {
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 
-  ASSERT_EQ(close_cb_calls, 0);
+  ASSERT_OK(close_cb_calls);
 }
 
 
@@ -89,10 +89,10 @@ static void connection_fail(uv_connect_cb connect_cb) {
   struct sockaddr_in client_addr, server_addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &client_addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &client_addr));
 
   /* There should be no servers listening on this port. */
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
 
   /* Try to connect to the server and do NUM_PINGS ping-pongs. */
   r = uv_tcp_init(uv_default_loop(), &tcp);
@@ -100,7 +100,7 @@ static void connection_fail(uv_connect_cb connect_cb) {
 
   /* We are never doing multiple reads/connects at a time anyway. so these
    * handles can be pre-initialized. */
-  ASSERT_EQ(0, uv_tcp_bind(&tcp, (const struct sockaddr*) &client_addr, 0));
+  ASSERT_OK(uv_tcp_bind(&tcp, (const struct sockaddr*) &client_addr, 0));
 
   r = uv_tcp_connect(&req,
                      &tcp,
@@ -127,8 +127,8 @@ TEST_IMPL(connection_fail) {
 
   connection_fail(on_connect_with_close);
 
-  ASSERT_EQ(timer_close_cb_calls, 0);
-  ASSERT_EQ(timer_cb_calls, 0);
+  ASSERT_OK(timer_close_cb_calls);
+  ASSERT_OK(timer_cb_calls);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -149,7 +149,7 @@ TEST_IMPL(connection_fail_doesnt_auto_close) {
   int r;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   connection_fail(on_connect_without_close);
 

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -39,19 +39,19 @@ TEST_IMPL(cwd_and_chdir) {
 
   size1 = sizeof buffer_orig;
   err = uv_cwd(buffer_orig, &size1);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   ASSERT_GT(size1, 0);
   ASSERT_NE(buffer_orig[size1], '/');
 
   err = uv_chdir(buffer_orig);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   size2 = sizeof buffer_new;
   err = uv_cwd(buffer_new, &size2);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   ASSERT_EQ(size1, size2);
-  ASSERT_EQ(strcmp(buffer_orig, buffer_new), 0);
+  ASSERT_OK(strcmp(buffer_orig, buffer_new));
 
   return 0;
 }

--- a/test/test-cwd-and-chdir.c
+++ b/test/test-cwd-and-chdir.c
@@ -34,24 +34,24 @@ TEST_IMPL(cwd_and_chdir) {
 
   size1 = 1;
   err = uv_cwd(buffer_orig, &size1);
-  ASSERT(err == UV_ENOBUFS);
-  ASSERT(size1 > 1);
+  ASSERT_EQ(err, UV_ENOBUFS);
+  ASSERT_GT(size1, 1);
 
   size1 = sizeof buffer_orig;
   err = uv_cwd(buffer_orig, &size1);
-  ASSERT(err == 0);
-  ASSERT(size1 > 0);
-  ASSERT(buffer_orig[size1] != '/');
+  ASSERT_EQ(err, 0);
+  ASSERT_GT(size1, 0);
+  ASSERT_NE(buffer_orig[size1], '/');
 
   err = uv_chdir(buffer_orig);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   size2 = sizeof buffer_new;
   err = uv_cwd(buffer_new, &size2);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
-  ASSERT(size1 == size2);
-  ASSERT(strcmp(buffer_orig, buffer_new) == 0);
+  ASSERT_EQ(size1, size2);
+  ASSERT_EQ(strcmp(buffer_orig, buffer_new), 0);
 
   return 0;
 }

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -42,7 +42,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT_OK(uv_timer_init(loop, &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, timer_cb_called);
   ASSERT_OK(uv_loop_close(loop));
 
   loop = uv_default_loop();
@@ -51,7 +51,7 @@ TEST_IMPL(default_loop_close) {
   ASSERT_OK(uv_timer_init(loop, &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(timer_cb_called, 2);
+  ASSERT_EQ(2, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -39,18 +39,18 @@ TEST_IMPL(default_loop_close) {
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(timer_cb_called, 1);
-  ASSERT_EQ(0, uv_loop_close(loop));
+  ASSERT_OK(uv_loop_close(loop));
 
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(timer_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-default-loop-close.c
+++ b/test/test-default-loop-close.c
@@ -39,19 +39,19 @@ TEST_IMPL(default_loop_close) {
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
-  ASSERT(0 == uv_loop_close(loop));
+  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(0, uv_loop_close(loop));
 
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(2 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(timer_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -54,11 +54,11 @@ static void do_accept(uv_timer_t* timer_handle) {
   ASSERT_NOT_NULL(accepted_handle);
 
   r = uv_tcp_init(uv_default_loop(), accepted_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   server = (uv_tcp_t*)timer_handle->data;
   r = uv_accept((uv_stream_t*)server, (uv_stream_t*)accepted_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   do_accept_called++;
 
@@ -79,19 +79,19 @@ static void connection_cb(uv_stream_t* tcp, int status) {
   int r;
   uv_timer_t* timer_handle;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   timer_handle = (uv_timer_t*)malloc(sizeof *timer_handle);
   ASSERT_NOT_NULL(timer_handle);
 
   /* Accept the client after 1 second */
   r = uv_timer_init(uv_default_loop(), timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   timer_handle->data = tcp;
 
   r = uv_timer_start(timer_handle, do_accept, 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connection_cb_called++;
 }
@@ -102,16 +102,16 @@ static void start_server(void) {
   uv_tcp_t* server = (uv_tcp_t*)malloc(sizeof *server);
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   ASSERT_NOT_NULL(server);
 
   r = uv_tcp_init(uv_default_loop(), server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -123,10 +123,10 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (nread >= 0) {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   } else {
     ASSERT_NOT_NULL(tcp);
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*)tcp, close_cb);
   }
 }
@@ -136,12 +136,12 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* Not that the server will send anything, but otherwise we'll never know
    * when the server closes the connection. */
   r = uv_read_start((uv_stream_t*)(req->handle), alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   connect_cb_called++;
 
@@ -155,18 +155,18 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   ASSERT_NOT_NULL(client);
   ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(connect_req,
                      client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -179,10 +179,10 @@ TEST_IMPL(delayed_accept) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == 2);
-  ASSERT(do_accept_called == 2);
-  ASSERT(connect_cb_called == 2);
-  ASSERT(close_cb_called == 7);
+  ASSERT_EQ(connection_cb_called, 2);
+  ASSERT_EQ(do_accept_called, 2);
+  ASSERT_EQ(connect_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 7);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -179,10 +179,10 @@ TEST_IMPL(delayed_accept) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connection_cb_called, 2);
-  ASSERT_EQ(do_accept_called, 2);
-  ASSERT_EQ(connect_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 7);
+  ASSERT_EQ(2, connection_cb_called);
+  ASSERT_EQ(2, do_accept_called);
+  ASSERT_EQ(2, connect_cb_called);
+  ASSERT_EQ(7, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-delayed-accept.c
+++ b/test/test-delayed-accept.c
@@ -54,11 +54,11 @@ static void do_accept(uv_timer_t* timer_handle) {
   ASSERT_NOT_NULL(accepted_handle);
 
   r = uv_tcp_init(uv_default_loop(), accepted_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   server = (uv_tcp_t*)timer_handle->data;
   r = uv_accept((uv_stream_t*)server, (uv_stream_t*)accepted_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   do_accept_called++;
 
@@ -79,19 +79,19 @@ static void connection_cb(uv_stream_t* tcp, int status) {
   int r;
   uv_timer_t* timer_handle;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   timer_handle = (uv_timer_t*)malloc(sizeof *timer_handle);
   ASSERT_NOT_NULL(timer_handle);
 
   /* Accept the client after 1 second */
   r = uv_timer_init(uv_default_loop(), timer_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   timer_handle->data = tcp;
 
   r = uv_timer_start(timer_handle, do_accept, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   connection_cb_called++;
 }
@@ -102,16 +102,16 @@ static void start_server(void) {
   uv_tcp_t* server = (uv_tcp_t*)malloc(sizeof *server);
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   ASSERT_NOT_NULL(server);
 
   r = uv_tcp_init(uv_default_loop(), server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)server, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -123,7 +123,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (nread >= 0) {
-    ASSERT_EQ(nread, 0);
+    ASSERT_OK(nread);
   } else {
     ASSERT_NOT_NULL(tcp);
     ASSERT_EQ(nread, UV_EOF);
@@ -136,12 +136,12 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   /* Not that the server will send anything, but otherwise we'll never know
    * when the server closes the connection. */
   r = uv_read_start((uv_stream_t*)(req->handle), alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   connect_cb_called++;
 
@@ -155,18 +155,18 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   ASSERT_NOT_NULL(client);
   ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(connect_req,
                      client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 

--- a/test/test-dlerror.c
+++ b/test/test-dlerror.c
@@ -38,7 +38,7 @@ TEST_IMPL(dlerror) {
   ASSERT_NOT_NULL(strstr(msg, dlerror_no_error));
 
   r = uv_dlopen(path, &lib);
-  ASSERT(r == -1);
+  ASSERT_EQ(r, -1);
 
   msg = uv_dlerror(&lib);
   ASSERT_NOT_NULL(msg);

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -48,13 +48,13 @@ struct thread_ctx {
 
 static void thread_main(void* arg) {
   int nwritten;
-  ASSERT(0 == kill(getpid(), SIGUSR1));
+  ASSERT_EQ(0, kill(getpid(), SIGUSR1));
 
   do
     nwritten = write(pipe_fds[1], test_buf, sizeof(test_buf));
   while (nwritten == -1 && errno == EINTR);
 
-  ASSERT(nwritten == sizeof(test_buf));
+  ASSERT_EQ(nwritten, sizeof(test_buf));
 }
 
 static void sig_func(uv_signal_t* handle, int signum) {
@@ -70,21 +70,21 @@ TEST_IMPL(eintr_handling) {
   iov = uv_buf_init(buf, sizeof(buf));
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_signal_init(loop, &signal));
-  ASSERT(0 == uv_signal_start(&signal, sig_func, SIGUSR1));
+  ASSERT_EQ(0, uv_signal_init(loop, &signal));
+  ASSERT_EQ(0, uv_signal_start(&signal, sig_func, SIGUSR1));
 
-  ASSERT(0 == pipe(pipe_fds));
-  ASSERT(0 == uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_EQ(0, pipe(pipe_fds));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
 
   nread = uv_fs_read(loop, &read_req, pipe_fds[0], &iov, 1, -1, NULL);
 
-  ASSERT(nread == sizeof(test_buf));
-  ASSERT(0 == strcmp(buf, test_buf));
+  ASSERT_EQ(nread, sizeof(test_buf));
+  ASSERT_EQ(0, strcmp(buf, test_buf));
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(0 == close(pipe_fds[0]));
-  ASSERT(0 == close(pipe_fds[1]));
+  ASSERT_EQ(0, close(pipe_fds[0]));
+  ASSERT_EQ(0, close(pipe_fds[1]));
   uv_close((uv_handle_t*) &signal, NULL);
 
   ASSERT_EQ(0, uv_thread_join(&thread));

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -48,7 +48,7 @@ struct thread_ctx {
 
 static void thread_main(void* arg) {
   int nwritten;
-  ASSERT_EQ(0, kill(getpid(), SIGUSR1));
+  ASSERT_OK(kill(getpid(), SIGUSR1));
 
   do
     nwritten = write(pipe_fds[1], test_buf, sizeof(test_buf));
@@ -70,24 +70,24 @@ TEST_IMPL(eintr_handling) {
   iov = uv_buf_init(buf, sizeof(buf));
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_signal_init(loop, &signal));
-  ASSERT_EQ(0, uv_signal_start(&signal, sig_func, SIGUSR1));
+  ASSERT_OK(uv_signal_init(loop, &signal));
+  ASSERT_OK(uv_signal_start(&signal, sig_func, SIGUSR1));
 
-  ASSERT_EQ(0, pipe(pipe_fds));
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_OK(pipe(pipe_fds));
+  ASSERT_OK(uv_thread_create(&thread, thread_main, &ctx));
 
   nread = uv_fs_read(loop, &read_req, pipe_fds[0], &iov, 1, -1, NULL);
 
   ASSERT_EQ(nread, sizeof(test_buf));
-  ASSERT_EQ(0, strcmp(buf, test_buf));
+  ASSERT_OK(strcmp(buf, test_buf));
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(0, close(pipe_fds[0]));
-  ASSERT_EQ(0, close(pipe_fds[1]));
+  ASSERT_OK(close(pipe_fds[0]));
+  ASSERT_OK(close(pipe_fds[1]));
   uv_close((uv_handle_t*) &signal, NULL);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-embed.c
+++ b/test/test-embed.c
@@ -36,7 +36,7 @@ static uv_barrier_t barrier;
 static void thread_main(void* arg) {
   ASSERT_LE(0, uv_barrier_wait(&barrier));
   uv_sleep(250);
-  ASSERT_EQ(0, uv_async_send(&async));
+  ASSERT_OK(uv_async_send(&async));
 }
 
 
@@ -50,9 +50,9 @@ TEST_IMPL(embed) {
   uv_loop_t* loop;
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_async_init(loop, &async, async_cb));
-  ASSERT_EQ(0, uv_barrier_init(&barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, NULL));
+  ASSERT_OK(uv_async_init(loop, &async, async_cb));
+  ASSERT_OK(uv_barrier_init(&barrier, 2));
+  ASSERT_OK(uv_thread_create(&thread, thread_main, NULL));
   ASSERT_LE(0, uv_barrier_wait(&barrier));
 
   while (uv_loop_alive(loop)) {
@@ -71,7 +71,7 @@ TEST_IMPL(embed) {
 #endif
   }
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_barrier_destroy(&barrier);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -84,7 +84,7 @@ TEST_IMPL(emfile) {
                            (const struct sockaddr*) &addr,
                            connect_cb));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
 
   /* Close the dups again. Ignore errors in the unlikely event that the
    * file descriptors were not contiguous.
@@ -100,7 +100,7 @@ TEST_IMPL(emfile) {
 
 
 static void connection_cb(uv_stream_t* server_handle, int status) {
-  ASSERT_NE(0 && "connection_cb should not be called.", 0);
+  ASSERT(0 && "connection_cb should not be called.");
 }
 
 

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -59,11 +59,11 @@ TEST_IMPL(emfile) {
   }
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
-  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 8, connection_cb));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_tcp_init(loop, &server_handle));
+  ASSERT_OK(uv_tcp_init(loop, &client_handle));
+  ASSERT_OK(uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server_handle, 8, connection_cb));
 
   /* Remember the first one so we can clean up afterwards. */
   do
@@ -79,11 +79,11 @@ TEST_IMPL(emfile) {
    * handling logic in src/unix/stream.c should ensure that connect_cb() runs
    * whereas connection_cb() should *not* run.
    */
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client_handle,
-                              (const struct sockaddr*) &addr,
-                              connect_cb));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client_handle,
+                           (const struct sockaddr*) &addr,
+                           connect_cb));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(connect_cb_called, 1);
 
   /* Close the dups again. Ignore errors in the unlikely event that the
@@ -108,7 +108,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   /* |status| should equal 0 because the connection should have been accepted,
    * it's just that the server immediately closes it again.
    */
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called += 1;
   uv_close((uv_handle_t*) &server_handle, NULL);
   uv_close((uv_handle_t*) &client_handle, NULL);

--- a/test/test-emfile.c
+++ b/test/test-emfile.c
@@ -54,37 +54,37 @@ TEST_IMPL(emfile) {
   /* Lower the file descriptor limit and use up all fds save one. */
   limits.rlim_cur = limits.rlim_max = maxfd + 1;
   if (setrlimit(RLIMIT_NOFILE, &limits)) {
-    ASSERT(errno == EPERM);  /* Valgrind blocks the setrlimit() call. */
+    ASSERT_EQ(errno, EPERM);  /* Valgrind blocks the setrlimit() call. */
     RETURN_SKIP("setrlimit(RLIMIT_NOFILE) failed, running under valgrind?");
   }
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_tcp_init(loop, &server_handle));
-  ASSERT(0 == uv_tcp_init(loop, &client_handle));
-  ASSERT(0 == uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server_handle, 8, connection_cb));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
+  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 8, connection_cb));
 
   /* Remember the first one so we can clean up afterwards. */
   do
     first_fd = dup(0);
   while (first_fd == -1 && errno == EINTR);
-  ASSERT(first_fd > 0);
+  ASSERT_GT(first_fd, 0);
 
   while (dup(0) != -1 || errno == EINTR);
-  ASSERT(errno == EMFILE);
+  ASSERT_EQ(errno, EMFILE);
   close(maxfd);
 
   /* Now connect and use up the last available file descriptor.  The EMFILE
    * handling logic in src/unix/stream.c should ensure that connect_cb() runs
    * whereas connection_cb() should *not* run.
    */
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client_handle,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == connect_cb_called);
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client_handle,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(connect_cb_called, 1);
 
   /* Close the dups again. Ignore errors in the unlikely event that the
    * file descriptors were not contiguous.
@@ -100,7 +100,7 @@ TEST_IMPL(emfile) {
 
 
 static void connection_cb(uv_stream_t* server_handle, int status) {
-  ASSERT(0 && "connection_cb should not be called.");
+  ASSERT_NE(0 && "connection_cb should not be called.", 0);
 }
 
 
@@ -108,7 +108,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   /* |status| should equal 0 because the connection should have been accepted,
    * it's just that the server immediately closes it again.
    */
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   connect_cb_called += 1;
   uv_close((uv_handle_t*) &server_handle, NULL);
   uv_close((uv_handle_t*) &client_handle, NULL);

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -129,7 +129,7 @@ TEST_IMPL(env_vars) {
     }
   }
 
-  ASSERT_EQ(found, 2);
+  ASSERT_EQ(2, found);
 #ifdef _WIN32
   ASSERT_GT(found_win_special, 0);
 #else

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -59,14 +59,14 @@ TEST_IMPL(env_vars) {
 
   /* Successfully set an environment variable */
   r = uv_os_setenv(name, "123456789");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Successfully read an environment variable */
   size = BUF_SIZE;
   buf[0] = '\0';
   r = uv_os_getenv(name, buf, &size);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(strcmp(buf, "123456789"), 0);
+  ASSERT_OK(r);
+  ASSERT_OK(strcmp(buf, "123456789"));
   ASSERT_EQ(size, BUF_SIZE - 1);
 
   /* Return UV_ENOBUFS if the buffer cannot hold the environment variable */
@@ -78,7 +78,7 @@ TEST_IMPL(env_vars) {
 
   /* Successfully delete an environment variable */
   r = uv_os_unsetenv(name);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Return UV_ENOENT retrieving an environment variable that does not exist */
   r = uv_os_getenv(name, buf, &size);
@@ -86,31 +86,31 @@ TEST_IMPL(env_vars) {
 
   /* Successfully delete an environment variable that does not exist */
   r = uv_os_unsetenv(name);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Setting an environment variable to the empty string does not delete it. */
   r = uv_os_setenv(name, "");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   size = BUF_SIZE;
   r = uv_os_getenv(name, buf, &size);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(size, 0);
-  ASSERT_EQ(strlen(buf), 0);
+  ASSERT_OK(r);
+  ASSERT_OK(size);
+  ASSERT_OK(strlen(buf));
 
   /* Check getting all env variables. */
   r = uv_os_setenv(name, "123456789");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_os_setenv(name2, "");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifdef _WIN32
   /* Create a special environment variable on Windows in case there are no
      naturally occurring ones. */
   r = uv_os_setenv("=Z:", "\\");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #endif
 
   r = uv_os_environ(&envitems, &envcount);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_GT(envcount, 0);
 
   found = 0;
@@ -120,10 +120,10 @@ TEST_IMPL(env_vars) {
     /* printf("Env: %s = %s\n", envitems[i].name, envitems[i].value); */
     if (strcmp(envitems[i].name, name) == 0) {
       found++;
-      ASSERT_EQ(strcmp(envitems[i].value, "123456789"), 0);
+      ASSERT_OK(strcmp(envitems[i].value, "123456789"));
     } else if (strcmp(envitems[i].name, name2) == 0) {
       found++;
-      ASSERT_EQ(strlen(envitems[i].value), 0);
+      ASSERT_OK(strlen(envitems[i].value));
     } else if (envitems[i].name[0] == '=') {
       found_win_special++;
     }
@@ -140,10 +140,10 @@ TEST_IMPL(env_vars) {
   uv_os_free_environ(envitems, envcount);
 
   r = uv_os_unsetenv(name);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_os_unsetenv(name2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   for (i = 1; i <= 4; i++) {
     size_t n;
@@ -158,14 +158,14 @@ TEST_IMPL(env_vars) {
     memset(p, 'x', n);
     p[n] = '\0';
 
-    ASSERT_EQ(0, uv_os_setenv(name, p));
-    ASSERT_EQ(0, uv_os_getenv(name, p, &size));
+    ASSERT_OK(uv_os_setenv(name, p));
+    ASSERT_OK(uv_os_getenv(name, p, &size));
     ASSERT_EQ(n, size);
 
     for (n = 0; n < size; n++)
       ASSERT_EQ('x', p[n]);
 
-    ASSERT_EQ(0, uv_os_unsetenv(name));
+    ASSERT_OK(uv_os_unsetenv(name));
     free(p);
   }
 

--- a/test/test-env-vars.c
+++ b/test/test-env-vars.c
@@ -35,83 +35,83 @@ TEST_IMPL(env_vars) {
 
   /* Reject invalid inputs when setting an environment variable */
   r = uv_os_setenv(NULL, "foo");
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_setenv(name, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_setenv(NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Reject invalid inputs when retrieving an environment variable */
   size = BUF_SIZE;
   r = uv_os_getenv(NULL, buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_getenv(name, NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_getenv(name, buf, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   size = 0;
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Reject invalid inputs when deleting an environment variable */
   r = uv_os_unsetenv(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Successfully set an environment variable */
   r = uv_os_setenv(name, "123456789");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Successfully read an environment variable */
   size = BUF_SIZE;
   buf[0] = '\0';
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == 0);
-  ASSERT(strcmp(buf, "123456789") == 0);
-  ASSERT(size == BUF_SIZE - 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(strcmp(buf, "123456789"), 0);
+  ASSERT_EQ(size, BUF_SIZE - 1);
 
   /* Return UV_ENOBUFS if the buffer cannot hold the environment variable */
   size = BUF_SIZE - 1;
   buf[0] = '\0';
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_ENOBUFS);
-  ASSERT(size == BUF_SIZE);
+  ASSERT_EQ(r, UV_ENOBUFS);
+  ASSERT_EQ(size, BUF_SIZE);
 
   /* Successfully delete an environment variable */
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Return UV_ENOENT retrieving an environment variable that does not exist */
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
 
   /* Successfully delete an environment variable that does not exist */
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Setting an environment variable to the empty string does not delete it. */
   r = uv_os_setenv(name, "");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   size = BUF_SIZE;
   r = uv_os_getenv(name, buf, &size);
-  ASSERT(r == 0);
-  ASSERT(size == 0);
-  ASSERT(strlen(buf) == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(size, 0);
+  ASSERT_EQ(strlen(buf), 0);
 
   /* Check getting all env variables. */
   r = uv_os_setenv(name, "123456789");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_os_setenv(name2, "");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   /* Create a special environment variable on Windows in case there are no
      naturally occurring ones. */
   r = uv_os_setenv("=Z:", "\\");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   r = uv_os_environ(&envitems, &envcount);
-  ASSERT(r == 0);
-  ASSERT(envcount > 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_GT(envcount, 0);
 
   found = 0;
   found_win_special = 0;
@@ -120,16 +120,16 @@ TEST_IMPL(env_vars) {
     /* printf("Env: %s = %s\n", envitems[i].name, envitems[i].value); */
     if (strcmp(envitems[i].name, name) == 0) {
       found++;
-      ASSERT(strcmp(envitems[i].value, "123456789") == 0);
+      ASSERT_EQ(strcmp(envitems[i].value, "123456789"), 0);
     } else if (strcmp(envitems[i].name, name2) == 0) {
       found++;
-      ASSERT(strlen(envitems[i].value) == 0);
+      ASSERT_EQ(strlen(envitems[i].value), 0);
     } else if (envitems[i].name[0] == '=') {
       found_win_special++;
     }
   }
 
-  ASSERT(found == 2);
+  ASSERT_EQ(found, 2);
 #ifdef _WIN32
   ASSERT_GT(found_win_special, 0);
 #else
@@ -140,10 +140,10 @@ TEST_IMPL(env_vars) {
   uv_os_free_environ(envitems, envcount);
 
   r = uv_os_unsetenv(name);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_os_unsetenv(name2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 1; i <= 4; i++) {
     size_t n;

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -51,8 +51,8 @@ TEST_IMPL(error_message) {
   }
 
   ASSERT_NULL(strstr(uv_strerror(UV_EINVAL), "Success"));
-  ASSERT(strcmp(uv_strerror(1337), "Unknown error") == 0);
-  ASSERT(strcmp(uv_strerror(-1337), "Unknown error") == 0);
+  ASSERT_EQ(strcmp(uv_strerror(1337), "Unknown error"), 0);
+  ASSERT_EQ(strcmp(uv_strerror(-1337), "Unknown error"), 0);
 
   ASSERT_NULL(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success"));
   ASSERT_NOT_NULL(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337"));
@@ -64,19 +64,19 @@ TEST_IMPL(error_message) {
 
 TEST_IMPL(sys_error) {
 #if defined(_WIN32)
-  ASSERT(uv_translate_sys_error(ERROR_NOACCESS) == UV_EACCES);
-  ASSERT(uv_translate_sys_error(ERROR_ELEVATION_REQUIRED) == UV_EACCES);
-  ASSERT(uv_translate_sys_error(WSAEADDRINUSE) == UV_EADDRINUSE);
-  ASSERT(uv_translate_sys_error(ERROR_BAD_PIPE) == UV_EPIPE);
+  ASSERT_EQ(uv_translate_sys_error(ERROR_NOACCESS), UV_EACCES);
+  ASSERT_EQ(uv_translate_sys_error(ERROR_ELEVATION_REQUIRED), UV_EACCES);
+  ASSERT_EQ(uv_translate_sys_error(WSAEADDRINUSE), UV_EADDRINUSE);
+  ASSERT_EQ(uv_translate_sys_error(ERROR_BAD_PIPE), UV_EPIPE);
 #else
-  ASSERT(uv_translate_sys_error(EPERM) == UV_EPERM);
-  ASSERT(uv_translate_sys_error(EPIPE) == UV_EPIPE);
-  ASSERT(uv_translate_sys_error(EINVAL) == UV_EINVAL);
+  ASSERT_EQ(uv_translate_sys_error(EPERM), UV_EPERM);
+  ASSERT_EQ(uv_translate_sys_error(EPIPE), UV_EPIPE);
+  ASSERT_EQ(uv_translate_sys_error(EINVAL), UV_EINVAL);
 #endif
-  ASSERT(uv_translate_sys_error(UV_EINVAL) == UV_EINVAL);
-  ASSERT(uv_translate_sys_error(UV_ERANGE) == UV_ERANGE);
-  ASSERT(uv_translate_sys_error(UV_EACCES) == UV_EACCES);
-  ASSERT(uv_translate_sys_error(0) == 0);
+  ASSERT_EQ(uv_translate_sys_error(UV_EINVAL), UV_EINVAL);
+  ASSERT_EQ(uv_translate_sys_error(UV_ERANGE), UV_ERANGE);
+  ASSERT_EQ(uv_translate_sys_error(UV_EACCES), UV_EACCES);
+  ASSERT_EQ(uv_translate_sys_error(0), 0);
 
   return 0;
 }

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -51,8 +51,8 @@ TEST_IMPL(error_message) {
   }
 
   ASSERT_NULL(strstr(uv_strerror(UV_EINVAL), "Success"));
-  ASSERT_EQ(strcmp(uv_strerror(1337), "Unknown error"), 0);
-  ASSERT_EQ(strcmp(uv_strerror(-1337), "Unknown error"), 0);
+  ASSERT_OK(strcmp(uv_strerror(1337), "Unknown error"));
+  ASSERT_OK(strcmp(uv_strerror(-1337), "Unknown error"));
 
   ASSERT_NULL(strstr(uv_strerror_r(UV_EINVAL, buf, sizeof(buf)), "Success"));
   ASSERT_NOT_NULL(strstr(uv_strerror_r(1337, buf, sizeof(buf)), "1337"));
@@ -76,7 +76,7 @@ TEST_IMPL(sys_error) {
   ASSERT_EQ(uv_translate_sys_error(UV_EINVAL), UV_EINVAL);
   ASSERT_EQ(uv_translate_sys_error(UV_ERANGE), UV_ERANGE);
   ASSERT_EQ(uv_translate_sys_error(UV_EACCES), UV_EACCES);
-  ASSERT_EQ(uv_translate_sys_error(0), 0);
+  ASSERT_OK(uv_translate_sys_error(0));
 
   return 0;
 }

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -51,7 +51,7 @@ static char socket_cb_read_buf[1024];
 static void socket_cb(uv_poll_t* poll, int status, int events) {
   ssize_t cnt;
   socket_cb_called++;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   printf("Socket cb got events %d\n", events);
   ASSERT_EQ(UV_READABLE, (events & UV_READABLE));
   if (socket_cb_read_fd) {
@@ -66,15 +66,15 @@ static void run_timer_loop_once(void) {
   uv_loop_t loop;
   uv_timer_t timer_handle;
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
   timer_cb_called = 0; /* Reset for the child. */
 
-  ASSERT_EQ(0, uv_timer_init(&loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(&loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
   ASSERT_EQ(timer_cb_called, 1);
-  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_OK(uv_loop_close(&loop));
 }
 
 
@@ -90,7 +90,7 @@ static void assert_wait_child(pid_t child_pid) {
   ASSERT_EQ(child_pid, waited_pid);
   ASSERT(WIFEXITED(child_stat)); /* Clean exit, not a signal. */
   ASSERT(!WIFSIGNALED(child_stat));
-  ASSERT_EQ(0, WEXITSTATUS(child_stat));
+  ASSERT_OK(WEXITSTATUS(child_stat));
 }
 
 
@@ -116,7 +116,7 @@ TEST_IMPL(fork_timer) {
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
     run_timer_loop_once();
   }
 
@@ -135,10 +135,10 @@ TEST_IMPL(fork_socketpair) {
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
+  ASSERT_OK(socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
 
   /* Create the server watcher in the parent, use it in the child. */
-  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
+  ASSERT_OK(uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
@@ -153,11 +153,11 @@ TEST_IMPL(fork_socketpair) {
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
-    ASSERT_EQ(socket_cb_called, 0);
-    ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(socket_cb_called);
+    ASSERT_OK(uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
     printf("Going to run the loop in the child\n");
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
     ASSERT_EQ(socket_cb_called, 1);
   }
 
@@ -176,16 +176,16 @@ TEST_IMPL(fork_socketpair_started) {
   char sync_buf[1];
   uv_poll_t poll_handle;
 
-  ASSERT_EQ(0, pipe(sync_pipe));
+  ASSERT_OK(pipe(sync_pipe));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
+  ASSERT_OK(socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
 
   /* Create and start the server watcher in the parent, use it in the child. */
-  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
-  ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
+  ASSERT_OK(uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
+  ASSERT_OK(uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
 
   /* Run the loop AFTER the poll watcher is registered to make sure it
      gets passed to the kernel. Use NOWAIT and expect a non-zero
@@ -202,31 +202,31 @@ TEST_IMPL(fork_socketpair_started) {
 
   if (child_pid != 0) {
     /* parent */
-    ASSERT_EQ(0, uv_poll_stop(&poll_handle));
+    ASSERT_OK(uv_poll_stop(&poll_handle));
     uv_close((uv_handle_t*)&poll_handle, NULL);
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT_EQ(socket_cb_called, 0);
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_OK(socket_cb_called);
     ASSERT_EQ(1, write(sync_pipe[1], "1", 1)); /* alert child */
     ASSERT_EQ(3, send(socket_fds[1], "hi\n", 3, 0));
 
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT_EQ(socket_cb_called, 0);
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_OK(socket_cb_called);
 
     assert_wait_child(child_pid);
   } else {
     /* child */
     printf("Child is %d\n", getpid());
     ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for parent */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
-    ASSERT_EQ(socket_cb_called, 0);
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(socket_cb_called);
 
     printf("Going to run the loop in the child\n");
     socket_cb_read_fd = socket_fds[0];
     socket_cb_read_size = 3;
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
     ASSERT_EQ(socket_cb_called, 1);
     printf("Buf %s\n", socket_cb_read_buf);
-    ASSERT_EQ(0, strcmp("hi\n", socket_cb_read_buf));
+    ASSERT_OK(strcmp("hi\n", socket_cb_read_buf));
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -253,15 +253,15 @@ TEST_IMPL(fork_signal_to_child) {
 
   fork_signal_cb_called = 0;    /* reset */
 
-  ASSERT_EQ(0, pipe(sync_pipe));
+  ASSERT_OK(pipe(sync_pipe));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT_EQ(0, uv_signal_init(uv_default_loop(), &signal_handle));
-  ASSERT_EQ(0, uv_signal_start(&signal_handle,
-                               fork_signal_to_child_cb,
-                               SIGUSR1));
+  ASSERT_OK(uv_signal_init(uv_default_loop(), &signal_handle));
+  ASSERT_OK(uv_signal_start(&signal_handle,
+                            fork_signal_to_child_cb,
+                            SIGUSR1));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
@@ -273,22 +273,22 @@ TEST_IMPL(fork_signal_to_child) {
   if (child_pid != 0) {
     /* parent */
     ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for child */
-    ASSERT_EQ(0, kill(child_pid, SIGUSR1));
+    ASSERT_OK(kill(child_pid, SIGUSR1));
     /* Run the loop, make sure we don't get the signal. */
     printf("Running loop in parent\n");
     uv_unref((uv_handle_t*)&signal_handle);
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
-    ASSERT_EQ(fork_signal_cb_called, 0);
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+    ASSERT_OK(fork_signal_cb_called);
     printf("Waiting for child in parent\n");
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
     ASSERT_EQ(1, write(sync_pipe[1], "1", 1)); /* alert parent */
     /* Get the signal. */
     ASSERT_NE(0, uv_loop_alive(uv_default_loop()));
     printf("Running loop in child\n");
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
     ASSERT_EQ(SIGUSR1, fork_signal_cb_called);
   }
 
@@ -310,16 +310,16 @@ TEST_IMPL(fork_signal_to_child_closed) {
 
   fork_signal_cb_called = 0;    /* reset */
 
-  ASSERT_EQ(0, pipe(sync_pipe));
-  ASSERT_EQ(0, pipe(sync_pipe2));
+  ASSERT_OK(pipe(sync_pipe));
+  ASSERT_OK(pipe(sync_pipe2));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT_EQ(0, uv_signal_init(uv_default_loop(), &signal_handle));
-  ASSERT_EQ(0, uv_signal_start(&signal_handle,
-                               fork_signal_to_child_cb,
-                               SIGUSR1));
+  ASSERT_OK(uv_signal_init(uv_default_loop(), &signal_handle));
+  ASSERT_OK(uv_signal_start(&signal_handle,
+                            fork_signal_to_child_cb,
+                            SIGUSR1));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
@@ -333,22 +333,22 @@ TEST_IMPL(fork_signal_to_child_closed) {
     printf("Wating on child in parent\n");
     ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for child */
     printf("Parent killing child\n");
-    ASSERT_EQ(0, kill(child_pid, SIGUSR1));
+    ASSERT_OK(kill(child_pid, SIGUSR1));
     /* Run the loop, make sure we don't get the signal. */
     printf("Running loop in parent\n");
     uv_unref((uv_handle_t*)&signal_handle); /* so the loop can exit;
                                                we *shouldn't* get any signals */
     run_timer_loop_once(); /* but while we share a pipe, we do, so
                               have something active. */
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
     printf("Signal in parent %d\n", fork_signal_cb_called);
-    ASSERT_EQ(fork_signal_cb_called, 0);
+    ASSERT_OK(fork_signal_cb_called);
     ASSERT_EQ(1, write(sync_pipe2[1], "1", 1)); /* alert child */
     printf("Waiting for child in parent\n");
     assert_wait_child(child_pid);
   } else {
     /* Child. Our signal handler should still be installed. */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
     printf("Checking loop in child\n");
     ASSERT_NE(0, uv_loop_alive(uv_default_loop()));
     printf("Alerting parent in child\n");
@@ -360,7 +360,7 @@ TEST_IMPL(fork_signal_to_child_closed) {
     */
     r = read(sync_pipe2[0], sync_buf, 1);
     ASSERT_NE(-1 <= r && r <= 1, 0);
-    ASSERT_EQ(fork_signal_cb_called, 0);
+    ASSERT_OK(fork_signal_cb_called);
     printf("Exiting child \n");
     /* Note that we're deliberately not running the loop
      * in the child, and also not closing the loop's handles,
@@ -385,21 +385,21 @@ TEST_IMPL(fork_close_signal_in_child) {
   uv_signal_t signal_handle;
   pid_t child_pid;
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_signal_init(&loop, &signal_handle));
-  ASSERT_EQ(0, uv_signal_start(&signal_handle, &fork_signal_cb, SIGHUP));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_signal_init(&loop, &signal_handle));
+  ASSERT_OK(uv_signal_start(&signal_handle, &fork_signal_cb, SIGHUP));
 
-  ASSERT_EQ(0, kill(getpid(), SIGHUP));
+  ASSERT_OK(kill(getpid(), SIGHUP));
   child_pid = fork();
   ASSERT_NE(child_pid, -1);
-  ASSERT_EQ(0, fork_signal_cb_called);
+  ASSERT_OK(fork_signal_cb_called);
 
   if (!child_pid) {
     uv_loop_fork(&loop);
     uv_close((uv_handle_t*)&signal_handle, &empty_close_cb);
     uv_run(&loop, UV_RUN_DEFAULT);
     /* Child doesn't receive the signal */
-    ASSERT_EQ(0, fork_signal_cb_called);
+    ASSERT_OK(fork_signal_cb_called);
   } else {
     /* Parent. Runing once to receive the signal */
     uv_run(&loop, UV_RUN_ONCE);
@@ -407,7 +407,7 @@ TEST_IMPL(fork_close_signal_in_child) {
 
     /* loop should stop after closing the only handle */
     uv_close((uv_handle_t*)&signal_handle, &empty_close_cb);
-    ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+    ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
     assert_wait_child(child_pid);
   }
@@ -427,7 +427,7 @@ static void create_file(const char* name) {
   file = r;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 }
 
@@ -449,7 +449,7 @@ static void touch_file(const char* name) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 }
 
@@ -469,11 +469,11 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
                                          const char* filename,
                                          int events,
                                          int status) {
-  ASSERT_EQ(fs_event_cb_called, 0);
+  ASSERT_OK(fs_event_cb_called);
   ++fs_event_cb_called;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 #if defined(__APPLE__) || defined(__linux__)
-  ASSERT_EQ(strcmp(filename, "watch_file"), 0);
+  ASSERT_OK(strcmp(filename, "watch_file"));
 #else
   ASSERT_NE(filename == NULL || strcmp(filename, "watch_file") == 0, 0);
 #endif
@@ -491,23 +491,23 @@ static void assert_watch_file_current_dir(uv_loop_t* const loop, int file_or_dir
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   /* watching a dir is the only way to get fsevents involved on apple
      platforms */
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         file_or_dir == 1 ? "." : "watch_file",
                         0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(timer_cb_touch_called, 0);
-  ASSERT_EQ(fs_event_cb_called, 0);
+  ASSERT_OK(timer_cb_touch_called);
+  ASSERT_OK(fs_event_cb_called);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -553,10 +553,10 @@ static int _do_fork_fs_events_child(int file_or_dir) {
     uv_loop_init(&loop);
     printf("Child first watch\n");
     assert_watch_file_current_dir(&loop, file_or_dir);
-    ASSERT_EQ(0, uv_loop_close(&loop));
+    ASSERT_OK(uv_loop_close(&loop));
     printf("Child second watch default loop\n");
     /* Ee can watch in the default loop. */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
     /* On some platforms (OS X), if we don't update the time now,
      * the timer cb fires before the event loop enters uv__io_poll,
      * instead of after, meaning we don't see the change! This may be
@@ -569,7 +569,7 @@ static int _do_fork_fs_events_child(int file_or_dir) {
        especially important on Apple platforms where if we're not
        careful trying to touch the CFRunLoop, even just to shut it
        down, that we allocated in the FS_TEST_DIR case would crash. */
-    ASSERT_EQ(0, uv_loop_close(uv_default_loop()));
+    ASSERT_OK(uv_loop_close(uv_default_loop()));
 
     printf("Exiting child \n");
   }
@@ -632,15 +632,15 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         "watch_file",
                         0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
@@ -654,13 +654,13 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
   } else {
     /* child */
     printf("Running child\n");
-    ASSERT_EQ(0, uv_loop_fork(loop));
+    ASSERT_OK(uv_loop_fork(loop));
 
     r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
-    ASSERT_EQ(timer_cb_touch_called, 0);
-    ASSERT_EQ(fs_event_cb_called, 0);
+    ASSERT_OK(timer_cb_touch_called);
+    ASSERT_OK(fs_event_cb_called);
     printf("Running loop in child \n");
     uv_run(loop, UV_RUN_DEFAULT);
 
@@ -691,7 +691,7 @@ static void work_cb(uv_work_t* req) {
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   after_work_cb_count++;
 }
 
@@ -700,11 +700,11 @@ static void assert_run_work(uv_loop_t* const loop) {
   uv_work_t work_req;
   int r;
 
-  ASSERT_EQ(work_cb_count, 0);
-  ASSERT_EQ(after_work_cb_count, 0);
+  ASSERT_OK(work_cb_count);
+  ASSERT_OK(after_work_cb_count);
   printf("Queue in %d\n", getpid());
   r = uv_queue_work(loop, &work_req, work_cb, after_work_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   printf("Running in %d\n", getpid());
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -751,7 +751,7 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
     uv_loop_close(&loop);
     printf("Child second watch default loop\n");
     /* We can work in the default loop. */
-    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_OK(uv_loop_fork(uv_default_loop()));
     assert_run_work(uv_default_loop());
     printf("Exiting child \n");
   }

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -51,12 +51,12 @@ static char socket_cb_read_buf[1024];
 static void socket_cb(uv_poll_t* poll, int status, int events) {
   ssize_t cnt;
   socket_cb_called++;
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
   printf("Socket cb got events %d\n", events);
-  ASSERT(UV_READABLE == (events & UV_READABLE));
+  ASSERT_EQ(UV_READABLE, (events & UV_READABLE));
   if (socket_cb_read_fd) {
     cnt = read(socket_cb_read_fd, socket_cb_read_buf, socket_cb_read_size);
-    ASSERT(cnt == socket_cb_read_size);
+    ASSERT_EQ(cnt, socket_cb_read_size);
   }
   uv_close((uv_handle_t*) poll, NULL);
 }
@@ -70,10 +70,10 @@ static void run_timer_loop_once(void) {
 
   timer_cb_called = 0; /* Reset for the child. */
 
-  ASSERT(0 == uv_timer_init(&loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1, 0));
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(&loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1, 0));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(timer_cb_called, 1);
   ASSERT_EQ(0, uv_loop_close(&loop));
 }
 
@@ -87,10 +87,10 @@ static void assert_wait_child(pid_t child_pid) {
   if (waited_pid == -1) {
     perror("Failed to wait");
   }
-  ASSERT(child_pid == waited_pid);
+  ASSERT_EQ(child_pid, waited_pid);
   ASSERT(WIFEXITED(child_stat)); /* Clean exit, not a signal. */
   ASSERT(!WIFSIGNALED(child_stat));
-  ASSERT(0 == WEXITSTATUS(child_stat));
+  ASSERT_EQ(0, WEXITSTATUS(child_stat));
 }
 
 
@@ -109,14 +109,14 @@ TEST_IMPL(fork_timer) {
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
     run_timer_loop_once();
   }
 
@@ -135,30 +135,30 @@ TEST_IMPL(fork_socketpair) {
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
 
   /* Create the server watcher in the parent, use it in the child. */
-  ASSERT(0 == uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
+  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
-    ASSERT(3 == send(socket_fds[1], "hi\n", 3, 0));
+    ASSERT_EQ(3, send(socket_fds[1], "hi\n", 3, 0));
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
-    ASSERT(0 == socket_cb_called);
-    ASSERT(0 == uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(socket_cb_called, 0);
+    ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
     printf("Going to run the loop in the child\n");
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT(1 == socket_cb_called);
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_EQ(socket_cb_called, 1);
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -176,57 +176,57 @@ TEST_IMPL(fork_socketpair_started) {
   char sync_buf[1];
   uv_poll_t poll_handle;
 
-  ASSERT(0 == pipe(sync_pipe));
+  ASSERT_EQ(0, pipe(sync_pipe));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds));
 
   /* Create and start the server watcher in the parent, use it in the child. */
-  ASSERT(0 == uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
-  ASSERT(0 == uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
+  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, socket_fds[0]));
+  ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
 
   /* Run the loop AFTER the poll watcher is registered to make sure it
      gets passed to the kernel. Use NOWAIT and expect a non-zero
      return to prove the poll watcher is active.
   */
-  ASSERT(1 == uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+  ASSERT_EQ(1, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
-    ASSERT(0 == uv_poll_stop(&poll_handle));
+    ASSERT_EQ(0, uv_poll_stop(&poll_handle));
     uv_close((uv_handle_t*)&poll_handle, NULL);
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT(0 == socket_cb_called);
-    ASSERT(1 == write(sync_pipe[1], "1", 1)); /* alert child */
-    ASSERT(3 == send(socket_fds[1], "hi\n", 3, 0));
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_EQ(socket_cb_called, 0);
+    ASSERT_EQ(1, write(sync_pipe[1], "1", 1)); /* alert child */
+    ASSERT_EQ(3, send(socket_fds[1], "hi\n", 3, 0));
 
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT(0 == socket_cb_called);
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_EQ(socket_cb_called, 0);
 
     assert_wait_child(child_pid);
   } else {
     /* child */
     printf("Child is %d\n", getpid());
-    ASSERT(1 == read(sync_pipe[0], sync_buf, 1)); /* wait for parent */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
-    ASSERT(0 == socket_cb_called);
+    ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for parent */
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(socket_cb_called, 0);
 
     printf("Going to run the loop in the child\n");
     socket_cb_read_fd = socket_fds[0];
     socket_cb_read_size = 3;
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT(1 == socket_cb_called);
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    ASSERT_EQ(socket_cb_called, 1);
     printf("Buf %s\n", socket_cb_read_buf);
-    ASSERT(0 == strcmp("hi\n", socket_cb_read_buf));
+    ASSERT_EQ(0, strcmp("hi\n", socket_cb_read_buf));
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -253,41 +253,43 @@ TEST_IMPL(fork_signal_to_child) {
 
   fork_signal_cb_called = 0;    /* reset */
 
-  ASSERT(0 == pipe(sync_pipe));
+  ASSERT_EQ(0, pipe(sync_pipe));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT(0 == uv_signal_init(uv_default_loop(), &signal_handle));
-  ASSERT(0 == uv_signal_start(&signal_handle, fork_signal_to_child_cb, SIGUSR1));
+  ASSERT_EQ(0, uv_signal_init(uv_default_loop(), &signal_handle));
+  ASSERT_EQ(0, uv_signal_start(&signal_handle,
+                               fork_signal_to_child_cb,
+                               SIGUSR1));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
-    ASSERT(1 == read(sync_pipe[0], sync_buf, 1)); /* wait for child */
-    ASSERT(0 == kill(child_pid, SIGUSR1));
+    ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for child */
+    ASSERT_EQ(0, kill(child_pid, SIGUSR1));
     /* Run the loop, make sure we don't get the signal. */
     printf("Running loop in parent\n");
     uv_unref((uv_handle_t*)&signal_handle);
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_NOWAIT));
-    ASSERT(0 == fork_signal_cb_called);
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+    ASSERT_EQ(fork_signal_cb_called, 0);
     printf("Waiting for child in parent\n");
     assert_wait_child(child_pid);
   } else {
     /* child */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
-    ASSERT(1 == write(sync_pipe[1], "1", 1)); /* alert parent */
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(1, write(sync_pipe[1], "1", 1)); /* alert parent */
     /* Get the signal. */
-    ASSERT(0 != uv_loop_alive(uv_default_loop()));
+    ASSERT_NE(0, uv_loop_alive(uv_default_loop()));
     printf("Running loop in child\n");
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-    ASSERT(SIGUSR1 == fork_signal_cb_called);
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_EQ(SIGUSR1, fork_signal_cb_called);
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -308,55 +310,57 @@ TEST_IMPL(fork_signal_to_child_closed) {
 
   fork_signal_cb_called = 0;    /* reset */
 
-  ASSERT(0 == pipe(sync_pipe));
-  ASSERT(0 == pipe(sync_pipe2));
+  ASSERT_EQ(0, pipe(sync_pipe));
+  ASSERT_EQ(0, pipe(sync_pipe2));
 
   /* Prime the loop. */
   run_timer_loop_once();
 
-  ASSERT(0 == uv_signal_init(uv_default_loop(), &signal_handle));
-  ASSERT(0 == uv_signal_start(&signal_handle, fork_signal_to_child_cb, SIGUSR1));
+  ASSERT_EQ(0, uv_signal_init(uv_default_loop(), &signal_handle));
+  ASSERT_EQ(0, uv_signal_start(&signal_handle,
+                               fork_signal_to_child_cb,
+                               SIGUSR1));
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
     printf("Wating on child in parent\n");
-    ASSERT(1 == read(sync_pipe[0], sync_buf, 1)); /* wait for child */
+    ASSERT_EQ(1, read(sync_pipe[0], sync_buf, 1)); /* wait for child */
     printf("Parent killing child\n");
-    ASSERT(0 == kill(child_pid, SIGUSR1));
+    ASSERT_EQ(0, kill(child_pid, SIGUSR1));
     /* Run the loop, make sure we don't get the signal. */
     printf("Running loop in parent\n");
     uv_unref((uv_handle_t*)&signal_handle); /* so the loop can exit;
                                                we *shouldn't* get any signals */
     run_timer_loop_once(); /* but while we share a pipe, we do, so
                               have something active. */
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
     printf("Signal in parent %d\n", fork_signal_cb_called);
-    ASSERT(0 == fork_signal_cb_called);
-    ASSERT(1 == write(sync_pipe2[1], "1", 1)); /* alert child */
+    ASSERT_EQ(fork_signal_cb_called, 0);
+    ASSERT_EQ(1, write(sync_pipe2[1], "1", 1)); /* alert child */
     printf("Waiting for child in parent\n");
     assert_wait_child(child_pid);
   } else {
     /* Child. Our signal handler should still be installed. */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
     printf("Checking loop in child\n");
-    ASSERT(0 != uv_loop_alive(uv_default_loop()));
+    ASSERT_NE(0, uv_loop_alive(uv_default_loop()));
     printf("Alerting parent in child\n");
-    ASSERT(1 == write(sync_pipe[1], "1", 1)); /* alert parent */
+    ASSERT_EQ(1, write(sync_pipe[1], "1", 1)); /* alert parent */
     /* Don't run the loop. Wait for the parent to call us */
     printf("Waiting on parent in child\n");
     /* Wait for parent. read may fail if the parent tripped an ASSERT
        and exited, so this ASSERT is generous.
     */
     r = read(sync_pipe2[0], sync_buf, 1);
-    ASSERT(-1 <= r && r <= 1);
-    ASSERT(0 == fork_signal_cb_called);
+    ASSERT_NE(-1 <= r && r <= 1, 0);
+    ASSERT_EQ(fork_signal_cb_called, 0);
     printf("Exiting child \n");
     /* Note that we're deliberately not running the loop
      * in the child, and also not closing the loop's handles,
@@ -419,11 +423,11 @@ static void create_file(const char* name) {
   uv_fs_t req;
 
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   file = r;
   uv_fs_req_cleanup(&req);
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -435,17 +439,17 @@ static void touch_file(const char* name) {
   uv_buf_t buf;
 
   r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   file = r;
   uv_fs_req_cleanup(&req);
 
   buf = uv_buf_init("foo", 4);
   r = uv_fs_write(NULL, &req, file, &buf, 1, -1, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 }
 
@@ -465,13 +469,13 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
                                          const char* filename,
                                          int events,
                                          int status) {
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
   ++fs_event_cb_called;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 #if defined(__APPLE__) || defined(__linux__)
-  ASSERT(strcmp(filename, "watch_file") == 0);
+  ASSERT_EQ(strcmp(filename, "watch_file"), 0);
 #else
-  ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
+  ASSERT_NE(filename == NULL || strcmp(filename, "watch_file") == 0, 0);
 #endif
   uv_close((uv_handle_t*)handle, NULL);
 }
@@ -487,28 +491,28 @@ static void assert_watch_file_current_dir(uv_loop_t* const loop, int file_or_dir
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   /* watching a dir is the only way to get fsevents involved on apple
      platforms */
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         file_or_dir == 1 ? "." : "watch_file",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(timer_cb_touch_called == 0);
-  ASSERT(fs_event_cb_called == 0);
+  ASSERT_EQ(timer_cb_touch_called, 0);
+  ASSERT_EQ(fs_event_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(timer_cb_touch_called == 1);
-  ASSERT(fs_event_cb_called == 1);
+  ASSERT_EQ(timer_cb_touch_called, 1);
+  ASSERT_EQ(fs_event_cb_called, 1);
 
   /* Cleanup */
   remove("watch_file");
@@ -533,7 +537,7 @@ static int _do_fork_fs_events_child(int file_or_dir) {
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* parent */
@@ -549,10 +553,10 @@ static int _do_fork_fs_events_child(int file_or_dir) {
     uv_loop_init(&loop);
     printf("Child first watch\n");
     assert_watch_file_current_dir(&loop, file_or_dir);
-    ASSERT(0 == uv_loop_close(&loop));
+    ASSERT_EQ(0, uv_loop_close(&loop));
     printf("Child second watch default loop\n");
     /* Ee can watch in the default loop. */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
     /* On some platforms (OS X), if we don't update the time now,
      * the timer cb fires before the event loop enters uv__io_poll,
      * instead of after, meaning we don't see the change! This may be
@@ -565,7 +569,7 @@ static int _do_fork_fs_events_child(int file_or_dir) {
        especially important on Apple platforms where if we're not
        careful trying to touch the CFRunLoop, even just to shut it
        down, that we allocated in the FS_TEST_DIR case would crash. */
-    ASSERT(0 == uv_loop_close(uv_default_loop()));
+    ASSERT_EQ(0, uv_loop_close(uv_default_loop()));
 
     printf("Exiting child \n");
   }
@@ -628,40 +632,40 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
   create_file("watch_file");
 
   r = uv_fs_event_init(loop, &fs_event);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fs_event_start(&fs_event,
                         fs_event_cb_file_current_dir,
                         "watch_file",
                         0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   child_pid = -1;
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
   if (child_pid != 0) {
     /* parent */
     assert_wait_child(child_pid);
   } else {
     /* child */
     printf("Running child\n");
-    ASSERT(0 == uv_loop_fork(loop));
+    ASSERT_EQ(0, uv_loop_fork(loop));
 
     r = uv_timer_start(&timer, timer_cb_touch, 100, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
-    ASSERT(timer_cb_touch_called == 0);
-    ASSERT(fs_event_cb_called == 0);
+    ASSERT_EQ(timer_cb_touch_called, 0);
+    ASSERT_EQ(fs_event_cb_called, 0);
     printf("Running loop in child \n");
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(timer_cb_touch_called == 1);
-    ASSERT(fs_event_cb_called == 1);
+    ASSERT_EQ(timer_cb_touch_called, 1);
+    ASSERT_EQ(fs_event_cb_called, 1);
 
     /* Cleanup */
     remove("watch_file");
@@ -687,7 +691,7 @@ static void work_cb(uv_work_t* req) {
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   after_work_cb_count++;
 }
 
@@ -696,16 +700,16 @@ static void assert_run_work(uv_loop_t* const loop) {
   uv_work_t work_req;
   int r;
 
-  ASSERT(work_cb_count == 0);
-  ASSERT(after_work_cb_count == 0);
+  ASSERT_EQ(work_cb_count, 0);
+  ASSERT_EQ(after_work_cb_count, 0);
   printf("Queue in %d\n", getpid());
   r = uv_queue_work(loop, &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   printf("Running in %d\n", getpid());
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 1);
-  ASSERT(after_work_cb_count == 1);
+  ASSERT_EQ(work_cb_count, 1);
+  ASSERT_EQ(after_work_cb_count, 1);
 
   /* cleanup  */
   work_cb_count = 0;
@@ -732,7 +736,7 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
 #else
   child_pid = fork();
 #endif
-  ASSERT(child_pid != -1);
+  ASSERT_NE(child_pid, -1);
 
   if (child_pid != 0) {
     /* Parent. We can still run work. */
@@ -747,7 +751,7 @@ TEST_IMPL(fork_threadpool_queue_work_simple) {
     uv_loop_close(&loop);
     printf("Child second watch default loop\n");
     /* We can work in the default loop. */
-    ASSERT(0 == uv_loop_fork(uv_default_loop()));
+    ASSERT_EQ(0, uv_loop_fork(uv_default_loop()));
     assert_run_work(uv_default_loop());
     printf("Exiting child \n");
   }

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -73,7 +73,7 @@ static void run_timer_loop_once(void) {
   ASSERT_OK(uv_timer_init(&loop, &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1, 0));
   ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, timer_cb_called);
   ASSERT_OK(uv_loop_close(&loop));
 }
 
@@ -158,7 +158,7 @@ TEST_IMPL(fork_socketpair) {
     ASSERT_OK(uv_poll_start(&poll_handle, UV_READABLE, socket_cb));
     printf("Going to run the loop in the child\n");
     ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT_EQ(socket_cb_called, 1);
+    ASSERT_EQ(1, socket_cb_called);
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -224,7 +224,7 @@ TEST_IMPL(fork_socketpair_started) {
     socket_cb_read_fd = socket_fds[0];
     socket_cb_read_size = 3;
     ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-    ASSERT_EQ(socket_cb_called, 1);
+    ASSERT_EQ(1, socket_cb_called);
     printf("Buf %s\n", socket_cb_read_buf);
     ASSERT_OK(strcmp("hi\n", socket_cb_read_buf));
   }
@@ -359,7 +359,7 @@ TEST_IMPL(fork_signal_to_child_closed) {
        and exited, so this ASSERT is generous.
     */
     r = read(sync_pipe2[0], sync_buf, 1);
-    ASSERT_NE(-1 <= r && r <= 1, 0);
+    ASSERT(-1 <= r && r <= 1);
     ASSERT_OK(fork_signal_cb_called);
     printf("Exiting child \n");
     /* Note that we're deliberately not running the loop
@@ -475,7 +475,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
 #if defined(__APPLE__) || defined(__linux__)
   ASSERT_OK(strcmp(filename, "watch_file"));
 #else
-  ASSERT_NE(filename == NULL || strcmp(filename, "watch_file") == 0, 0);
+  ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
 #endif
   uv_close((uv_handle_t*)handle, NULL);
 }
@@ -511,8 +511,8 @@ static void assert_watch_file_current_dir(uv_loop_t* const loop, int file_or_dir
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(timer_cb_touch_called, 1);
-  ASSERT_EQ(fs_event_cb_called, 1);
+  ASSERT_EQ(1, timer_cb_touch_called);
+  ASSERT_EQ(1, fs_event_cb_called);
 
   /* Cleanup */
   remove("watch_file");
@@ -664,8 +664,8 @@ TEST_IMPL(fork_fs_events_file_parent_child) {
     printf("Running loop in child \n");
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT_EQ(timer_cb_touch_called, 1);
-    ASSERT_EQ(fs_event_cb_called, 1);
+    ASSERT_EQ(1, timer_cb_touch_called);
+    ASSERT_EQ(1, fs_event_cb_called);
 
     /* Cleanup */
     remove("watch_file");
@@ -708,8 +708,8 @@ static void assert_run_work(uv_loop_t* const loop) {
   printf("Running in %d\n", getpid());
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(work_cb_count, 1);
-  ASSERT_EQ(after_work_cb_count, 1);
+  ASSERT_EQ(1, work_cb_count);
+  ASSERT_EQ(1, after_work_cb_count);
 
   /* cleanup  */
   work_cb_count = 0;

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -49,16 +49,16 @@ static void handle_result(uv_fs_t* req) {
   int r;
 
   ASSERT_EQ(req->fs_type, UV_FS_COPYFILE);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
 
   /* Verify that the file size and mode are the same. */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   size = stat_req.statbuf.st_size;
   mode = stat_req.statbuf.st_mode;
   uv_fs_req_cleanup(&stat_req);
   r = uv_fs_stat(NULL, &stat_req, dst, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(stat_req.statbuf.st_size, size);
   ASSERT_EQ(stat_req.statbuf.st_mode, mode);
   uv_fs_req_cleanup(&stat_req);
@@ -91,7 +91,7 @@ static void touch_file(const char* name, unsigned int size) {
 
   r = uv_fs_close(NULL, &req, file, NULL);
   uv_fs_req_cleanup(&req);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -123,11 +123,11 @@ TEST_IMPL(fs_copyfile) {
   /* Succeeds if src and dst files are identical. */
   touch_file(src, 12);
   r = uv_fs_copyfile(NULL, &req, src, src, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
   /* Verify that the src file did not get truncated. */
   r = uv_fs_stat(NULL, &req, src, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(req.statbuf.st_size, 12);
   uv_fs_req_cleanup(&req);
   unlink(src);
@@ -135,53 +135,53 @@ TEST_IMPL(fs_copyfile) {
   /* Copies file synchronously. Creates new file. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
 
   /* Copies a file of size zero. */
   unlink(dst);
   touch_file(src, 0);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
 
   /* Copies file synchronously. Overwrites existing file. */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
 
   /* Fails to overwrites existing file. */
-  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  ASSERT_OK(uv_fs_chmod(NULL, &req, dst, 0644, NULL));
   uv_fs_req_cleanup(&req);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_EXCL, NULL);
   ASSERT_EQ(r, UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
   /* Truncates when an existing destination is larger than the source file. */
-  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  ASSERT_OK(uv_fs_chmod(NULL, &req, dst, 0644, NULL));
   uv_fs_req_cleanup(&req);
   touch_file(src, 1);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
 
   /* Copies a larger file. */
   unlink(dst);
   touch_file(src, 4096 * 2);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
   unlink(src);
 
   /* Copies file asynchronously */
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(result_check_count, 5);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(result_check_count, 6);
   /* Ensure file is user-writable (not copied from src). */
-  ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
+  ASSERT_OK(uv_fs_chmod(NULL, &req, dst, 0644, NULL));
   uv_fs_req_cleanup(&req);
 
   /* If the flags are invalid, the loop should not be kept open */
@@ -193,7 +193,7 @@ TEST_IMPL(fs_copyfile) {
   /* Copies file using UV_FS_COPYFILE_FICLONE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   handle_result(&req);
 
   /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -48,19 +48,19 @@ static void handle_result(uv_fs_t* req) {
   uint64_t mode;
   int r;
 
-  ASSERT(req->fs_type == UV_FS_COPYFILE);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_COPYFILE);
+  ASSERT_EQ(req->result, 0);
 
   /* Verify that the file size and mode are the same. */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   size = stat_req.statbuf.st_size;
   mode = stat_req.statbuf.st_mode;
   uv_fs_req_cleanup(&stat_req);
   r = uv_fs_stat(NULL, &stat_req, dst, NULL);
-  ASSERT(r == 0);
-  ASSERT(stat_req.statbuf.st_size == size);
-  ASSERT(stat_req.statbuf.st_mode == mode);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(stat_req.statbuf.st_size, size);
+  ASSERT_EQ(stat_req.statbuf.st_mode, mode);
   uv_fs_req_cleanup(&stat_req);
   uv_fs_req_cleanup(req);
   result_check_count++;
@@ -77,7 +77,7 @@ static void touch_file(const char* name, unsigned int size) {
   r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT | O_TRUNC,
                  S_IWUSR | S_IRUSR, NULL);
   uv_fs_req_cleanup(&req);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   file = r;
 
   buf = uv_buf_init("a", 1);
@@ -86,12 +86,12 @@ static void touch_file(const char* name, unsigned int size) {
   for (i = 0; i < size; i++) {
     r = uv_fs_write(NULL, &req, file, &buf, 1, i, NULL);
     uv_fs_req_cleanup(&req);
-    ASSERT(r >= 0);
+    ASSERT_GE(r, 0);
   }
 
   r = uv_fs_close(NULL, &req, file, NULL);
   uv_fs_req_cleanup(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -105,25 +105,25 @@ TEST_IMPL(fs_copyfile) {
 
   /* Fails with EINVAL if bad flags are passed. */
   r = uv_fs_copyfile(NULL, &req, src, dst, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&req);
 
   /* Fails with ENOENT if source does not exist. */
   unlink(src);
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(req.result == UV_ENOENT);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
   uv_fs_req_cleanup(&req);
   /* The destination should not exist. */
   r = uv_fs_stat(NULL, &req, dst, NULL);
-  ASSERT(r != 0);
+  ASSERT(r);
   uv_fs_req_cleanup(&req);
 
   /* Succeeds if src and dst files are identical. */
   touch_file(src, 12);
   r = uv_fs_copyfile(NULL, &req, src, src, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
   /* Verify that the src file did not get truncated. */
   r = uv_fs_stat(NULL, &req, src, NULL);
@@ -135,26 +135,26 @@ TEST_IMPL(fs_copyfile) {
   /* Copies file synchronously. Creates new file. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies a file of size zero. */
   unlink(dst);
   touch_file(src, 0);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies file synchronously. Overwrites existing file. */
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Fails to overwrites existing file. */
   ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
   uv_fs_req_cleanup(&req);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_EXCL, NULL);
-  ASSERT(r == UV_EEXIST);
+  ASSERT_EQ(r, UV_EEXIST);
   uv_fs_req_cleanup(&req);
 
   /* Truncates when an existing destination is larger than the source file. */
@@ -169,17 +169,17 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   touch_file(src, 4096 * 2);
   r = uv_fs_copyfile(NULL, &req, src, dst, 0, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
   unlink(src);
 
   /* Copies file asynchronously */
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
-  ASSERT(r == 0);
-  ASSERT(result_check_count == 5);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(result_check_count, 5);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(result_check_count == 6);
+  ASSERT_EQ(result_check_count, 6);
   /* Ensure file is user-writable (not copied from src). */
   ASSERT_EQ(uv_fs_chmod(NULL, &req, dst, 0644, NULL), 0);
   uv_fs_req_cleanup(&req);
@@ -187,20 +187,20 @@ TEST_IMPL(fs_copyfile) {
   /* If the flags are invalid, the loop should not be kept open */
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
 
   /* Copies file using UV_FS_COPYFILE_FICLONE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   handle_result(&req);
 
   /* Copies file using UV_FS_COPYFILE_FICLONE_FORCE. */
   unlink(dst);
   r = uv_fs_copyfile(NULL, &req, fixture, dst, UV_FS_COPYFILE_FICLONE_FORCE,
                      NULL);
-  ASSERT(r <= 0);
+  ASSERT_LE(r, 0);
 
   if (r == 0)
     handle_result(&req);
@@ -213,8 +213,8 @@ TEST_IMPL(fs_copyfile) {
   r = uv_fs_copyfile(NULL, &req, fixture, dst, 0, NULL);
   /* On IBMi PASE, qsecofr users can overwrite read-only files */
 # ifndef __PASE__
-  ASSERT(req.result == UV_EACCES);
-  ASSERT(r == UV_EACCES);
+  ASSERT_EQ(req.result, UV_EACCES);
+  ASSERT_EQ(r, UV_EACCES);
 # endif
   uv_fs_req_cleanup(&req);
 #endif

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -128,7 +128,7 @@ TEST_IMPL(fs_copyfile) {
   /* Verify that the src file did not get truncated. */
   r = uv_fs_stat(NULL, &req, src, NULL);
   ASSERT_OK(r);
-  ASSERT_EQ(req.statbuf.st_size, 12);
+  ASSERT_EQ(12, req.statbuf.st_size);
   uv_fs_req_cleanup(&req);
   unlink(src);
 
@@ -177,9 +177,9 @@ TEST_IMPL(fs_copyfile) {
   unlink(dst);
   r = uv_fs_copyfile(loop, &req, fixture, dst, 0, handle_result);
   ASSERT_OK(r);
-  ASSERT_EQ(result_check_count, 5);
+  ASSERT_EQ(5, result_check_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(result_check_count, 6);
+  ASSERT_EQ(6, result_check_count);
   /* Ensure file is user-writable (not copied from src). */
   ASSERT_OK(uv_fs_chmod(NULL, &req, dst, 0644, NULL));
   uv_fs_req_cleanup(&req);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -131,7 +131,7 @@ static void fs_event_cb_dir(uv_fs_event_t* handle, const char* filename,
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT_OK(strcmp(filename, "file1"));
   #else
-  ASSERT_NE(filename == NULL || strcmp(filename, "file1") == 0, 0);
+  ASSERT(filename == NULL || strcmp(filename, "file1") == 0);
   #endif
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
@@ -324,7 +324,7 @@ static void fs_event_cb_file(uv_fs_event_t* handle, const char* filename,
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT_OK(strcmp(filename, "file2"));
   #else
-  ASSERT_NE(filename == NULL || strcmp(filename, "file2") == 0, 0);
+  ASSERT(filename == NULL || strcmp(filename, "file2") == 0);
   #endif
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
@@ -340,7 +340,7 @@ static void fs_event_cb_file_current_dir(uv_fs_event_t* handle,
   #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
   ASSERT_OK(strcmp(filename, "watch_file"));
   #else
-  ASSERT_NE(filename == NULL || strcmp(filename, "watch_file") == 0, 0);
+  ASSERT(filename == NULL || strcmp(filename, "watch_file") == 0);
   #endif
 
   uv_close((uv_handle_t*)handle, close_cb);
@@ -429,7 +429,7 @@ TEST_IMPL(fs_event_watch_dir) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(fs_event_cb_called, fs_event_created + fs_event_removed);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   /* Cleanup */
   fs_event_unlink_files(NULL);
@@ -489,8 +489,8 @@ TEST_IMPL(fs_event_watch_dir_recursive) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(fs_multievent_cb_called, fs_event_created + fs_event_removed);
-  ASSERT_EQ(fs_event_cb_called, 3);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(3, fs_event_cb_called);
+  ASSERT_EQ(3, close_cb_called);
 
   /* Cleanup */
   fs_event_unlink_files_in_subdir(NULL);
@@ -537,9 +537,9 @@ TEST_IMPL(fs_event_watch_dir_short_path) {
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT_EQ(fs_event_cb_called, 1);
-    ASSERT_EQ(timer_cb_called, 1);
-    ASSERT_EQ(close_cb_called, 1);
+    ASSERT_EQ(1, fs_event_cb_called);
+    ASSERT_EQ(1, timer_cb_called);
+    ASSERT_EQ(1, close_cb_called);
   }
 
   /* Cleanup */
@@ -583,9 +583,9 @@ TEST_IMPL(fs_event_watch_file) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(fs_event_cb_called, 1);
-  ASSERT_EQ(timer_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, fs_event_cb_called);
+  ASSERT_EQ(2, timer_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   /* Cleanup */
   remove("watch_dir/file2");
@@ -638,7 +638,7 @@ TEST_IMPL(fs_event_watch_file_exact_path) {
   ASSERT_OK(r);
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(timer_cb_exact_called, 2);
+  ASSERT_EQ(2, timer_cb_exact_called);
 
   /* Cleanup */
   remove("watch_dir/file.js");
@@ -716,10 +716,10 @@ TEST_IMPL(fs_event_watch_file_current_dir) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(timer_cb_touch_called, 1);
+  ASSERT_EQ(1, timer_cb_touch_called);
   /* FSEvents on macOS sometimes sends one change event, sometimes two. */
   ASSERT_NE(0, fs_event_cb_called);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   /* Cleanup */
   remove("watch_file");
@@ -783,7 +783,7 @@ TEST_IMPL(fs_event_no_callback_after_close) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_OK(fs_event_cb_called);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   /* Cleanup */
   remove("watch_dir/file1");
@@ -820,7 +820,7 @@ TEST_IMPL(fs_event_no_callback_on_close) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_OK(fs_event_cb_called);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   /* Cleanup */
   remove("watch_dir/file1");
@@ -862,7 +862,7 @@ TEST_IMPL(fs_event_immediate_close) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -893,7 +893,7 @@ TEST_IMPL(fs_event_close_with_pending_event) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   /* Clean up */
   remove("watch_dir/file");
@@ -932,7 +932,7 @@ TEST_IMPL(fs_event_close_with_pending_delete_event) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   /* Clean up */
   remove("watch_dir/");
@@ -971,8 +971,8 @@ TEST_IMPL(fs_event_close_in_callback) {
 
   uv_run(loop, UV_RUN_ONCE);
 
-  ASSERT_EQ(close_cb_called, 2);
-  ASSERT_EQ(fs_event_cb_called, 3);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(3, fs_event_cb_called);
 
   /* Clean up */
   fs_event_unlink_files(NULL);
@@ -1010,7 +1010,7 @@ TEST_IMPL(fs_event_start_and_close) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   remove("watch_dir/");
   MAKE_VALGRIND_HAPPY(loop);
@@ -1061,7 +1061,7 @@ TEST_IMPL(fs_event_getpath) {
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT_EQ(close_cb_called, 1);
+    ASSERT_EQ(1, close_cb_called);
     close_cb_called = 0;
   }
 
@@ -1129,8 +1129,8 @@ TEST_IMPL(fs_event_error_reporting) {
     ASSERT_OK(uv_timer_init(loop, &timer));
     ASSERT_OK(uv_timer_start(&timer, timer_cb_nop, 2, 0));
     uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT_EQ(timer_cb_called, 1);
-    ASSERT_EQ(close_cb_called, 1);
+    ASSERT_EQ(1, timer_cb_called);
+    ASSERT_EQ(1, close_cb_called);
     if (fs_event_error_reported != 0)
       break;
   }
@@ -1149,7 +1149,7 @@ TEST_IMPL(fs_event_error_reporting) {
 
     close_cb_called = 0;
     uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT_EQ(close_cb_called, 1);
+    ASSERT_EQ(1, close_cb_called);
 
     uv_loop_close(loop);
   } while (i-- != 0);

--- a/test/test-fs-fd-hash.c
+++ b/test/test-fs-fd-hash.c
@@ -43,7 +43,7 @@ void assert_nonexistent(int fd) {
 void assert_existent(int fd) {
   struct uv__fd_info_s info = { 0 };
   ASSERT(uv__fd_hash_get(fd, &info));
-  ASSERT(info.flags == fd + FD_DIFF);
+  ASSERT_EQ(info.flags, fd + FD_DIFF);
 }
 
 void assert_insertion(int fd) {
@@ -58,7 +58,7 @@ void assert_removal(int fd) {
   struct uv__fd_info_s info = { 0 };
   assert_existent(fd);
   uv__fd_hash_remove(fd, &info);
-  ASSERT(info.flags == fd + FD_DIFF);
+  ASSERT_EQ(info.flags, fd + FD_DIFF);
   assert_nonexistent(fd);
 }
 
@@ -106,7 +106,7 @@ TEST_IMPL(fs_fd_hash) {
   {
     struct uv__fd_info_s info = { 0 };
     ASSERT(uv__fd_hash_get(0, &info));
-    ASSERT(info.flags == FD_DIFF + FD_DIFF);
+    ASSERT_EQ(info.flags, FD_DIFF + FD_DIFF);
   }
   {
     /* Leave as it was, will be again tested below */

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -64,12 +64,12 @@ static void setup(void) {
   /* empty_dir */
   r = uv_fs_rmdir(NULL, &rmdir_req, empty_dir, NULL);
   ASSERT(r == 0 || r == UV_ENOENT);
-  ASSERT(rmdir_req.result == 0 || rmdir_req.result == UV_ENOENT);
+  ASSERT_NE(rmdir_req.result == 0 || rmdir_req.result == UV_ENOENT, 0);
   uv_fs_req_cleanup(&rmdir_req);
 
   r = uv_fs_mkdir(NULL, &mkdir_req, empty_dir, 0755, NULL);
-  ASSERT(r == 0);
-  ASSERT(mkdir_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(mkdir_req.result, 0);
   uv_fs_req_cleanup(&mkdir_req);
 }
 
@@ -81,7 +81,7 @@ static void refresh(void) {
 
   r = uv_fs_unlink(NULL, &unlink_req, absent_file, NULL);
   ASSERT(r == 0 || r == UV_ENOENT);
-  ASSERT(unlink_req.result == 0 || unlink_req.result == UV_ENOENT);
+  ASSERT_NE(unlink_req.result == 0 || unlink_req.result == UV_ENOENT, 0);
   uv_fs_req_cleanup(&unlink_req);
 
   /* empty_file */
@@ -89,13 +89,13 @@ static void refresh(void) {
 
   r = uv_fs_open(NULL, &open_req, empty_file,
     UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req.result, 0);
   uv_fs_req_cleanup(&open_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* dummy_file */
@@ -103,19 +103,19 @@ static void refresh(void) {
 
   r = uv_fs_open(NULL, &open_req, dummy_file,
     UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_WRONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req.result, 0);
   uv_fs_req_cleanup(&open_req);
 
   iov = uv_buf_init("a", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 }
 
@@ -131,14 +131,14 @@ static void openFail(char *file, int error) {
   refresh();
 
   r = uv_fs_open(NULL, &open_req, file, flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == error);
-  ASSERT(open_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(open_req.result, error);
   uv_fs_req_cleanup(&open_req);
 
   /* Ensure the first call does not create the file */
   r = uv_fs_open(NULL, &open_req, file, flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r == error);
-  ASSERT(open_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(open_req.result, error);
   uv_fs_req_cleanup(&open_req);
 
   cleanup();
@@ -150,8 +150,8 @@ static void refreshOpen(char *file) {
   refresh();
 
   r = uv_fs_open(NULL, &open_req, file, flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req.result, 0);
   uv_fs_req_cleanup(&open_req);
 }
 
@@ -162,37 +162,37 @@ static void writeExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init("b", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init("c", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(write_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(write_req.result, 1);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Check contents */
   r = uv_fs_open(NULL, &open_req, file, UV_FS_O_RDONLY, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req.result, 0);
   uv_fs_req_cleanup(&open_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == size);
-  ASSERT(read_req.result == size);
-  ASSERT(strncmp(buf, expected, size) == 0);
+  ASSERT_EQ(r, size);
+  ASSERT_EQ(read_req.result, size);
+  ASSERT_EQ(strncmp(buf, expected, size), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -205,19 +205,19 @@ static void writeFail(char *file, int error) {
 
   iov = uv_buf_init("z", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(write_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(write_req.result, error);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init("z", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(write_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(write_req.result, error);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -230,14 +230,14 @@ static void readExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == size);
-  ASSERT(read_req.result == size);
-  ASSERT(strncmp(buf, expected, size) == 0);
+  ASSERT_EQ(r, size);
+  ASSERT_EQ(read_req.result, size);
+  ASSERT_EQ(strncmp(buf, expected, size), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -250,19 +250,19 @@ static void readFail(char *file, int error) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(read_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(read_req.result, error);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT(r == error);
-  ASSERT(read_req.result == error);
+  ASSERT_EQ(r, error);
+  ASSERT_EQ(read_req.result, error);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -64,7 +64,7 @@ static void setup(void) {
   /* empty_dir */
   r = uv_fs_rmdir(NULL, &rmdir_req, empty_dir, NULL);
   ASSERT(r == 0 || r == UV_ENOENT);
-  ASSERT_NE(rmdir_req.result == 0 || rmdir_req.result == UV_ENOENT, 0);
+  ASSERT(rmdir_req.result == 0 || rmdir_req.result == UV_ENOENT);
   uv_fs_req_cleanup(&rmdir_req);
 
   r = uv_fs_mkdir(NULL, &mkdir_req, empty_dir, 0755, NULL);
@@ -81,7 +81,7 @@ static void refresh(void) {
 
   r = uv_fs_unlink(NULL, &unlink_req, absent_file, NULL);
   ASSERT(r == 0 || r == UV_ENOENT);
-  ASSERT_NE(unlink_req.result == 0 || unlink_req.result == UV_ENOENT, 0);
+  ASSERT(unlink_req.result == 0 || unlink_req.result == UV_ENOENT);
   uv_fs_req_cleanup(&unlink_req);
 
   /* empty_file */
@@ -109,8 +109,8 @@ static void refresh(void) {
 
   iov = uv_buf_init("a", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 1);
-  ASSERT_EQ(write_req.result, 1);
+  ASSERT_EQ(1, r);
+  ASSERT_EQ(1, write_req.result);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
@@ -162,14 +162,14 @@ static void writeExpect(char *file, char *expected, int size) {
 
   iov = uv_buf_init("b", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 1);
-  ASSERT_EQ(write_req.result, 1);
+  ASSERT_EQ(1, r);
+  ASSERT_EQ(1, write_req.result);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init("c", 1);
   r = uv_fs_write(NULL, &write_req, open_req.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 1);
-  ASSERT_EQ(write_req.result, 1);
+  ASSERT_EQ(1, r);
+  ASSERT_EQ(1, write_req.result);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);

--- a/test/test-fs-open-flags.c
+++ b/test/test-fs-open-flags.c
@@ -68,8 +68,8 @@ static void setup(void) {
   uv_fs_req_cleanup(&rmdir_req);
 
   r = uv_fs_mkdir(NULL, &mkdir_req, empty_dir, 0755, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(mkdir_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(mkdir_req.result);
   uv_fs_req_cleanup(&mkdir_req);
 }
 
@@ -94,8 +94,8 @@ static void refresh(void) {
   uv_fs_req_cleanup(&open_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* dummy_file */
@@ -114,8 +114,8 @@ static void refresh(void) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 }
 
@@ -173,8 +173,8 @@ static void writeExpect(char *file, char *expected, int size) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Check contents */
@@ -187,12 +187,12 @@ static void writeExpect(char *file, char *expected, int size) {
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
   ASSERT_EQ(r, size);
   ASSERT_EQ(read_req.result, size);
-  ASSERT_EQ(strncmp(buf, expected, size), 0);
+  ASSERT_OK(strncmp(buf, expected, size));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -216,8 +216,8 @@ static void writeFail(char *file, int error) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -232,12 +232,12 @@ static void readExpect(char *file, char *expected, int size) {
   r = uv_fs_read(NULL, &read_req, open_req.result, &iov, 1, -1, NULL);
   ASSERT_EQ(r, size);
   ASSERT_EQ(read_req.result, size);
-  ASSERT_EQ(strncmp(buf, expected, size), 0);
+  ASSERT_OK(strncmp(buf, expected, size));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();
@@ -261,8 +261,8 @@ static void readFail(char *file, int error) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   cleanup();

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -103,44 +103,44 @@ static void poll_cb(uv_fs_poll_t* handle,
 
   memset(&zero_statbuf, 0, sizeof(zero_statbuf));
 
-  ASSERT(handle == &poll_handle);
-  ASSERT(1 == uv_is_active((uv_handle_t*) handle));
+  ASSERT_PTR_EQ(handle, &poll_handle);
+  ASSERT_EQ(1, uv_is_active((uv_handle_t*) handle));
   ASSERT_NOT_NULL(prev);
   ASSERT_NOT_NULL(curr);
 
   switch (poll_cb_called++) {
   case 0:
-    ASSERT(status == UV_ENOENT);
-    ASSERT(0 == memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 == memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(status, UV_ENOENT);
+    ASSERT_EQ(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     touch_file(FIXTURE);
     break;
 
   case 1:
-    ASSERT(status == 0);
-    ASSERT(0 == memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 20, 0));
+    ASSERT_EQ(status, 0);
+    ASSERT_EQ(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 20, 0));
     break;
 
   case 2:
-    ASSERT(status == 0);
-    ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 200, 0));
+    ASSERT_EQ(status, 0);
+    ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 200, 0));
     break;
 
   case 3:
-    ASSERT(status == 0);
-    ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 != memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(status, 0);
+    ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     remove(FIXTURE);
     break;
 
   case 4:
-    ASSERT(status == UV_ENOENT);
-    ASSERT(0 != memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT(0 == memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(status, UV_ENOENT);
+    ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_EQ(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     uv_close((uv_handle_t*)handle, close_cb);
     break;
 
@@ -155,14 +155,14 @@ TEST_IMPL(fs_poll) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
-  ASSERT(0 == uv_fs_poll_init(loop, &poll_handle));
-  ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+  ASSERT_EQ(0, uv_fs_poll_init(loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(poll_cb_called == 5);
-  ASSERT(timer_cb_called == 2);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(poll_cb_called, 5);
+  ASSERT_EQ(timer_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -176,21 +176,21 @@ TEST_IMPL(fs_poll_getpath) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_fs_poll_init(loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_init(loop, &poll_handle));
   len = sizeof buf;
-  ASSERT(UV_EINVAL == uv_fs_poll_getpath(&poll_handle, buf, &len));
-  ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+  ASSERT_EQ(UV_EINVAL, uv_fs_poll_getpath(&poll_handle, buf, &len));
+  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   len = sizeof buf;
-  ASSERT(0 == uv_fs_poll_getpath(&poll_handle, buf, &len));
-  ASSERT(buf[len - 1] != 0);
-  ASSERT(buf[len] == '\0');
-  ASSERT(0 == memcmp(buf, FIXTURE, len));
+  ASSERT_EQ(0, uv_fs_poll_getpath(&poll_handle, buf, &len));
+  ASSERT_NE(buf[len - 1], 0);
+  ASSERT_EQ(buf[len], '\0');
+  ASSERT_EQ(0, memcmp(buf, FIXTURE, len));
 
   uv_close((uv_handle_t*) &poll_handle, close_cb);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -203,14 +203,14 @@ TEST_IMPL(fs_poll_close_request) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
-  ASSERT(0 == uv_fs_poll_init(&loop, &poll_handle));
-  ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -223,18 +223,18 @@ TEST_IMPL(fs_poll_close_request_multi_start_stop) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
-  ASSERT(0 == uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
 
   for (i = 0; i < 10; ++i) {
-    ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
-    ASSERT(0 == uv_fs_poll_stop(&poll_handle));
+    ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+    ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
   }
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -247,18 +247,18 @@ TEST_IMPL(fs_poll_close_request_multi_stop_start) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
-  ASSERT(0 == uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
 
   for (i = 0; i < 10; ++i) {
-    ASSERT(0 == uv_fs_poll_stop(&poll_handle));
-    ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+    ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
+    ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   }
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -271,21 +271,21 @@ TEST_IMPL(fs_poll_close_request_stop_when_active) {
 
   remove(FIXTURE);
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   /* Set up all handles. */
-  ASSERT(0 == uv_fs_poll_init(&loop, &poll_handle));
-  ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_noop, FIXTURE, 100));
+  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_noop, FIXTURE, 100));
   uv_run(&loop, UV_RUN_ONCE);
 
   /* Close the timer handle, and do not crash. */
-  ASSERT(0 == uv_fs_poll_stop(&poll_handle));
+  ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
   uv_run(&loop, UV_RUN_ONCE);
 
   /* Clean up after the test. */
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   uv_run(&loop, UV_RUN_ONCE);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -160,9 +160,9 @@ TEST_IMPL(fs_poll) {
   ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(poll_cb_called, 5);
-  ASSERT_EQ(timer_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(5, poll_cb_called);
+  ASSERT_EQ(2, timer_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -182,7 +182,7 @@ TEST_IMPL(fs_poll_getpath) {
   ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   len = sizeof buf;
   ASSERT_OK(uv_fs_poll_getpath(&poll_handle, buf, &len));
-  ASSERT_NE(buf[len - 1], 0);
+  ASSERT_NE(0, buf[len - 1]);
   ASSERT_EQ(buf[len], '\0');
   ASSERT_OK(memcmp(buf, FIXTURE, len));
 
@@ -190,7 +190,7 @@ TEST_IMPL(fs_poll_getpath) {
 
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -210,7 +210,7 @@ TEST_IMPL(fs_poll_close_request) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -234,7 +234,7 @@ TEST_IMPL(fs_poll_close_request_multi_start_stop) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -258,7 +258,7 @@ TEST_IMPL(fs_poll_close_request_multi_stop_start) {
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -285,7 +285,7 @@ TEST_IMPL(fs_poll_close_request_stop_when_active) {
   /* Clean up after the test. */
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   uv_run(&loop, UV_RUN_ONCE);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-fs-poll.c
+++ b/test/test-fs-poll.c
@@ -111,27 +111,27 @@ static void poll_cb(uv_fs_poll_t* handle,
   switch (poll_cb_called++) {
   case 0:
     ASSERT_EQ(status, UV_ENOENT);
-    ASSERT_EQ(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT_EQ(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_OK(memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_OK(memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     touch_file(FIXTURE);
     break;
 
   case 1:
-    ASSERT_EQ(status, 0);
-    ASSERT_EQ(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_OK(status);
+    ASSERT_OK(memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 20, 0));
+    ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 20, 0));
     break;
 
   case 2:
-    ASSERT_EQ(status, 0);
+    ASSERT_OK(status);
     ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 200, 0));
+    ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 200, 0));
     break;
 
   case 3:
-    ASSERT_EQ(status, 0);
+    ASSERT_OK(status);
     ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
     ASSERT_NE(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     remove(FIXTURE);
@@ -140,7 +140,7 @@ static void poll_cb(uv_fs_poll_t* handle,
   case 4:
     ASSERT_EQ(status, UV_ENOENT);
     ASSERT_NE(0, memcmp(prev, &zero_statbuf, sizeof(zero_statbuf)));
-    ASSERT_EQ(0, memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
+    ASSERT_OK(memcmp(curr, &zero_statbuf, sizeof(zero_statbuf)));
     uv_close((uv_handle_t*)handle, close_cb);
     break;
 
@@ -155,10 +155,10 @@ TEST_IMPL(fs_poll) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_fs_poll_init(loop, &poll_handle));
-  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_fs_poll_init(loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb, FIXTURE, 100));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(poll_cb_called, 5);
   ASSERT_EQ(timer_cb_called, 2);
@@ -176,19 +176,19 @@ TEST_IMPL(fs_poll_getpath) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_fs_poll_init(loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_init(loop, &poll_handle));
   len = sizeof buf;
   ASSERT_EQ(UV_EINVAL, uv_fs_poll_getpath(&poll_handle, buf, &len));
-  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+  ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   len = sizeof buf;
-  ASSERT_EQ(0, uv_fs_poll_getpath(&poll_handle, buf, &len));
+  ASSERT_OK(uv_fs_poll_getpath(&poll_handle, buf, &len));
   ASSERT_NE(buf[len - 1], 0);
   ASSERT_EQ(buf[len], '\0');
-  ASSERT_EQ(0, memcmp(buf, FIXTURE, len));
+  ASSERT_OK(memcmp(buf, FIXTURE, len));
 
   uv_close((uv_handle_t*) &poll_handle, close_cb);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(close_cb_called, 1);
 
@@ -203,10 +203,10 @@ TEST_IMPL(fs_poll_close_request) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
-  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
-  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+  ASSERT_OK(uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
     uv_run(&loop, UV_RUN_ONCE);
@@ -223,13 +223,13 @@ TEST_IMPL(fs_poll_close_request_multi_start_stop) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
-  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_init(&loop, &poll_handle));
 
   for (i = 0; i < 10; ++i) {
-    ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
-    ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
+    ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+    ASSERT_OK(uv_fs_poll_stop(&poll_handle));
   }
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
@@ -247,13 +247,13 @@ TEST_IMPL(fs_poll_close_request_multi_stop_start) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
-  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_init(&loop, &poll_handle));
 
   for (i = 0; i < 10; ++i) {
-    ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
-    ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
+    ASSERT_OK(uv_fs_poll_stop(&poll_handle));
+    ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   }
   uv_close((uv_handle_t*) &poll_handle, close_cb);
   while (close_cb_called == 0)
@@ -271,15 +271,15 @@ TEST_IMPL(fs_poll_close_request_stop_when_active) {
 
   remove(FIXTURE);
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
   /* Set up all handles. */
-  ASSERT_EQ(0, uv_fs_poll_init(&loop, &poll_handle));
-  ASSERT_EQ(0, uv_fs_poll_start(&poll_handle, poll_cb_noop, FIXTURE, 100));
+  ASSERT_OK(uv_fs_poll_init(&loop, &poll_handle));
+  ASSERT_OK(uv_fs_poll_start(&poll_handle, poll_cb_noop, FIXTURE, 100));
   uv_run(&loop, UV_RUN_ONCE);
 
   /* Close the timer handle, and do not crash. */
-  ASSERT_EQ(0, uv_fs_poll_stop(&poll_handle));
+  ASSERT_OK(uv_fs_poll_stop(&poll_handle));
   uv_run(&loop, UV_RUN_ONCE);
 
   /* Clean up after the test. */

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -47,9 +47,9 @@ static void cleanup_test_files(void) {
 }
 
 static void empty_closedir_cb(uv_fs_t* req) {
-  ASSERT(req == &closedir_req);
-  ASSERT(req->fs_type == UV_FS_CLOSEDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &closedir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_CLOSEDIR);
+  ASSERT_EQ(req->result, 0);
   ++empty_closedir_cb_count;
   uv_fs_req_cleanup(req);
 }
@@ -58,25 +58,25 @@ static void empty_readdir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &readdir_req);
-  ASSERT(req->fs_type == UV_FS_READDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &readdir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_READDIR);
+  ASSERT_EQ(req->result, 0);
   dir = req->ptr;
   uv_fs_req_cleanup(req);
   r = uv_fs_closedir(uv_default_loop(),
                      &closedir_req,
                      dir,
                      empty_closedir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void empty_opendir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &opendir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, 0);
   ASSERT_NOT_NULL(req->ptr);
   dir = req->ptr;
   dir->dirents = dirents;
@@ -85,7 +85,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     empty_readdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(req);
   ++empty_opendir_cb_count;
 }
@@ -115,9 +115,9 @@ TEST_IMPL(fs_readdir_empty_dir) {
                     &opendir_req,
                     path,
                     NULL);
-  ASSERT(r == 0);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, 0);
   ASSERT_NOT_NULL(opendir_req.ptr);
   dir = opendir_req.ptr;
   uv_fs_req_cleanup(&opendir_req);
@@ -130,13 +130,13 @@ TEST_IMPL(fs_readdir_empty_dir) {
                                   &readdir_req,
                                   dir,
                                   NULL);
-  ASSERT(nb_entries_read == 0);
+  ASSERT_EQ(nb_entries_read, 0);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT(closedir_req.result == 0);
+  ASSERT_EQ(closedir_req.result, 0);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */
@@ -147,13 +147,13 @@ TEST_IMPL(fs_readdir_empty_dir) {
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
 
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, empty_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(empty_opendir_cb_count == 0);
-  ASSERT(empty_closedir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(empty_opendir_cb_count, 0);
+  ASSERT_EQ(empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(empty_opendir_cb_count == 1);
-  ASSERT(empty_closedir_cb_count == 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(empty_opendir_cb_count, 1);
+  ASSERT_EQ(empty_closedir_cb_count, 1);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
   uv_fs_req_cleanup(&rmdir_req);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -168,9 +168,9 @@ TEST_IMPL(fs_readdir_empty_dir) {
 static int non_existing_opendir_cb_count;
 
 static void non_existing_opendir_cb(uv_fs_t* req) {
-  ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == UV_ENOENT);
+  ASSERT_PTR_EQ(req, &opendir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, UV_ENOENT);
   ASSERT_NULL(req->ptr);
 
   uv_fs_req_cleanup(req);
@@ -188,9 +188,9 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
 
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, UV_ENOENT);
   ASSERT_NULL(opendir_req.ptr);
   uv_fs_req_cleanup(&opendir_req);
 
@@ -202,11 +202,11 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
                     &opendir_req,
                     path,
                     non_existing_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(non_existing_opendir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_existing_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(non_existing_opendir_cb_count == 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_existing_opendir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -220,9 +220,9 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
 static int file_opendir_cb_count;
 
 static void file_opendir_cb(uv_fs_t* req) {
-  ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == UV_ENOTDIR);
+  ASSERT_PTR_EQ(req, &opendir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, UV_ENOTDIR);
   ASSERT_NULL(req->ptr);
 
   uv_fs_req_cleanup(req);
@@ -241,9 +241,9 @@ TEST_IMPL(fs_readdir_file) {
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, NULL);
 
-  ASSERT(r == UV_ENOTDIR);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == UV_ENOTDIR);
+  ASSERT_EQ(r, UV_ENOTDIR);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, UV_ENOTDIR);
   ASSERT_NULL(opendir_req.ptr);
 
   uv_fs_req_cleanup(&opendir_req);
@@ -253,11 +253,11 @@ TEST_IMPL(fs_readdir_file) {
 
   /* Testing the async flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, file_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(file_opendir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(file_opendir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(file_opendir_cb_count == 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(file_opendir_cb_count, 1);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -273,8 +273,8 @@ static int non_empty_readdir_cb_count;
 static int non_empty_closedir_cb_count;
 
 static void non_empty_closedir_cb(uv_fs_t* req) {
-  ASSERT(req == &closedir_req);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &closedir_req);
+  ASSERT_EQ(req->result, 0);
   uv_fs_req_cleanup(req);
   ++non_empty_closedir_cb_count;
 }
@@ -282,30 +282,30 @@ static void non_empty_closedir_cb(uv_fs_t* req) {
 static void non_empty_readdir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
 
-  ASSERT(req == &readdir_req);
-  ASSERT(req->fs_type == UV_FS_READDIR);
+  ASSERT_PTR_EQ(req, &readdir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_READDIR);
   dir = req->ptr;
 
   if (req->result == 0) {
     uv_fs_req_cleanup(req);
-    ASSERT(non_empty_readdir_cb_count == 3);
+    ASSERT_EQ(non_empty_readdir_cb_count, 3);
     uv_fs_closedir(uv_default_loop(),
                    &closedir_req,
                    dir,
                    non_empty_closedir_cb);
   } else {
-    ASSERT(req->result == 1);
-    ASSERT(dir->dirents == dirents);
+    ASSERT_EQ(req->result, 1);
+    ASSERT_EQ(dir->dirents, dirents);
     ASSERT(strcmp(dirents[0].name, "file1") == 0 ||
            strcmp(dirents[0].name, "file2") == 0 ||
            strcmp(dirents[0].name, "test_subdir") == 0);
 #ifdef HAVE_DIRENT_TYPES
     if (!strcmp(dirents[0].name, "test_subdir"))
-      ASSERT(dirents[0].type == UV_DIRENT_DIR);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_DIR);
     else
-      ASSERT(dirents[0].type == UV_DIRENT_FILE);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_FILE);
 #else
-    ASSERT(dirents[0].type == UV_DIRENT_UNKNOWN);
+    ASSERT_EQ(dirents[0].type, UV_DIRENT_UNKNOWN);
 #endif /* HAVE_DIRENT_TYPES */
 
     ++non_empty_readdir_cb_count;
@@ -323,9 +323,9 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
   uv_dir_t* dir;
   int r;
 
-  ASSERT(req == &opendir_req);
-  ASSERT(req->fs_type == UV_FS_OPENDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &opendir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(req->result, 0);
   ASSERT_NOT_NULL(req->ptr);
 
   dir = req->ptr;
@@ -336,7 +336,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     non_empty_readdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(req);
   ++non_empty_opendir_cb_count;
 }
@@ -353,7 +353,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   cleanup_test_files();
 
   r = uv_fs_mkdir(uv_default_loop(), &mkdir_req, "test_dir", 0755, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Create two files synchronously. */
   r = uv_fs_open(uv_default_loop(),
@@ -361,13 +361,13 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                  "test_dir/file1",
                  O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&create_req);
   r = uv_fs_close(uv_default_loop(),
                   &close_req,
                   create_req.result,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(uv_default_loop(),
@@ -375,13 +375,13 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                  "test_dir/file2",
                  O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&create_req);
   r = uv_fs_close(uv_default_loop(),
                   &close_req,
                   create_req.result,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_mkdir(uv_default_loop(),
@@ -389,7 +389,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                   "test_dir/test_subdir",
                   0755,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&mkdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -397,9 +397,9 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
 
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, "test_dir", NULL);
-  ASSERT(r == 0);
-  ASSERT(opendir_req.fs_type == UV_FS_OPENDIR);
-  ASSERT(opendir_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
+  ASSERT_EQ(opendir_req.result, 0);
   ASSERT_NOT_NULL(opendir_req.ptr);
 
   entries_count = 0;
@@ -417,23 +417,23 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
          strcmp(dirents[0].name, "test_subdir") == 0);
 #ifdef HAVE_DIRENT_TYPES
     if (!strcmp(dirents[0].name, "test_subdir"))
-      ASSERT(dirents[0].type == UV_DIRENT_DIR);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_DIR);
     else
-      ASSERT(dirents[0].type == UV_DIRENT_FILE);
+      ASSERT_EQ(dirents[0].type, UV_DIRENT_FILE);
 #else
-    ASSERT(dirents[0].type == UV_DIRENT_UNKNOWN);
+    ASSERT_EQ(dirents[0].type, UV_DIRENT_UNKNOWN);
 #endif /* HAVE_DIRENT_TYPES */
     uv_fs_req_cleanup(&readdir_req);
     ++entries_count;
   }
 
-  ASSERT(entries_count == 3);
+  ASSERT_EQ(entries_count, 3);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT(closedir_req.result == 0);
+  ASSERT_EQ(closedir_req.result, 0);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */
@@ -445,13 +445,13 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                     &opendir_req,
                     "test_dir",
                     non_empty_opendir_cb);
-  ASSERT(r == 0);
-  ASSERT(non_empty_opendir_cb_count == 0);
-  ASSERT(non_empty_closedir_cb_count == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_empty_opendir_cb_count, 0);
+  ASSERT_EQ(non_empty_closedir_cb_count, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(non_empty_opendir_cb_count == 1);
-  ASSERT(non_empty_closedir_cb_count == 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(non_empty_opendir_cb_count, 1);
+  ASSERT_EQ(non_empty_closedir_cb_count, 1);
 
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, "test_subdir", NULL);
   uv_fs_req_cleanup(&rmdir_req);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -152,8 +152,8 @@ TEST_IMPL(fs_readdir_empty_dir) {
   ASSERT_OK(empty_closedir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(empty_opendir_cb_count, 1);
-  ASSERT_EQ(empty_closedir_cb_count, 1);
+  ASSERT_EQ(1, empty_opendir_cb_count);
+  ASSERT_EQ(1, empty_closedir_cb_count);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
   uv_fs_req_cleanup(&rmdir_req);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -206,7 +206,7 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
   ASSERT_OK(non_existing_opendir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(non_existing_opendir_cb_count, 1);
+  ASSERT_EQ(1, non_existing_opendir_cb_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -257,7 +257,7 @@ TEST_IMPL(fs_readdir_file) {
   ASSERT_OK(file_opendir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(file_opendir_cb_count, 1);
+  ASSERT_EQ(1, file_opendir_cb_count);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -288,13 +288,13 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
 
   if (req->result == 0) {
     uv_fs_req_cleanup(req);
-    ASSERT_EQ(non_empty_readdir_cb_count, 3);
+    ASSERT_EQ(3, non_empty_readdir_cb_count);
     uv_fs_closedir(uv_default_loop(),
                    &closedir_req,
                    dir,
                    non_empty_closedir_cb);
   } else {
-    ASSERT_EQ(req->result, 1);
+    ASSERT_EQ(1, req->result);
     ASSERT_EQ(dir->dirents, dirents);
     ASSERT(strcmp(dirents[0].name, "file1") == 0 ||
            strcmp(dirents[0].name, "file2") == 0 ||
@@ -427,7 +427,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
     ++entries_count;
   }
 
-  ASSERT_EQ(entries_count, 3);
+  ASSERT_EQ(3, entries_count);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -450,8 +450,8 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   ASSERT_OK(non_empty_closedir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(non_empty_opendir_cb_count, 1);
-  ASSERT_EQ(non_empty_closedir_cb_count, 1);
+  ASSERT_EQ(1, non_empty_opendir_cb_count);
+  ASSERT_EQ(1, non_empty_closedir_cb_count);
 
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, "test_subdir", NULL);
   uv_fs_req_cleanup(&rmdir_req);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -49,7 +49,7 @@ static void cleanup_test_files(void) {
 static void empty_closedir_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &closedir_req);
   ASSERT_EQ(req->fs_type, UV_FS_CLOSEDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ++empty_closedir_cb_count;
   uv_fs_req_cleanup(req);
 }
@@ -60,14 +60,14 @@ static void empty_readdir_cb(uv_fs_t* req) {
 
   ASSERT_PTR_EQ(req, &readdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_READDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   dir = req->ptr;
   uv_fs_req_cleanup(req);
   r = uv_fs_closedir(uv_default_loop(),
                      &closedir_req,
                      dir,
                      empty_closedir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static void empty_opendir_cb(uv_fs_t* req) {
@@ -76,7 +76,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
 
   ASSERT_PTR_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_NOT_NULL(req->ptr);
   dir = req->ptr;
   dir->dirents = dirents;
@@ -85,7 +85,7 @@ static void empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     empty_readdir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(req);
   ++empty_opendir_cb_count;
 }
@@ -115,9 +115,9 @@ TEST_IMPL(fs_readdir_empty_dir) {
                     &opendir_req,
                     path,
                     NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
-  ASSERT_EQ(opendir_req.result, 0);
+  ASSERT_OK(opendir_req.result);
   ASSERT_NOT_NULL(opendir_req.ptr);
   dir = opendir_req.ptr;
   uv_fs_req_cleanup(&opendir_req);
@@ -130,13 +130,13 @@ TEST_IMPL(fs_readdir_empty_dir) {
                                   &readdir_req,
                                   dir,
                                   NULL);
-  ASSERT_EQ(nb_entries_read, 0);
+  ASSERT_OK(nb_entries_read);
   uv_fs_req_cleanup(&readdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT_EQ(closedir_req.result, 0);
+  ASSERT_OK(closedir_req.result);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */
@@ -147,11 +147,11 @@ TEST_IMPL(fs_readdir_empty_dir) {
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
 
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, empty_opendir_cb);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(empty_opendir_cb_count, 0);
-  ASSERT_EQ(empty_closedir_cb_count, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(empty_opendir_cb_count);
+  ASSERT_OK(empty_closedir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(empty_opendir_cb_count, 1);
   ASSERT_EQ(empty_closedir_cb_count, 1);
   uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, NULL);
@@ -202,10 +202,10 @@ TEST_IMPL(fs_readdir_non_existing_dir) {
                     &opendir_req,
                     path,
                     non_existing_opendir_cb);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(non_existing_opendir_cb_count, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(non_existing_opendir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(non_existing_opendir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -253,10 +253,10 @@ TEST_IMPL(fs_readdir_file) {
 
   /* Testing the async flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, path, file_opendir_cb);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(file_opendir_cb_count, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(file_opendir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(file_opendir_cb_count, 1);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -274,7 +274,7 @@ static int non_empty_closedir_cb_count;
 
 static void non_empty_closedir_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &closedir_req);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   uv_fs_req_cleanup(req);
   ++non_empty_closedir_cb_count;
 }
@@ -325,7 +325,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
 
   ASSERT_PTR_EQ(req, &opendir_req);
   ASSERT_EQ(req->fs_type, UV_FS_OPENDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_NOT_NULL(req->ptr);
 
   dir = req->ptr;
@@ -336,7 +336,7 @@ static void non_empty_opendir_cb(uv_fs_t* req) {
                     &readdir_req,
                     dir,
                     non_empty_readdir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(req);
   ++non_empty_opendir_cb_count;
 }
@@ -353,7 +353,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   cleanup_test_files();
 
   r = uv_fs_mkdir(uv_default_loop(), &mkdir_req, "test_dir", 0755, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Create two files synchronously. */
   r = uv_fs_open(uv_default_loop(),
@@ -367,7 +367,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                   &close_req,
                   create_req.result,
                   NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(uv_default_loop(),
@@ -381,7 +381,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                   &close_req,
                   create_req.result,
                   NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_mkdir(uv_default_loop(),
@@ -389,7 +389,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                   "test_dir/test_subdir",
                   0755,
                   NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&mkdir_req);
 
   /* Fill the req to ensure that required fields are cleaned up. */
@@ -397,9 +397,9 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
 
   /* Testing the synchronous flavor. */
   r = uv_fs_opendir(uv_default_loop(), &opendir_req, "test_dir", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(opendir_req.fs_type, UV_FS_OPENDIR);
-  ASSERT_EQ(opendir_req.result, 0);
+  ASSERT_OK(opendir_req.result);
   ASSERT_NOT_NULL(opendir_req.ptr);
 
   entries_count = 0;
@@ -433,7 +433,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   /* Fill the req to ensure that required fields are cleaned up. */
   memset(&closedir_req, 0xdb, sizeof(closedir_req));
   uv_fs_closedir(uv_default_loop(), &closedir_req, dir, NULL);
-  ASSERT_EQ(closedir_req.result, 0);
+  ASSERT_OK(closedir_req.result);
   uv_fs_req_cleanup(&closedir_req);
 
   /* Testing the asynchronous flavor. */
@@ -445,11 +445,11 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
                     &opendir_req,
                     "test_dir",
                     non_empty_opendir_cb);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(non_empty_opendir_cb_count, 0);
-  ASSERT_EQ(non_empty_closedir_cb_count, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(non_empty_opendir_cb_count);
+  ASSERT_OK(non_empty_closedir_cb_count);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(non_empty_opendir_cb_count, 1);
   ASSERT_EQ(non_empty_closedir_cb_count, 1);
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -170,8 +170,8 @@ static void check_permission(const char* filename, unsigned int mode) {
   uv_stat_t* s;
 
   r = uv_fs_stat(NULL, &req, filename, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
 
   s = &req.statbuf;
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
@@ -196,7 +196,7 @@ static void dummy_cb(uv_fs_t* req) {
 
 static void link_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_LINK);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   link_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -204,15 +204,15 @@ static void link_cb(uv_fs_t* req) {
 
 static void symlink_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_SYMLINK);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   symlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void readlink_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_READLINK);
-  ASSERT_EQ(req->result, 0);
-  ASSERT_EQ(strcmp(req->ptr, "test_file_symlink2"), 0);
+  ASSERT_OK(req->result);
+  ASSERT_OK(strcmp(req->ptr, "test_file_symlink2"));
   readlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -222,15 +222,15 @@ static void realpath_cb(uv_fs_t* req) {
   char test_file_abs_buf[PATHMAX];
   size_t test_file_abs_size = sizeof(test_file_abs_buf);
   ASSERT_EQ(req->fs_type, UV_FS_REALPATH);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
 
   uv_cwd(test_file_abs_buf, &test_file_abs_size);
 #ifdef _WIN32
   strcat(test_file_abs_buf, "\\test_file");
-  ASSERT_EQ(stricmp(req->ptr, test_file_abs_buf), 0);
+  ASSERT_OK(stricmp(req->ptr, test_file_abs_buf));
 #else
   strcat(test_file_abs_buf, "/test_file");
-  ASSERT_EQ(strcmp(req->ptr, test_file_abs_buf), 0);
+  ASSERT_OK(strcmp(req->ptr, test_file_abs_buf));
 #endif
   realpath_cb_count++;
   uv_fs_req_cleanup(req);
@@ -246,7 +246,7 @@ static void access_cb(uv_fs_t* req) {
 
 static void fchmod_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_FCHMOD);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   fchmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -255,7 +255,7 @@ static void fchmod_cb(uv_fs_t* req) {
 
 static void chmod_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_CHMOD);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   chmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -264,7 +264,7 @@ static void chmod_cb(uv_fs_t* req) {
 
 static void fchown_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_FCHOWN);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   fchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -272,14 +272,14 @@ static void fchown_cb(uv_fs_t* req) {
 
 static void chown_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   chown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void lchown_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_LCHOWN);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   lchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -288,13 +288,13 @@ static void chown_root_cb(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
 #if defined(_WIN32) || defined(__MSYS__)
   /* On windows, chown is a no-op and always succeeds. */
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
 #else
   /* On unix, chown'ing the root directory is not allowed -
    * unless you're root, of course.
    */
   if (geteuid() == 0)
-    ASSERT_EQ(req->result, 0);
+    ASSERT_OK(req->result);
   else
 #   if defined(__CYGWIN__)
     /* On Cygwin, uid 0 is invalid (no root). */
@@ -316,7 +316,7 @@ static void chown_root_cb(uv_fs_t* req) {
 static void unlink_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &unlink_req);
   ASSERT_EQ(req->fs_type, UV_FS_UNLINK);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   unlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -324,7 +324,7 @@ static void unlink_cb(uv_fs_t* req) {
 static void fstat_cb(uv_fs_t* req) {
   uv_stat_t* s = req->ptr;
   ASSERT_EQ(req->fs_type, UV_FS_FSTAT);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_EQ(s->st_size, sizeof(test_buf));
   uv_fs_req_cleanup(req);
   fstat_cb_count++;
@@ -335,13 +335,13 @@ static void statfs_cb(uv_fs_t* req) {
   uv_statfs_t* stats;
 
   ASSERT_EQ(req->fs_type, UV_FS_STATFS);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_NOT_NULL(req->ptr);
   stats = req->ptr;
 
 #if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
   defined(__OpenBSD__) || defined(__NetBSD__)
-  ASSERT_EQ(stats->f_type, 0);
+  ASSERT_OK(stats->f_type);
 #else
   ASSERT_GT(stats->f_type, 0);
 #endif
@@ -352,8 +352,8 @@ static void statfs_cb(uv_fs_t* req) {
   ASSERT_LE(stats->f_bavail, stats->f_bfree);
 
 #ifdef _WIN32
-  ASSERT_EQ(stats->f_files, 0);
-  ASSERT_EQ(stats->f_ffree, 0);
+  ASSERT_OK(stats->f_files);
+  ASSERT_OK(stats->f_ffree);
 #else
   /* There is no assertion for stats->f_files that makes sense, so ignore it. */
   ASSERT_LE(stats->f_ffree, stats->f_files);
@@ -368,12 +368,12 @@ static void close_cb(uv_fs_t* req) {
   int r;
   ASSERT_PTR_EQ(req, &close_req);
   ASSERT_EQ(req->fs_type, UV_FS_CLOSE);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   close_cb_count++;
   uv_fs_req_cleanup(req);
   if (close_cb_count == 3) {
     r = uv_fs_unlink(loop, &unlink_req, "test_file2", unlink_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
@@ -382,11 +382,11 @@ static void ftruncate_cb(uv_fs_t* req) {
   int r;
   ASSERT_PTR_EQ(req, &ftruncate_req);
   ASSERT_EQ(req->fs_type, UV_FS_FTRUNCATE);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static void fail_cb(uv_fs_t* req) {
@@ -401,14 +401,14 @@ static void read_cb(uv_fs_t* req) {
   read_cb_count++;
   uv_fs_req_cleanup(req);
   if (read_cb_count == 1) {
-    ASSERT_EQ(strcmp(buf, test_buf), 0);
+    ASSERT_OK(strcmp(buf, test_buf));
     r = uv_fs_ftruncate(loop, &ftruncate_req, open_req1.result, 7,
         ftruncate_cb);
   } else {
-    ASSERT_EQ(strcmp(buf, "test-bu"), 0);
+    ASSERT_OK(strcmp(buf, "test-bu"));
     r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
   }
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -422,13 +422,13 @@ static void open_cb(uv_fs_t* req) {
   }
   open_cb_count++;
   ASSERT(req->path);
-  ASSERT_EQ(memcmp(req->path, "test_file2\0", 11), 0);
+  ASSERT_OK(memcmp(req->path, "test_file2\0", 11));
   uv_fs_req_cleanup(req);
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
       read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -448,11 +448,11 @@ static void fsync_cb(uv_fs_t* req) {
   int r;
   ASSERT_PTR_EQ(req, &fsync_req);
   ASSERT_EQ(req->fs_type, UV_FS_FSYNC);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -460,11 +460,11 @@ static void fdatasync_cb(uv_fs_t* req) {
   int r;
   ASSERT_PTR_EQ(req, &fdatasync_req);
   ASSERT_EQ(req->fs_type, UV_FS_FDATASYNC);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fsync(loop, &fsync_req, open_req1.result, fsync_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -476,7 +476,7 @@ static void write_cb(uv_fs_t* req) {
   write_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fdatasync(loop, &fdatasync_req, open_req1.result, fdatasync_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -489,14 +489,14 @@ static void create_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(loop, &write_req, req->result, &iov, 1, -1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
 static void rename_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &rename_req);
   ASSERT_EQ(req->fs_type, UV_FS_RENAME);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   rename_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -505,10 +505,10 @@ static void rename_cb(uv_fs_t* req) {
 static void mkdir_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &mkdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_MKDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   mkdir_cb_count++;
   ASSERT(req->path);
-  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
+  ASSERT_OK(memcmp(req->path, "test_dir\0", 9));
   uv_fs_req_cleanup(req);
 }
 
@@ -517,16 +517,16 @@ static void check_mkdtemp_result(uv_fs_t* req) {
   int r;
 
   ASSERT_EQ(req->fs_type, UV_FS_MKDTEMP);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT(req->path);
   ASSERT_EQ(strlen(req->path), 15);
-  ASSERT_EQ(memcmp(req->path, "test_dir_", 9), 0);
+  ASSERT_OK(memcmp(req->path, "test_dir_", 9));
   ASSERT_NE(memcmp(req->path + 9, "XXXXXX", 6), 0);
   check_permission(req->path, 0700);
 
   /* Check if req->path is actually a directory */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(((uv_stat_t*)stat_req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&stat_req);
 }
@@ -546,13 +546,13 @@ static void check_mkstemp_result(uv_fs_t* req) {
   ASSERT_GE(req->result, 0);
   ASSERT(req->path);
   ASSERT_EQ(strlen(req->path), 16);
-  ASSERT_EQ(memcmp(req->path, "test_file_", 10), 0);
+  ASSERT_OK(memcmp(req->path, "test_file_", 10));
   ASSERT_NE(memcmp(req->path + 10, "XXXXXX", 6), 0);
   check_permission(req->path, 0600);
 
   /* Check if req->path is actually a file */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(stat_req.statbuf.st_mode & S_IFREG);
   uv_fs_req_cleanup(&stat_req);
 }
@@ -568,10 +568,10 @@ static void mkstemp_cb(uv_fs_t* req) {
 static void rmdir_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &rmdir_req);
   ASSERT_EQ(req->fs_type, UV_FS_RMDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   rmdir_cb_count++;
   ASSERT(req->path);
-  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
+  ASSERT_OK(memcmp(req->path, "test_dir\0", 9));
   uv_fs_req_cleanup(req);
 }
 
@@ -611,7 +611,7 @@ static void scandir_cb(uv_fs_t* req) {
   }
   scandir_cb_count++;
   ASSERT(req->path);
-  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
+  ASSERT_OK(memcmp(req->path, "test_dir\0", 9));
   uv_fs_req_cleanup(req);
   ASSERT(!req->ptr);
 }
@@ -622,7 +622,7 @@ static void empty_scandir_cb(uv_fs_t* req) {
 
   ASSERT_PTR_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_NULL(req->ptr);
   ASSERT_EQ(UV_EOF, uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
@@ -655,7 +655,7 @@ static void file_scandir_cb(uv_fs_t* req) {
 static void stat_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &stat_req);
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT(req->ptr);
   stat_cb_count++;
   uv_fs_req_cleanup(req);
@@ -664,7 +664,7 @@ static void stat_cb(uv_fs_t* req) {
 
 static void stat_batch_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT(req->ptr);
   stat_cb_count++;
   uv_fs_req_cleanup(req);
@@ -684,7 +684,7 @@ static void sendfile_cb(uv_fs_t* req) {
 static void sendfile_nodata_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &sendfile_req);
   ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -724,9 +724,9 @@ TEST_IMPL(fs_file_noent) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, open_noent_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(open_cb_count, 0);
+  ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 1);
 
@@ -752,9 +752,9 @@ TEST_IMPL(fs_file_nametoolong) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, name, O_RDONLY, 0, open_nametoolong_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(open_cb_count, 0);
+  ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 1);
 
@@ -783,7 +783,7 @@ TEST_IMPL(fs_file_loop) {
   if (r == UV_ENOENT)
     return 0;
 #endif
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
@@ -792,9 +792,9 @@ TEST_IMPL(fs_file_loop) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, open_loop_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(open_cb_count, 0);
+  ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 1);
 
@@ -817,9 +817,9 @@ static void check_utime(const char* path,
   else
     r = uv_fs_stat(loop, &req, path, NULL);
 
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(req.result);
   s = &req.statbuf;
 
   if (s->st_atim.tv_nsec == 0 && s->st_mtim.tv_nsec == 0) {
@@ -869,7 +869,7 @@ static void utime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
   ASSERT_PTR_EQ(req, &utime_req);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_EQ(req->fs_type, UV_FS_UTIME);
 
   c = req->data;
@@ -884,7 +884,7 @@ static void futime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
   ASSERT_PTR_EQ(req, &futime_req);
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_EQ(req->fs_type, UV_FS_FUTIME);
 
   c = req->data;
@@ -898,7 +898,7 @@ static void futime_cb(uv_fs_t* req) {
 static void lutime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT_EQ(req->result, 0);
+  ASSERT_OK(req->result);
   ASSERT_EQ(req->fs_type, UV_FS_LUTIME);
 
   c = req->data;
@@ -920,7 +920,7 @@ TEST_IMPL(fs_file_async) {
 
   r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IRUSR | S_IWUSR, create_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(create_cb_count, 1);
@@ -930,7 +930,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(close_cb_count, 1);
 
   r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", rename_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(create_cb_count, 1);
@@ -939,7 +939,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(rename_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 1);
@@ -951,7 +951,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(ftruncate_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 2);
@@ -994,8 +994,8 @@ static void fs_file_sync(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | add_flags, 0, NULL);
@@ -1007,22 +1007,22 @@ static void fs_file_sync(int add_flags) {
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(read_req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_ftruncate(NULL, &ftruncate_req, open_req1.result, 7, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(ftruncate_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(ftruncate_req.result);
   uv_fs_req_cleanup(&ftruncate_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(rename_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(rename_req.result);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY | add_flags, 0,
@@ -1036,17 +1036,17 @@ static void fs_file_sync(int add_flags) {
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(read_req.result, 0);
-  ASSERT_EQ(strcmp(buf, "test-bu"), 0);
+  ASSERT_OK(strcmp(buf, "test-bu"));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_unlink(NULL, &unlink_req, "test_file2", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(unlink_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(unlink_req.result);
   uv_fs_req_cleanup(&unlink_req);
 
   /* Cleanup */
@@ -1078,13 +1078,13 @@ static void fs_file_write_null_buffer(int add_flags) {
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(write_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(write_req.result);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   unlink("test_file");
@@ -1110,7 +1110,7 @@ TEST_IMPL(fs_async_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(mkdir_cb_count, 1);
@@ -1121,7 +1121,7 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
@@ -1129,11 +1129,11 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(loop, &scandir_req, "test_dir", 0, scandir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(scandir_cb_count, 1);
@@ -1151,35 +1151,35 @@ TEST_IMPL(fs_async_dir) {
   ASSERT(!scandir_req.ptr);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(stat_cb_count, 4);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file1", unlink_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(unlink_cb_count, 1);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file2", unlink_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(unlink_cb_count, 2);
 
   r = uv_fs_rmdir(loop, &rmdir_req, "test_dir", rmdir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(rmdir_cb_count, 1);
 
@@ -1212,7 +1212,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
     setup(f);
 
   r = close(f);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Test starts here. */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
@@ -1228,22 +1228,22 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
 
   r = uv_fs_sendfile(loop, &sendfile_req, open_req2.result, open_req1.result,
       1, 131072, cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(sendfile_cb_count, 1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
   r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   memset(&s1, 0, sizeof(s1));
   memset(&s2, 0, sizeof(s2));
-  ASSERT_EQ(0, stat("test_file", &s1));
-  ASSERT_EQ(0, stat("test_file2", &s2));
+  ASSERT_OK(stat("test_file", &s1));
+  ASSERT_OK(stat("test_file2", &s2));
   ASSERT_EQ(s2.st_size, expected_size);
 
   if (expected_size > 0) {
@@ -1297,14 +1297,14 @@ TEST_IMPL(fs_mkdtemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdtemp(loop, &mkdtemp_req1, path_template, mkdtemp_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(mkdtemp_cb_count, 1);
 
   /* sync mkdtemp */
   r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_mkdtemp_result(&mkdtemp_req2);
 
   /* mkdtemp return different values on subsequent calls */
@@ -1330,7 +1330,7 @@ TEST_IMPL(fs_mkstemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkstemp(loop, &mkstemp_req1, path_template, mkstemp_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(mkstemp_cb_count, 1);
@@ -1347,7 +1347,7 @@ TEST_IMPL(fs_mkstemp) {
   ASSERT_EQ(UV_EINVAL, uv_fs_mkstemp(NULL, &mkstemp_req3, "test_file", NULL));
 
   /* Make sure that path is empty string */
-  ASSERT_EQ(0, strlen(mkstemp_req3.path));
+  ASSERT_OK(strlen(mkstemp_req3.path));
 
   uv_fs_req_cleanup(&mkstemp_req3);
 
@@ -1373,7 +1373,7 @@ TEST_IMPL(fs_mkstemp) {
   r = uv_fs_read(NULL, &req, fd, &iov, 1, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(NULL, &req, fd, NULL);
@@ -1419,9 +1419,9 @@ TEST_IMPL(fs_fstat) {
 
 #ifndef _WIN32
   memset(&t, 0, sizeof(t));
-  ASSERT_EQ(0, fstat(file, &t));
-  ASSERT_EQ(0, uv_fs_fstat(NULL, &req, file, NULL));
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(fstat(file, &t));
+  ASSERT_OK(uv_fs_fstat(NULL, &req, file, NULL));
+  ASSERT_OK(req.result);
   s = req.ptr;
 # if defined(__APPLE__)
   ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtimespec.tv_sec);
@@ -1445,14 +1445,14 @@ TEST_IMPL(fs_fstat) {
 
   memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
   r = uv_fs_fstat(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   s = req.ptr;
   ASSERT_EQ(s->st_size, sizeof(test_buf));
 
 #ifndef _WIN32
   r = fstat(file, &t);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(s->st_dev, (uint64_t) t.st_dev);
   ASSERT_EQ(s->st_mode, (uint64_t) t.st_mode);
@@ -1474,11 +1474,11 @@ TEST_IMPL(fs_fstat) {
 #elif defined(_AIX)    || \
       defined(__MVS__)
   ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
-  ASSERT_EQ(s->st_atim.tv_nsec, 0);
+  ASSERT_OK(s->st_atim.tv_nsec);
   ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
-  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
+  ASSERT_OK(s->st_mtim.tv_nsec);
   ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
-  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
+  ASSERT_OK(s->st_ctim.tv_nsec);
 #elif defined(__ANDROID__)
   ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
   ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimensec);
@@ -1509,11 +1509,11 @@ TEST_IMPL(fs_fstat) {
 # endif
 #else
   ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
-  ASSERT_EQ(s->st_atim.tv_nsec, 0);
+  ASSERT_OK(s->st_atim.tv_nsec);
   ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
-  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
+  ASSERT_OK(s->st_mtim.tv_nsec);
   ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
-  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
+  ASSERT_OK(s->st_ctim.tv_nsec);
 #endif
 #endif
 
@@ -1521,22 +1521,22 @@ TEST_IMPL(fs_fstat) {
   ASSERT_EQ(s->st_flags, t.st_flags);
   ASSERT_EQ(s->st_gen, t.st_gen);
 #else
-  ASSERT_EQ(s->st_flags, 0);
-  ASSERT_EQ(s->st_gen, 0);
+  ASSERT_OK(s->st_flags);
+  ASSERT_OK(s->st_gen);
 #endif
 
   uv_fs_req_cleanup(&req);
 
   /* Now do the uv_fs_fstat call asynchronously */
   r = uv_fs_fstat(loop, &req, file, fstat_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(fstat_cb_count, 1);
 
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1564,8 +1564,8 @@ TEST_IMPL(fs_fstat_stdio) {
 
   for (fd = 0; fd <= 2; ++fd) {
     res = uv_fs_fstat(NULL, &req, fd, NULL);
-    ASSERT_EQ(res, 0);
-    ASSERT_EQ(req.result, 0);
+    ASSERT_OK(res);
+    ASSERT_OK(req.result);
 
 #ifdef _WIN32
     st = req.ptr;
@@ -1611,7 +1611,7 @@ TEST_IMPL(fs_access) {
 
   /* File should not exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
@@ -1626,31 +1626,31 @@ TEST_IMPL(fs_access) {
 
   /* File should exist */
   r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* Directory access */
   r = uv_fs_mkdir(NULL, &req, "test_dir", 0777, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_access(NULL, &req, "test_dir", W_OK, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1694,8 +1694,8 @@ TEST_IMPL(fs_chmod) {
 #ifndef _WIN32
   /* Make the file write-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0200, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0200);
@@ -1703,16 +1703,16 @@ TEST_IMPL(fs_chmod) {
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
 
   /* Make the file read+write with sync uv_fs_fchmod */
   r = uv_fs_fchmod(NULL, &req, file, 0600, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0600);
@@ -1724,7 +1724,7 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0200, chmod_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(chmod_cb_count, 1);
   chmod_cb_count = 0; /* reset for the next test */
@@ -1736,7 +1736,7 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0400, chmod_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(chmod_cb_count, 1);
 
@@ -1746,7 +1746,7 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_fchmod(loop, &req, file, 0600, fchmod_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(fchmod_cb_count, 1);
 
@@ -1797,16 +1797,16 @@ TEST_IMPL(fs_unlink_readonly) {
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1863,8 +1863,8 @@ TEST_IMPL(fs_unlink_archive_readonly) {
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1903,19 +1903,19 @@ TEST_IMPL(fs_chown) {
 
   /* sync chown */
   r = uv_fs_chown(NULL, &req, "test_file", -1, -1, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* sync fchown */
   r = uv_fs_fchown(NULL, &req, file, -1, -1, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* async chown */
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(chown_cb_count, 1);
 
@@ -1923,14 +1923,14 @@ TEST_IMPL(fs_chown) {
   /* chown to root (fail) */
   chown_cb_count = 0;
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(chown_cb_count, 1);
 #endif
 
   /* async fchown */
   r = uv_fs_fchown(loop, &req, file, -1, -1, fchown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(fchown_cb_count, 1);
 
@@ -1938,27 +1938,27 @@ TEST_IMPL(fs_chown) {
   /* Haiku doesn't support hardlink */
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* sync lchown */
   r = uv_fs_lchown(NULL, &req, "test_file_link", -1, -1, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* async lchown */
   r = uv_fs_lchown(loop, &req, "test_file_link", -1, -1, lchown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(lchown_cb_count, 1);
 #endif
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -2006,8 +2006,8 @@ TEST_IMPL(fs_link) {
 
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
@@ -2021,13 +2021,13 @@ TEST_IMPL(fs_link) {
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
 
   close(link);
 
   /* async link */
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(link_cb_count, 1);
 
@@ -2042,7 +2042,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2068,8 +2068,8 @@ TEST_IMPL(fs_readlink) {
     uv_fs_t req;
 
     loop = uv_default_loop();
-    ASSERT_EQ(0, uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
-    ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+    ASSERT_OK(uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
+    ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
     ASSERT_EQ(dummy_cb_count, 1);
     ASSERT_NULL(req.ptr);
     ASSERT_EQ(req.result, UV_ENOENT);
@@ -2098,8 +2098,8 @@ TEST_IMPL(fs_readlink) {
     uv_fs_req_cleanup(&req);
 
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT_EQ(r, 0);
-    ASSERT_EQ(req.result, 0);
+    ASSERT_OK(r);
+    ASSERT_OK(req.result);
     uv_fs_req_cleanup(&req);
 
     /* Test */
@@ -2120,8 +2120,8 @@ TEST_IMPL(fs_realpath) {
   uv_fs_t req;
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(dummy_cb_count, 1);
   ASSERT_NULL(req.ptr);
   ASSERT_EQ(req.result, UV_ENOENT);
@@ -2196,8 +2196,8 @@ TEST_IMPL(fs_symlink) {
     }
   }
 #endif
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
@@ -2211,7 +2211,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2221,7 +2221,7 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink_symlink",
                     0,
                     NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
 #if defined(__MSYS__)
@@ -2229,16 +2229,16 @@ TEST_IMPL(fs_symlink) {
 #endif
 
   r = uv_fs_readlink(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(strcmp(req.ptr, "test_file_symlink"), 0);
+  ASSERT_OK(r);
+  ASSERT_OK(strcmp(req.ptr, "test_file_symlink"));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifdef _WIN32
-  ASSERT_EQ(stricmp(req.ptr, test_file_abs_buf), 0);
+  ASSERT_OK(stricmp(req.ptr, test_file_abs_buf));
 #else
-  ASSERT_EQ(strcmp(req.ptr, test_file_abs_buf), 0);
+  ASSERT_OK(strcmp(req.ptr, test_file_abs_buf));
 #endif
   uv_fs_req_cleanup(&req);
 
@@ -2249,7 +2249,7 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2",
                     0,
                     symlink_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(symlink_cb_count, 1);
 
@@ -2264,7 +2264,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2274,16 +2274,16 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2_symlink",
                     0,
                     NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(loop, &req, "test_file_symlink2_symlink", readlink_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(readlink_cb_count, 1);
 
   r = uv_fs_realpath(loop, &req, "test_file", realpath_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(realpath_cb_count, 1);
 
@@ -2346,17 +2346,17 @@ int test_symlink_dir_impl(int type) {
                 "creation of directory symlinks");
   }
   fprintf(stderr, "r == %i\n", r);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #if defined(__MSYS__)
   RETURN_SKIP("symlink reading is not supported on MSYS2");
 #endif
@@ -2374,21 +2374,21 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifdef _WIN32
-  ASSERT_EQ(strcmp(req.ptr, test_dir + 4), 0);
+  ASSERT_OK(strcmp(req.ptr, test_dir + 4));
 #else
-  ASSERT_EQ(strcmp(req.ptr, test_dir), 0);
+  ASSERT_OK(strcmp(req.ptr, test_dir));
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifdef _WIN32
   ASSERT_EQ(strlen(req.ptr), test_dir_abs_size - 5);
-  ASSERT_EQ(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5), 0);
+  ASSERT_OK(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5));
 #else
-  ASSERT_EQ(strcmp(req.ptr, test_dir_abs_buf), 0);
+  ASSERT_OK(strcmp(req.ptr, test_dir_abs_buf));
 #endif
   uv_fs_req_cleanup(&req);
 
@@ -2397,7 +2397,7 @@ int test_symlink_dir_impl(int type) {
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
@@ -2405,7 +2405,7 @@ int test_symlink_dir_impl(int type) {
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
@@ -2421,7 +2421,7 @@ int test_symlink_dir_impl(int type) {
 
   /* unlink will remove the directory symlink */
   r = uv_fs_unlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
@@ -2512,11 +2512,11 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   shared via SMB as "Macintosh HD".
 
   r = uv_fs_stat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 */
 
@@ -2527,11 +2527,11 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   the scope of this test.
 
   r = uv_fs_stat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 */
 
@@ -2540,7 +2540,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   ASSERT_EQ(scandir_req.result, 1);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT_EQ(strcmp(dent.name, "test_file"), 0);
+    ASSERT_OK(strcmp(dent.name, "test_file"));
     /* uv_fs_scandir incorrectly identifies non-symlink reparse points
        as links because it doesn't open the file and verify the reparse
        point tag. The PowerShell Get-ChildItem command shares this
@@ -2577,7 +2577,7 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
     MAKE_VALGRIND_HAPPY(loop);
     return TEST_SKIP;
   }
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = snprintf(windowsapps_path,
               sizeof(localappdata),
               "%s\\Microsoft\\WindowsApps",
@@ -2603,7 +2603,7 @@ TEST_IMPL(fs_lstat_windows_store_apps) {
                  dirent.name) < 0) {
       continue;
     }
-    ASSERT_EQ(uv_fs_lstat(loop, &stat_req, file_path, NULL), 0);
+    ASSERT_OK(uv_fs_lstat(loop, &stat_req, file_path, NULL));
   }
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -2631,8 +2631,8 @@ TEST_IMPL(fs_utime) {
   atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
 
   r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   check_utime(path, atime, mtime, /* test_lutime */ 0);
@@ -2645,7 +2645,7 @@ TEST_IMPL(fs_utime) {
   /* async utime */
   utime_req.data = &checkme;
   r = uv_fs_utime(loop, &utime_req, path, atime, mtime, utime_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(utime_cb_count, 1);
 
@@ -2670,7 +2670,7 @@ TEST_IMPL(fs_utime_round) {
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
-  ASSERT_EQ(0, uv_fs_close(loop, &req, r, NULL));
+  ASSERT_OK(uv_fs_close(loop, &req, r, NULL));
 
   atime = mtime = -14245440.25;  /* 1969-07-20T02:56:00.25Z */
 
@@ -2685,8 +2685,8 @@ TEST_IMPL(fs_utime_round) {
     RETURN_SKIP("utime on some OS (z/OS, IBM i PASE, AIX) or filesystems may reject pre-epoch timestamps");
   }
 #endif
-  ASSERT_EQ(0, r);
-  ASSERT_EQ(0, req.result);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
   check_utime(path, atime, mtime, /* test_lutime */ 0);
   unlink(path);
@@ -2701,26 +2701,26 @@ TEST_IMPL(fs_stat_root) {
   int r;
 
   r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\..\\..\\..\\..\\..\\..", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_stat(NULL, &stat_req, "..", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* stats the current directory on c: */
   r = uv_fs_stat(NULL, &stat_req, "c:", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_stat(NULL, &stat_req, "c:\\", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_stat(NULL, &stat_req, "\\\\?\\C:\\", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -2762,8 +2762,8 @@ TEST_IMPL(fs_futime) {
   ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
 #endif
   uv_fs_req_cleanup(&req);
 
@@ -2778,7 +2778,7 @@ TEST_IMPL(fs_futime) {
   /* async futime */
   futime_req.data = &checkme;
   r = uv_fs_futime(loop, &futime_req, file, atime, mtime, futime_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(futime_cb_count, 1);
 
@@ -2821,8 +2821,8 @@ TEST_IMPL(fs_lutime) {
         "Symlink creation requires elevated console (with admin rights)");
   }
 #endif
-  ASSERT_EQ(s, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(s);
+  ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
   /* Test the synchronous version. */
@@ -2839,7 +2839,7 @@ TEST_IMPL(fs_lutime) {
   ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("lutime is not implemented for z/OS and AIX versions below 7.1");
 #endif
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   lutime_cb(&req);
   ASSERT_EQ(lutime_cb_count, 1);
 
@@ -2851,7 +2851,7 @@ TEST_IMPL(fs_lutime) {
   checkme.path = symlink_path;
 
   r = uv_fs_lutime(loop, &req, symlink_path, atime, mtime, lutime_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(lutime_cb_count, 2);
 
@@ -2896,16 +2896,16 @@ TEST_IMPL(fs_scandir_empty_dir) {
   memset(&req, 0xdb, sizeof(req));
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(req.result);
   ASSERT_NULL(req.ptr);
   ASSERT_EQ(UV_EOF, uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, empty_scandir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(scandir_cb_count, 0);
+  ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(scandir_cb_count, 1);
 
@@ -2940,9 +2940,9 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, non_existent_scandir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(scandir_cb_count, 0);
+  ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(scandir_cb_count, 1);
 
@@ -2962,9 +2962,9 @@ TEST_IMPL(fs_scandir_file) {
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, file_scandir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(scandir_cb_count, 0);
+  ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(scandir_cb_count, 1);
 
@@ -3007,12 +3007,12 @@ TEST_IMPL(fs_open_dir) {
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fs_open(loop, &req, path, O_RDONLY, 0, open_cb_simple);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(open_cb_count, 0);
+  ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(open_cb_count, 1);
 
@@ -3042,8 +3042,8 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
@@ -3059,8 +3059,8 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags,
@@ -3074,14 +3074,14 @@ static void fs_file_open_append(int add_flags) {
   printf("read = %d\n", r);
   ASSERT_EQ(r, 26);
   ASSERT_EQ(read_req.result, 26);
-  ASSERT_EQ(memcmp(buf,
+  ASSERT_OK(memcmp(buf,
                    "test-buffer\n\0test-buffer\n\0",
-                   sizeof("test-buffer\n\0test-buffer\n\0") - 1), 0);
+                   sizeof("test-buffer\n\0test-buffer\n\0") - 1));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3118,8 +3118,8 @@ TEST_IMPL(fs_rename_to_existing_file) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
@@ -3129,13 +3129,13 @@ TEST_IMPL(fs_rename_to_existing_file) {
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(rename_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(rename_req.result);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
@@ -3148,12 +3148,12 @@ TEST_IMPL(fs_rename_to_existing_file) {
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(read_req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3207,11 +3207,11 @@ static void fs_read_bufs(int add_flags) {
   ASSERT_EQ(read_req.result, /* 446 - 256 */ 190);
   uv_fs_req_cleanup(&read_req);
 
-  ASSERT_EQ(0, memcmp(bufs[1].base + 0, bufs[2].base, 128));
-  ASSERT_EQ(0, memcmp(bufs[1].base + 128, bufs[3].base, 190 - 128));
+  ASSERT_OK(memcmp(bufs[1].base + 0, bufs[2].base, 128));
+  ASSERT_OK(memcmp(bufs[1].base + 128, bufs[3].base, 190 - 128));
 
-  ASSERT_EQ(0, uv_fs_close(NULL, &close_req, open_req1.result, NULL));
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(uv_fs_close(NULL, &close_req, open_req1.result, NULL));
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 }
 TEST_IMPL(fs_read_bufs) {
@@ -3247,8 +3247,8 @@ static void fs_read_file_eof(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3262,19 +3262,19 @@ static void fs_read_file_eof(int add_flags) {
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(read_req.result, 0);
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  read_req.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(read_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3312,8 +3312,8 @@ static void fs_write_multiple_bufs(int add_flags) {
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3327,18 +3327,18 @@ static void fs_write_multiple_bufs(int add_flags) {
   /* Read the strings back to separate buffers. */
   iovs[0] = uv_buf_init(buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
-  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
+  ASSERT_OK(lseek(open_req1.result, 0, SEEK_CUR));
   r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, 2, -1, NULL);
   ASSERT_GE(r, 0);
   ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
-  ASSERT_EQ(strcmp(buf2, test_buf2), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
+  ASSERT_OK(strcmp(buf2, test_buf2));
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(read_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   /* Read the strings back to separate buffers. */
@@ -3355,20 +3355,20 @@ static void fs_write_multiple_bufs(int add_flags) {
   } else {
     ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
   }
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
-  ASSERT_EQ(strcmp(buf2, test_buf2), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
+  ASSERT_OK(strcmp(buf2, test_buf2));
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  sizeof(test_buf) + sizeof(test_buf2), NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(read_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3435,8 +3435,8 @@ static void fs_write_alotof_bufs(int add_flags) {
                               sizeof(test_buf));
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
@@ -3452,9 +3452,9 @@ static void fs_write_alotof_bufs(int add_flags) {
   ASSERT_EQ((size_t)read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
-    ASSERT_EQ(strncmp(buffer + index * sizeof(test_buf),
+    ASSERT_OK(strncmp(buffer + index * sizeof(test_buf),
                       test_buf,
-                      sizeof(test_buf)), 0);
+                      sizeof(test_buf)));
 
   uv_fs_req_cleanup(&read_req);
   free(buffer);
@@ -3469,13 +3469,13 @@ static void fs_write_alotof_bufs(int add_flags) {
                  1,
                  -1,
                  NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(read_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3564,15 +3564,15 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
   ASSERT_EQ((size_t)read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
-    ASSERT_EQ(strncmp(buffer + index * sizeof(test_buf),
+    ASSERT_OK(strncmp(buffer + index * sizeof(test_buf),
                       test_buf,
-                      sizeof(test_buf)), 0);
+                      sizeof(test_buf)));
 
   uv_fs_req_cleanup(&read_req);
   free(buffer);
 
   r = uv_fs_stat(NULL, &stat_req, "test_file", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ((int64_t)((uv_stat_t*)stat_req.ptr)->st_size,
             offset + (int64_t)write_req.result);
   uv_fs_req_cleanup(&stat_req);
@@ -3585,13 +3585,13 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  1,
                  offset + write_req.result,
                  NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(read_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3614,7 +3614,7 @@ TEST_IMPL(fs_read_dir) {
   /* Setup */
   rmdir("test_dir");
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(mkdir_cb_count, 1);
   /* Setup Done Here */
@@ -3651,7 +3651,7 @@ TEST_IMPL(fs_read_dir) {
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3760,13 +3760,13 @@ static void test_fs_partial(int doread) {
 
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_signal_init(loop, &signal));
-  ASSERT_EQ(0, uv_signal_start(&signal, sig_func, SIGUSR1));
+  ASSERT_OK(uv_signal_init(loop, &signal));
+  ASSERT_OK(uv_signal_start(&signal, sig_func, SIGUSR1));
 
-  ASSERT_EQ(0, pipe(pipe_fds));
+  ASSERT_OK(pipe(pipe_fds));
 
   ctx.fd = pipe_fds[doread];
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_OK(uv_thread_create(&thread, thread_main, &ctx));
 
   if (doread) {
     uv_buf_t* read_iovs;
@@ -3795,22 +3795,22 @@ static void test_fs_partial(int doread) {
     uv_fs_req_cleanup(&write_req);
   }
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
 
   ASSERT_MEM_EQ(buffer, ctx.data, ctx.size);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(0, close(pipe_fds[1]));
+  ASSERT_OK(close(pipe_fds[1]));
   uv_close((uv_handle_t*) &signal, NULL);
 
   { /* Make sure we read everything that we wrote. */
       int result;
       result = uv_fs_read(loop, &read_req, pipe_fds[0], iovs, 1, -1, NULL);
-      ASSERT_EQ(result, 0);
+      ASSERT_OK(result);
       uv_fs_req_cleanup(&read_req);
   }
-  ASSERT_EQ(0, close(pipe_fds[0]));
+  ASSERT_OK(close(pipe_fds[0]));
 
   free(iovs);
   free(buffer);
@@ -3921,8 +3921,8 @@ TEST_IMPL(get_osfhandle_valid_handle) {
 #endif
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup. */
@@ -3967,8 +3967,8 @@ TEST_IMPL(open_osfhandle_valid_handle) {
 #endif
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup. */
@@ -3997,18 +3997,18 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 0, NULL);
   ASSERT_EQ(r, sizeof(test_buf));
-  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
+  ASSERT_OK(lseek(open_req1.result, 0, SEEK_CUR));
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, 0, NULL);
   ASSERT_EQ(r, sizeof(test_buf));
-  ASSERT_EQ(strcmp(buf, test_buf), 0);
-  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
+  ASSERT_OK(strcmp(buf, test_buf));
+  ASSERT_OK(lseek(open_req1.result, 0, SEEK_CUR));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4036,7 +4036,7 @@ static void fs_file_pos_common(void) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&read_req);
 
   /* Write without offset should change the position */
@@ -4047,7 +4047,7 @@ static void fs_file_pos_common(void) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&read_req);
 }
 
@@ -4056,7 +4056,7 @@ static void fs_file_pos_close_check(const char *contents, int size) {
 
   /* Close */
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   /* Confirm file contents */
@@ -4068,11 +4068,11 @@ static void fs_file_pos_close_check(const char *contents, int size) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   ASSERT_EQ(r, size);
-  ASSERT_EQ(strncmp(buf, contents, size), 0);
+  ASSERT_OK(strncmp(buf, contents, size));
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4104,7 +4104,7 @@ static void fs_file_pos_write(int add_flags) {
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&read_req);
 
   fs_file_pos_close_check("aecd", 4);
@@ -4291,8 +4291,8 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL,
@@ -4306,8 +4306,8 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4342,8 +4342,8 @@ TEST_IMPL(fs_file_flag_no_buffering) {
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(close_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   /* FILE_APPEND_DATA and FILE_FLAG_NO_BUFFERING are mutually exclusive: */
@@ -4395,7 +4395,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     /* Setup - clear the ACL and remove the file */
     loop = uv_default_loop();
     r = uv_os_get_passwd(&pwd);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     call_icacls("icacls test_file_icacls /remove \"%s\" /inheritance:e",
                 pwd.username);
     uv_fs_chmod(loop, &req, "test_file_icacls", S_IWUSR, NULL);
@@ -4412,8 +4412,8 @@ TEST_IMPL(fs_open_readonly_acl) {
     ASSERT_GE(open_req1.result, 0);
     uv_fs_req_cleanup(&open_req1);
     r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-    ASSERT_EQ(r, 0);
-    ASSERT_EQ(close_req.result, 0);
+    ASSERT_OK(r);
+    ASSERT_OK(close_req.result);
     uv_fs_req_cleanup(&close_req);
 
     /* Set up ACL */
@@ -4445,7 +4445,7 @@ TEST_IMPL(fs_open_readonly_acl) {
                 pwd.username);
     unlink("test_file_icacls");
     uv_os_free_passwd(&pwd);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     MAKE_VALGRIND_HAPPY(loop);
     return 0;
 }
@@ -4471,7 +4471,7 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     file = req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_fs_req_cleanup(&req);
     /* Make the file read-only and clear archive flag */
     r = SetFileAttributes("test_file", FILE_ATTRIBUTE_READONLY);
@@ -4484,11 +4484,11 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     file = req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_fchmod(NULL, &req, file, S_IWUSR, NULL);
-    ASSERT_EQ(r, 0);
-    ASSERT_EQ(req.result, 0);
+    ASSERT_OK(r);
+    ASSERT_OK(req.result);
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_fs_req_cleanup(&req);
     check_permission("test_file", S_IWUSR);
 
@@ -4521,13 +4521,13 @@ TEST_IMPL(fs_statfs) {
 
   /* Test the synchronous version. */
   r = uv_fs_statfs(NULL, &req, ".", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   statfs_cb(&req);
   ASSERT_EQ(statfs_cb_count, 1);
 
   /* Test the asynchronous version. */
   r = uv_fs_statfs(loop, &req, ".", statfs_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(statfs_cb_count, 2);
 
@@ -4562,13 +4562,13 @@ TEST_IMPL(fs_stat_batch_multiple) {
   rmdir("test_dir");
 
   r = uv_fs_mkdir(NULL, &mkdir_req, "test_dir", 0755, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   loop = uv_default_loop();
 
   for (i = 0; i < (int) ARRAY_SIZE(req); ++i) {
     r = uv_fs_stat(loop, &req[i], "test_dir", stat_batch_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_run(loop, UV_RUN_DEFAULT);
@@ -4593,7 +4593,7 @@ TEST_IMPL(fs_wtf) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdir(NULL, &mkdir_req, "test_dir", 0777, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_fs_req_cleanup(&mkdir_req);
 
   file_handle = CreateFileW(L"test_dir/hi\xD801\x0037",
@@ -4616,7 +4616,7 @@ TEST_IMPL(fs_wtf) {
     snprintf(test_file_buf, sizeof(test_file_buf), "test_dir\\%s", dent.name);
     printf("stat %s\n", test_file_buf);
     r = uv_fs_stat(NULL, &stat_req, test_file_buf, NULL);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
   uv_fs_req_cleanup(&scandir_req);
   ASSERT_NULL(scandir_req.ptr);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -170,8 +170,8 @@ static void check_permission(const char* filename, unsigned int mode) {
   uv_stat_t* s;
 
   r = uv_fs_stat(NULL, &req, filename, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
 
   s = &req.statbuf;
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
@@ -195,24 +195,24 @@ static void dummy_cb(uv_fs_t* req) {
 
 
 static void link_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_LINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_LINK);
+  ASSERT_EQ(req->result, 0);
   link_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void symlink_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_SYMLINK);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_SYMLINK);
+  ASSERT_EQ(req->result, 0);
   symlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void readlink_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_READLINK);
-  ASSERT(req->result == 0);
-  ASSERT(strcmp(req->ptr, "test_file_symlink2") == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_READLINK);
+  ASSERT_EQ(req->result, 0);
+  ASSERT_EQ(strcmp(req->ptr, "test_file_symlink2"), 0);
   readlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -221,16 +221,16 @@ static void readlink_cb(uv_fs_t* req) {
 static void realpath_cb(uv_fs_t* req) {
   char test_file_abs_buf[PATHMAX];
   size_t test_file_abs_size = sizeof(test_file_abs_buf);
-  ASSERT(req->fs_type == UV_FS_REALPATH);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_REALPATH);
+  ASSERT_EQ(req->result, 0);
 
   uv_cwd(test_file_abs_buf, &test_file_abs_size);
 #ifdef _WIN32
   strcat(test_file_abs_buf, "\\test_file");
-  ASSERT(stricmp(req->ptr, test_file_abs_buf) == 0);
+  ASSERT_EQ(stricmp(req->ptr, test_file_abs_buf), 0);
 #else
   strcat(test_file_abs_buf, "/test_file");
-  ASSERT(strcmp(req->ptr, test_file_abs_buf) == 0);
+  ASSERT_EQ(strcmp(req->ptr, test_file_abs_buf), 0);
 #endif
   realpath_cb_count++;
   uv_fs_req_cleanup(req);
@@ -238,15 +238,15 @@ static void realpath_cb(uv_fs_t* req) {
 
 
 static void access_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_ACCESS);
+  ASSERT_EQ(req->fs_type, UV_FS_ACCESS);
   access_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void fchmod_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_FCHMOD);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_FCHMOD);
+  ASSERT_EQ(req->result, 0);
   fchmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -254,8 +254,8 @@ static void fchmod_cb(uv_fs_t* req) {
 
 
 static void chmod_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHMOD);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_CHMOD);
+  ASSERT_EQ(req->result, 0);
   chmod_cb_count++;
   uv_fs_req_cleanup(req);
   check_permission("test_file", *(int*)req->data);
@@ -263,42 +263,42 @@ static void chmod_cb(uv_fs_t* req) {
 
 
 static void fchown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_FCHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_FCHOWN);
+  ASSERT_EQ(req->result, 0);
   fchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void chown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
+  ASSERT_EQ(req->result, 0);
   chown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void lchown_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_LCHOWN);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_LCHOWN);
+  ASSERT_EQ(req->result, 0);
   lchown_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void chown_root_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_CHOWN);
+  ASSERT_EQ(req->fs_type, UV_FS_CHOWN);
 #if defined(_WIN32) || defined(__MSYS__)
   /* On windows, chown is a no-op and always succeeds. */
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
 #else
   /* On unix, chown'ing the root directory is not allowed -
    * unless you're root, of course.
    */
   if (geteuid() == 0)
-    ASSERT(req->result == 0);
+    ASSERT_EQ(req->result, 0);
   else
 #   if defined(__CYGWIN__)
     /* On Cygwin, uid 0 is invalid (no root). */
-    ASSERT(req->result == UV_EINVAL);
+    ASSERT_EQ(req->result, UV_EINVAL);
 #   elif defined(__PASE__)
     /* On IBMi PASE, there is no root user. uid 0 is user qsecofr.
      * User may grant qsecofr's privileges, including changing 
@@ -306,7 +306,7 @@ static void chown_root_cb(uv_fs_t* req) {
      */
     ASSERT(req->result == 0 || req->result == UV_EPERM);
 #   else
-    ASSERT(req->result == UV_EPERM);
+    ASSERT_EQ(req->result, UV_EPERM);
 #   endif
 #endif
   chown_cb_count++;
@@ -314,18 +314,18 @@ static void chown_root_cb(uv_fs_t* req) {
 }
 
 static void unlink_cb(uv_fs_t* req) {
-  ASSERT(req == &unlink_req);
-  ASSERT(req->fs_type == UV_FS_UNLINK);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &unlink_req);
+  ASSERT_EQ(req->fs_type, UV_FS_UNLINK);
+  ASSERT_EQ(req->result, 0);
   unlink_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void fstat_cb(uv_fs_t* req) {
   uv_stat_t* s = req->ptr;
-  ASSERT(req->fs_type == UV_FS_FSTAT);
-  ASSERT(req->result == 0);
-  ASSERT(s->st_size == sizeof(test_buf));
+  ASSERT_EQ(req->fs_type, UV_FS_FSTAT);
+  ASSERT_EQ(req->result, 0);
+  ASSERT_EQ(s->st_size, sizeof(test_buf));
   uv_fs_req_cleanup(req);
   fstat_cb_count++;
 }
@@ -334,29 +334,29 @@ static void fstat_cb(uv_fs_t* req) {
 static void statfs_cb(uv_fs_t* req) {
   uv_statfs_t* stats;
 
-  ASSERT(req->fs_type == UV_FS_STATFS);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_STATFS);
+  ASSERT_EQ(req->result, 0);
   ASSERT_NOT_NULL(req->ptr);
   stats = req->ptr;
 
 #if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
   defined(__OpenBSD__) || defined(__NetBSD__)
-  ASSERT(stats->f_type == 0);
+  ASSERT_EQ(stats->f_type, 0);
 #else
-  ASSERT(stats->f_type > 0);
+  ASSERT_GT(stats->f_type, 0);
 #endif
 
-  ASSERT(stats->f_bsize > 0);
-  ASSERT(stats->f_blocks > 0);
-  ASSERT(stats->f_bfree <= stats->f_blocks);
-  ASSERT(stats->f_bavail <= stats->f_bfree);
+  ASSERT_GT(stats->f_bsize, 0);
+  ASSERT_GT(stats->f_blocks, 0);
+  ASSERT_LE(stats->f_bfree, stats->f_blocks);
+  ASSERT_LE(stats->f_bavail, stats->f_bfree);
 
 #ifdef _WIN32
-  ASSERT(stats->f_files == 0);
-  ASSERT(stats->f_ffree == 0);
+  ASSERT_EQ(stats->f_files, 0);
+  ASSERT_EQ(stats->f_ffree, 0);
 #else
   /* There is no assertion for stats->f_files that makes sense, so ignore it. */
-  ASSERT(stats->f_ffree <= stats->f_files);
+  ASSERT_LE(stats->f_ffree, stats->f_files);
 #endif
   uv_fs_req_cleanup(req);
   ASSERT_NULL(req->ptr);
@@ -366,27 +366,27 @@ static void statfs_cb(uv_fs_t* req) {
 
 static void close_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &close_req);
-  ASSERT(req->fs_type == UV_FS_CLOSE);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &close_req);
+  ASSERT_EQ(req->fs_type, UV_FS_CLOSE);
+  ASSERT_EQ(req->result, 0);
   close_cb_count++;
   uv_fs_req_cleanup(req);
   if (close_cb_count == 3) {
     r = uv_fs_unlink(loop, &unlink_req, "test_file2", unlink_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
 
 static void ftruncate_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &ftruncate_req);
-  ASSERT(req->fs_type == UV_FS_FTRUNCATE);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &ftruncate_req);
+  ASSERT_EQ(req->fs_type, UV_FS_FTRUNCATE);
+  ASSERT_EQ(req->result, 0);
   ftruncate_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void fail_cb(uv_fs_t* req) {
@@ -395,45 +395,45 @@ static void fail_cb(uv_fs_t* req) {
 
 static void read_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &read_req);
-  ASSERT(req->fs_type == UV_FS_READ);
-  ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
+  ASSERT_PTR_EQ(req, &read_req);
+  ASSERT_EQ(req->fs_type, UV_FS_READ);
+  ASSERT_GE(req->result, 0);  /* FIXME(bnoordhuis) Check if requested size? */
   read_cb_count++;
   uv_fs_req_cleanup(req);
   if (read_cb_count == 1) {
-    ASSERT(strcmp(buf, test_buf) == 0);
+    ASSERT_EQ(strcmp(buf, test_buf), 0);
     r = uv_fs_ftruncate(loop, &ftruncate_req, open_req1.result, 7,
         ftruncate_cb);
   } else {
-    ASSERT(strcmp(buf, "test-bu") == 0);
+    ASSERT_EQ(strcmp(buf, "test-bu"), 0);
     r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
   }
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void open_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &open_req1);
-  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_PTR_EQ(req, &open_req1);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
     ASSERT(0);
   }
   open_cb_count++;
   ASSERT(req->path);
-  ASSERT(memcmp(req->path, "test_file2\0", 11) == 0);
+  ASSERT_EQ(memcmp(req->path, "test_file2\0", 11), 0);
   uv_fs_req_cleanup(req);
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(loop, &read_req, open_req1.result, &iov, 1, -1,
       read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void open_cb_simple(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
     ASSERT(0);
@@ -446,69 +446,69 @@ static void open_cb_simple(uv_fs_t* req) {
 
 static void fsync_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &fsync_req);
-  ASSERT(req->fs_type == UV_FS_FSYNC);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &fsync_req);
+  ASSERT_EQ(req->fs_type, UV_FS_FSYNC);
+  ASSERT_EQ(req->result, 0);
   fsync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_close(loop, &close_req, open_req1.result, close_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void fdatasync_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &fdatasync_req);
-  ASSERT(req->fs_type == UV_FS_FDATASYNC);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &fdatasync_req);
+  ASSERT_EQ(req->fs_type, UV_FS_FDATASYNC);
+  ASSERT_EQ(req->result, 0);
   fdatasync_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fsync(loop, &fsync_req, open_req1.result, fsync_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void write_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &write_req);
-  ASSERT(req->fs_type == UV_FS_WRITE);
-  ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
+  ASSERT_PTR_EQ(req, &write_req);
+  ASSERT_EQ(req->fs_type, UV_FS_WRITE);
+  ASSERT_GE(req->result, 0);  /* FIXME(bnoordhuis) Check if requested size? */
   write_cb_count++;
   uv_fs_req_cleanup(req);
   r = uv_fs_fdatasync(loop, &fdatasync_req, open_req1.result, fdatasync_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void create_cb(uv_fs_t* req) {
   int r;
-  ASSERT(req == &open_req1);
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result >= 0);
+  ASSERT_PTR_EQ(req, &open_req1);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_GE(req->result, 0);
   create_cb_count++;
   uv_fs_req_cleanup(req);
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(loop, &write_req, req->result, &iov, 1, -1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void rename_cb(uv_fs_t* req) {
-  ASSERT(req == &rename_req);
-  ASSERT(req->fs_type == UV_FS_RENAME);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &rename_req);
+  ASSERT_EQ(req->fs_type, UV_FS_RENAME);
+  ASSERT_EQ(req->result, 0);
   rename_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void mkdir_cb(uv_fs_t* req) {
-  ASSERT(req == &mkdir_req);
-  ASSERT(req->fs_type == UV_FS_MKDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &mkdir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_MKDIR);
+  ASSERT_EQ(req->result, 0);
   mkdir_cb_count++;
   ASSERT(req->path);
-  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
   uv_fs_req_cleanup(req);
 }
 
@@ -516,24 +516,24 @@ static void mkdir_cb(uv_fs_t* req) {
 static void check_mkdtemp_result(uv_fs_t* req) {
   int r;
 
-  ASSERT(req->fs_type == UV_FS_MKDTEMP);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->fs_type, UV_FS_MKDTEMP);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->path);
-  ASSERT(strlen(req->path) == 15);
-  ASSERT(memcmp(req->path, "test_dir_", 9) == 0);
-  ASSERT(memcmp(req->path + 9, "XXXXXX", 6) != 0);
+  ASSERT_EQ(strlen(req->path), 15);
+  ASSERT_EQ(memcmp(req->path, "test_dir_", 9), 0);
+  ASSERT_NE(memcmp(req->path + 9, "XXXXXX", 6), 0);
   check_permission(req->path, 0700);
 
   /* Check if req->path is actually a directory */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(((uv_stat_t*)stat_req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&stat_req);
 }
 
 
 static void mkdtemp_cb(uv_fs_t* req) {
-  ASSERT(req == &mkdtemp_req1);
+  ASSERT_PTR_EQ(req, &mkdtemp_req1);
   check_mkdtemp_result(req);
   mkdtemp_cb_count++;
 }
@@ -542,36 +542,36 @@ static void mkdtemp_cb(uv_fs_t* req) {
 static void check_mkstemp_result(uv_fs_t* req) {
   int r;
 
-  ASSERT(req->fs_type == UV_FS_MKSTEMP);
-  ASSERT(req->result >= 0);
+  ASSERT_EQ(req->fs_type, UV_FS_MKSTEMP);
+  ASSERT_GE(req->result, 0);
   ASSERT(req->path);
-  ASSERT(strlen(req->path) == 16);
-  ASSERT(memcmp(req->path, "test_file_", 10) == 0);
-  ASSERT(memcmp(req->path + 10, "XXXXXX", 6) != 0);
+  ASSERT_EQ(strlen(req->path), 16);
+  ASSERT_EQ(memcmp(req->path, "test_file_", 10), 0);
+  ASSERT_NE(memcmp(req->path + 10, "XXXXXX", 6), 0);
   check_permission(req->path, 0600);
 
   /* Check if req->path is actually a file */
   r = uv_fs_stat(NULL, &stat_req, req->path, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(stat_req.statbuf.st_mode & S_IFREG);
   uv_fs_req_cleanup(&stat_req);
 }
 
 
 static void mkstemp_cb(uv_fs_t* req) {
-  ASSERT(req == &mkstemp_req1);
+  ASSERT_PTR_EQ(req, &mkstemp_req1);
   check_mkstemp_result(req);
   mkstemp_cb_count++;
 }
 
 
 static void rmdir_cb(uv_fs_t* req) {
-  ASSERT(req == &rmdir_req);
-  ASSERT(req->fs_type == UV_FS_RMDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &rmdir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_RMDIR);
+  ASSERT_EQ(req->result, 0);
   rmdir_cb_count++;
   ASSERT(req->path);
-  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
   uv_fs_req_cleanup(req);
 }
 
@@ -588,30 +588,30 @@ static void assert_is_file_type(uv_dirent_t dent) {
    *     https://github.com/libuv/libuv/issues/501
    */
   #if defined(__APPLE__) || defined(_WIN32)
-    ASSERT(dent.type == UV_DIRENT_FILE);
+    ASSERT_EQ(dent.type, UV_DIRENT_FILE);
   #else
-    ASSERT(dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN);
+    ASSERT_NE(dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN, 0);
   #endif
 #else
-  ASSERT(dent.type == UV_DIRENT_UNKNOWN);
+  ASSERT_EQ(dent.type, UV_DIRENT_UNKNOWN);
 #endif
 }
 
 
 static void scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
-  ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == 2);
+  ASSERT_PTR_EQ(req, &scandir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, 2);
   ASSERT(req->ptr);
 
   while (UV_EOF != uv_fs_scandir_next(req, &dent)) {
-    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
+    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
     assert_is_file_type(dent);
   }
   scandir_cb_count++;
   ASSERT(req->path);
-  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  ASSERT_EQ(memcmp(req->path, "test_dir\0", 9), 0);
   uv_fs_req_cleanup(req);
   ASSERT(!req->ptr);
 }
@@ -620,11 +620,11 @@ static void scandir_cb(uv_fs_t* req) {
 static void empty_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
-  ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &scandir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, 0);
   ASSERT_NULL(req->ptr);
-  ASSERT(UV_EOF == uv_fs_scandir_next(req, &dent));
+  ASSERT_EQ(UV_EOF, uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
 }
@@ -632,20 +632,20 @@ static void empty_scandir_cb(uv_fs_t* req) {
 static void non_existent_scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
 
-  ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == UV_ENOENT);
+  ASSERT_PTR_EQ(req, &scandir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, UV_ENOENT);
   ASSERT_NULL(req->ptr);
-  ASSERT(UV_ENOENT == uv_fs_scandir_next(req, &dent));
+  ASSERT_EQ(UV_ENOENT, uv_fs_scandir_next(req, &dent));
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
 }
 
 
 static void file_scandir_cb(uv_fs_t* req) {
-  ASSERT(req == &scandir_req);
-  ASSERT(req->fs_type == UV_FS_SCANDIR);
-  ASSERT(req->result == UV_ENOTDIR);
+  ASSERT_PTR_EQ(req, &scandir_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
+  ASSERT_EQ(req->result, UV_ENOTDIR);
   ASSERT_NULL(req->ptr);
   uv_fs_req_cleanup(req);
   scandir_cb_count++;
@@ -653,9 +653,9 @@ static void file_scandir_cb(uv_fs_t* req) {
 
 
 static void stat_cb(uv_fs_t* req) {
-  ASSERT(req == &stat_req);
+  ASSERT_PTR_EQ(req, &stat_req);
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr);
   stat_cb_count++;
   uv_fs_req_cleanup(req);
@@ -664,7 +664,7 @@ static void stat_cb(uv_fs_t* req) {
 
 static void stat_batch_cb(uv_fs_t* req) {
   ASSERT(req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT);
-  ASSERT(req->result == 0);
+  ASSERT_EQ(req->result, 0);
   ASSERT(req->ptr);
   stat_cb_count++;
   uv_fs_req_cleanup(req);
@@ -673,40 +673,40 @@ static void stat_batch_cb(uv_fs_t* req) {
 
 
 static void sendfile_cb(uv_fs_t* req) {
-  ASSERT(req == &sendfile_req);
-  ASSERT(req->fs_type == UV_FS_SENDFILE);
-  ASSERT(req->result == 65545);
+  ASSERT_PTR_EQ(req, &sendfile_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
+  ASSERT_EQ(req->result, 65545);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void sendfile_nodata_cb(uv_fs_t* req) {
-  ASSERT(req == &sendfile_req);
-  ASSERT(req->fs_type == UV_FS_SENDFILE);
-  ASSERT(req->result == 0);
+  ASSERT_PTR_EQ(req, &sendfile_req);
+  ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
+  ASSERT_EQ(req->result, 0);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 
 static void open_noent_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ENOENT);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ENOENT);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void open_nametoolong_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ENAMETOOLONG);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ENAMETOOLONG);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
 
 static void open_loop_cb(uv_fs_t* req) {
-  ASSERT(req->fs_type == UV_FS_OPEN);
-  ASSERT(req->result == UV_ELOOP);
+  ASSERT_EQ(req->fs_type, UV_FS_OPEN);
+  ASSERT_EQ(req->result, UV_ELOOP);
   open_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -719,16 +719,16 @@ TEST_IMPL(fs_file_noent) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &req, "does_not_exist", O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, open_noent_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   /* TODO add EACCES test */
 
@@ -747,16 +747,16 @@ TEST_IMPL(fs_file_nametoolong) {
   name[TOO_LONG_NAME_LENGTH] = 0;
 
   r = uv_fs_open(NULL, &req, name, O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ENAMETOOLONG);
-  ASSERT(req.result == UV_ENAMETOOLONG);
+  ASSERT_EQ(r, UV_ENAMETOOLONG);
+  ASSERT_EQ(req.result, UV_ENAMETOOLONG);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, name, O_RDONLY, 0, open_nametoolong_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -783,20 +783,20 @@ TEST_IMPL(fs_file_loop) {
   if (r == UV_ENOENT)
     return 0;
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
-  ASSERT(r == UV_ELOOP);
-  ASSERT(req.result == UV_ELOOP);
+  ASSERT_EQ(r, UV_ELOOP);
+  ASSERT_EQ(req.result, UV_ELOOP);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, open_loop_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   unlink("test_symlink");
 
@@ -868,9 +868,9 @@ static void check_utime(const char* path,
 static void utime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req == &utime_req);
-  ASSERT(req->result == 0);
-  ASSERT(req->fs_type == UV_FS_UTIME);
+  ASSERT_PTR_EQ(req, &utime_req);
+  ASSERT_EQ(req->result, 0);
+  ASSERT_EQ(req->fs_type, UV_FS_UTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
@@ -883,9 +883,9 @@ static void utime_cb(uv_fs_t* req) {
 static void futime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req == &futime_req);
-  ASSERT(req->result == 0);
-  ASSERT(req->fs_type == UV_FS_FUTIME);
+  ASSERT_PTR_EQ(req, &futime_req);
+  ASSERT_EQ(req->result, 0);
+  ASSERT_EQ(req->fs_type, UV_FS_FUTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
@@ -898,8 +898,8 @@ static void futime_cb(uv_fs_t* req) {
 static void lutime_cb(uv_fs_t* req) {
   utime_check_t* c;
 
-  ASSERT(req->result == 0);
-  ASSERT(req->fs_type == UV_FS_LUTIME);
+  ASSERT_EQ(req->result, 0);
+  ASSERT_EQ(req->fs_type, UV_FS_LUTIME);
 
   c = req->data;
   check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 1);
@@ -920,48 +920,48 @@ TEST_IMPL(fs_file_async) {
 
   r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IRUSR | S_IWUSR, create_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(fsync_cb_count == 1);
-  ASSERT(fdatasync_cb_count == 1);
-  ASSERT(close_cb_count == 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(fsync_cb_count, 1);
+  ASSERT_EQ(fdatasync_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 1);
 
   r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", rename_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(close_cb_count == 1);
-  ASSERT(rename_cb_count == 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 1);
+  ASSERT_EQ(rename_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
-  ASSERT(read_cb_count == 1);
-  ASSERT(close_cb_count == 2);
-  ASSERT(rename_cb_count == 1);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(ftruncate_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(read_cb_count, 1);
+  ASSERT_EQ(close_cb_count, 2);
+  ASSERT_EQ(rename_cb_count, 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(ftruncate_cb_count, 1);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 2);
-  ASSERT(read_cb_count == 2);
-  ASSERT(close_cb_count == 3);
-  ASSERT(rename_cb_count == 1);
-  ASSERT(unlink_cb_count == 1);
-  ASSERT(create_cb_count == 1);
-  ASSERT(write_cb_count == 1);
-  ASSERT(ftruncate_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 2);
+  ASSERT_EQ(read_cb_count, 2);
+  ASSERT_EQ(close_cb_count, 3);
+  ASSERT_EQ(rename_cb_count, 1);
+  ASSERT_EQ(unlink_cb_count, 1);
+  ASSERT_EQ(create_cb_count, 1);
+  ASSERT_EQ(write_cb_count, 1);
+  ASSERT_EQ(ftruncate_cb_count, 1);
 
   /* Cleanup. */
   unlink("test_file");
@@ -983,70 +983,70 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_open(loop, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | add_flags, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(read_req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(read_req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_ftruncate(NULL, &ftruncate_req, open_req1.result, 7, NULL);
-  ASSERT(r == 0);
-  ASSERT(ftruncate_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(ftruncate_req.result, 0);
   uv_fs_req_cleanup(&ftruncate_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT(r == 0);
-  ASSERT(rename_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(rename_req.result, 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(read_req.result >= 0);
-  ASSERT(strcmp(buf, "test-bu") == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(read_req.result, 0);
+  ASSERT_EQ(strcmp(buf, "test-bu"), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_unlink(NULL, &unlink_req, "test_file2", NULL);
-  ASSERT(r == 0);
-  ASSERT(unlink_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(unlink_req.result, 0);
   uv_fs_req_cleanup(&unlink_req);
 
   /* Cleanup */
@@ -1072,19 +1072,19 @@ static void fs_file_write_null_buffer(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
-  ASSERT(write_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   unlink("test_file");
@@ -1110,78 +1110,78 @@ TEST_IMPL(fs_async_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdir_cb_count == 1);
+  ASSERT_EQ(mkdir_cb_count, 1);
 
   /* Create 2 files synchronously. */
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(loop, &scandir_req, "test_dir", 0, scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   /* sync uv_fs_scandir */
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
+    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
   ASSERT(!scandir_req.ptr);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_stat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_fs_lstat(loop, &stat_req, "test_dir/", stat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(stat_cb_count == 4);
+  ASSERT_EQ(stat_cb_count, 4);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file1", unlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(unlink_cb_count == 1);
+  ASSERT_EQ(unlink_cb_count, 1);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file2", unlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(unlink_cb_count == 2);
+  ASSERT_EQ(unlink_cb_count, 2);
 
   r = uv_fs_rmdir(loop, &rmdir_req, "test_dir", rmdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(rmdir_cb_count == 1);
+  ASSERT_EQ(rmdir_cb_count, 1);
 
   /* Cleanup */
   unlink("test_dir/file1");
@@ -1206,58 +1206,58 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   unlink("test_file2");
 
   f = open("test_file", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
-  ASSERT(f != -1);
+  ASSERT_NE(f, -1);
 
   if (setup != NULL)
     setup(f);
 
   r = close(f);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Test starts here. */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req2.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req2.result, 0);
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_sendfile(loop, &sendfile_req, open_req2.result, open_req1.result,
       1, 131072, cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(sendfile_cb_count == 1);
+  ASSERT_EQ(sendfile_cb_count, 1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
   r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   memset(&s1, 0, sizeof(s1));
   memset(&s2, 0, sizeof(s2));
-  ASSERT(0 == stat("test_file", &s1));
-  ASSERT(0 == stat("test_file2", &s2));
-  ASSERT(s2.st_size == expected_size);
+  ASSERT_EQ(0, stat("test_file", &s1));
+  ASSERT_EQ(0, stat("test_file2", &s2));
+  ASSERT_EQ(s2.st_size, expected_size);
 
   if (expected_size > 0) {
     ASSERT_UINT64_EQ(s1.st_size, s2.st_size + 1);
     r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDWR, 0, NULL);
-    ASSERT(r >= 0);
-    ASSERT(open_req1.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(open_req1.result, 0);
     uv_fs_req_cleanup(&open_req1);
 
     memset(buf1, 0, sizeof(buf1));
     iov = uv_buf_init(buf1, sizeof(buf1));
     r = uv_fs_read(NULL, &req, open_req1.result, &iov, 1, -1, NULL);
-    ASSERT(r >= 0);
-    ASSERT(req.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(req.result, 0);
     ASSERT_EQ(buf1[0], 'e'); /* 'e' from begin */
     uv_fs_req_cleanup(&req);
   } else {
@@ -1274,9 +1274,9 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
 
 
 static void sendfile_setup(int f) {
-  ASSERT(6 == write(f, "begin\n", 6));
-  ASSERT(65542 == lseek(f, 65536, SEEK_CUR));
-  ASSERT(4 == write(f, "end\n", 4));
+  ASSERT_EQ(6, write(f, "begin\n", 6));
+  ASSERT_EQ(65542, lseek(f, 65536, SEEK_CUR));
+  ASSERT_EQ(4, write(f, "end\n", 4));
 }
 
 
@@ -1297,18 +1297,18 @@ TEST_IMPL(fs_mkdtemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkdtemp(loop, &mkdtemp_req1, path_template, mkdtemp_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdtemp_cb_count == 1);
+  ASSERT_EQ(mkdtemp_cb_count, 1);
 
   /* sync mkdtemp */
   r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   check_mkdtemp_result(&mkdtemp_req2);
 
   /* mkdtemp return different values on subsequent calls */
-  ASSERT(strcmp(mkdtemp_req1.path, mkdtemp_req2.path) != 0);
+  ASSERT_NE(strcmp(mkdtemp_req1.path, mkdtemp_req2.path), 0);
 
   /* Cleanup */
   rmdir(mkdtemp_req1.path);
@@ -1330,18 +1330,18 @@ TEST_IMPL(fs_mkstemp) {
   loop = uv_default_loop();
 
   r = uv_fs_mkstemp(loop, &mkstemp_req1, path_template, mkstemp_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkstemp_cb_count == 1);
+  ASSERT_EQ(mkstemp_cb_count, 1);
 
   /* sync mkstemp */
   r = uv_fs_mkstemp(NULL, &mkstemp_req2, path_template, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   check_mkstemp_result(&mkstemp_req2);
 
   /* mkstemp return different values on subsequent calls */
-  ASSERT(strcmp(mkstemp_req1.path, mkstemp_req2.path) != 0);
+  ASSERT_NE(strcmp(mkstemp_req1.path, mkstemp_req2.path), 0);
 
   /* invalid template returns EINVAL */
   ASSERT_EQ(UV_EINVAL, uv_fs_mkstemp(NULL, &mkstemp_req3, "test_file", NULL));
@@ -1354,8 +1354,8 @@ TEST_IMPL(fs_mkstemp) {
   /* We can write to the opened file */
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, mkstemp_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   /* Cleanup */
@@ -1365,15 +1365,15 @@ TEST_IMPL(fs_mkstemp) {
   uv_fs_req_cleanup(&req);
 
   fd = uv_fs_open(NULL, &req, mkstemp_req1.path , O_RDONLY, 0, NULL);
-  ASSERT(fd >= 0);
+  ASSERT_GE(fd, 0);
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &req, fd, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(NULL, &req, fd, NULL);
@@ -1412,20 +1412,20 @@ TEST_IMPL(fs_fstat) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
 #ifndef _WIN32
   memset(&t, 0, sizeof(t));
-  ASSERT(0 == fstat(file, &t));
-  ASSERT(0 == uv_fs_fstat(NULL, &req, file, NULL));
-  ASSERT(req.result == 0);
+  ASSERT_EQ(0, fstat(file, &t));
+  ASSERT_EQ(0, uv_fs_fstat(NULL, &req, file, NULL));
+  ASSERT_EQ(req.result, 0);
   s = req.ptr;
 # if defined(__APPLE__)
-  ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
-  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtimespec.tv_nsec);
+  ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtimespec.tv_sec);
+  ASSERT_EQ(s->st_birthtim.tv_nsec, t.st_birthtimespec.tv_nsec);
 # elif defined(__linux__)
   /* If statx() is supported, the birth time should be equal to the change time
    * because we just created the file. On older kernels, it's set to zero.
@@ -1439,53 +1439,53 @@ TEST_IMPL(fs_fstat) {
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
   r = uv_fs_fstat(NULL, &req, file, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   s = req.ptr;
-  ASSERT(s->st_size == sizeof(test_buf));
+  ASSERT_EQ(s->st_size, sizeof(test_buf));
 
 #ifndef _WIN32
   r = fstat(file, &t);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(s->st_dev == (uint64_t) t.st_dev);
-  ASSERT(s->st_mode == (uint64_t) t.st_mode);
-  ASSERT(s->st_nlink == (uint64_t) t.st_nlink);
-  ASSERT(s->st_uid == (uint64_t) t.st_uid);
-  ASSERT(s->st_gid == (uint64_t) t.st_gid);
-  ASSERT(s->st_rdev == (uint64_t) t.st_rdev);
-  ASSERT(s->st_ino == (uint64_t) t.st_ino);
-  ASSERT(s->st_size == (uint64_t) t.st_size);
-  ASSERT(s->st_blksize == (uint64_t) t.st_blksize);
-  ASSERT(s->st_blocks == (uint64_t) t.st_blocks);
+  ASSERT_EQ(s->st_dev, (uint64_t) t.st_dev);
+  ASSERT_EQ(s->st_mode, (uint64_t) t.st_mode);
+  ASSERT_EQ(s->st_nlink, (uint64_t) t.st_nlink);
+  ASSERT_EQ(s->st_uid, (uint64_t) t.st_uid);
+  ASSERT_EQ(s->st_gid, (uint64_t) t.st_gid);
+  ASSERT_EQ(s->st_rdev, (uint64_t) t.st_rdev);
+  ASSERT_EQ(s->st_ino, (uint64_t) t.st_ino);
+  ASSERT_EQ(s->st_size, (uint64_t) t.st_size);
+  ASSERT_EQ(s->st_blksize, (uint64_t) t.st_blksize);
+  ASSERT_EQ(s->st_blocks, (uint64_t) t.st_blocks);
 #if defined(__APPLE__)
-  ASSERT(s->st_atim.tv_sec == t.st_atimespec.tv_sec);
-  ASSERT(s->st_atim.tv_nsec == t.st_atimespec.tv_nsec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtimespec.tv_sec);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtimespec.tv_nsec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctimespec.tv_sec);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atimespec.tv_sec);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimespec.tv_nsec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtimespec.tv_sec);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtimespec.tv_nsec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctimespec.tv_sec);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctimespec.tv_nsec);
 #elif defined(_AIX)    || \
       defined(__MVS__)
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == 0);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == 0);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == 0);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_nsec, 0);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #elif defined(__ANDROID__)
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == t.st_atimensec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtimensec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctimensec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimensec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtimensec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctimensec);
 #elif defined(__sun)           || \
       defined(__DragonFly__)   || \
       defined(__FreeBSD__)     || \
@@ -1496,47 +1496,47 @@ TEST_IMPL(fs_fstat) {
       defined(_SVID_SOURCE)    || \
       defined(_XOPEN_SOURCE)   || \
       defined(_DEFAULT_SOURCE)
-  ASSERT(s->st_atim.tv_sec == t.st_atim.tv_sec);
-  ASSERT(s->st_atim.tv_nsec == t.st_atim.tv_nsec);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtim.tv_sec);
-  ASSERT(s->st_mtim.tv_nsec == t.st_mtim.tv_nsec);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctim.tv_sec);
-  ASSERT(s->st_ctim.tv_nsec == t.st_ctim.tv_nsec);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atim.tv_sec);
+  ASSERT_EQ(s->st_atim.tv_nsec, t.st_atim.tv_nsec);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtim.tv_sec);
+  ASSERT_EQ(s->st_mtim.tv_nsec, t.st_mtim.tv_nsec);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctim.tv_sec);
+  ASSERT_EQ(s->st_ctim.tv_nsec, t.st_ctim.tv_nsec);
 # if defined(__FreeBSD__)    || \
      defined(__NetBSD__)
-  ASSERT(s->st_birthtim.tv_sec == t.st_birthtim.tv_sec);
-  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtim.tv_nsec);
+  ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtim.tv_sec);
+  ASSERT_EQ(s->st_birthtim.tv_nsec, t.st_birthtim.tv_nsec);
 # endif
 #else
-  ASSERT(s->st_atim.tv_sec == t.st_atime);
-  ASSERT(s->st_atim.tv_nsec == 0);
-  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
-  ASSERT(s->st_mtim.tv_nsec == 0);
-  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
-  ASSERT(s->st_ctim.tv_nsec == 0);
+  ASSERT_EQ(s->st_atim.tv_sec, t.st_atime);
+  ASSERT_EQ(s->st_atim.tv_nsec, 0);
+  ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtime);
+  ASSERT_EQ(s->st_mtim.tv_nsec, 0);
+  ASSERT_EQ(s->st_ctim.tv_sec, t.st_ctime);
+  ASSERT_EQ(s->st_ctim.tv_nsec, 0);
 #endif
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
-  ASSERT(s->st_flags == t.st_flags);
-  ASSERT(s->st_gen == t.st_gen);
+  ASSERT_EQ(s->st_flags, t.st_flags);
+  ASSERT_EQ(s->st_gen, t.st_gen);
 #else
-  ASSERT(s->st_flags == 0);
-  ASSERT(s->st_gen == 0);
+  ASSERT_EQ(s->st_flags, 0);
+  ASSERT_EQ(s->st_gen, 0);
 #endif
 
   uv_fs_req_cleanup(&req);
 
   /* Now do the uv_fs_fstat call asynchronously */
   r = uv_fs_fstat(loop, &req, file, fstat_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fstat_cb_count == 1);
+  ASSERT_EQ(fstat_cb_count, 1);
 
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1564,8 +1564,8 @@ TEST_IMPL(fs_fstat_stdio) {
 
   for (fd = 0; fd <= 2; ++fd) {
     res = uv_fs_fstat(NULL, &req, fd, NULL);
-    ASSERT(res == 0);
-    ASSERT(req.result == 0);
+    ASSERT_EQ(res, 0);
+    ASSERT_EQ(req.result, 0);
 
 #ifdef _WIN32
     st = req.ptr;
@@ -1573,9 +1573,11 @@ TEST_IMPL(fs_fstat_stdio) {
     switch (ft) {
     case UV_TTY:
     case UV_NAMED_PIPE:
-      ASSERT(st->st_mode == (ft == UV_TTY ? S_IFCHR : S_IFIFO));
-      ASSERT(st->st_nlink == 1);
-      ASSERT(st->st_rdev == (ft == UV_TTY ? FILE_DEVICE_CONSOLE : FILE_DEVICE_NAMED_PIPE) << 16);
+      ASSERT_EQ(st->st_mode, (ft == UV_TTY ? S_IFCHR : S_IFIFO));
+      ASSERT_EQ(st->st_nlink, 1);
+      ASSERT_EQ(st->st_rdev,
+                (ft == UV_TTY ? FILE_DEVICE_CONSOLE : FILE_DEVICE_NAMED_PIPE)
+                << 16);
       break;
     default:
       break;
@@ -1603,52 +1605,52 @@ TEST_IMPL(fs_access) {
 
   /* File should not exist */
   r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
-  ASSERT(r < 0);
-  ASSERT(req.result < 0);
+  ASSERT_LT(r, 0);
+  ASSERT_LT(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* File should not exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(access_cb_count == 1);
+  ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Create file */
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
   r = uv_fs_access(NULL, &req, "test_file", F_OK, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* File should exist */
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(access_cb_count == 1);
+  ASSERT_EQ(access_cb_count, 1);
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* Directory access */
   r = uv_fs_mkdir(NULL, &req, "test_dir", 0777, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_access(NULL, &req, "test_dir", W_OK, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1678,22 +1680,22 @@ TEST_IMPL(fs_chmod) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
 #ifndef _WIN32
   /* Make the file write-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0200, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0200);
@@ -1701,16 +1703,16 @@ TEST_IMPL(fs_chmod) {
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
 
   /* Make the file read+write with sync uv_fs_fchmod */
   r = uv_fs_fchmod(NULL, &req, file, 0600, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0600);
@@ -1722,9 +1724,9 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0200, chmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chmod_cb_count == 1);
+  ASSERT_EQ(chmod_cb_count, 1);
   chmod_cb_count = 0; /* reset for the next test */
 #endif
 
@@ -1734,9 +1736,9 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_chmod(loop, &req, "test_file", 0400, chmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chmod_cb_count == 1);
+  ASSERT_EQ(chmod_cb_count, 1);
 
   /* async fchmod */
   {
@@ -1744,9 +1746,9 @@ TEST_IMPL(fs_chmod) {
     req.data = &mode;
   }
   r = uv_fs_fchmod(loop, &req, file, 0600, fchmod_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fchmod_cb_count == 1);
+  ASSERT_EQ(fchmod_cb_count, 1);
 
   uv_fs_close(loop, &req, file, NULL);
 
@@ -1780,31 +1782,31 @@ TEST_IMPL(fs_unlink_readonly) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(loop, &req, file, NULL);
 
   /* Make the file read-only */
   r = uv_fs_chmod(NULL, &req, "test_file", 0400, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1839,30 +1841,30 @@ TEST_IMPL(fs_unlink_archive_readonly) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(loop, &req, file, NULL);
 
   /* Make the file read-only and clear archive flag */
   r = SetFileAttributes("test_file", FILE_ATTRIBUTE_READONLY);
-  ASSERT(r != 0);
+  ASSERT(r);
   uv_fs_req_cleanup(&req);
 
   check_permission("test_file", 0400);
 
   /* Try to unlink the file */
   r = uv_fs_unlink(NULL, &req, "test_file", NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1894,69 +1896,69 @@ TEST_IMPL(fs_chown) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   /* sync chown */
   r = uv_fs_chown(NULL, &req, "test_file", -1, -1, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync fchown */
   r = uv_fs_fchown(NULL, &req, file, -1, -1, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* async chown */
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chown_cb_count == 1);
+  ASSERT_EQ(chown_cb_count, 1);
 
 #ifndef __MVS__
   /* chown to root (fail) */
   chown_cb_count = 0;
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(chown_cb_count == 1);
+  ASSERT_EQ(chown_cb_count, 1);
 #endif
 
   /* async fchown */
   r = uv_fs_fchown(loop, &req, file, -1, -1, fchown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(fchown_cb_count == 1);
+  ASSERT_EQ(fchown_cb_count, 1);
 
 #ifndef __HAIKU__
   /* Haiku doesn't support hardlink */
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* sync lchown */
   r = uv_fs_lchown(NULL, &req, "test_file_link", -1, -1, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /* async lchown */
   r = uv_fs_lchown(loop, &req, "test_file_link", -1, -1, lchown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(lchown_cb_count == 1);
+  ASSERT_EQ(lchown_cb_count, 1);
 #endif
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   /*
@@ -1989,58 +1991,58 @@ TEST_IMPL(fs_link) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(loop, &req, file, NULL);
 
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
 
   close(link);
 
   /* async link */
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(link_cb_count == 1);
+  ASSERT_EQ(link_cb_count, 1);
 
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2066,16 +2068,16 @@ TEST_IMPL(fs_readlink) {
     uv_fs_t req;
 
     loop = uv_default_loop();
-    ASSERT(0 == uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
-    ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-    ASSERT(dummy_cb_count == 1);
+    ASSERT_EQ(0, uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
+    ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+    ASSERT_EQ(dummy_cb_count, 1);
     ASSERT_NULL(req.ptr);
-    ASSERT(req.result == UV_ENOENT);
+    ASSERT_EQ(req.result, UV_ENOENT);
     uv_fs_req_cleanup(&req);
 
-    ASSERT(UV_ENOENT == uv_fs_readlink(NULL, &req, "no_such_file", NULL));
+    ASSERT_EQ(UV_ENOENT, uv_fs_readlink(NULL, &req, "no_such_file", NULL));
     ASSERT_NULL(req.ptr);
-    ASSERT(req.result == UV_ENOENT);
+    ASSERT_EQ(req.result, UV_ENOENT);
     uv_fs_req_cleanup(&req);
   }
 
@@ -2118,16 +2120,16 @@ TEST_IMPL(fs_realpath) {
   uv_fs_t req;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(dummy_cb_count == 1);
+  ASSERT_EQ(0, uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(dummy_cb_count, 1);
   ASSERT_NULL(req.ptr);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
-  ASSERT(UV_ENOENT == uv_fs_realpath(NULL, &req, "no_such_file", NULL));
+  ASSERT_EQ(UV_ENOENT, uv_fs_realpath(NULL, &req, "no_such_file", NULL));
   ASSERT_NULL(req.ptr);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -2162,15 +2164,15 @@ TEST_IMPL(fs_symlink) {
 
   r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result;
   uv_fs_req_cleanup(&req);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &req, file, &iov, 1, -1, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(req.result == sizeof(test_buf));
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(req.result, sizeof(test_buf));
   uv_fs_req_cleanup(&req);
 
   uv_fs_close(loop, &req, file, NULL);
@@ -2194,22 +2196,22 @@ TEST_IMPL(fs_symlink) {
     }
   }
 #endif
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2219,7 +2221,7 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink_symlink",
                     0,
                     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
 #if defined(__MSYS__)
@@ -2227,16 +2229,16 @@ TEST_IMPL(fs_symlink) {
 #endif
 
   r = uv_fs_readlink(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT(r == 0);
-  ASSERT(strcmp(req.ptr, "test_file_symlink") == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(strcmp(req.ptr, "test_file_symlink"), 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_file_symlink_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
-  ASSERT(stricmp(req.ptr, test_file_abs_buf) == 0);
+  ASSERT_EQ(stricmp(req.ptr, test_file_abs_buf), 0);
 #else
-  ASSERT(strcmp(req.ptr, test_file_abs_buf) == 0);
+  ASSERT_EQ(strcmp(req.ptr, test_file_abs_buf), 0);
 #endif
   uv_fs_req_cleanup(&req);
 
@@ -2247,22 +2249,22 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2",
                     0,
                     symlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(symlink_cb_count == 1);
+  ASSERT_EQ(symlink_cb_count, 1);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   link = req.result;
   uv_fs_req_cleanup(&req);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &req, link, &iov, 1, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
 
   uv_fs_close(loop, &req, link, NULL);
 
@@ -2272,18 +2274,18 @@ TEST_IMPL(fs_symlink) {
                     "test_file_symlink2_symlink",
                     0,
                     NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(loop, &req, "test_file_symlink2_symlink", readlink_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(readlink_cb_count == 1);
+  ASSERT_EQ(readlink_cb_count, 1);
 
   r = uv_fs_realpath(loop, &req, "test_file", realpath_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(realpath_cb_count == 1);
+  ASSERT_EQ(realpath_cb_count, 1);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -2344,74 +2346,74 @@ int test_symlink_dir_impl(int type) {
                 "creation of directory symlinks");
   }
   fprintf(stderr, "r == %i\n", r);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_stat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFDIR);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #if defined(__MSYS__)
   RETURN_SKIP("symlink reading is not supported on MSYS2");
 #endif
   ASSERT(((uv_stat_t*)req.ptr)->st_mode & S_IFLNK);
 #ifdef _WIN32
-  ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen(test_dir + 4));
+  ASSERT_EQ(((uv_stat_t*)req.ptr)->st_size, strlen(test_dir + 4));
 #else
 # ifdef __PASE__
   /* On IBMi PASE, st_size returns the length of the symlink itself. */
-  ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen("test_dir_symlink"));
+  ASSERT_EQ(((uv_stat_t*)req.ptr)->st_size, strlen("test_dir_symlink"));
 # else
-  ASSERT(((uv_stat_t*)req.ptr)->st_size == strlen(test_dir));
+  ASSERT_EQ(((uv_stat_t*)req.ptr)->st_size, strlen(test_dir));
 # endif
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_readlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
-  ASSERT(strcmp(req.ptr, test_dir + 4) == 0);
+  ASSERT_EQ(strcmp(req.ptr, test_dir + 4), 0);
 #else
-  ASSERT(strcmp(req.ptr, test_dir) == 0);
+  ASSERT_EQ(strcmp(req.ptr, test_dir), 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_realpath(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
-  ASSERT(strlen(req.ptr) == test_dir_abs_size - 5);
-  ASSERT(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5) == 0);
+  ASSERT_EQ(strlen(req.ptr), test_dir_abs_size - 5);
+  ASSERT_EQ(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5), 0);
 #else
-  ASSERT(strcmp(req.ptr, test_dir_abs_buf) == 0);
+  ASSERT_EQ(strcmp(req.ptr, test_dir_abs_buf), 0);
 #endif
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
+    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
@@ -2419,19 +2421,19 @@ int test_symlink_dir_impl(int type) {
 
   /* unlink will remove the directory symlink */
   r = uv_fs_unlink(NULL, &req, "test_dir_symlink", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
-  ASSERT(r == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 2);
-  ASSERT(scandir_req.result == 2);
+  ASSERT_EQ(r, 2);
+  ASSERT_EQ(scandir_req.result, 2);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
+    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
@@ -2481,7 +2483,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
                            FILE_FLAG_OPEN_REPARSE_POINT |
                              FILE_FLAG_BACKUP_SEMANTICS,
                            NULL);
-  ASSERT(file_handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(file_handle, INVALID_HANDLE_VALUE);
 
   memset(&reparse_buffer, 0, REPARSE_GUID_DATA_BUFFER_HEADER_SIZE);
   reparse_buffer.ReparseTag = REPARSE_TAG;
@@ -2496,7 +2498,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
                       0,
                       &bytes_returned,
                       NULL);
-  ASSERT(r != 0);
+  ASSERT(r);
 
   CloseHandle(file_handle);
 
@@ -2510,11 +2512,11 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   shared via SMB as "Macintosh HD".
 
   r = uv_fs_stat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "\\\\<mac_ip>\\Macintosh HD\\.DS_Store", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 */
 
@@ -2525,25 +2527,25 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
   the scope of this test.
 
   r = uv_fs_stat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_lstat(NULL, &req, "test_dir/test_file", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&req);
 */
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT(r == 1);
-  ASSERT(scandir_req.result == 1);
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(scandir_req.result, 1);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT(strcmp(dent.name, "test_file") == 0);
+    ASSERT_EQ(strcmp(dent.name, "test_file"), 0);
     /* uv_fs_scandir incorrectly identifies non-symlink reparse points
        as links because it doesn't open the file and verify the reparse
        point tag. The PowerShell Get-ChildItem command shares this
        behavior, so it's reasonable to leave it as is. */
-    ASSERT(dent.type == UV_DIRENT_LINK);
+    ASSERT_EQ(dent.type, UV_DIRENT_LINK);
   }
   uv_fs_req_cleanup(&scandir_req);
   ASSERT(!scandir_req.ptr);
@@ -2621,16 +2623,16 @@ TEST_IMPL(fs_utime) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
   uv_fs_close(loop, &req, r, NULL);
 
   atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
 
   r = uv_fs_utime(NULL, &req, path, atime, mtime, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   uv_fs_req_cleanup(&req);
 
   check_utime(path, atime, mtime, /* test_lutime */ 0);
@@ -2643,9 +2645,9 @@ TEST_IMPL(fs_utime) {
   /* async utime */
   utime_req.data = &checkme;
   r = uv_fs_utime(loop, &utime_req, path, atime, mtime, utime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(utime_cb_count == 1);
+  ASSERT_EQ(utime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2699,26 +2701,26 @@ TEST_IMPL(fs_stat_root) {
   int r;
 
   r = uv_fs_stat(NULL, &stat_req, "\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\..\\..\\..\\..\\..\\..", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "..\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* stats the current directory on c: */
   r = uv_fs_stat(NULL, &stat_req, "c:", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "c:\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_stat(NULL, &stat_req, "\\\\?\\C:\\", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -2742,26 +2744,26 @@ TEST_IMPL(fs_futime) {
   loop = uv_default_loop();
   unlink(path);
   r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
   uv_fs_close(loop, &req, r, NULL);
 
   atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
 
   r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   file = req.result; /* FIXME probably not how it's supposed to be used */
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_futime(NULL, &req, file, atime, mtime, NULL);
 #if defined(__CYGWIN__) || defined(__MSYS__)
-  ASSERT(r == UV_ENOSYS);
+  ASSERT_EQ(r, UV_ENOSYS);
   RETURN_SKIP("futime not supported on Cygwin");
 #else
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
 #endif
   uv_fs_req_cleanup(&req);
 
@@ -2776,9 +2778,9 @@ TEST_IMPL(fs_futime) {
   /* async futime */
   futime_req.data = &checkme;
   r = uv_fs_futime(loop, &futime_req, file, atime, mtime, futime_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(futime_cb_count == 1);
+  ASSERT_EQ(futime_cb_count, 1);
 
   /* Cleanup. */
   unlink(path);
@@ -2869,8 +2871,8 @@ TEST_IMPL(fs_stat_missing_path) {
   loop = uv_default_loop();
 
   r = uv_fs_stat(NULL, &req, "non_existent_file", NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -2894,18 +2896,18 @@ TEST_IMPL(fs_scandir_empty_dir) {
   memset(&req, 0xdb, sizeof(req));
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
-  ASSERT(r == 0);
-  ASSERT(req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(req.result, 0);
   ASSERT_NULL(req.ptr);
-  ASSERT(UV_EOF == uv_fs_scandir_next(&req, &dent));
+  ASSERT_EQ(UV_EOF, uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, empty_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   uv_fs_rmdir(NULL, &req, path, NULL);
   uv_fs_req_cleanup(&req);
@@ -2931,18 +2933,18 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
   memset(&req, 0xdb, sizeof(req));
 
   r = uv_fs_scandir(NULL, &req, path, 0, NULL);
-  ASSERT(r == UV_ENOENT);
-  ASSERT(req.result == UV_ENOENT);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(req.result, UV_ENOENT);
   ASSERT_NULL(req.ptr);
-  ASSERT(UV_ENOENT == uv_fs_scandir_next(&req, &dent));
+  ASSERT_EQ(UV_ENOENT, uv_fs_scandir_next(&req, &dent));
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, non_existent_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -2956,15 +2958,15 @@ TEST_IMPL(fs_scandir_file) {
   loop = uv_default_loop();
 
   r = uv_fs_scandir(NULL, &scandir_req, path, 0, NULL);
-  ASSERT(r == UV_ENOTDIR);
+  ASSERT_EQ(r, UV_ENOTDIR);
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(loop, &scandir_req, path, 0, file_scandir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(scandir_cb_count == 0);
+  ASSERT_EQ(scandir_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(scandir_cb_count == 1);
+  ASSERT_EQ(scandir_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -2998,21 +3000,21 @@ TEST_IMPL(fs_open_dir) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
   ASSERT_NULL(req.ptr);
   file = r;
   uv_fs_req_cleanup(&req);
 
   r = uv_fs_close(NULL, &req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fs_open(loop, &req, path, O_RDONLY, 0, open_cb_simple);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(open_cb_count == 0);
+  ASSERT_EQ(open_cb_count, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(open_cb_count == 1);
+  ASSERT_EQ(open_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -3029,57 +3031,57 @@ static void fs_file_open_append(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_RDWR | O_APPEND | add_flags, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags,
       S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   printf("read = %d\n", r);
-  ASSERT(r == 26);
-  ASSERT(read_req.result == 26);
-  ASSERT(memcmp(buf,
-                "test-buffer\n\0test-buffer\n\0",
-                sizeof("test-buffer\n\0test-buffer\n\0") - 1) == 0);
+  ASSERT_EQ(r, 26);
+  ASSERT_EQ(read_req.result, 26);
+  ASSERT_EQ(memcmp(buf,
+                   "test-buffer\n\0test-buffer\n\0",
+                   sizeof("test-buffer\n\0test-buffer\n\0") - 1), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3105,53 +3107,53 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_rename(NULL, &rename_req, "test_file", "test_file2", NULL);
-  ASSERT(r == 0);
-  ASSERT(rename_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(rename_req.result, 0);
   uv_fs_req_cleanup(&rename_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(read_req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(read_req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3167,49 +3169,49 @@ static void fs_read_bufs(int add_flags) {
   char scratch[768];
   uv_buf_t bufs[4];
 
-  ASSERT(0 <= uv_fs_open(NULL, &open_req1,
-                         "test/fixtures/lorem_ipsum.txt",
-                         O_RDONLY | add_flags, 0, NULL));
-  ASSERT(open_req1.result >= 0);
+  ASSERT_LE(0, uv_fs_open(NULL, &open_req1,
+                          "test/fixtures/lorem_ipsum.txt",
+                          O_RDONLY | add_flags, 0, NULL));
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
-  ASSERT(UV_EINVAL == uv_fs_read(NULL, &read_req, open_req1.result,
-                                 NULL, 0, 0, NULL));
-  ASSERT(UV_EINVAL == uv_fs_read(NULL, &read_req, open_req1.result,
-                                 NULL, 1, 0, NULL));
-  ASSERT(UV_EINVAL == uv_fs_read(NULL, &read_req, open_req1.result,
-                                 bufs, 0, 0, NULL));
+  ASSERT_EQ(UV_EINVAL, uv_fs_read(NULL, &read_req, open_req1.result,
+                                  NULL, 0, 0, NULL));
+  ASSERT_EQ(UV_EINVAL, uv_fs_read(NULL, &read_req, open_req1.result,
+                                  NULL, 1, 0, NULL));
+  ASSERT_EQ(UV_EINVAL, uv_fs_read(NULL, &read_req, open_req1.result,
+                                  bufs, 0, 0, NULL));
 
   bufs[0] = uv_buf_init(scratch + 0, 256);
   bufs[1] = uv_buf_init(scratch + 256, 256);
   bufs[2] = uv_buf_init(scratch + 512, 128);
   bufs[3] = uv_buf_init(scratch + 640, 128);
 
-  ASSERT(446 == uv_fs_read(NULL,
-                           &read_req,
-                           open_req1.result,
-                           bufs + 0,
-                           2,  /* 2x 256 bytes. */
-                           0,  /* Positional read. */
-                           NULL));
-  ASSERT(read_req.result == 446);
+  ASSERT_EQ(446, uv_fs_read(NULL,
+                            &read_req,
+                            open_req1.result,
+                            bufs + 0,
+                            2,  /* 2x 256 bytes. */
+                            0,  /* Positional read. */
+                            NULL));
+  ASSERT_EQ(read_req.result, 446);
   uv_fs_req_cleanup(&read_req);
 
-  ASSERT(190 == uv_fs_read(NULL,
-                           &read_req,
-                           open_req1.result,
-                           bufs + 2,
-                           2,  /* 2x 128 bytes. */
-                           256,  /* Positional read. */
-                           NULL));
-  ASSERT(read_req.result == /* 446 - 256 */ 190);
+  ASSERT_EQ(190, uv_fs_read(NULL,
+                            &read_req,
+                            open_req1.result,
+                            bufs + 2,
+                            2,  /* 2x 128 bytes. */
+                            256,  /* Positional read. */
+                            NULL));
+  ASSERT_EQ(read_req.result, /* 446 - 256 */ 190);
   uv_fs_req_cleanup(&read_req);
 
-  ASSERT(0 == memcmp(bufs[1].base + 0, bufs[2].base, 128));
-  ASSERT(0 == memcmp(bufs[1].base + 128, bufs[3].base, 190 - 128));
+  ASSERT_EQ(0, memcmp(bufs[1].base + 0, bufs[2].base, 128));
+  ASSERT_EQ(0, memcmp(bufs[1].base + 128, bufs[3].base, 190 - 128));
 
-  ASSERT(0 == uv_fs_close(NULL, &close_req, open_req1.result, NULL));
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(0, uv_fs_close(NULL, &close_req, open_req1.result, NULL));
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 }
 TEST_IMPL(fs_read_bufs) {
@@ -3234,45 +3236,45 @@ static void fs_read_file_eof(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(read_req.result >= 0);
-  ASSERT(strcmp(buf, test_buf) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(read_req.result, 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  read_req.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3298,26 +3300,26 @@ static void fs_write_multiple_bufs(int add_flags) {
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
       O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iovs[0] = uv_buf_init(test_buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(test_buf2, sizeof(test_buf2));
   r = uv_fs_write(NULL, &write_req, open_req1.result, iovs, 2, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(write_req.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(write_req.result, 0);
   uv_fs_req_cleanup(&write_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
       NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   memset(buf, 0, sizeof(buf));
@@ -3325,48 +3327,48 @@ static void fs_write_multiple_bufs(int add_flags) {
   /* Read the strings back to separate buffers. */
   iovs[0] = uv_buf_init(buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
-  ASSERT(lseek(open_req1.result, 0, SEEK_CUR) == 0);
+  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
   r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, 2, -1, NULL);
-  ASSERT(r >= 0);
-  ASSERT(read_req.result == sizeof(test_buf) + sizeof(test_buf2));
-  ASSERT(strcmp(buf, test_buf) == 0);
-  ASSERT(strcmp(buf2, test_buf2) == 0);
+  ASSERT_GE(r, 0);
+  ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_EQ(strcmp(buf2, test_buf2), 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   /* Read the strings back to separate buffers. */
   iovs[0] = uv_buf_init(buf, sizeof(test_buf));
   iovs[1] = uv_buf_init(buf2, sizeof(test_buf2));
   r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, 2, 0, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   if (read_req.result == sizeof(test_buf)) {
     /* Infer that preadv is not available. */
     uv_fs_req_cleanup(&read_req);
     r = uv_fs_read(NULL, &read_req, open_req1.result, &iovs[1], 1, read_req.result, NULL);
-    ASSERT(r >= 0);
-    ASSERT(read_req.result == sizeof(test_buf2));
+    ASSERT_GE(r, 0);
+    ASSERT_EQ(read_req.result, sizeof(test_buf2));
   } else {
-    ASSERT(read_req.result == sizeof(test_buf) + sizeof(test_buf2));
+    ASSERT_EQ(read_req.result, sizeof(test_buf) + sizeof(test_buf2));
   }
-  ASSERT(strcmp(buf, test_buf) == 0);
-  ASSERT(strcmp(buf2, test_buf2) == 0);
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_EQ(strcmp(buf2, test_buf2), 0);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1,
                  sizeof(test_buf) + sizeof(test_buf2), NULL);
-  ASSERT(r == 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3406,8 +3408,8 @@ static void fs_write_alotof_bufs(int add_flags) {
                  O_RDWR | O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   for (index = 0; index < iovcount; ++index)
@@ -3420,8 +3422,8 @@ static void fs_write_alotof_bufs(int add_flags) {
                   iovcount,
                   -1,
                   NULL);
-  ASSERT(r >= 0);
-  ASSERT((size_t)write_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_GE(r, 0);
+  ASSERT_EQ((size_t)write_req.result, sizeof(test_buf) * iovcount);
   uv_fs_req_cleanup(&write_req);
 
   /* Read the strings back to separate buffers. */
@@ -3433,31 +3435,32 @@ static void fs_write_alotof_bufs(int add_flags) {
                               sizeof(test_buf));
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
     NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_read(NULL, &read_req, open_req1.result, iovs, iovcount, -1, NULL);
   if (iovcount > iovmax)
     iovcount = iovmax;
-  ASSERT(r >= 0);
-  ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_GE(r, 0);
+  ASSERT_EQ((size_t)read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
-    ASSERT(strncmp(buffer + index * sizeof(test_buf),
-                   test_buf,
-                   sizeof(test_buf)) == 0);
+    ASSERT_EQ(strncmp(buffer + index * sizeof(test_buf),
+                      test_buf,
+                      sizeof(test_buf)), 0);
 
   uv_fs_req_cleanup(&read_req);
   free(buffer);
 
-  ASSERT(lseek(open_req1.result, write_req.result, SEEK_SET) == write_req.result);
+  ASSERT_EQ(lseek(open_req1.result, write_req.result, SEEK_SET),
+            write_req.result);
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL,
                  &read_req,
@@ -3466,13 +3469,13 @@ static void fs_write_alotof_bufs(int add_flags) {
                  1,
                  -1,
                  NULL);
-  ASSERT(r == 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3518,14 +3521,14 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  O_RDWR | O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(filler, filler_len);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == filler_len);
-  ASSERT(write_req.result == filler_len);
+  ASSERT_EQ(r, filler_len);
+  ASSERT_EQ(write_req.result, filler_len);
   uv_fs_req_cleanup(&write_req);
   offset = (int64_t)r;
 
@@ -3539,8 +3542,8 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                   iovcount,
                   offset,
                   NULL);
-  ASSERT(r >= 0);
-  ASSERT((size_t)write_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_GE(r, 0);
+  ASSERT_EQ((size_t)write_req.result, sizeof(test_buf) * iovcount);
   uv_fs_req_cleanup(&write_req);
 
   /* Read the strings back to separate buffers. */
@@ -3553,25 +3556,25 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
 
   r = uv_fs_read(NULL, &read_req, open_req1.result,
                  iovs, iovcount, offset, NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   if (r == sizeof(test_buf))
     iovcount = 1; /* Infer that preadv is not available. */
   else if (iovcount > iovmax)
     iovcount = iovmax;
-  ASSERT((size_t)read_req.result == sizeof(test_buf) * iovcount);
+  ASSERT_EQ((size_t)read_req.result, sizeof(test_buf) * iovcount);
 
   for (index = 0; index < iovcount; ++index)
-    ASSERT(strncmp(buffer + index * sizeof(test_buf),
-                   test_buf,
-                   sizeof(test_buf)) == 0);
+    ASSERT_EQ(strncmp(buffer + index * sizeof(test_buf),
+                      test_buf,
+                      sizeof(test_buf)), 0);
 
   uv_fs_req_cleanup(&read_req);
   free(buffer);
 
   r = uv_fs_stat(NULL, &stat_req, "test_file", NULL);
-  ASSERT(r == 0);
-  ASSERT((int64_t)((uv_stat_t*)stat_req.ptr)->st_size ==
-         offset + (int64_t)write_req.result);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ((int64_t)((uv_stat_t*)stat_req.ptr)->st_size,
+            offset + (int64_t)write_req.result);
   uv_fs_req_cleanup(&stat_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -3582,13 +3585,13 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
                  1,
                  offset + write_req.result,
                  NULL);
-  ASSERT(r == 0);
-  ASSERT(read_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(read_req.result, 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3611,9 +3614,9 @@ TEST_IMPL(fs_read_dir) {
   /* Setup */
   rmdir("test_dir");
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(mkdir_cb_count == 1);
+  ASSERT_EQ(mkdir_cb_count, 1);
   /* Setup Done Here */
 
   /* Get a file descriptor for the directory */
@@ -3623,7 +3626,7 @@ TEST_IMPL(fs_read_dir) {
                  UV_FS_O_RDONLY | UV_FS_O_DIRECTORY,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
 
   /* Try to read data from the directory */
@@ -3643,12 +3646,12 @@ TEST_IMPL(fs_read_dir) {
    */
   ASSERT((r >= 0) || (r == UV_EISDIR));
 #else
-  ASSERT(r == UV_EISDIR);
+  ASSERT_EQ(r, UV_EISDIR);
 #endif
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -3695,7 +3698,7 @@ static void thread_main(void* arg) {
     if (ctx->doread) {
       result = write(ctx->fd, data, nbytes);
       /* Should not see EINTR (or other errors) */
-      ASSERT(result == nbytes);
+      ASSERT_EQ(result, nbytes);
     } else {
       result = read(ctx->fd, data, nbytes);
       /* Should not see EINTR (or other errors),
@@ -3757,13 +3760,13 @@ static void test_fs_partial(int doread) {
 
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_signal_init(loop, &signal));
-  ASSERT(0 == uv_signal_start(&signal, sig_func, SIGUSR1));
+  ASSERT_EQ(0, uv_signal_init(loop, &signal));
+  ASSERT_EQ(0, uv_signal_start(&signal, sig_func, SIGUSR1));
 
-  ASSERT(0 == pipe(pipe_fds));
+  ASSERT_EQ(0, pipe(pipe_fds));
 
   ctx.fd = pipe_fds[doread];
-  ASSERT(0 == uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
 
   if (doread) {
     uv_buf_t* read_iovs;
@@ -3780,34 +3783,34 @@ static void test_fs_partial(int doread) {
         iovcount -= read_iovcount;
         nread += result;
       } else {
-        ASSERT(result == UV_EINTR);
+        ASSERT_EQ(result, UV_EINTR);
       }
       uv_fs_req_cleanup(&read_req);
     }
   } else {
     int result;
     result = uv_fs_write(loop, &write_req, pipe_fds[1], iovs, iovcount, -1, NULL);
-    ASSERT(write_req.result == result);
-    ASSERT(result == ctx.size);
+    ASSERT_EQ(write_req.result, result);
+    ASSERT_EQ(result, ctx.size);
     uv_fs_req_cleanup(&write_req);
   }
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   ASSERT_MEM_EQ(buffer, ctx.data, ctx.size);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(0 == close(pipe_fds[1]));
+  ASSERT_EQ(0, close(pipe_fds[1]));
   uv_close((uv_handle_t*) &signal, NULL);
 
   { /* Make sure we read everything that we wrote. */
       int result;
       result = uv_fs_read(loop, &read_req, pipe_fds[0], iovs, 1, -1, NULL);
-      ASSERT(result == 0);
+      ASSERT_EQ(result, 0);
       uv_fs_req_cleanup(&read_req);
   }
-  ASSERT(0 == close(pipe_fds[0]));
+  ASSERT_EQ(0, close(pipe_fds[0]));
 
   free(iovs);
   free(buffer);
@@ -3832,13 +3835,13 @@ TEST_IMPL(fs_read_write_null_arguments) {
   int r;
 
   r = uv_fs_read(NULL, &read_req, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_write(NULL, &write_req, 0, NULL, 0, -1, NULL);
   /* Validate some memory management on failed input validation before sending
      fs work to the thread pool. */
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   ASSERT_NULL(write_req.path);
   ASSERT_NULL(write_req.ptr);
 #ifdef _WIN32
@@ -3853,36 +3856,36 @@ TEST_IMPL(fs_read_write_null_arguments) {
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_read(NULL, &read_req, 0, &iov, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(NULL, &write_req, 0, &iov, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_fs_req_cleanup(&write_req);
 
   /* If the arguments are invalid, the loop should not be kept open */
   loop = uv_default_loop();
 
   r = uv_fs_read(loop, &read_req, 0, NULL, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_write(loop, &write_req, 0, NULL, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_read(loop, &read_req, 0, &iov, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(NULL, 0);
   r = uv_fs_write(loop, &write_req, 0, &iov, 0, -1, fail_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_run(loop, UV_RUN_DEFAULT);
   uv_fs_req_cleanup(&write_req);
 
@@ -3906,20 +3909,20 @@ TEST_IMPL(get_osfhandle_valid_handle) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   fd = uv_get_osfhandle(open_req1.result);
 #ifdef _WIN32
-  ASSERT(fd != INVALID_HANDLE_VALUE);
+  ASSERT_NE(fd, INVALID_HANDLE_VALUE);
 #else
-  ASSERT(fd >= 0);
+  ASSERT_GE(fd, 0);
 #endif
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup. */
@@ -3945,27 +3948,27 @@ TEST_IMPL(open_osfhandle_valid_handle) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   handle = uv_get_osfhandle(open_req1.result);
 #ifdef _WIN32
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
 #else
-  ASSERT(handle >= 0);
+  ASSERT_GE(handle, 0);
 #endif
 
   fd = uv_open_osfhandle(handle);
 #ifdef _WIN32
-  ASSERT(fd > 0);
+  ASSERT_GT(fd, 0);
 #else
-  ASSERT(fd == open_req1.result);
+  ASSERT_EQ(fd, open_req1.result);
 #endif
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup. */
@@ -3988,24 +3991,24 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
                  O_RDWR | O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r > 0);
+  ASSERT_GT(r, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(test_buf, sizeof(test_buf));
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 0, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(lseek(open_req1.result, 0, SEEK_CUR) == 0);
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, 0, NULL);
-  ASSERT(r == sizeof(test_buf));
-  ASSERT(strcmp(buf, test_buf) == 0);
-  ASSERT(lseek(open_req1.result, 0, SEEK_CUR) == 0);
+  ASSERT_EQ(r, sizeof(test_buf));
+  ASSERT_EQ(strcmp(buf, test_buf), 0);
+  ASSERT_EQ(lseek(open_req1.result, 0, SEEK_CUR), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4021,30 +4024,30 @@ static void fs_file_pos_common(void) {
 
   iov = uv_buf_init("abc", 3);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 3);
+  ASSERT_EQ(r, 3);
   uv_fs_req_cleanup(&write_req);
 
   /* Read with offset should not change the position */
   iov = uv_buf_init(buf, 1);
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
-  ASSERT(buf[0] == 'b');
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(buf[0], 'b');
   uv_fs_req_cleanup(&read_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 
   /* Write without offset should change the position */
   iov = uv_buf_init("d", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 }
 
@@ -4053,23 +4056,23 @@ static void fs_file_pos_close_check(const char *contents, int size) {
 
   /* Close */
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Confirm file contents */
   r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == size);
-  ASSERT(strncmp(buf, contents, size) == 0);
+  ASSERT_EQ(r, size);
+  ASSERT_EQ(strncmp(buf, contents, size), 0);
   uv_fs_req_cleanup(&read_req);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4088,7 +4091,7 @@ static void fs_file_pos_write(int add_flags) {
                  O_TRUNC | O_CREAT | O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r > 0);
+  ASSERT_GT(r, 0);
   uv_fs_req_cleanup(&open_req1);
 
   fs_file_pos_common();
@@ -4096,12 +4099,12 @@ static void fs_file_pos_write(int add_flags) {
   /* Write with offset should not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&read_req);
 
   fs_file_pos_close_check("aecd", 4);
@@ -4126,7 +4129,7 @@ static void fs_file_pos_append(int add_flags) {
                  O_APPEND | O_CREAT | O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r > 0);
+  ASSERT_GT(r, 0);
   uv_fs_req_cleanup(&open_req1);
 
   fs_file_pos_common();
@@ -4135,13 +4138,13 @@ static void fs_file_pos_append(int add_flags) {
    * but does not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT(r == 1);
-  ASSERT(buf[0] == 'e');
+  ASSERT_EQ(r, 1);
+  ASSERT_EQ(buf[0], 'e');
   uv_fs_req_cleanup(&read_req);
 
   fs_file_pos_close_check("abcde", 5);
@@ -4160,97 +4163,97 @@ TEST_IMPL(fs_null_req) {
   int r;
 
   r = uv_fs_open(NULL, NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_close(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_read(NULL, NULL, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_write(NULL, NULL, 0, NULL, 0, -1, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_unlink(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkdir(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkdtemp(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_mkstemp(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_rmdir(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_scandir(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_link(NULL, NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_symlink(NULL, NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_readlink(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_realpath(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_chown(NULL, NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fchown(NULL, NULL, 0, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_stat(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_lstat(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fstat(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_rename(NULL, NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fsync(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fdatasync(NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_ftruncate(NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_copyfile(NULL, NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_sendfile(NULL, NULL, 0, 0, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_access(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_chmod(NULL, NULL, NULL, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_fchmod(NULL, NULL, 0, 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_utime(NULL, NULL, NULL, 0.0, 0.0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_futime(NULL, NULL, 0, 0.0, 0.0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_fs_statfs(NULL, NULL, NULL, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* This should be a no-op. */
   uv_fs_req_cleanup(NULL);
@@ -4265,7 +4268,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   /* Setup. */
   unlink("test_file");
 
-  ASSERT(UV_FS_O_EXLOCK > 0);
+  ASSERT_GT(UV_FS_O_EXLOCK, 0);
 
   r = uv_fs_open(NULL,
                  &open_req1,
@@ -4273,8 +4276,8 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  O_RDWR | O_CREAT | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_open(NULL,
@@ -4283,13 +4286,13 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  O_RDONLY | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r < 0);
-  ASSERT(open_req2.result < 0);
+  ASSERT_LT(r, 0);
+  ASSERT_LT(open_req2.result, 0);
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL,
@@ -4298,13 +4301,13 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
                  O_RDONLY | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req2.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req2.result, 0);
   uv_fs_req_cleanup(&open_req2);
 
   r = uv_fs_close(NULL, &close_req, open_req2.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* Cleanup */
@@ -4322,10 +4325,10 @@ TEST_IMPL(fs_file_flag_no_buffering) {
   /* Setup. */
   unlink("test_file");
 
-  ASSERT(UV_FS_O_APPEND > 0);
-  ASSERT(UV_FS_O_CREAT > 0);
-  ASSERT(UV_FS_O_DIRECT > 0);
-  ASSERT(UV_FS_O_RDWR > 0);
+  ASSERT_GT(UV_FS_O_APPEND, 0);
+  ASSERT_GT(UV_FS_O_CREAT, 0);
+  ASSERT_GT(UV_FS_O_DIRECT, 0);
+  ASSERT_GT(UV_FS_O_RDWR, 0);
 
   /* FILE_APPEND_DATA must be excluded from FILE_GENERIC_WRITE: */
   r = uv_fs_open(NULL,
@@ -4334,13 +4337,13 @@ TEST_IMPL(fs_file_flag_no_buffering) {
                  UV_FS_O_RDWR | UV_FS_O_CREAT | UV_FS_O_DIRECT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r >= 0);
-  ASSERT(open_req1.result >= 0);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-  ASSERT(r == 0);
-  ASSERT(close_req.result == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(close_req.result, 0);
   uv_fs_req_cleanup(&close_req);
 
   /* FILE_APPEND_DATA and FILE_FLAG_NO_BUFFERING are mutually exclusive: */
@@ -4350,8 +4353,8 @@ TEST_IMPL(fs_file_flag_no_buffering) {
                  UV_FS_O_APPEND | UV_FS_O_DIRECT,
                  S_IWUSR | S_IRUSR,
                  NULL);
-  ASSERT(r == UV_EINVAL);
-  ASSERT(open_req2.result == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
+  ASSERT_EQ(open_req2.result, UV_EINVAL);
   uv_fs_req_cleanup(&open_req2);
 
   /* Cleanup */
@@ -4392,7 +4395,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     /* Setup - clear the ACL and remove the file */
     loop = uv_default_loop();
     r = uv_os_get_passwd(&pwd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     call_icacls("icacls test_file_icacls /remove \"%s\" /inheritance:e",
                 pwd.username);
     uv_fs_chmod(loop, &req, "test_file_icacls", S_IWUSR, NULL);
@@ -4405,12 +4408,12 @@ TEST_IMPL(fs_open_readonly_acl) {
                    O_RDONLY | O_CREAT,
                    S_IRUSR,
                    NULL);
-    ASSERT(r >= 0);
-    ASSERT(open_req1.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(open_req1.result, 0);
     uv_fs_req_cleanup(&open_req1);
     r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
-    ASSERT(r == 0);
-    ASSERT(close_req.result == 0);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(close_req.result, 0);
     uv_fs_req_cleanup(&close_req);
 
     /* Set up ACL */
@@ -4442,7 +4445,7 @@ TEST_IMPL(fs_open_readonly_acl) {
                 pwd.username);
     unlink("test_file_icacls");
     uv_os_free_passwd(&pwd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     MAKE_VALGRIND_HAPPY(loop);
     return 0;
 }
@@ -4463,35 +4466,35 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
                    O_WRONLY | O_CREAT,
                    S_IWUSR | S_IRUSR,
                    NULL);
-    ASSERT(r >= 0);
-    ASSERT(req.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(req.result, 0);
     file = req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_fs_req_cleanup(&req);
     /* Make the file read-only and clear archive flag */
     r = SetFileAttributes("test_file", FILE_ATTRIBUTE_READONLY);
-    ASSERT(r != 0);
+    ASSERT(r);
     check_permission("test_file", 0400);
     /* Try fchmod */
     r = uv_fs_open(NULL, &req, "test_file", O_RDONLY, 0, NULL);
-    ASSERT(r >= 0);
-    ASSERT(req.result >= 0);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(req.result, 0);
     file = req.result;
     uv_fs_req_cleanup(&req);
     r = uv_fs_fchmod(NULL, &req, file, S_IWUSR, NULL);
-    ASSERT(r == 0);
-    ASSERT(req.result == 0);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(req.result, 0);
     uv_fs_req_cleanup(&req);
     r = uv_fs_close(NULL, &req, file, NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_fs_req_cleanup(&req);
     check_permission("test_file", S_IWUSR);
 
     /* Restore Archive flag for rest of the tests */
     r = SetFileAttributes("test_file", FILE_ATTRIBUTE_ARCHIVE);
-    ASSERT(r != 0);
+    ASSERT(r);
 
     return 0;
 }
@@ -4503,7 +4506,7 @@ TEST_IMPL(fs_invalid_mkdir_name) {
 
   loop = uv_default_loop();
   r = uv_fs_mkdir(loop, &req, "invalid>", 0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   ASSERT_EQ(UV_EINVAL, uv_fs_mkdir(loop, &req, "test:lol", 0, NULL));
 
   return 0;
@@ -4518,15 +4521,15 @@ TEST_IMPL(fs_statfs) {
 
   /* Test the synchronous version. */
   r = uv_fs_statfs(NULL, &req, ".", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   statfs_cb(&req);
-  ASSERT(statfs_cb_count == 1);
+  ASSERT_EQ(statfs_cb_count, 1);
 
   /* Test the asynchronous version. */
   r = uv_fs_statfs(loop, &req, ".", statfs_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(statfs_cb_count == 2);
+  ASSERT_EQ(statfs_cb_count, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -4538,13 +4541,13 @@ TEST_IMPL(fs_get_system_error) {
   int system_error;
 
   r = uv_fs_statfs(NULL, &req, "non_existing_file", NULL);
-  ASSERT(r != 0);
+  ASSERT(r);
 
   system_error = uv_fs_get_system_error(&req);
 #ifdef _WIN32
-  ASSERT(system_error == ERROR_FILE_NOT_FOUND);
+  ASSERT_EQ(system_error, ERROR_FILE_NOT_FOUND);
 #else
-  ASSERT(system_error == ENOENT);
+  ASSERT_EQ(system_error, ENOENT);
 #endif
 
   return 0;
@@ -4601,7 +4604,7 @@ TEST_IMPL(fs_wtf) {
                             FILE_FLAG_OPEN_REPARSE_POINT |
                               FILE_FLAG_BACKUP_SEMANTICS,
                             NULL);
-  ASSERT(file_handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(file_handle, INVALID_HANDLE_VALUE);
 
   CloseHandle(file_handle);
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -519,9 +519,9 @@ static void check_mkdtemp_result(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_MKDTEMP);
   ASSERT_OK(req->result);
   ASSERT(req->path);
-  ASSERT_EQ(strlen(req->path), 15);
+  ASSERT_EQ(15, strlen(req->path));
   ASSERT_OK(memcmp(req->path, "test_dir_", 9));
-  ASSERT_NE(memcmp(req->path + 9, "XXXXXX", 6), 0);
+  ASSERT_NE(0, memcmp(req->path + 9, "XXXXXX", 6));
   check_permission(req->path, 0700);
 
   /* Check if req->path is actually a directory */
@@ -545,9 +545,9 @@ static void check_mkstemp_result(uv_fs_t* req) {
   ASSERT_EQ(req->fs_type, UV_FS_MKSTEMP);
   ASSERT_GE(req->result, 0);
   ASSERT(req->path);
-  ASSERT_EQ(strlen(req->path), 16);
+  ASSERT_EQ(16, strlen(req->path));
   ASSERT_OK(memcmp(req->path, "test_file_", 10));
-  ASSERT_NE(memcmp(req->path + 10, "XXXXXX", 6), 0);
+  ASSERT_NE(0, memcmp(req->path + 10, "XXXXXX", 6));
   check_permission(req->path, 0600);
 
   /* Check if req->path is actually a file */
@@ -590,7 +590,7 @@ static void assert_is_file_type(uv_dirent_t dent) {
   #if defined(__APPLE__) || defined(_WIN32)
     ASSERT_EQ(dent.type, UV_DIRENT_FILE);
   #else
-    ASSERT_NE(dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN, 0);
+    ASSERT(dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN);
   #endif
 #else
   ASSERT_EQ(dent.type, UV_DIRENT_UNKNOWN);
@@ -602,11 +602,11 @@ static void scandir_cb(uv_fs_t* req) {
   uv_dirent_t dent;
   ASSERT_PTR_EQ(req, &scandir_req);
   ASSERT_EQ(req->fs_type, UV_FS_SCANDIR);
-  ASSERT_EQ(req->result, 2);
+  ASSERT_EQ(2, req->result);
   ASSERT(req->ptr);
 
   while (UV_EOF != uv_fs_scandir_next(req, &dent)) {
-    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
+    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
     assert_is_file_type(dent);
   }
   scandir_cb_count++;
@@ -675,7 +675,7 @@ static void stat_batch_cb(uv_fs_t* req) {
 static void sendfile_cb(uv_fs_t* req) {
   ASSERT_PTR_EQ(req, &sendfile_req);
   ASSERT_EQ(req->fs_type, UV_FS_SENDFILE);
-  ASSERT_EQ(req->result, 65545);
+  ASSERT_EQ(65545, req->result);
   sendfile_cb_count++;
   uv_fs_req_cleanup(req);
 }
@@ -728,7 +728,7 @@ TEST_IMPL(fs_file_noent) {
 
   ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(1, open_cb_count);
 
   /* TODO add EACCES test */
 
@@ -756,7 +756,7 @@ TEST_IMPL(fs_file_nametoolong) {
 
   ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(1, open_cb_count);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -796,7 +796,7 @@ TEST_IMPL(fs_file_loop) {
 
   ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(1, open_cb_count);
 
   unlink("test_symlink");
 
@@ -923,45 +923,45 @@ TEST_IMPL(fs_file_async) {
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(create_cb_count, 1);
-  ASSERT_EQ(write_cb_count, 1);
-  ASSERT_EQ(fsync_cb_count, 1);
-  ASSERT_EQ(fdatasync_cb_count, 1);
-  ASSERT_EQ(close_cb_count, 1);
+  ASSERT_EQ(1, create_cb_count);
+  ASSERT_EQ(1, write_cb_count);
+  ASSERT_EQ(1, fsync_cb_count);
+  ASSERT_EQ(1, fdatasync_cb_count);
+  ASSERT_EQ(1, close_cb_count);
 
   r = uv_fs_rename(loop, &rename_req, "test_file", "test_file2", rename_cb);
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(create_cb_count, 1);
-  ASSERT_EQ(write_cb_count, 1);
-  ASSERT_EQ(close_cb_count, 1);
-  ASSERT_EQ(rename_cb_count, 1);
+  ASSERT_EQ(1, create_cb_count);
+  ASSERT_EQ(1, write_cb_count);
+  ASSERT_EQ(1, close_cb_count);
+  ASSERT_EQ(1, rename_cb_count);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 1);
-  ASSERT_EQ(read_cb_count, 1);
-  ASSERT_EQ(close_cb_count, 2);
-  ASSERT_EQ(rename_cb_count, 1);
-  ASSERT_EQ(create_cb_count, 1);
-  ASSERT_EQ(write_cb_count, 1);
-  ASSERT_EQ(ftruncate_cb_count, 1);
+  ASSERT_EQ(1, open_cb_count);
+  ASSERT_EQ(1, read_cb_count);
+  ASSERT_EQ(2, close_cb_count);
+  ASSERT_EQ(1, rename_cb_count);
+  ASSERT_EQ(1, create_cb_count);
+  ASSERT_EQ(1, write_cb_count);
+  ASSERT_EQ(1, ftruncate_cb_count);
 
   r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 2);
-  ASSERT_EQ(read_cb_count, 2);
-  ASSERT_EQ(close_cb_count, 3);
-  ASSERT_EQ(rename_cb_count, 1);
-  ASSERT_EQ(unlink_cb_count, 1);
-  ASSERT_EQ(create_cb_count, 1);
-  ASSERT_EQ(write_cb_count, 1);
-  ASSERT_EQ(ftruncate_cb_count, 1);
+  ASSERT_EQ(2, open_cb_count);
+  ASSERT_EQ(2, read_cb_count);
+  ASSERT_EQ(3, close_cb_count);
+  ASSERT_EQ(1, rename_cb_count);
+  ASSERT_EQ(1, unlink_cb_count);
+  ASSERT_EQ(1, create_cb_count);
+  ASSERT_EQ(1, write_cb_count);
+  ASSERT_EQ(1, ftruncate_cb_count);
 
   /* Cleanup. */
   unlink("test_file");
@@ -1113,7 +1113,7 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(mkdir_cb_count, 1);
+  ASSERT_EQ(1, mkdir_cb_count);
 
   /* Create 2 files synchronously. */
   r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
@@ -1136,15 +1136,15 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(scandir_cb_count, 1);
+  ASSERT_EQ(1, scandir_cb_count);
 
   /* sync uv_fs_scandir */
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT_EQ(r, 2);
-  ASSERT_EQ(scandir_req.result, 2);
+  ASSERT_EQ(2, r);
+  ASSERT_EQ(2, scandir_req.result);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
+    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
@@ -1166,22 +1166,22 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(stat_cb_count, 4);
+  ASSERT_EQ(4, stat_cb_count);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file1", unlink_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(unlink_cb_count, 1);
+  ASSERT_EQ(1, unlink_cb_count);
 
   r = uv_fs_unlink(loop, &unlink_req, "test_dir/file2", unlink_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(unlink_cb_count, 2);
+  ASSERT_EQ(2, unlink_cb_count);
 
   r = uv_fs_rmdir(loop, &rmdir_req, "test_dir", rmdir_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(rmdir_cb_count, 1);
+  ASSERT_EQ(1, rmdir_cb_count);
 
   /* Cleanup */
   unlink("test_dir/file1");
@@ -1231,7 +1231,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(sendfile_cb_count, 1);
+  ASSERT_EQ(1, sendfile_cb_count);
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT_OK(r);
@@ -1300,7 +1300,7 @@ TEST_IMPL(fs_mkdtemp) {
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(mkdtemp_cb_count, 1);
+  ASSERT_EQ(1, mkdtemp_cb_count);
 
   /* sync mkdtemp */
   r = uv_fs_mkdtemp(NULL, &mkdtemp_req2, path_template, NULL);
@@ -1308,7 +1308,7 @@ TEST_IMPL(fs_mkdtemp) {
   check_mkdtemp_result(&mkdtemp_req2);
 
   /* mkdtemp return different values on subsequent calls */
-  ASSERT_NE(strcmp(mkdtemp_req1.path, mkdtemp_req2.path), 0);
+  ASSERT_NE(0, strcmp(mkdtemp_req1.path, mkdtemp_req2.path));
 
   /* Cleanup */
   rmdir(mkdtemp_req1.path);
@@ -1333,7 +1333,7 @@ TEST_IMPL(fs_mkstemp) {
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(mkstemp_cb_count, 1);
+  ASSERT_EQ(1, mkstemp_cb_count);
 
   /* sync mkstemp */
   r = uv_fs_mkstemp(NULL, &mkstemp_req2, path_template, NULL);
@@ -1341,7 +1341,7 @@ TEST_IMPL(fs_mkstemp) {
   check_mkstemp_result(&mkstemp_req2);
 
   /* mkstemp return different values on subsequent calls */
-  ASSERT_NE(strcmp(mkstemp_req1.path, mkstemp_req2.path), 0);
+  ASSERT_NE(0, strcmp(mkstemp_req1.path, mkstemp_req2.path));
 
   /* invalid template returns EINVAL */
   ASSERT_EQ(UV_EINVAL, uv_fs_mkstemp(NULL, &mkstemp_req3, "test_file", NULL));
@@ -1531,7 +1531,7 @@ TEST_IMPL(fs_fstat) {
   r = uv_fs_fstat(loop, &req, file, fstat_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(fstat_cb_count, 1);
+  ASSERT_EQ(1, fstat_cb_count);
 
 
   r = uv_fs_close(NULL, &req, file, NULL);
@@ -1574,7 +1574,7 @@ TEST_IMPL(fs_fstat_stdio) {
     case UV_TTY:
     case UV_NAMED_PIPE:
       ASSERT_EQ(st->st_mode, (ft == UV_TTY ? S_IFCHR : S_IFIFO));
-      ASSERT_EQ(st->st_nlink, 1);
+      ASSERT_EQ(1, st->st_nlink);
       ASSERT_EQ(st->st_rdev,
                 (ft == UV_TTY ? FILE_DEVICE_CONSOLE : FILE_DEVICE_NAMED_PIPE)
                 << 16);
@@ -1613,7 +1613,7 @@ TEST_IMPL(fs_access) {
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(access_cb_count, 1);
+  ASSERT_EQ(1, access_cb_count);
   access_cb_count = 0; /* reset for the next test */
 
   /* Create file */
@@ -1634,7 +1634,7 @@ TEST_IMPL(fs_access) {
   r = uv_fs_access(loop, &req, "test_file", F_OK, access_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(access_cb_count, 1);
+  ASSERT_EQ(1, access_cb_count);
   access_cb_count = 0; /* reset for the next test */
 
   /* Close file */
@@ -1726,7 +1726,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_chmod(loop, &req, "test_file", 0200, chmod_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(chmod_cb_count, 1);
+  ASSERT_EQ(1, chmod_cb_count);
   chmod_cb_count = 0; /* reset for the next test */
 #endif
 
@@ -1738,7 +1738,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_chmod(loop, &req, "test_file", 0400, chmod_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(chmod_cb_count, 1);
+  ASSERT_EQ(1, chmod_cb_count);
 
   /* async fchmod */
   {
@@ -1748,7 +1748,7 @@ TEST_IMPL(fs_chmod) {
   r = uv_fs_fchmod(loop, &req, file, 0600, fchmod_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(fchmod_cb_count, 1);
+  ASSERT_EQ(1, fchmod_cb_count);
 
   uv_fs_close(loop, &req, file, NULL);
 
@@ -1917,7 +1917,7 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_chown(loop, &req, "test_file", -1, -1, chown_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(chown_cb_count, 1);
+  ASSERT_EQ(1, chown_cb_count);
 
 #ifndef __MVS__
   /* chown to root (fail) */
@@ -1925,14 +1925,14 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_chown(loop, &req, "test_file", 0, 0, chown_root_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(chown_cb_count, 1);
+  ASSERT_EQ(1, chown_cb_count);
 #endif
 
   /* async fchown */
   r = uv_fs_fchown(loop, &req, file, -1, -1, fchown_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(fchown_cb_count, 1);
+  ASSERT_EQ(1, fchown_cb_count);
 
 #ifndef __HAIKU__
   /* Haiku doesn't support hardlink */
@@ -1952,7 +1952,7 @@ TEST_IMPL(fs_chown) {
   r = uv_fs_lchown(loop, &req, "test_file_link", -1, -1, lchown_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(lchown_cb_count, 1);
+  ASSERT_EQ(1, lchown_cb_count);
 #endif
 
   /* Close file */
@@ -2029,7 +2029,7 @@ TEST_IMPL(fs_link) {
   r = uv_fs_link(loop, &req, "test_file", "test_file_link2", link_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(link_cb_count, 1);
+  ASSERT_EQ(1, link_cb_count);
 
   r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
@@ -2070,7 +2070,7 @@ TEST_IMPL(fs_readlink) {
     loop = uv_default_loop();
     ASSERT_OK(uv_fs_readlink(loop, &req, "no_such_file", dummy_cb));
     ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-    ASSERT_EQ(dummy_cb_count, 1);
+    ASSERT_EQ(1, dummy_cb_count);
     ASSERT_NULL(req.ptr);
     ASSERT_EQ(req.result, UV_ENOENT);
     uv_fs_req_cleanup(&req);
@@ -2122,7 +2122,7 @@ TEST_IMPL(fs_realpath) {
   loop = uv_default_loop();
   ASSERT_OK(uv_fs_realpath(loop, &req, "no_such_file", dummy_cb));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(dummy_cb_count, 1);
+  ASSERT_EQ(1, dummy_cb_count);
   ASSERT_NULL(req.ptr);
   ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
@@ -2251,7 +2251,7 @@ TEST_IMPL(fs_symlink) {
                     symlink_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(symlink_cb_count, 1);
+  ASSERT_EQ(1, symlink_cb_count);
 
   r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
@@ -2280,12 +2280,12 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_readlink(loop, &req, "test_file_symlink2_symlink", readlink_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(readlink_cb_count, 1);
+  ASSERT_EQ(1, readlink_cb_count);
 
   r = uv_fs_realpath(loop, &req, "test_file", realpath_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(realpath_cb_count, 1);
+  ASSERT_EQ(1, realpath_cb_count);
 
   /*
    * Run the loop just to check we don't have make any extraneous uv_ref()
@@ -2409,11 +2409,11 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir_symlink", 0, NULL);
-  ASSERT_EQ(r, 2);
-  ASSERT_EQ(scandir_req.result, 2);
+  ASSERT_EQ(2, r);
+  ASSERT_EQ(2, scandir_req.result);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
+    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
@@ -2429,11 +2429,11 @@ int test_symlink_dir_impl(int type) {
   uv_fs_req_cleanup(&scandir_req);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT_EQ(r, 2);
-  ASSERT_EQ(scandir_req.result, 2);
+  ASSERT_EQ(2, r);
+  ASSERT_EQ(2, scandir_req.result);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
-    ASSERT_NE(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0, 0);
+    ASSERT(strcmp(dent.name, "file1") == 0 || strcmp(dent.name, "file2") == 0);
     assert_is_file_type(dent);
   }
   uv_fs_req_cleanup(&scandir_req);
@@ -2536,8 +2536,8 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
 */
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT_EQ(r, 1);
-  ASSERT_EQ(scandir_req.result, 1);
+  ASSERT_EQ(1, r);
+  ASSERT_EQ(1, scandir_req.result);
   ASSERT(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     ASSERT_OK(strcmp(dent.name, "test_file"));
@@ -2647,7 +2647,7 @@ TEST_IMPL(fs_utime) {
   r = uv_fs_utime(loop, &utime_req, path, atime, mtime, utime_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(utime_cb_count, 1);
+  ASSERT_EQ(1, utime_cb_count);
 
   /* Cleanup. */
   unlink(path);
@@ -2780,7 +2780,7 @@ TEST_IMPL(fs_futime) {
   r = uv_fs_futime(loop, &futime_req, file, atime, mtime, futime_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(futime_cb_count, 1);
+  ASSERT_EQ(1, futime_cb_count);
 
   /* Cleanup. */
   unlink(path);
@@ -2841,7 +2841,7 @@ TEST_IMPL(fs_lutime) {
 #endif
   ASSERT_OK(r);
   lutime_cb(&req);
-  ASSERT_EQ(lutime_cb_count, 1);
+  ASSERT_EQ(1, lutime_cb_count);
 
   /* Test the asynchronous version. */
   atime = mtime = 1291404900; /* 2010-12-03 20:35:00 */
@@ -2853,7 +2853,7 @@ TEST_IMPL(fs_lutime) {
   r = uv_fs_lutime(loop, &req, symlink_path, atime, mtime, lutime_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(lutime_cb_count, 2);
+  ASSERT_EQ(2, lutime_cb_count);
 
   /* Cleanup. */
   unlink(path);
@@ -2907,7 +2907,7 @@ TEST_IMPL(fs_scandir_empty_dir) {
 
   ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(scandir_cb_count, 1);
+  ASSERT_EQ(1, scandir_cb_count);
 
   uv_fs_rmdir(NULL, &req, path, NULL);
   uv_fs_req_cleanup(&req);
@@ -2944,7 +2944,7 @@ TEST_IMPL(fs_scandir_non_existent_dir) {
 
   ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(scandir_cb_count, 1);
+  ASSERT_EQ(1, scandir_cb_count);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -2966,7 +2966,7 @@ TEST_IMPL(fs_scandir_file) {
 
   ASSERT_OK(scandir_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(scandir_cb_count, 1);
+  ASSERT_EQ(1, scandir_cb_count);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -3014,7 +3014,7 @@ TEST_IMPL(fs_open_dir) {
 
   ASSERT_OK(open_cb_count);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(open_cb_count, 1);
+  ASSERT_EQ(1, open_cb_count);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -3072,8 +3072,8 @@ static void fs_file_open_append(int add_flags) {
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
   printf("read = %d\n", r);
-  ASSERT_EQ(r, 26);
-  ASSERT_EQ(read_req.result, 26);
+  ASSERT_EQ(26, r);
+  ASSERT_EQ(26, read_req.result);
   ASSERT_OK(memcmp(buf,
                    "test-buffer\n\0test-buffer\n\0",
                    sizeof("test-buffer\n\0test-buffer\n\0") - 1));
@@ -3194,7 +3194,7 @@ static void fs_read_bufs(int add_flags) {
                             2,  /* 2x 256 bytes. */
                             0,  /* Positional read. */
                             NULL));
-  ASSERT_EQ(read_req.result, 446);
+  ASSERT_EQ(446, read_req.result);
   uv_fs_req_cleanup(&read_req);
 
   ASSERT_EQ(190, uv_fs_read(NULL,
@@ -3616,7 +3616,7 @@ TEST_IMPL(fs_read_dir) {
   r = uv_fs_mkdir(loop, &mkdir_req, "test_dir", 0755, mkdir_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(mkdir_cb_count, 1);
+  ASSERT_EQ(1, mkdir_cb_count);
   /* Setup Done Here */
 
   /* Get a file descriptor for the directory */
@@ -4024,13 +4024,13 @@ static void fs_file_pos_common(void) {
 
   iov = uv_buf_init("abc", 3);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 3);
+  ASSERT_EQ(3, r);
   uv_fs_req_cleanup(&write_req);
 
   /* Read with offset should not change the position */
   iov = uv_buf_init(buf, 1);
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   ASSERT_EQ(buf[0], 'b');
   uv_fs_req_cleanup(&read_req);
 
@@ -4042,7 +4042,7 @@ static void fs_file_pos_common(void) {
   /* Write without offset should change the position */
   iov = uv_buf_init("d", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -4099,7 +4099,7 @@ static void fs_file_pos_write(int add_flags) {
   /* Write with offset should not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
@@ -4138,12 +4138,12 @@ static void fs_file_pos_append(int add_flags) {
    * but does not change the position */
   iov = uv_buf_init("e", 1);
   r = uv_fs_write(NULL, &write_req, open_req1.result, &iov, 1, 1, NULL);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   uv_fs_req_cleanup(&write_req);
 
   iov = uv_buf_init(buf, sizeof(buf));
   r = uv_fs_read(NULL, &read_req, open_req1.result, &iov, 1, -1, NULL);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   ASSERT_EQ(buf[0], 'e');
   uv_fs_req_cleanup(&read_req);
 
@@ -4523,13 +4523,13 @@ TEST_IMPL(fs_statfs) {
   r = uv_fs_statfs(NULL, &req, ".", NULL);
   ASSERT_OK(r);
   statfs_cb(&req);
-  ASSERT_EQ(statfs_cb_count, 1);
+  ASSERT_EQ(1, statfs_cb_count);
 
   /* Test the asynchronous version. */
   r = uv_fs_statfs(loop, &req, ".", statfs_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(statfs_cb_count, 2);
+  ASSERT_EQ(2, statfs_cb_count);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -4609,8 +4609,8 @@ TEST_IMPL(fs_wtf) {
   CloseHandle(file_handle);
 
   r = uv_fs_scandir(NULL, &scandir_req, "test_dir", 0, NULL);
-  ASSERT_EQ(r, 1);
-  ASSERT_EQ(scandir_req.result, 1);
+  ASSERT_EQ(1, r);
+  ASSERT_EQ(1, scandir_req.result);
   ASSERT_NOT_NULL(scandir_req.ptr);
   while (UV_EOF != uv_fs_scandir_next(&scandir_req, &dent)) {
     snprintf(test_file_buf, sizeof(test_file_buf), "test_dir\\%s", dent.name);

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -87,7 +87,7 @@ TEST_IMPL(get_currentexe) {
   size = 2;
   r = uv_exepath(buffer, &size);
   ASSERT_OK(r);
-  ASSERT_EQ(size, 1);
+  ASSERT_EQ(1, size);
   ASSERT_NE(buffer[0], '\0');
   ASSERT_EQ(buffer[1], '\0');
 

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -78,25 +78,25 @@ TEST_IMPL(get_currentexe) {
 
   size = 1;
   r = uv_exepath(buffer, &size);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(size, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(size);
   ASSERT_EQ(buffer[0], '\0');
 
   memset(buffer, -1, sizeof(buffer));
 
   size = 2;
   r = uv_exepath(buffer, &size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(size, 1);
   ASSERT_NE(buffer[0], '\0');
   ASSERT_EQ(buffer[1], '\0');
 
   /* Verify uv_exepath is not affected by uv_set_process_title(). */
   r = uv_set_process_title("foobar");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   size = sizeof(buffer);
   r = uv_exepath(buffer, &size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   match = strstr(buffer, path);
   /* Verify that the path returned from uv_exepath is a subdirectory of

--- a/test/test-get-currentexe.c
+++ b/test/test-get-currentexe.c
@@ -60,36 +60,36 @@ TEST_IMPL(get_currentexe) {
    * executable_path.
    */
   ASSERT(match && !strcmp(match, path));
-  ASSERT(size == strlen(buffer));
+  ASSERT_EQ(size, strlen(buffer));
 
   /* Negative tests */
   size = sizeof(buffer) / sizeof(buffer[0]);
   r = uv_exepath(NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_exepath(buffer, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   size = 0;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   memset(buffer, -1, sizeof(buffer));
 
   size = 1;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == 0);
-  ASSERT(size == 0);
-  ASSERT(buffer[0] == '\0');
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(size, 0);
+  ASSERT_EQ(buffer[0], '\0');
 
   memset(buffer, -1, sizeof(buffer));
 
   size = 2;
   r = uv_exepath(buffer, &size);
-  ASSERT(r == 0);
-  ASSERT(size == 1);
-  ASSERT(buffer[0] != '\0');
-  ASSERT(buffer[1] == '\0');
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(size, 1);
+  ASSERT_NE(buffer[0], '\0');
+  ASSERT_EQ(buffer[1], '\0');
 
   /* Verify uv_exepath is not affected by uv_set_process_title(). */
   r = uv_set_process_title("foobar");

--- a/test/test-get-loadavg.c
+++ b/test/test-get-loadavg.c
@@ -27,9 +27,9 @@ TEST_IMPL(get_loadavg) {
   double avg[3] = {-1, -1, -1};
   uv_loadavg(avg);
 
-  ASSERT(avg[0] >= 0);
-  ASSERT(avg[1] >= 0);
-  ASSERT(avg[2] >= 0);
+  ASSERT_GE(avg[0], 0);
+  ASSERT_GE(avg[1], 0);
+  ASSERT_GE(avg[2], 0);
 
   return 0;
 }

--- a/test/test-get-memory.c
+++ b/test/test-get-memory.c
@@ -35,13 +35,13 @@ TEST_IMPL(get_memory) {
          (unsigned long long) constrained_mem,
          (unsigned long long) available_mem);
 
-  ASSERT(free_mem > 0);
-  ASSERT(total_mem > 0);
+  ASSERT_GT(free_mem, 0);
+  ASSERT_GT(total_mem, 0);
   /* On IBMi PASE, the amount of memory in use is always zero. */
 #ifdef __PASE__
-  ASSERT(total_mem == free_mem);
+  ASSERT_EQ(total_mem, free_mem);
 #else
-  ASSERT(total_mem > free_mem);
+  ASSERT_GT(total_mem, free_mem);
 #endif
   ASSERT_LE(available_mem, total_mem);
   /* we'd really want to test if available <= free, but that is fragile:

--- a/test/test-get-passwd.c
+++ b/test/test-get-passwd.c
@@ -39,7 +39,7 @@ TEST_IMPL(get_passwd) {
 
   /* Test the normal case */
   r = uv_os_get_passwd(&pwd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   len = strlen(pwd.username);
   ASSERT_GT(len, 0);
 
@@ -114,7 +114,7 @@ TEST_IMPL(get_passwd2) {
 
   /* Test the normal case */
   r = uv_os_get_passwd(&pwd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_os_get_passwd2(&pwd2, pwd.uid);
 
@@ -123,7 +123,7 @@ TEST_IMPL(get_passwd2) {
   (void) &len;
 
 #else
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(pwd.uid, pwd2.uid);
   ASSERT_STR_EQ(pwd.username, pwd2.username);
   ASSERT_STR_EQ(pwd.shell, pwd2.shell);
@@ -131,7 +131,7 @@ TEST_IMPL(get_passwd2) {
   uv_os_free_passwd(&pwd2);
 
   r = uv_os_get_passwd2(&pwd2, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   len = strlen(pwd2.username);
   ASSERT_GT(len, 0);
@@ -174,7 +174,7 @@ TEST_IMPL(get_group) {
   int r;
 
   r = uv_os_get_passwd(&pwd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_os_get_group(&grp, pwd.gid);
 
@@ -183,7 +183,7 @@ TEST_IMPL(get_group) {
   (void) &len;
 
 #else
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(pwd.gid, grp.gid);
 
   len = strlen(grp.groupname);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -40,7 +40,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
                                 int status,
                                 struct addrinfo* res) {
 
-  ASSERT_EQ(fail_cb_called, 0);
+  ASSERT_OK(fail_cb_called);
   ASSERT_LT(status, 0);
   ASSERT_NULL(res);
   uv_freeaddrinfo(res);  /* Should not crash. */
@@ -97,13 +97,13 @@ TEST_IMPL(getaddrinfo_fail) {
                                       NULL));
 
   /* Use a FQDN by ending in a period */
-  ASSERT_EQ(0, uv_getaddrinfo(uv_default_loop(),
-                              &req,
-                              getaddrinfo_fail_cb,
-                              "example.invalid.",
-                              NULL,
-                              NULL));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_getaddrinfo(uv_default_loop(),
+                           &req,
+                           getaddrinfo_fail_cb,
+                           "example.invalid.",
+                           NULL,
+                           NULL));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(fail_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -147,7 +147,7 @@ TEST_IMPL(getaddrinfo_basic) {
                      name,
                      NULL,
                      NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -165,12 +165,12 @@ TEST_IMPL(getaddrinfo_basic_sync) {
 #endif
   uv_getaddrinfo_t req;
 
-  ASSERT_EQ(0, uv_getaddrinfo(uv_default_loop(),
-                             &req,
-                             NULL,
-                             name,
-                             NULL,
-                             NULL));
+  ASSERT_OK(uv_getaddrinfo(uv_default_loop(),
+                           &req,
+                           NULL,
+                           name,
+                           NULL,
+                           NULL));
   uv_freeaddrinfo(req.addrinfo);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -201,7 +201,7 @@ TEST_IMPL(getaddrinfo_concurrent) {
                        name,
                        NULL,
                        NULL);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -104,7 +104,7 @@ TEST_IMPL(getaddrinfo_fail) {
                            NULL,
                            NULL));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(fail_cb_called, 1);
+  ASSERT_EQ(1, fail_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -151,7 +151,7 @@ TEST_IMPL(getaddrinfo_basic) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(getaddrinfo_cbs, 1);
+  ASSERT_EQ(1, getaddrinfo_cbs);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -207,7 +207,7 @@ TEST_IMPL(getaddrinfo_concurrent) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   for (i = 0; i < CONCURRENT_COUNT; i++) {
-    ASSERT_EQ(callback_counts[i], 1);
+    ASSERT_EQ(1, callback_counts[i]);
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -40,8 +40,8 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
                                 int status,
                                 struct addrinfo* res) {
 
-  ASSERT(fail_cb_called == 0);
-  ASSERT(status < 0);
+  ASSERT_EQ(fail_cb_called, 0);
+  ASSERT_LT(status, 0);
   ASSERT_NULL(res);
   uv_freeaddrinfo(res);  /* Should not crash. */
   fail_cb_called++;
@@ -51,7 +51,7 @@ static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req,
 static void getaddrinfo_basic_cb(uv_getaddrinfo_t* handle,
                                  int status,
                                  struct addrinfo* res) {
-  ASSERT(handle == getaddrinfo_handle);
+  ASSERT_PTR_EQ(handle, getaddrinfo_handle);
   getaddrinfo_cbs++;
   free(handle);
   uv_freeaddrinfo(res);
@@ -66,7 +66,7 @@ static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle,
 
   for (i = 0; i < CONCURRENT_COUNT; i++) {
     if (&getaddrinfo_handles[i] == handle) {
-      ASSERT(i == *data);
+      ASSERT_EQ(i, *data);
 
       callback_counts[i]++;
       break;
@@ -89,22 +89,22 @@ TEST_IMPL(getaddrinfo_fail) {
   
   uv_getaddrinfo_t req;
 
-  ASSERT(UV_EINVAL == uv_getaddrinfo(uv_default_loop(),
-                                     &req,
-                                     (uv_getaddrinfo_cb) abort,
-                                     NULL,
-                                     NULL,
-                                     NULL));
+  ASSERT_EQ(UV_EINVAL, uv_getaddrinfo(uv_default_loop(),
+                                      &req,
+                                      (uv_getaddrinfo_cb) abort,
+                                      NULL,
+                                      NULL,
+                                      NULL));
 
   /* Use a FQDN by ending in a period */
-  ASSERT(0 == uv_getaddrinfo(uv_default_loop(),
-                             &req,
-                             getaddrinfo_fail_cb,
-                             "example.invalid.",
-                             NULL,
-                             NULL));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(fail_cb_called == 1);
+  ASSERT_EQ(0, uv_getaddrinfo(uv_default_loop(),
+                              &req,
+                              getaddrinfo_fail_cb,
+                              "example.invalid.",
+                              NULL,
+                              NULL));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(fail_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -119,12 +119,12 @@ TEST_IMPL(getaddrinfo_fail_sync) {
   uv_getaddrinfo_t req;
 
   /* Use a FQDN by ending in a period */
-  ASSERT(0 > uv_getaddrinfo(uv_default_loop(),
-                            &req,
-                            NULL,
-                            "example.invalid.",
-                            NULL,
-                            NULL));
+  ASSERT_GT(0, uv_getaddrinfo(uv_default_loop(),
+                              &req,
+                              NULL,
+                              "example.invalid.",
+                              NULL,
+                              NULL));
   uv_freeaddrinfo(req.addrinfo);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -147,11 +147,11 @@ TEST_IMPL(getaddrinfo_basic) {
                      name,
                      NULL,
                      NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(getaddrinfo_cbs == 1);
+  ASSERT_EQ(getaddrinfo_cbs, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -165,7 +165,7 @@ TEST_IMPL(getaddrinfo_basic_sync) {
 #endif
   uv_getaddrinfo_t req;
 
-  ASSERT(0 == uv_getaddrinfo(uv_default_loop(),
+  ASSERT_EQ(0, uv_getaddrinfo(uv_default_loop(),
                              &req,
                              NULL,
                              name,
@@ -201,13 +201,13 @@ TEST_IMPL(getaddrinfo_concurrent) {
                        name,
                        NULL,
                        NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   for (i = 0; i < CONCURRENT_COUNT; i++) {
-    ASSERT(callback_counts[i] == 1);
+    ASSERT_EQ(callback_counts[i], 1);
   }
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -50,7 +50,7 @@ TEST_IMPL(gethostname) {
   /* Successfully get the hostname */
   size = UV_MAXHOSTNAMESIZE;
   r = uv_os_gethostname(buf, &size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(size > 0 && size == strlen(buf));
   ASSERT_EQ(size + 1, enobufs_size);
 

--- a/test/test-gethostname.c
+++ b/test/test-gethostname.c
@@ -32,27 +32,27 @@ TEST_IMPL(gethostname) {
   /* Reject invalid inputs */
   size = 1;
   r = uv_os_gethostname(NULL, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_gethostname(buf, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   size = 0;
   r = uv_os_gethostname(buf, &size);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Return UV_ENOBUFS if the buffer cannot hold the hostname */
   enobufs_size = 1;
   buf[0] = '\0';
   r = uv_os_gethostname(buf, &enobufs_size);
   ASSERT_EQ(r, UV_ENOBUFS);
-  ASSERT(buf[0] == '\0');
-  ASSERT(enobufs_size > 1);
+  ASSERT_EQ(buf[0], '\0');
+  ASSERT_GT(enobufs_size, 1);
 
   /* Successfully get the hostname */
   size = UV_MAXHOSTNAMESIZE;
   r = uv_os_gethostname(buf, &size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(size > 0 && size == strlen(buf));
-  ASSERT(size + 1 == enobufs_size);
+  ASSERT_EQ(size + 1, enobufs_size);
 
   return 0;
 }

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -39,7 +39,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
                             const char* hostname,
                             const char* service) {
   ASSERT_NOT_NULL(handle);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT_NOT_NULL(hostname);
   ASSERT_NOT_NULL(service);
 }
@@ -54,14 +54,14 @@ TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
   r = uv_ip4_addr(address_ip4, port, &addr4);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr4,
                      0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -76,15 +76,15 @@ TEST_IMPL(getnameinfo_basic_ip4_sync) {
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
 
-  ASSERT(0 == uv_ip4_addr(address_ip4, port, &addr4));
+  ASSERT_EQ(0, uv_ip4_addr(address_ip4, port, &addr4));
 
-  ASSERT(0 == uv_getnameinfo(uv_default_loop(),
+  ASSERT_EQ(0, uv_getnameinfo(uv_default_loop(),
                              &req,
                              NULL,
                              (const struct sockaddr*)&addr4,
                              0));
-  ASSERT(req.host[0] != '\0');
-  ASSERT(req.service[0] != '\0');
+  ASSERT_NE(req.host[0], '\0');
+  ASSERT_NE(req.service[0], '\0');
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -100,14 +100,14 @@ TEST_IMPL(getnameinfo_basic_ip6) {
   int r;
 
   r = uv_ip6_addr(address_ip6, port, &addr6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr6,
                      0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-getnameinfo.c
+++ b/test/test-getnameinfo.c
@@ -39,7 +39,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
                             const char* hostname,
                             const char* service) {
   ASSERT_NOT_NULL(handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_NOT_NULL(hostname);
   ASSERT_NOT_NULL(service);
 }
@@ -54,14 +54,14 @@ TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
   r = uv_ip4_addr(address_ip4, port, &addr4);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr4,
                      0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -76,13 +76,13 @@ TEST_IMPL(getnameinfo_basic_ip4_sync) {
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
 
-  ASSERT_EQ(0, uv_ip4_addr(address_ip4, port, &addr4));
+  ASSERT_OK(uv_ip4_addr(address_ip4, port, &addr4));
 
-  ASSERT_EQ(0, uv_getnameinfo(uv_default_loop(),
-                             &req,
-                             NULL,
-                             (const struct sockaddr*)&addr4,
-                             0));
+  ASSERT_OK(uv_getnameinfo(uv_default_loop(),
+                           &req,
+                           NULL,
+                           (const struct sockaddr*)&addr4,
+                           0));
   ASSERT_NE(req.host[0], '\0');
   ASSERT_NE(req.service[0], '\0');
 
@@ -100,14 +100,14 @@ TEST_IMPL(getnameinfo_basic_ip6) {
   int r;
 
   r = uv_ip6_addr(address_ip6, port, &addr6);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getnameinfo(uv_default_loop(),
                      &req,
                      &getnameinfo_req,
                      (const struct sockaddr*)&addr6,
                      0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -73,7 +73,7 @@ static void after_read(uv_stream_t* handle,
 
   req = (uv_shutdown_t*) malloc(sizeof *req);
   r = uv_shutdown(req, handle, after_shutdown);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -84,22 +84,22 @@ static void check_sockname(struct sockaddr* addr, const char* compare_ip,
   char check_ip[17];
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr(compare_ip, compare_port, &compare_addr));
+  ASSERT_OK(uv_ip4_addr(compare_ip, compare_port, &compare_addr));
 
   /* Both addresses should be ipv4 */
   ASSERT_EQ(check_addr.sin_family, AF_INET);
   ASSERT_EQ(compare_addr.sin_family, AF_INET);
 
   /* Check if the ip matches */
-  ASSERT_EQ(memcmp(&check_addr.sin_addr,
+  ASSERT_OK(memcmp(&check_addr.sin_addr,
             &compare_addr.sin_addr,
-            sizeof compare_addr.sin_addr), 0);
+            sizeof compare_addr.sin_addr));
 
   /* Check if the port matches. If port == 0 anything goes. */
   ASSERT_NE(compare_port == 0 || check_addr.sin_port == compare_addr.sin_port, 0);
 
   r = uv_ip4_name(&check_addr, (char*) check_ip, sizeof check_ip);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   printf("%s: %s:%d\n", context, check_ip, ntohs(check_addr.sin_port));
 }
@@ -114,34 +114,34 @@ static void on_connection(uv_stream_t* server, int status) {
   if (status != 0) {
     fprintf(stderr, "Connect error %s\n", uv_err_name(status));
   }
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   handle = malloc(sizeof(*handle));
   ASSERT_NOT_NULL(handle);
 
   r = uv_tcp_init(loop, handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* associate server with stream */
   handle->data = server;
 
   r = uv_accept(server, (uv_stream_t*)handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(handle, &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&sockname, "127.0.0.1", server_port, "accepted socket");
   getsocknamecount_tcp++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername(handle, &peername, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&peername, "127.0.0.1", connect_port, "accepted socket peer");
   getpeernamecount++;
 
   r = uv_read_start((uv_stream_t*)handle, alloc, after_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -149,17 +149,17 @@ static void on_connect(uv_connect_t* req, int status) {
   struct sockaddr sockname, peername;
   int r, namelen;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname((uv_tcp_t*) req->handle, &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&sockname, "127.0.0.1", 0, "connected socket");
   getsocknamecount_tcp++;
 
   namelen = sizeof peername;
   r = uv_tcp_getpeername((uv_tcp_t*) req->handle, &peername, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&peername, "127.0.0.1", server_port, "connected socket peer");
   getpeernamecount++;
 
@@ -173,7 +173,7 @@ static int tcp_listener(void) {
   int namelen;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", server_port, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", server_port, &addr));
 
   r = uv_tcp_init(loop, &tcpServer);
   if (r) {
@@ -196,7 +196,7 @@ static int tcp_listener(void) {
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&tcpServer, &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&sockname, "0.0.0.0", server_port, "server socket");
   getsocknamecount_tcp++;
 
@@ -214,7 +214,7 @@ static void tcp_connector(void) {
   struct sockaddr sockname;
   int r, namelen;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", server_port, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", server_port, &server_addr));
 
   r = uv_tcp_init(loop, &tcp);
   tcp.data = &connect_req;
@@ -255,7 +255,7 @@ static void udp_recv(uv_udp_t* handle,
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof(sockname);
   r = uv_udp_getsockname(&udp, &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&sockname, "0.0.0.0", 0, "udp receiving socket");
   getsocknamecount_udp++;
 
@@ -275,7 +275,7 @@ static int udp_listener(void) {
   int namelen;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", server_port, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", server_port, &addr));
 
   r = uv_udp_init(loop, &udpServer);
   if (r) {
@@ -292,12 +292,12 @@ static int udp_listener(void) {
   memset(&sockname, -1, sizeof sockname);
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&udpServer, &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   check_sockname(&sockname, "0.0.0.0", server_port, "udp listener socket");
   getsocknamecount_udp++;
 
   r = uv_udp_recv_start(&udpServer, alloc, udp_recv);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   return 0;
 }
@@ -312,7 +312,7 @@ static void udp_sender(void) {
   ASSERT(!r);
 
   buf = uv_buf_init("PING", 4);
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", server_port, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", server_port, &server_addr));
 
   r = uv_udp_send(&send_req,
                   &udp,
@@ -354,8 +354,8 @@ TEST_IMPL(getsockname_udp) {
 
   ASSERT_EQ(getsocknamecount_udp, 2);
 
-  ASSERT_EQ(udp.send_queue_size, 0);
-  ASSERT_EQ(udpServer.send_queue_size, 0);
+  ASSERT_OK(udp.send_queue_size);
+  ASSERT_OK(udpServer.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-getsockname.c
+++ b/test/test-getsockname.c
@@ -96,7 +96,7 @@ static void check_sockname(struct sockaddr* addr, const char* compare_ip,
             sizeof compare_addr.sin_addr));
 
   /* Check if the port matches. If port == 0 anything goes. */
-  ASSERT_NE(compare_port == 0 || check_addr.sin_port == compare_addr.sin_port, 0);
+  ASSERT(compare_port == 0 || check_addr.sin_port == compare_addr.sin_port);
 
   r = uv_ip4_name(&check_addr, (char*) check_ip, sizeof check_ip);
   ASSERT_OK(r);
@@ -334,8 +334,8 @@ TEST_IMPL(getsockname_tcp) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(getsocknamecount_tcp, 3);
-  ASSERT_EQ(getpeernamecount, 3);
+  ASSERT_EQ(3, getsocknamecount_tcp);
+  ASSERT_EQ(3, getpeernamecount);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -352,7 +352,7 @@ TEST_IMPL(getsockname_udp) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(getsocknamecount_udp, 2);
+  ASSERT_EQ(2, getsocknamecount_udp);
 
   ASSERT_OK(udp.send_queue_size);
   ASSERT_OK(udpServer.send_queue_size);

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -30,9 +30,9 @@ int cookie3;
 
 
 TEST_IMPL(handle_type_name) {
-  ASSERT(strcmp(uv_handle_type_name(UV_NAMED_PIPE), "pipe") == 0);
-  ASSERT(strcmp(uv_handle_type_name(UV_UDP), "udp") == 0);
-  ASSERT(strcmp(uv_handle_type_name(UV_FILE), "file") == 0);
+  ASSERT_EQ(strcmp(uv_handle_type_name(UV_NAMED_PIPE), "pipe"), 0);
+  ASSERT_EQ(strcmp(uv_handle_type_name(UV_UDP), "udp"), 0);
+  ASSERT_EQ(strcmp(uv_handle_type_name(UV_FILE), "file"), 0);
   ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX));
   ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX + 1));
   ASSERT_NULL(uv_handle_type_name(UV_UNKNOWN_HANDLE));
@@ -41,9 +41,9 @@ TEST_IMPL(handle_type_name) {
 
 
 TEST_IMPL(req_type_name) {
-  ASSERT(strcmp(uv_req_type_name(UV_REQ), "req") == 0);
-  ASSERT(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send") == 0);
-  ASSERT(strcmp(uv_req_type_name(UV_WORK), "work") == 0);
+  ASSERT_EQ(strcmp(uv_req_type_name(UV_REQ), "req"), 0);
+  ASSERT_EQ(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send"), 0);
+  ASSERT_EQ(strcmp(uv_req_type_name(UV_WORK), "work"), 0);
   ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX));
   ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX + 1));
   ASSERT_NULL(uv_req_type_name(UV_UNKNOWN_REQ));
@@ -60,48 +60,48 @@ TEST_IMPL(getters_setters) {
   loop = malloc(uv_loop_size());
   ASSERT_NOT_NULL(loop);
   r = uv_loop_init(loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_loop_set_data(loop, &cookie1);
-  ASSERT(loop->data == &cookie1);
-  ASSERT(uv_loop_get_data(loop) == &cookie1);
+  ASSERT_PTR_EQ(loop->data, &cookie1);
+  ASSERT_PTR_EQ(uv_loop_get_data(loop), &cookie1);
 
   pipe = malloc(uv_handle_size(UV_NAMED_PIPE));
   r = uv_pipe_init(loop, pipe, 0);
-  ASSERT(r == 0);
-  ASSERT(uv_handle_get_type((uv_handle_t*)pipe) == UV_NAMED_PIPE);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(uv_handle_get_type((uv_handle_t*)pipe), UV_NAMED_PIPE);
 
-  ASSERT(uv_handle_get_loop((uv_handle_t*)pipe) == loop);
+  ASSERT_EQ(uv_handle_get_loop((uv_handle_t*)pipe), loop);
   pipe->data = &cookie2;
-  ASSERT(uv_handle_get_data((uv_handle_t*)pipe) == &cookie2);
+  ASSERT_PTR_EQ(uv_handle_get_data((uv_handle_t*)pipe), &cookie2);
   uv_handle_set_data((uv_handle_t*)pipe, &cookie1);
-  ASSERT(uv_handle_get_data((uv_handle_t*)pipe) == &cookie1);
-  ASSERT(pipe->data == &cookie1);
+  ASSERT_PTR_EQ(uv_handle_get_data((uv_handle_t*)pipe), &cookie1);
+  ASSERT_PTR_EQ(pipe->data, &cookie1);
 
-  ASSERT(uv_stream_get_write_queue_size((uv_stream_t*)pipe) == 0);
+  ASSERT_EQ(uv_stream_get_write_queue_size((uv_stream_t*)pipe), 0);
   pipe->write_queue_size++;
-  ASSERT(uv_stream_get_write_queue_size((uv_stream_t*)pipe) == 1);
+  ASSERT_EQ(uv_stream_get_write_queue_size((uv_stream_t*)pipe), 1);
   pipe->write_queue_size--;
   uv_close((uv_handle_t*)pipe, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   fs = malloc(uv_req_size(UV_FS));
   uv_fs_stat(loop, fs, ".", NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(uv_fs_get_type(fs) == UV_FS_STAT);
-  ASSERT(uv_fs_get_result(fs) == 0);
-  ASSERT(uv_fs_get_ptr(fs) == uv_fs_get_statbuf(fs));
+  ASSERT_EQ(uv_fs_get_type(fs), UV_FS_STAT);
+  ASSERT_EQ(uv_fs_get_result(fs), 0);
+  ASSERT_EQ(uv_fs_get_ptr(fs), uv_fs_get_statbuf(fs));
   ASSERT(uv_fs_get_statbuf(fs)->st_mode & S_IFDIR);
-  ASSERT(strcmp(uv_fs_get_path(fs), ".") == 0);
+  ASSERT_EQ(strcmp(uv_fs_get_path(fs), "."), 0);
   uv_fs_req_cleanup(fs);
 
   r = uv_loop_close(loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   free(pipe);
   free(fs);

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -30,9 +30,9 @@ int cookie3;
 
 
 TEST_IMPL(handle_type_name) {
-  ASSERT_EQ(strcmp(uv_handle_type_name(UV_NAMED_PIPE), "pipe"), 0);
-  ASSERT_EQ(strcmp(uv_handle_type_name(UV_UDP), "udp"), 0);
-  ASSERT_EQ(strcmp(uv_handle_type_name(UV_FILE), "file"), 0);
+  ASSERT_OK(strcmp(uv_handle_type_name(UV_NAMED_PIPE), "pipe"));
+  ASSERT_OK(strcmp(uv_handle_type_name(UV_UDP), "udp"));
+  ASSERT_OK(strcmp(uv_handle_type_name(UV_FILE), "file"));
   ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX));
   ASSERT_NULL(uv_handle_type_name(UV_HANDLE_TYPE_MAX + 1));
   ASSERT_NULL(uv_handle_type_name(UV_UNKNOWN_HANDLE));
@@ -41,9 +41,9 @@ TEST_IMPL(handle_type_name) {
 
 
 TEST_IMPL(req_type_name) {
-  ASSERT_EQ(strcmp(uv_req_type_name(UV_REQ), "req"), 0);
-  ASSERT_EQ(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send"), 0);
-  ASSERT_EQ(strcmp(uv_req_type_name(UV_WORK), "work"), 0);
+  ASSERT_OK(strcmp(uv_req_type_name(UV_REQ), "req"));
+  ASSERT_OK(strcmp(uv_req_type_name(UV_UDP_SEND), "udp_send"));
+  ASSERT_OK(strcmp(uv_req_type_name(UV_WORK), "work"));
   ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX));
   ASSERT_NULL(uv_req_type_name(UV_REQ_TYPE_MAX + 1));
   ASSERT_NULL(uv_req_type_name(UV_UNKNOWN_REQ));
@@ -60,7 +60,7 @@ TEST_IMPL(getters_setters) {
   loop = malloc(uv_loop_size());
   ASSERT_NOT_NULL(loop);
   r = uv_loop_init(loop);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_loop_set_data(loop, &cookie1);
   ASSERT_PTR_EQ(loop->data, &cookie1);
@@ -68,7 +68,7 @@ TEST_IMPL(getters_setters) {
 
   pipe = malloc(uv_handle_size(UV_NAMED_PIPE));
   r = uv_pipe_init(loop, pipe, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(uv_handle_get_type((uv_handle_t*)pipe), UV_NAMED_PIPE);
 
   ASSERT_EQ(uv_handle_get_loop((uv_handle_t*)pipe), loop);
@@ -78,30 +78,30 @@ TEST_IMPL(getters_setters) {
   ASSERT_PTR_EQ(uv_handle_get_data((uv_handle_t*)pipe), &cookie1);
   ASSERT_PTR_EQ(pipe->data, &cookie1);
 
-  ASSERT_EQ(uv_stream_get_write_queue_size((uv_stream_t*)pipe), 0);
+  ASSERT_OK(uv_stream_get_write_queue_size((uv_stream_t*)pipe));
   pipe->write_queue_size++;
   ASSERT_EQ(uv_stream_get_write_queue_size((uv_stream_t*)pipe), 1);
   pipe->write_queue_size--;
   uv_close((uv_handle_t*)pipe, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   fs = malloc(uv_req_size(UV_FS));
   uv_fs_stat(loop, fs, ".", NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(uv_fs_get_type(fs), UV_FS_STAT);
-  ASSERT_EQ(uv_fs_get_result(fs), 0);
+  ASSERT_OK(uv_fs_get_result(fs));
   ASSERT_EQ(uv_fs_get_ptr(fs), uv_fs_get_statbuf(fs));
   ASSERT(uv_fs_get_statbuf(fs)->st_mode & S_IFDIR);
-  ASSERT_EQ(strcmp(uv_fs_get_path(fs), "."), 0);
+  ASSERT_OK(strcmp(uv_fs_get_path(fs), "."));
   uv_fs_req_cleanup(fs);
 
   r = uv_loop_close(loop);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   free(pipe);
   free(fs);

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -80,7 +80,7 @@ TEST_IMPL(getters_setters) {
 
   ASSERT_OK(uv_stream_get_write_queue_size((uv_stream_t*)pipe));
   pipe->write_queue_size++;
-  ASSERT_EQ(uv_stream_get_write_queue_size((uv_stream_t*)pipe), 1);
+  ASSERT_EQ(1, uv_stream_get_write_queue_size((uv_stream_t*)pipe));
   pipe->write_queue_size--;
   uv_close((uv_handle_t*)pipe, NULL);
 

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -28,12 +28,12 @@ TEST_IMPL(gettimeofday) {
 
   tv.tv_sec = 0;
   r = uv_gettimeofday(&tv);
-  ASSERT(r == 0);
-  ASSERT(tv.tv_sec != 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_NE(tv.tv_sec, 0);
 
   /* Test invalid input. */
   r = uv_gettimeofday(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -29,7 +29,7 @@ TEST_IMPL(gettimeofday) {
   tv.tv_sec = 0;
   r = uv_gettimeofday(&tv);
   ASSERT_OK(r);
-  ASSERT_NE(tv.tv_sec, 0);
+  ASSERT_NE(0, tv.tv_sec);
 
   /* Test invalid input. */
   r = uv_gettimeofday(NULL);

--- a/test/test-gettimeofday.c
+++ b/test/test-gettimeofday.c
@@ -28,7 +28,7 @@ TEST_IMPL(gettimeofday) {
 
   tv.tv_sec = 0;
   r = uv_gettimeofday(&tv);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(tv.tv_sec, 0);
 
   /* Test invalid input. */

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -56,49 +56,49 @@ TEST_IMPL(handle_fileno) {
   uv_loop_t* loop;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_idle_init(loop, &idle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &idle, &fd);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_close((uv_handle_t*) &idle, NULL);
 
   r = uv_tcp_init(loop, &tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_tcp_bind(&tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &tcp, NULL);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_udp_init(loop, &udp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_udp_bind(&udp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &udp, NULL);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_init(loop, &pipe, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
   r = uv_pipe_bind(&pipe, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_close((uv_handle_t*) &pipe, NULL);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   tty_fd = get_tty_fd();
   if (tty_fd < 0) {
@@ -106,14 +106,14 @@ TEST_IMPL(handle_fileno) {
     fflush(stderr);
   } else {
     r = uv_tty_init(loop, &tty, tty_fd, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     ASSERT(uv_is_readable((uv_stream_t*) &tty));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty));
     r = uv_fileno((uv_handle_t*) &tty, &fd);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_close((uv_handle_t*) &tty, NULL);
     r = uv_fileno((uv_handle_t*) &tty, &fd);
-    ASSERT(r == UV_EBADF);
+    ASSERT_EQ(r, UV_EBADF);
     ASSERT(!uv_is_readable((uv_stream_t*) &tty));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty));
   }

--- a/test/test-handle-fileno.c
+++ b/test/test-handle-fileno.c
@@ -56,46 +56,46 @@ TEST_IMPL(handle_fileno) {
   uv_loop_t* loop;
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_idle_init(loop, &idle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &idle, &fd);
   ASSERT_EQ(r, UV_EINVAL);
   uv_close((uv_handle_t*) &idle, NULL);
 
   r = uv_tcp_init(loop, &tcp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
   ASSERT_EQ(r, UV_EBADF);
   r = uv_tcp_bind(&tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_close((uv_handle_t*) &tcp, NULL);
   r = uv_fileno((uv_handle_t*) &tcp, &fd);
   ASSERT_EQ(r, UV_EBADF);
 
   r = uv_udp_init(loop, &udp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
   ASSERT_EQ(r, UV_EBADF);
   r = uv_udp_bind(&udp, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_close((uv_handle_t*) &udp, NULL);
   r = uv_fileno((uv_handle_t*) &udp, &fd);
   ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_init(loop, &pipe, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
   ASSERT_EQ(r, UV_EBADF);
   r = uv_pipe_bind(&pipe, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_close((uv_handle_t*) &pipe, NULL);
   r = uv_fileno((uv_handle_t*) &pipe, &fd);
   ASSERT_EQ(r, UV_EBADF);
@@ -106,11 +106,11 @@ TEST_IMPL(handle_fileno) {
     fflush(stderr);
   } else {
     r = uv_tty_init(loop, &tty, tty_fd, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     ASSERT(uv_is_readable((uv_stream_t*) &tty));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty));
     r = uv_fileno((uv_handle_t*) &tty, &fd);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_close((uv_handle_t*) &tty, NULL);
     r = uv_fileno((uv_handle_t*) &tty, &fd);
     ASSERT_EQ(r, UV_EBADF);

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -34,39 +34,39 @@ TEST_IMPL(homedir) {
   /* Test the normal case */
   len = sizeof homedir;
   homedir[0] = '\0';
-  ASSERT(strlen(homedir) == 0);
+  ASSERT_EQ(strlen(homedir), 0);
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == 0);
-  ASSERT(strlen(homedir) == len);
-  ASSERT(len > 0);
-  ASSERT(homedir[len] == '\0');
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(strlen(homedir), len);
+  ASSERT_GT(len, 0);
+  ASSERT_EQ(homedir[len], '\0');
 
 #ifdef _WIN32
   if (len == 3 && homedir[1] == ':')
-    ASSERT(homedir[2] == '\\');
+    ASSERT_EQ(homedir[2], '\\');
   else
-    ASSERT(homedir[len - 1] != '\\');
+    ASSERT_NE(homedir[len - 1], '\\');
 #else
   if (len == 1)
-    ASSERT(homedir[0] == '/');
+    ASSERT_EQ(homedir[0], '/');
   else
-    ASSERT(homedir[len - 1] != '/');
+    ASSERT_NE(homedir[len - 1], '/');
 #endif
 
   /* Test the case where the buffer is too small */
   len = SMALLPATH;
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == UV_ENOBUFS);
-  ASSERT(len > SMALLPATH);
+  ASSERT_EQ(r, UV_ENOBUFS);
+  ASSERT_GT(len, SMALLPATH);
 
   /* Test invalid inputs */
   r = uv_os_homedir(NULL, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_homedir(homedir, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   len = 0;
   r = uv_os_homedir(homedir, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   return 0;
 }

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -34,9 +34,9 @@ TEST_IMPL(homedir) {
   /* Test the normal case */
   len = sizeof homedir;
   homedir[0] = '\0';
-  ASSERT_EQ(strlen(homedir), 0);
+  ASSERT_OK(strlen(homedir));
   r = uv_os_homedir(homedir, &len);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(strlen(homedir), len);
   ASSERT_GT(len, 0);
   ASSERT_EQ(homedir[len], '\0');

--- a/test/test-hrtime.c
+++ b/test/test-hrtime.c
@@ -45,7 +45,7 @@ TEST_IMPL(hrtime) {
      * that the difference between the two hrtime values has a reasonable
      * lower bound.
      */
-    ASSERT(diff > (uint64_t) 25 * NANOSEC / MILLISEC);
+    ASSERT_UINT64_GT(diff, (uint64_t) 25 * NANOSEC / MILLISEC);
     --i;
   }
   return 0;

--- a/test/test-hrtime.c
+++ b/test/test-hrtime.c
@@ -57,8 +57,8 @@ TEST_IMPL(clock_gettime) {
 
   ASSERT_EQ(UV_EINVAL, uv_clock_gettime(1337, &t));
   ASSERT_EQ(UV_EFAULT, uv_clock_gettime(1337, NULL));
-  ASSERT_EQ(0, uv_clock_gettime(UV_CLOCK_MONOTONIC, &t));
-  ASSERT_EQ(0, uv_clock_gettime(UV_CLOCK_REALTIME, &t));
+  ASSERT_OK(uv_clock_gettime(UV_CLOCK_MONOTONIC, &t));
+  ASSERT_OK(uv_clock_gettime(UV_CLOCK_REALTIME, &t));
   ASSERT_GT(1682500000000ll, t.tv_sec);  /* 2023-04-26T09:06:40.000Z */
 
   return 0;

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -91,8 +91,8 @@ TEST_IMPL(idle_starvation) {
   ASSERT_OK(r);
 
   ASSERT_GT(idle_cb_called, 0);
-  ASSERT_EQ(timer_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(1, timer_cb_called);
+  ASSERT_EQ(3, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -73,22 +73,22 @@ TEST_IMPL(idle_starvation) {
   int r;
 
   r = uv_idle_init(uv_default_loop(), &idle_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_idle_start(&idle_handle, idle_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&timer_handle, timer_cb, 50, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_GT(idle_cb_called, 0);
   ASSERT_EQ(timer_cb_called, 1);
@@ -105,19 +105,19 @@ static void idle_stop(uv_idle_t* handle) {
 
 
 TEST_IMPL(idle_check) {
-  ASSERT_EQ(0, uv_idle_init(uv_default_loop(), &idle_handle));
-  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_stop));
+  ASSERT_OK(uv_idle_init(uv_default_loop(), &idle_handle));
+  ASSERT_OK(uv_idle_start(&idle_handle, idle_stop));
 
-  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+  ASSERT_OK(uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_OK(uv_check_start(&check_handle, check_cb));
 
   ASSERT_EQ(1, uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(1, check_cb_called);
 
-  ASSERT_EQ(0, close_cb_called);
+  ASSERT_OK(close_cb_called);
   uv_close((uv_handle_t*) &idle_handle, close_cb);
   uv_close((uv_handle_t*) &check_handle, close_cb);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-idle.c
+++ b/test/test-idle.c
@@ -39,7 +39,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_PTR_EQ(handle, &timer_handle);
 
   uv_close((uv_handle_t*) &idle_handle, close_cb);
   uv_close((uv_handle_t*) &check_handle, close_cb);
@@ -52,7 +52,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void idle_cb(uv_idle_t* handle) {
-  ASSERT(handle == &idle_handle);
+  ASSERT_PTR_EQ(handle, &idle_handle);
 
   idle_cb_called++;
   fprintf(stderr, "idle_cb %d\n", idle_cb_called);
@@ -61,7 +61,7 @@ static void idle_cb(uv_idle_t* handle) {
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT(handle == &check_handle);
+  ASSERT_PTR_EQ(handle, &check_handle);
 
   check_cb_called++;
   fprintf(stderr, "check_cb %d\n", check_cb_called);
@@ -73,26 +73,26 @@ TEST_IMPL(idle_starvation) {
   int r;
 
   r = uv_idle_init(uv_default_loop(), &idle_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_idle_start(&idle_handle, idle_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, timer_cb, 50, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(idle_cb_called > 0);
-  ASSERT(timer_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_GT(idle_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -31,66 +31,66 @@ TEST_IMPL(utf8_decode1) {
   /* ASCII. */
   p = b;
   snprintf(b, sizeof(b), "%c\x7F", 0x00);
-  ASSERT(0 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 1);
-  ASSERT(127 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
+  ASSERT_EQ(0, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 1);
+  ASSERT_EQ(127, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 2);
 
   /* Two-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xC2\x80\xDF\xBF");
-  ASSERT(128 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
-  ASSERT(0x7FF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ(128, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 2);
+  ASSERT_EQ(0x7FF, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 4);
 
   /* Three-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xE0\xA0\x80\xEF\xBF\xBF");
-  ASSERT(0x800 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 3);
-  ASSERT(0xFFFF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 6);
+  ASSERT_EQ(0x800, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 3);
+  ASSERT_EQ(0xFFFF, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 6);
 
   /* Four-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xF0\x90\x80\x80\xF4\x8F\xBF\xBF");
-  ASSERT(0x10000 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
-  ASSERT(0x10FFFF == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 8);
+  ASSERT_EQ(0x10000, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 4);
+  ASSERT_EQ(0x10FFFF, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 8);
 
   /* Four-byte sequences > U+10FFFF; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xF4\x90\xC0\xC0\xF7\xBF\xBF\xBF");
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 8);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 4);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 8);
 
   /* Overlong; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xC0\x80\xC1\x80");
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 2);
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 4);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 2);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 4);
 
   /* Surrogate pairs; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xED\xA0\x80\xED\xA3\xBF");
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 3);
-  ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT(p == b + 6);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 3);
+  ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_EQ(p, b + 6);
 
   /* Simply illegal. */
   p = b;
   snprintf(b, sizeof(b), "\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF");
 
   for (i = 1; i <= 8; i++) {
-    ASSERT((unsigned) -1 == uv__utf8_decode1(&p, b + sizeof(b)));
-    ASSERT(p == b + i);
+    ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
+    ASSERT_EQ(p, b + i);
   }
 
   return 0;
@@ -122,7 +122,7 @@ TEST_IMPL(utf8_decode1_overrun) {
   do {                                                                        \
     char d[256] = {0};                                                        \
     static const char s[] = "" input "";                                      \
-    ASSERT(err == uv__idna_toascii(s, s + sizeof(s) - 1, d, d + sizeof(d)));  \
+    ASSERT_EQ(err, uv__idna_toascii(s, s + sizeof(s) - 1, d, d + sizeof(d))); \
   } while (0)
 
 #define T(input, expected)                                                    \
@@ -132,13 +132,13 @@ TEST_IMPL(utf8_decode1_overrun) {
     char d2[256] = {0};                                                       \
     static const char s[] = "" input "";                                      \
     n = uv__idna_toascii(s, s + sizeof(s) - 1, d1, d1 + sizeof(d1));          \
-    ASSERT(n == sizeof(expected));                                            \
-    ASSERT(0 == memcmp(d1, expected, n));                                     \
+    ASSERT_EQ(n, sizeof(expected));                                           \
+    ASSERT_EQ(0, memcmp(d1, expected, n));                                    \
     /* Sanity check: encoding twice should not change the output. */          \
     n = uv__idna_toascii(d1, d1 + strlen(d1), d2, d2 + sizeof(d2));           \
-    ASSERT(n == sizeof(expected));                                            \
-    ASSERT(0 == memcmp(d2, expected, n));                                     \
-    ASSERT(0 == memcmp(d1, d2, sizeof(d2)));                                  \
+    ASSERT_EQ(n, sizeof(expected));                                           \
+    ASSERT_EQ(0, memcmp(d2, expected, n));                                    \
+    ASSERT_EQ(0, memcmp(d1, d2, sizeof(d2)));                                 \
   } while (0)
 
 TEST_IMPL(idna_toascii) {

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -31,7 +31,7 @@ TEST_IMPL(utf8_decode1) {
   /* ASCII. */
   p = b;
   snprintf(b, sizeof(b), "%c\x7F", 0x00);
-  ASSERT_EQ(0, uv__utf8_decode1(&p, b + sizeof(b)));
+  ASSERT_OK(uv__utf8_decode1(&p, b + sizeof(b)));
   ASSERT_EQ(p, b + 1);
   ASSERT_EQ(127, uv__utf8_decode1(&p, b + sizeof(b)));
   ASSERT_EQ(p, b + 2);
@@ -133,12 +133,12 @@ TEST_IMPL(utf8_decode1_overrun) {
     static const char s[] = "" input "";                                      \
     n = uv__idna_toascii(s, s + sizeof(s) - 1, d1, d1 + sizeof(d1));          \
     ASSERT_EQ(n, sizeof(expected));                                           \
-    ASSERT_EQ(0, memcmp(d1, expected, n));                                    \
+    ASSERT_OK(memcmp(d1, expected, n));                                       \
     /* Sanity check: encoding twice should not change the output. */          \
     n = uv__idna_toascii(d1, d1 + strlen(d1), d2, d2 + sizeof(d2));           \
     ASSERT_EQ(n, sizeof(expected));                                           \
-    ASSERT_EQ(0, memcmp(d2, expected, n));                                    \
-    ASSERT_EQ(0, memcmp(d1, d2, sizeof(d2)));                                 \
+    ASSERT_OK(memcmp(d2, expected, n));                                       \
+    ASSERT_OK(memcmp(d1, d2, sizeof(d2)));                                    \
   } while (0)
 
 TEST_IMPL(idna_toascii) {

--- a/test/test-ip-name.c
+++ b/test/test-ip-name.c
@@ -40,20 +40,20 @@ TEST_IMPL(ip_name) {
     struct sockaddr_in6* addr6 = &test_addr.addr6;
 
     /* test ip4_name */
-    ASSERT_EQ(0, uv_ip4_addr("192.168.0.1", TEST_PORT, addr4));
-    ASSERT_EQ(0, uv_ip4_name(addr4, dst, INET_ADDRSTRLEN));
-    ASSERT_EQ(0, strcmp("192.168.0.1", dst));
+    ASSERT_OK(uv_ip4_addr("192.168.0.1", TEST_PORT, addr4));
+    ASSERT_OK(uv_ip4_name(addr4, dst, INET_ADDRSTRLEN));
+    ASSERT_OK(strcmp("192.168.0.1", dst));
 
-    ASSERT_EQ(0, uv_ip_name(addr, dst, INET_ADDRSTRLEN));
-    ASSERT_EQ(0, strcmp("192.168.0.1", dst));
+    ASSERT_OK(uv_ip_name(addr, dst, INET_ADDRSTRLEN));
+    ASSERT_OK(strcmp("192.168.0.1", dst));
 
     /* test ip6_name */
-    ASSERT_EQ(0, uv_ip6_addr("fe80::2acf:daff:fedd:342a", TEST_PORT, addr6));
-    ASSERT_EQ(0, uv_ip6_name(addr6, dst, INET6_ADDRSTRLEN));
-    ASSERT_EQ(0, strcmp("fe80::2acf:daff:fedd:342a", dst));
+    ASSERT_OK(uv_ip6_addr("fe80::2acf:daff:fedd:342a", TEST_PORT, addr6));
+    ASSERT_OK(uv_ip6_name(addr6, dst, INET6_ADDRSTRLEN));
+    ASSERT_OK(strcmp("fe80::2acf:daff:fedd:342a", dst));
 
-    ASSERT_EQ(0, uv_ip_name(addr, dst, INET6_ADDRSTRLEN));
-    ASSERT_EQ(0, strcmp("fe80::2acf:daff:fedd:342a", dst));
+    ASSERT_OK(uv_ip_name(addr, dst, INET6_ADDRSTRLEN));
+    ASSERT_OK(strcmp("fe80::2acf:daff:fedd:342a", dst));
 
     /* test other sa_family */
     addr->sa_family = AF_UNIX;

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -30,13 +30,13 @@ TEST_IMPL(ip4_addr) {
   struct sockaddr_in addr;
   char dst[16];
 
-  ASSERT_EQ(0, uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF", dst, sizeof(dst)));
-  ASSERT_EQ(0, strcmp(dst, "255.255.255.255"));
+  ASSERT_OK(uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF", dst, sizeof(dst)));
+  ASSERT_OK(strcmp(dst, "255.255.255.255"));
   ASSERT_EQ(UV_ENOSPC, uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF",
                                     dst, sizeof(dst) - 1));
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_ip4_addr("255.255.255.255", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("255.255.255.255", TEST_PORT, &addr));
   ASSERT_EQ(UV_EINVAL, uv_ip4_addr("255.255.255*000", TEST_PORT, &addr));
   ASSERT_EQ(UV_EINVAL, uv_ip4_addr("255.255.255.256", TEST_PORT, &addr));
   ASSERT_EQ(UV_EINVAL, uv_ip4_addr("2555.0.0.0", TEST_PORT, &addr));

--- a/test/test-ip4-addr.c
+++ b/test/test-ip4-addr.c
@@ -30,25 +30,25 @@ TEST_IMPL(ip4_addr) {
   struct sockaddr_in addr;
   char dst[16];
 
-  ASSERT(0 == uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF", dst, sizeof(dst)));
-  ASSERT(0 == strcmp(dst, "255.255.255.255"));
-  ASSERT(UV_ENOSPC == uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF",
-                                   dst, sizeof(dst) - 1));
+  ASSERT_EQ(0, uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF", dst, sizeof(dst)));
+  ASSERT_EQ(0, strcmp(dst, "255.255.255.255"));
+  ASSERT_EQ(UV_ENOSPC, uv_inet_ntop(AF_INET, "\xFF\xFF\xFF\xFF",
+                                    dst, sizeof(dst) - 1));
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_ip4_addr("255.255.255.255", TEST_PORT, &addr));
-  ASSERT(UV_EINVAL == uv_ip4_addr("255.255.255*000", TEST_PORT, &addr));
-  ASSERT(UV_EINVAL == uv_ip4_addr("255.255.255.256", TEST_PORT, &addr));
-  ASSERT(UV_EINVAL == uv_ip4_addr("2555.0.0.0", TEST_PORT, &addr));
-  ASSERT(UV_EINVAL == uv_ip4_addr("255", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("255.255.255.255", TEST_PORT, &addr));
+  ASSERT_EQ(UV_EINVAL, uv_ip4_addr("255.255.255*000", TEST_PORT, &addr));
+  ASSERT_EQ(UV_EINVAL, uv_ip4_addr("255.255.255.256", TEST_PORT, &addr));
+  ASSERT_EQ(UV_EINVAL, uv_ip4_addr("2555.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(UV_EINVAL, uv_ip4_addr("255", TEST_PORT, &addr));
 
 #ifdef SIN6_LEN
-  ASSERT(addr.sin_len == sizeof(addr));
+  ASSERT_EQ(addr.sin_len, sizeof(addr));
 #endif
 
   /* for broken address family */
-  ASSERT(UV_EAFNOSUPPORT == uv_inet_pton(42, "127.0.0.1",
-    &addr.sin_addr.s_addr));
+  ASSERT_EQ(UV_EAFNOSUPPORT, uv_inet_pton(42, "127.0.0.1",
+                                          &addr.sin_addr.s_addr));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -51,7 +51,7 @@ TEST_IMPL(ip6_addr_link_local) {
   int ix;
   int r;
 
-  ASSERT_EQ(0, uv_interface_addresses(&addresses, &count));
+  ASSERT_OK(uv_interface_addresses(&addresses, &count));
 
   for (ix = 0; ix < count; ix++) {
     address = addresses + ix;
@@ -59,10 +59,10 @@ TEST_IMPL(ip6_addr_link_local) {
     if (address->address.address6.sin6_family != AF_INET6)
       continue;
 
-    ASSERT_EQ(0, uv_inet_ntop(AF_INET6,
-                              &address->address.address6.sin6_addr,
-                              string_address,
-                              sizeof(string_address)));
+    ASSERT_OK(uv_inet_ntop(AF_INET6,
+                           &address->address.address6.sin6_addr,
+                           string_address,
+                           sizeof(string_address)));
 
     /* Skip addresses that are not link-local. */
     if (strncmp(string_address, "fe80::", 6) != 0)
@@ -72,23 +72,23 @@ TEST_IMPL(ip6_addr_link_local) {
     device_name = address->name;
 
     scoped_addr_len = sizeof(scoped_addr);
-    ASSERT_EQ(0, uv_if_indextoname(iface_index,
-                                   scoped_addr,
-                                   &scoped_addr_len));
+    ASSERT_OK(uv_if_indextoname(iface_index,
+                                scoped_addr,
+                                &scoped_addr_len));
 #ifndef _WIN32
     /* This assert fails on Windows, as Windows semantics are different. */
-    ASSERT_EQ(0, strcmp(device_name, scoped_addr));
+    ASSERT_OK(strcmp(device_name, scoped_addr));
 #endif
 
     interface_id_len = sizeof(interface_id);
     r = uv_if_indextoiid(iface_index, interface_id, &interface_id_len);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 #ifdef _WIN32
     /* On Windows, the interface identifier is the numeric string of the index. */
     ASSERT_EQ(strtoul(interface_id, NULL, 10), iface_index);
 #else
     /* On Unix/Linux, the interface identifier is the interface device name. */
-    ASSERT_EQ(0, strcmp(device_name, interface_id));
+    ASSERT_OK(strcmp(device_name, interface_id));
 #endif
 
     snprintf(scoped_addr,
@@ -104,7 +104,7 @@ TEST_IMPL(ip6_addr_link_local) {
             device_name);
     fflush(stderr);
 
-    ASSERT_EQ(0, uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
+    ASSERT_OK(uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
     fprintf(stderr, "Got scope_id 0x%2x\n", (unsigned)addr.sin6_scope_id);
     fflush(stderr);
     ASSERT_EQ(iface_index, addr.sin6_scope_id);
@@ -141,10 +141,10 @@ TEST_IMPL(ip6_addr_link_local) {
     X("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255.255")                    \
 
 #define TEST_GOOD(ADDR)                                                       \
-    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR, &addr));                        \
-    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                 \
-    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                 \
-    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));         \
+    ASSERT_OK(uv_inet_pton(AF_INET6, ADDR, &addr));                           \
+    ASSERT_OK(uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                    \
+    ASSERT_OK(uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                    \
+    ASSERT_OK(uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));            \
 
 #define TEST_BAD(ADDR)                                                        \
     ASSERT_NE(0, uv_inet_pton(AF_INET6, ADDR, &addr));                        \
@@ -167,7 +167,7 @@ TEST_IMPL(ip6_pton) {
 
 TEST_IMPL(ip6_sin6_len) {
   struct sockaddr_in6 s;
-  ASSERT_EQ(0, uv_ip6_addr("::", 0, &s));
+  ASSERT_OK(uv_ip6_addr("::", 0, &s));
 #ifdef SIN6_LEN
   ASSERT_EQ(s.sin6_len, sizeof(s));
 #endif

--- a/test/test-ip6-addr.c
+++ b/test/test-ip6-addr.c
@@ -51,7 +51,7 @@ TEST_IMPL(ip6_addr_link_local) {
   int ix;
   int r;
 
-  ASSERT(0 == uv_interface_addresses(&addresses, &count));
+  ASSERT_EQ(0, uv_interface_addresses(&addresses, &count));
 
   for (ix = 0; ix < count; ix++) {
     address = addresses + ix;
@@ -59,10 +59,10 @@ TEST_IMPL(ip6_addr_link_local) {
     if (address->address.address6.sin6_family != AF_INET6)
       continue;
 
-    ASSERT(0 == uv_inet_ntop(AF_INET6,
-                             &address->address.address6.sin6_addr,
-                             string_address,
-                             sizeof(string_address)));
+    ASSERT_EQ(0, uv_inet_ntop(AF_INET6,
+                              &address->address.address6.sin6_addr,
+                              string_address,
+                              sizeof(string_address)));
 
     /* Skip addresses that are not link-local. */
     if (strncmp(string_address, "fe80::", 6) != 0)
@@ -72,21 +72,23 @@ TEST_IMPL(ip6_addr_link_local) {
     device_name = address->name;
 
     scoped_addr_len = sizeof(scoped_addr);
-    ASSERT(0 == uv_if_indextoname(iface_index, scoped_addr, &scoped_addr_len));
+    ASSERT_EQ(0, uv_if_indextoname(iface_index,
+                                   scoped_addr,
+                                   &scoped_addr_len));
 #ifndef _WIN32
     /* This assert fails on Windows, as Windows semantics are different. */
-    ASSERT(0 == strcmp(device_name, scoped_addr));
+    ASSERT_EQ(0, strcmp(device_name, scoped_addr));
 #endif
 
     interface_id_len = sizeof(interface_id);
     r = uv_if_indextoiid(iface_index, interface_id, &interface_id_len);
-    ASSERT(0 == r);
+    ASSERT_EQ(r, 0);
 #ifdef _WIN32
     /* On Windows, the interface identifier is the numeric string of the index. */
-    ASSERT(strtoul(interface_id, NULL, 10) == iface_index);
+    ASSERT_EQ(strtoul(interface_id, NULL, 10), iface_index);
 #else
     /* On Unix/Linux, the interface identifier is the interface device name. */
-    ASSERT(0 == strcmp(device_name, interface_id));
+    ASSERT_EQ(0, strcmp(device_name, interface_id));
 #endif
 
     snprintf(scoped_addr,
@@ -102,16 +104,18 @@ TEST_IMPL(ip6_addr_link_local) {
             device_name);
     fflush(stderr);
 
-    ASSERT(0 == uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
+    ASSERT_EQ(0, uv_ip6_addr(scoped_addr, TEST_PORT, &addr));
     fprintf(stderr, "Got scope_id 0x%2x\n", (unsigned)addr.sin6_scope_id);
     fflush(stderr);
-    ASSERT(iface_index == addr.sin6_scope_id);
+    ASSERT_EQ(iface_index, addr.sin6_scope_id);
   }
 
   uv_free_interface_addresses(addresses, count);
 
   scoped_addr_len = sizeof(scoped_addr);
-  ASSERT(0 != uv_if_indextoname((unsigned int)-1, scoped_addr, &scoped_addr_len));
+  ASSERT_NE(0, uv_if_indextoname((unsigned int)-1,
+                                 scoped_addr,
+                                 &scoped_addr_len));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -137,16 +141,16 @@ TEST_IMPL(ip6_addr_link_local) {
     X("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255.255")                    \
 
 #define TEST_GOOD(ADDR)                                                       \
-    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR, &addr));                         \
-    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                  \
-    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                  \
-    ASSERT(0 == uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));          \
+    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR, &addr));                        \
+    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                 \
+    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                 \
+    ASSERT_EQ(0, uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));         \
 
 #define TEST_BAD(ADDR)                                                        \
-    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR, &addr));                         \
-    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                  \
-    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                  \
-    ASSERT(0 != uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));          \
+    ASSERT_NE(0, uv_inet_pton(AF_INET6, ADDR, &addr));                        \
+    ASSERT_NE(0, uv_inet_pton(AF_INET6, ADDR "%en1", &addr));                 \
+    ASSERT_NE(0, uv_inet_pton(AF_INET6, ADDR "%%%%", &addr));                 \
+    ASSERT_NE(0, uv_inet_pton(AF_INET6, ADDR "%en1:1.2.3.4", &addr));         \
 
 TEST_IMPL(ip6_pton) {
   struct in6_addr addr;
@@ -165,7 +169,7 @@ TEST_IMPL(ip6_sin6_len) {
   struct sockaddr_in6 s;
   ASSERT_EQ(0, uv_ip6_addr("::", 0, &s));
 #ifdef SIN6_LEN
-  ASSERT(s.sin6_len == sizeof(s));
+  ASSERT_EQ(s.sin6_len, sizeof(s));
 #endif
   return 0;
 }

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -49,7 +49,7 @@ static size_t bytes_read;
 static void write_cb(uv_write_t* req, int status) {
   struct write_info* write_info =
       container_of(req, struct write_info, write_req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   bytes_written += BUFFERS_PER_WRITE * BUFFER_SIZE;
   free(write_info);
 }
@@ -75,7 +75,7 @@ static void do_write(uv_stream_t* handle) {
 
   r = uv_write(
       &write_info->write_req, handle, bufs, BUFFERS_PER_WRITE, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -94,18 +94,18 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   ssize_t i;
   int r;
 
-  ASSERT(nread >= 0);
+  ASSERT_GE(nread, 0);
   bytes_read += nread;
 
   for (i = 0; i < nread; i++)
-    ASSERT(buf->base[i] == BUFFER_CONTENT);
+    ASSERT_EQ(buf->base[i], BUFFER_CONTENT);
   free(buf->base);
 
   if (bytes_read >= XFER_SIZE) {
     r = uv_read_stop(handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_shutdown(&shutdown_req, handle, shutdown_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -121,13 +121,13 @@ static void do_writes_and_reads(uv_stream_t* handle) {
   }
 
   r = uv_read_start(handle, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(handle->loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(bytes_written == XFER_SIZE);
-  ASSERT(bytes_read == XFER_SIZE);
+  ASSERT_EQ(bytes_written, XFER_SIZE);
+  ASSERT_EQ(bytes_read, XFER_SIZE);
 }
 
 TEST_IMPL(ipc_heavy_traffic_deadlock_bug) {
@@ -146,9 +146,9 @@ int ipc_helper_heavy_traffic_deadlock_bug(void) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_open(&pipe, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   notify_parent_process();
   do_writes_and_reads((uv_stream_t*) &pipe);

--- a/test/test-ipc-heavy-traffic-deadlock-bug.c
+++ b/test/test-ipc-heavy-traffic-deadlock-bug.c
@@ -49,7 +49,7 @@ static size_t bytes_read;
 static void write_cb(uv_write_t* req, int status) {
   struct write_info* write_info =
       container_of(req, struct write_info, write_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   bytes_written += BUFFERS_PER_WRITE * BUFFER_SIZE;
   free(write_info);
 }
@@ -75,7 +75,7 @@ static void do_write(uv_stream_t* handle) {
 
   r = uv_write(
       &write_info->write_req, handle, bufs, BUFFERS_PER_WRITE, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -103,9 +103,9 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
   if (bytes_read >= XFER_SIZE) {
     r = uv_read_stop(handle);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     r = uv_shutdown(&shutdown_req, handle, shutdown_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
@@ -121,10 +121,10 @@ static void do_writes_and_reads(uv_stream_t* handle) {
   }
 
   r = uv_read_start(handle, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(handle->loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(bytes_written, XFER_SIZE);
   ASSERT_EQ(bytes_read, XFER_SIZE);
@@ -146,9 +146,9 @@ int ipc_helper_heavy_traffic_deadlock_bug(void) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_open(&pipe, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   notify_parent_process();
   do_writes_and_reads((uv_stream_t*) &pipe);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -112,7 +112,7 @@ static void recv_cb(uv_stream_t* handle,
      * acceptable value. */
     if (nread == UV_EOF) {
       /* UV_EOF is only acceptable for the final recv_cb call */
-      ASSERT_EQ(recv_cb_count, 2);
+      ASSERT_EQ(2, recv_cb_count);
     } else {
       ASSERT_GE(nread, 0);
       ASSERT_GT(uv_pipe_pending_count(pipe), 0);
@@ -193,7 +193,7 @@ static int run_test(int inprocess) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(recv_cb_count, 2);
+  ASSERT_EQ(2, recv_cb_count);
 
   if (inprocess) {
     r = uv_thread_join(&tid);

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -96,7 +96,7 @@ static void recv_cb(uv_stream_t* handle,
   free(buf->base);
 
   pipe = (uv_pipe_t*) handle;
-  ASSERT(pipe == &ctx.channel);
+  ASSERT_EQ(pipe, &ctx.channel);
 
   do {
     if (++recv_cb_count == 1) {
@@ -112,13 +112,13 @@ static void recv_cb(uv_stream_t* handle,
      * acceptable value. */
     if (nread == UV_EOF) {
       /* UV_EOF is only acceptable for the final recv_cb call */
-      ASSERT(recv_cb_count == 2);
+      ASSERT_EQ(recv_cb_count, 2);
     } else {
-      ASSERT(nread >= 0);
-      ASSERT(uv_pipe_pending_count(pipe) > 0);
+      ASSERT_GE(nread, 0);
+      ASSERT_GT(uv_pipe_pending_count(pipe), 0);
 
       pending = uv_pipe_pending_type(pipe);
-      ASSERT(pending == ctx.expected_type);
+      ASSERT_EQ(pending, ctx.expected_type);
 
       if (pending == UV_NAMED_PIPE)
         r = uv_pipe_init(ctx.channel.loop, &recv->pipe, 0);
@@ -126,10 +126,10 @@ static void recv_cb(uv_stream_t* handle,
         r = uv_tcp_init(ctx.channel.loop, &recv->tcp);
       else
         abort();
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
 
       r = uv_accept(handle, &recv->stream);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
   } while (uv_pipe_pending_count(pipe) > 0);
 
@@ -143,8 +143,8 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(req == &ctx.connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &ctx.connect_req);
+  ASSERT_EQ(status, 0);
 
   buf = uv_buf_init(".", 1);
   r = uv_write2(&ctx.write_req,
@@ -152,7 +152,7 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send.stream,
                 NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Perform two writes to the same pipe to make sure that on Windows we are
    * not running into issue 505:
@@ -163,10 +163,10 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send2.stream,
                 NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&ctx.channel, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static int run_test(int inprocess) {
@@ -176,12 +176,12 @@ static int run_test(int inprocess) {
 
   if (inprocess) {
     r = uv_thread_create(&tid, ipc_send_recv_helper_threadproc, (void *) 42);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_sleep(1000);
 
     r = uv_pipe_init(uv_default_loop(), &ctx.channel, 1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_pipe_connect(&ctx.connect_req, &ctx.channel, TEST_PIPENAME_3, connect_cb);
   } else {
@@ -191,13 +191,13 @@ static int run_test(int inprocess) {
   }
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(recv_cb_count == 2);
+  ASSERT_EQ(recv_cb_count, 2);
 
   if (inprocess) {
     r = uv_thread_join(&tid);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   return 0;
@@ -209,19 +209,19 @@ static int run_ipc_send_recv_pipe(int inprocess) {
   ctx.expected_type = UV_NAMED_PIPE;
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send.pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&ctx.send.pipe, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send2.pipe, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&ctx.send2.pipe, TEST_PIPENAME_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_test(inprocess);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -245,24 +245,24 @@ static int run_ipc_send_recv_tcp(int inprocess) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   ctx.expected_type = UV_TCP;
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send.tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send2.tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&ctx.send.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&ctx.send2.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_test(inprocess);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -286,7 +286,7 @@ TEST_IMPL(ipc_send_recv_tcp_inprocess) {
 /* Everything here runs in a child process or second thread. */
 
 static void write2_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   /* After two successful writes in the child process, allow the child
    * process to be closed. */
@@ -337,10 +337,10 @@ static void read_cb(uv_stream_t* handle,
       r = uv_tcp_init(ctx2.channel.loop, &recv->tcp);
     else
       abort();
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_accept(handle, &recv->stream);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     wrbuf = uv_buf_init(".", 1);
     r = uv_write2(write_req,
@@ -349,27 +349,27 @@ static void read_cb(uv_stream_t* handle,
                   1,
                   &recv->stream,
                   write2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
 static void send_recv_start(void) {
   int r;
-  ASSERT(1 == uv_is_readable((uv_stream_t*)&ctx2.channel));
-  ASSERT(1 == uv_is_writable((uv_stream_t*)&ctx2.channel));
-  ASSERT(0 == uv_is_closing((uv_handle_t*)&ctx2.channel));
+  ASSERT_EQ(1, uv_is_readable((uv_stream_t*)&ctx2.channel));
+  ASSERT_EQ(1, uv_is_writable((uv_stream_t*)&ctx2.channel));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*)&ctx2.channel));
 
   r = uv_read_start((uv_stream_t*)&ctx2.channel, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void listen_cb(uv_stream_t* handle, int status) {
   int r;
-  ASSERT(handle == (uv_stream_t*)&ctx2.listen);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(handle, (uv_stream_t*)&ctx2.listen);
+  ASSERT_EQ(status, 0);
 
   r = uv_accept((uv_stream_t*)&ctx2.listen, (uv_stream_t*)&ctx2.channel);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   send_recv_start();
 }
@@ -382,27 +382,27 @@ int run_ipc_send_recv_helper(uv_loop_t* loop, int inprocess) {
   memset(&ctx2, 0, sizeof(ctx2));
 
   r = uv_pipe_init(loop, &ctx2.listen, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(loop, &ctx2.channel, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (inprocess) {
     r = uv_pipe_bind(&ctx2.listen, TEST_PIPENAME_3);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_listen((uv_stream_t*)&ctx2.listen, SOMAXCONN, listen_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   } else {
     r = uv_pipe_open(&ctx2.channel, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     send_recv_start();
   }
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return 0;
 }
@@ -414,7 +414,7 @@ int ipc_send_recv_helper(void) {
   int r;
 
   r = run_ipc_send_recv_helper(uv_default_loop(), 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -425,11 +425,11 @@ void ipc_send_recv_helper_threadproc(void* arg) {
   uv_loop_t loop;
 
   r = uv_loop_init(&loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = run_ipc_send_recv_helper(&loop, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_loop_close(&loop);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -126,10 +126,10 @@ static void recv_cb(uv_stream_t* handle,
         r = uv_tcp_init(ctx.channel.loop, &recv->tcp);
       else
         abort();
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
 
       r = uv_accept(handle, &recv->stream);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
     }
   } while (uv_pipe_pending_count(pipe) > 0);
 
@@ -144,7 +144,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_buf_t buf;
 
   ASSERT_PTR_EQ(req, &ctx.connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   buf = uv_buf_init(".", 1);
   r = uv_write2(&ctx.write_req,
@@ -152,7 +152,7 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send.stream,
                 NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Perform two writes to the same pipe to make sure that on Windows we are
    * not running into issue 505:
@@ -163,10 +163,10 @@ static void connect_cb(uv_connect_t* req, int status) {
                 &buf, 1,
                 &ctx.send2.stream,
                 NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*)&ctx.channel, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static int run_test(int inprocess) {
@@ -176,12 +176,12 @@ static int run_test(int inprocess) {
 
   if (inprocess) {
     r = uv_thread_create(&tid, ipc_send_recv_helper_threadproc, (void *) 42);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     uv_sleep(1000);
 
     r = uv_pipe_init(uv_default_loop(), &ctx.channel, 1);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     uv_pipe_connect(&ctx.connect_req, &ctx.channel, TEST_PIPENAME_3, connect_cb);
   } else {
@@ -191,13 +191,13 @@ static int run_test(int inprocess) {
   }
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(recv_cb_count, 2);
 
   if (inprocess) {
     r = uv_thread_join(&tid);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   return 0;
@@ -209,19 +209,19 @@ static int run_ipc_send_recv_pipe(int inprocess) {
   ctx.expected_type = UV_NAMED_PIPE;
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send.pipe, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&ctx.send.pipe, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_init(uv_default_loop(), &ctx.send2.pipe, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&ctx.send2.pipe, TEST_PIPENAME_2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = run_test(inprocess);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -245,24 +245,24 @@ static int run_ipc_send_recv_tcp(int inprocess) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   ctx.expected_type = UV_TCP;
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send.tcp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &ctx.send2.tcp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&ctx.send.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&ctx.send2.tcp, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = run_test(inprocess);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -286,7 +286,7 @@ TEST_IMPL(ipc_send_recv_tcp_inprocess) {
 /* Everything here runs in a child process or second thread. */
 
 static void write2_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   /* After two successful writes in the child process, allow the child
    * process to be closed. */
@@ -337,10 +337,10 @@ static void read_cb(uv_stream_t* handle,
       r = uv_tcp_init(ctx2.channel.loop, &recv->tcp);
     else
       abort();
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept(handle, &recv->stream);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     wrbuf = uv_buf_init(".", 1);
     r = uv_write2(write_req,
@@ -349,7 +349,7 @@ static void read_cb(uv_stream_t* handle,
                   1,
                   &recv->stream,
                   write2_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
@@ -357,19 +357,19 @@ static void send_recv_start(void) {
   int r;
   ASSERT_EQ(1, uv_is_readable((uv_stream_t*)&ctx2.channel));
   ASSERT_EQ(1, uv_is_writable((uv_stream_t*)&ctx2.channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*)&ctx2.channel));
+  ASSERT_OK(uv_is_closing((uv_handle_t*)&ctx2.channel));
 
   r = uv_read_start((uv_stream_t*)&ctx2.channel, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static void listen_cb(uv_stream_t* handle, int status) {
   int r;
   ASSERT_PTR_EQ(handle, (uv_stream_t*)&ctx2.listen);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_accept((uv_stream_t*)&ctx2.listen, (uv_stream_t*)&ctx2.channel);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   send_recv_start();
 }
@@ -382,27 +382,27 @@ int run_ipc_send_recv_helper(uv_loop_t* loop, int inprocess) {
   memset(&ctx2, 0, sizeof(ctx2));
 
   r = uv_pipe_init(loop, &ctx2.listen, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_init(loop, &ctx2.channel, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (inprocess) {
     r = uv_pipe_bind(&ctx2.listen, TEST_PIPENAME_3);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_listen((uv_stream_t*)&ctx2.listen, SOMAXCONN, listen_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   } else {
     r = uv_pipe_open(&ctx2.channel, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     send_recv_start();
   }
 
   notify_parent_process();
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   return 0;
 }
@@ -414,7 +414,7 @@ int ipc_send_recv_helper(void) {
   int r;
 
   r = run_ipc_send_recv_helper(uv_default_loop(), 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -425,11 +425,11 @@ void ipc_send_recv_helper_threadproc(void* arg) {
   uv_loop_t loop;
 
   r = uv_loop_init(&loop);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = run_ipc_send_recv_helper(&loop, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_loop_close(&loop);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -68,16 +68,16 @@ static void on_connection(uv_stream_t* server, int status) {
 
   if (!local_conn_accepted) {
     /* Accept the connection and close it.  Also and close the server. */
-    ASSERT_EQ(status, 0);
+    ASSERT_OK(status);
     ASSERT_PTR_EQ(&tcp_server, server);
 
     conn = malloc(sizeof(*conn));
     ASSERT_NOT_NULL(conn);
     r = uv_tcp_init(server->loop, conn);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept(server, (uv_stream_t*)conn);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     uv_close((uv_handle_t*)conn, close_server_conn_cb);
     uv_close((uv_handle_t*)server, NULL);
@@ -91,8 +91,8 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT_EQ(exit_status, 0);
-  ASSERT_EQ(term_signal, 0);
+  ASSERT_OK(exit_status);
+  ASSERT_OK(term_signal);
   uv_close((uv_handle_t*)process, NULL);
 }
 
@@ -126,14 +126,14 @@ static void make_many_connections(void) {
     ASSERT_NOT_NULL(conn);
 
     r = uv_tcp_init(uv_default_loop(), &conn->conn);
-    ASSERT_EQ(r, 0);
-    ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+    ASSERT_OK(r);
+    ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
     r = uv_tcp_connect(&conn->conn_req,
                        (uv_tcp_t*) &conn->conn,
                        (const struct sockaddr*) &addr,
                        connect_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     conn->conn.data = conn;
   }
@@ -179,13 +179,13 @@ static void on_read(uv_stream_t* handle,
     /* Accept the pending TCP server, and start listening on it. */
     ASSERT_EQ(pending, UV_TCP);
     r = uv_tcp_init(uv_default_loop(), &tcp_server);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept((uv_stream_t*)pipe, (uv_stream_t*)&tcp_server);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_listen((uv_stream_t*)&tcp_server, BACKLOG, on_connection);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     tcp_server_listening = 1;
 
@@ -194,13 +194,13 @@ static void on_read(uv_stream_t* handle,
 
     outbuf = uv_buf_init("foobar\n", 7);
     r = uv_write(&write_req, (uv_stream_t*)pipe, &outbuf, 1, NULL);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     /* Create a bunch of connections to get both servers to accept. */
     make_many_connections();
   } else if (memcmp("accepted_connection\n", buf->base, nread) == 0) {
     /* Remote server has accepted a connection.  Close the channel. */
-    ASSERT_EQ(0, uv_pipe_pending_count(pipe));
+    ASSERT_OK(uv_pipe_pending_count(pipe));
     ASSERT_EQ(pending, UV_UNKNOWN_HANDLE);
     remote_conn_accepted = 1;
     uv_close((uv_handle_t*)&channel, NULL);
@@ -248,28 +248,28 @@ static void on_read_listen_after_bound_twice(uv_stream_t* handle,
     /* Accept the first TCP server, and start listening on it. */
     ASSERT_EQ(pending, UV_TCP);
     r = uv_tcp_init(uv_default_loop(), &tcp_server);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept((uv_stream_t*)pipe, (uv_stream_t*)&tcp_server);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_listen((uv_stream_t*)&tcp_server, BACKLOG, on_connection);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   } else if (read_cb_called == 2) {
     /* Accept the second TCP server, and start listening on it. */
     ASSERT_EQ(pending, UV_TCP);
     r = uv_tcp_init(uv_default_loop(), &tcp_server2);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept((uv_stream_t*)pipe, (uv_stream_t*)&tcp_server2);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_listen((uv_stream_t*)&tcp_server2, BACKLOG, on_connection);
     ASSERT_EQ(r, UV_EADDRINUSE);
 
     uv_close((uv_handle_t*)&tcp_server, NULL);
     uv_close((uv_handle_t*)&tcp_server2, NULL);
-    ASSERT_EQ(0, uv_pipe_pending_count(pipe));
+    ASSERT_OK(uv_pipe_pending_count(pipe));
     uv_close((uv_handle_t*)&channel, NULL);
   }
 
@@ -288,12 +288,12 @@ void spawn_helper(uv_pipe_t* channel,
   uv_stdio_container_t stdio[3];
 
   r = uv_pipe_init(uv_default_loop(), channel, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(channel->ipc, 0);
 
   exepath_size = sizeof(exepath);
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   exepath[exepath_size] = '\0';
   args[0] = exepath;
@@ -315,12 +315,12 @@ void spawn_helper(uv_pipe_t* channel,
   stdio[2].data.fd = 2;
 
   r = uv_spawn(uv_default_loop(), process, &options);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
 static void on_tcp_write(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(req->handle, &tcp_connection);
   tcp_write_cb_called++;
 }
@@ -385,10 +385,10 @@ static void on_read_connection(uv_stream_t* handle,
   /* Accept the pending TCP connection */
   ASSERT_EQ(pending, UV_TCP);
   r = uv_tcp_init(uv_default_loop(), &tcp_connection);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(handle, (uv_stream_t*)&tcp_connection);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Make sure that the expected data is correctly multiplexed. */
   ASSERT_MEM_EQ("hello\n", buf->base, nread);
@@ -397,10 +397,10 @@ static void on_read_connection(uv_stream_t* handle,
   outbuf = uv_buf_init("world\n", 6);
   r = uv_write(&write_req, (uv_stream_t*)&tcp_connection, &outbuf, 1,
     on_tcp_write);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*)&tcp_connection, on_read_alloc, on_tcp_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   free(buf->base);
 }
@@ -422,7 +422,7 @@ static int run_ipc_test(const char* helper, uv_read_cb read_cb) {
   uv_read_start((uv_stream_t*)&channel, on_alloc, read_cb);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -474,19 +474,19 @@ TEST_IMPL(listen_with_simultaneous_accepts) {
   int r;
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_simultaneous_accepts(&server, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(server.reqs_pending, 32);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -499,19 +499,19 @@ TEST_IMPL(listen_no_simultaneous_accepts) {
   int r;
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_simultaneous_accepts(&server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(server.reqs_pending, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -532,7 +532,7 @@ TEST_IMPL(ipc_listen_after_bind_twice) {
 TEST_IMPL(ipc_send_zero) {
   int r;
   r = run_ipc_test("ipc_helper_send_zero", on_read_send_zero);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   return 0;
 }
 
@@ -563,7 +563,7 @@ static void tcp_connection_write_cb(uv_write_t* req, int status) {
 
 
 static void send_zero_write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   send_zero_write++;
 }
 
@@ -591,7 +591,7 @@ static void on_tcp_child_process_read(uv_stream_t* tcp,
   /* Write to the socket */
   outbuf = uv_buf_init("hello again\n", 12);
   r = uv_write(&conn.tcp_write_req, tcp, &outbuf, 1, tcp_connection_write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   tcp_conn_read_cb_called++;
 }
@@ -600,9 +600,9 @@ static void on_tcp_child_process_read(uv_stream_t* tcp,
 static void connect_child_process_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   r = uv_read_start(req->handle, on_read_alloc, on_tcp_child_process_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -615,21 +615,21 @@ static void ipc_on_connection(uv_stream_t* server, int status) {
      * Accept the connection and close it.  Also let the other
      * side know.
      */
-    ASSERT_EQ(status, 0);
+    ASSERT_OK(status);
     ASSERT_PTR_EQ(&tcp_server, server);
 
     r = uv_tcp_init(server->loop, &conn.conn);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_accept(server, (uv_stream_t*)&conn.conn);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     uv_close((uv_handle_t*)&conn.conn, close_cb);
 
     buf = uv_buf_init("accepted_connection\n", 20);
     r = uv_write2(&conn_notify_req, (uv_stream_t*)&channel, &buf, 1,
       NULL, conn_notify_write_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     connection_accepted = 1;
   }
@@ -646,28 +646,28 @@ static void ipc_on_connection_tcp_conn(uv_stream_t* server, int status) {
   uv_buf_t buf;
   uv_tcp_t* conn;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(&tcp_server, server);
 
   conn = malloc(sizeof(*conn));
   ASSERT_NOT_NULL(conn);
 
   r = uv_tcp_init(server->loop, conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(server, (uv_stream_t*)conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Send the accepted connection to the other process */
   buf = uv_buf_init("hello\n", 6);
   r = uv_write2(&conn_notify_req, (uv_stream_t*)&channel, &buf, 1,
     (uv_stream_t*)conn, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*) conn,
                     on_read_alloc,
                     on_tcp_child_process_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*)conn, close_and_free_cb);
 }
@@ -682,41 +682,41 @@ int ipc_helper(int listen_after_write) {
   int r;
   uv_buf_t buf;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_open(&channel, 0);
 
   ASSERT_EQ(1, uv_is_readable((uv_stream_t*) &channel));
   ASSERT_EQ(1, uv_is_writable((uv_stream_t*) &channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &channel));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &channel));
 
   r = uv_tcp_init(uv_default_loop(), &tcp_server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (!listen_after_write) {
     r = uv_listen((uv_stream_t*)&tcp_server, BACKLOG, ipc_on_connection);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   buf = uv_buf_init("hello\n", 6);
   r = uv_write2(&write_req, (uv_stream_t*)&channel, &buf, 1,
       (uv_stream_t*)&tcp_server, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (listen_after_write) {
     r = uv_listen((uv_stream_t*)&tcp_server, BACKLOG, ipc_on_connection);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   notify_parent_process();
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(connection_accepted, 1);
   ASSERT_EQ(close_cb_called, 3);
@@ -736,39 +736,39 @@ int ipc_helper_tcp_connection(void) {
   struct sockaddr_in addr;
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_open(&channel, 0);
 
   ASSERT_EQ(1, uv_is_readable((uv_stream_t*) &channel));
   ASSERT_EQ(1, uv_is_writable((uv_stream_t*) &channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &channel));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &channel));
 
   r = uv_tcp_init(uv_default_loop(), &tcp_server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&tcp_server, BACKLOG, ipc_on_connection_tcp_conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Make a connection to the server */
   r = uv_tcp_init(uv_default_loop(), &conn.conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_connect(&conn.conn_req,
                      (uv_tcp_t*) &conn.conn,
                      (const struct sockaddr*) &addr,
                      connect_child_process_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(tcp_conn_read_cb_called, 1);
   ASSERT_EQ(tcp_conn_write_cb_called, 1);
@@ -787,38 +787,38 @@ int ipc_helper_bind_twice(void) {
   int r;
   uv_buf_t buf;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_pipe_init(uv_default_loop(), &channel, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_open(&channel, 0);
 
   ASSERT_EQ(1, uv_is_readable((uv_stream_t*) &channel));
   ASSERT_EQ(1, uv_is_writable((uv_stream_t*) &channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &channel));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &channel));
 
   buf = uv_buf_init("hello\n", 6);
 
   r = uv_tcp_init(uv_default_loop(), &tcp_server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_init(uv_default_loop(), &tcp_server2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&tcp_server2, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_write2(&write_req, (uv_stream_t*)&channel, &buf, 1,
                 (uv_stream_t*)&tcp_server, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_write2(&write_req2, (uv_stream_t*)&channel, &buf, 1,
                 (uv_stream_t*)&tcp_server2, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -831,13 +831,13 @@ int ipc_helper_send_zero(void) {
   zero_buf = uv_buf_init(0, 0);
 
   r = uv_pipe_init(uv_default_loop(), &channel, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_open(&channel, 0);
 
   ASSERT_EQ(1, uv_is_readable((uv_stream_t*) &channel));
   ASSERT_EQ(1, uv_is_writable((uv_stream_t*) &channel));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &channel));
+  ASSERT_OK(uv_is_closing((uv_handle_t*) &channel));
 
   r = uv_write(&write_req,
                (uv_stream_t*)&channel,
@@ -845,10 +845,10 @@ int ipc_helper_send_zero(void) {
                1,
                send_zero_write_cb);
 
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(send_zero_write, 1);
 

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -289,7 +289,7 @@ void spawn_helper(uv_pipe_t* channel,
 
   r = uv_pipe_init(uv_default_loop(), channel, 1);
   ASSERT_OK(r);
-  ASSERT_NE(channel->ipc, 0);
+  ASSERT_NE(0, channel->ipc);
 
   exepath_size = sizeof(exepath);
   r = uv_exepath(exepath, &exepath_size);
@@ -434,10 +434,10 @@ TEST_IMPL(ipc_listen_before_write) {
   RETURN_SKIP(NO_SEND_HANDLE_ON_PIPE);
 #endif
   int r = run_ipc_test("ipc_helper_listen_before_write", on_read);
-  ASSERT_EQ(local_conn_accepted, 1);
-  ASSERT_EQ(remote_conn_accepted, 1);
-  ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(1, local_conn_accepted);
+  ASSERT_EQ(1, remote_conn_accepted);
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(1, exit_cb_called);
   return r;
 }
 
@@ -447,10 +447,10 @@ TEST_IMPL(ipc_listen_after_write) {
   RETURN_SKIP(NO_SEND_HANDLE_ON_PIPE);
 #endif
   int r = run_ipc_test("ipc_helper_listen_after_write", on_read);
-  ASSERT_EQ(local_conn_accepted, 1);
-  ASSERT_EQ(remote_conn_accepted, 1);
-  ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(1, local_conn_accepted);
+  ASSERT_EQ(1, remote_conn_accepted);
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(1, exit_cb_called);
   return r;
 }
 
@@ -460,10 +460,10 @@ TEST_IMPL(ipc_tcp_connection) {
   RETURN_SKIP(NO_SEND_HANDLE_ON_PIPE);
 #endif
   int r = run_ipc_test("ipc_helper_tcp_connection", on_read_connection);
-  ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(tcp_write_cb_called, 1);
-  ASSERT_EQ(tcp_read_cb_called, 1);
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(1, tcp_write_cb_called);
+  ASSERT_EQ(1, tcp_read_cb_called);
+  ASSERT_EQ(1, exit_cb_called);
   return r;
 }
 
@@ -487,7 +487,7 @@ TEST_IMPL(listen_with_simultaneous_accepts) {
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
   ASSERT_OK(r);
-  ASSERT_EQ(server.reqs_pending, 32);
+  ASSERT_EQ(32, server.reqs_pending);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -512,7 +512,7 @@ TEST_IMPL(listen_no_simultaneous_accepts) {
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
   ASSERT_OK(r);
-  ASSERT_EQ(server.reqs_pending, 1);
+  ASSERT_EQ(1, server.reqs_pending);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -523,8 +523,8 @@ TEST_IMPL(ipc_listen_after_bind_twice) {
   RETURN_SKIP(NO_SEND_HANDLE_ON_PIPE);
 #endif
   int r = run_ipc_test("ipc_helper_bind_twice", on_read_listen_after_bound_twice);
-  ASSERT_EQ(read_cb_called, 2);
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(2, read_cb_called);
+  ASSERT_EQ(1, exit_cb_called);
   return r;
 }
 #endif
@@ -718,8 +718,8 @@ int ipc_helper(int listen_after_write) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(connection_accepted, 1);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(1, connection_accepted);
+  ASSERT_EQ(3, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -770,9 +770,9 @@ int ipc_helper_tcp_connection(void) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(tcp_conn_read_cb_called, 1);
-  ASSERT_EQ(tcp_conn_write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 4);
+  ASSERT_EQ(1, tcp_conn_read_cb_called);
+  ASSERT_EQ(1, tcp_conn_write_cb_called);
+  ASSERT_EQ(4, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -850,7 +850,7 @@ int ipc_helper_send_zero(void) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(send_zero_write, 1);
+  ASSERT_EQ(1, send_zero_write);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -37,7 +37,7 @@ static void work_cb(uv_work_t* req) {
 
 static void after_work_cb(uv_work_t* req, int status) {
   ASSERT(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -51,16 +51,16 @@ TEST_IMPL(loop_alive) {
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   /* loops with requests are alive */
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-loop-alive.c
+++ b/test/test-loop-alive.c
@@ -37,7 +37,7 @@ static void work_cb(uv_work_t* req) {
 
 static void after_work_cb(uv_work_t* req, int status) {
   ASSERT(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -51,16 +51,16 @@ TEST_IMPL(loop_alive) {
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   /* loops with requests are alive */
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(uv_loop_alive(uv_default_loop()));
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(!uv_loop_alive(uv_default_loop()));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -35,7 +35,7 @@ TEST_IMPL(loop_close) {
   uv_loop_t loop;
 
   loop.data = &loop;
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
   ASSERT_PTR_EQ(loop.data, (void*) &loop);
 
   uv_timer_init(&loop, &timer_handle);
@@ -47,10 +47,10 @@ TEST_IMPL(loop_close) {
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_PTR_EQ(loop.data, (void*) &loop);
-  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_OK(uv_loop_close(&loop));
   ASSERT_PTR_EQ(loop.data, (void*) &loop);
 
   return 0;
@@ -67,11 +67,11 @@ static void loop_instant_close_after_work_cb(uv_work_t* req, int status) {
 TEST_IMPL(loop_instant_close) {
   static uv_loop_t loop;
   static uv_work_t req;
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_queue_work(&loop,
-                             &req,
-                             loop_instant_close_work_cb,
-                             loop_instant_close_after_work_cb));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_queue_work(&loop,
+                          &req,
+                          loop_instant_close_work_cb,
+                          loop_instant_close_after_work_cb));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-close.c
+++ b/test/test-loop-close.c
@@ -35,23 +35,23 @@ TEST_IMPL(loop_close) {
   uv_loop_t loop;
 
   loop.data = &loop;
-  ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(loop.data == (void*) &loop);
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_PTR_EQ(loop.data, (void*) &loop);
 
   uv_timer_init(&loop, &timer_handle);
   uv_timer_start(&timer_handle, timer_cb, 100, 100);
 
-  ASSERT(UV_EBUSY == uv_loop_close(&loop));
+  ASSERT_EQ(UV_EBUSY, uv_loop_close(&loop));
 
   uv_run(&loop, UV_RUN_DEFAULT);
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(loop.data == (void*) &loop);
-  ASSERT(0 == uv_loop_close(&loop));
-  ASSERT(loop.data == (void*) &loop);
+  ASSERT_PTR_EQ(loop.data, (void*) &loop);
+  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_PTR_EQ(loop.data, (void*) &loop);
 
   return 0;
 }
@@ -67,11 +67,11 @@ static void loop_instant_close_after_work_cb(uv_work_t* req, int status) {
 TEST_IMPL(loop_instant_close) {
   static uv_loop_t loop;
   static uv_work_t req;
-  ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(0 == uv_queue_work(&loop,
-                            &req,
-                            loop_instant_close_work_cb,
-                            loop_instant_close_after_work_cb));
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_queue_work(&loop,
+                             &req,
+                             loop_instant_close_work_cb,
+                             loop_instant_close_after_work_cb));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-loop-configure.c
+++ b/test/test-loop-configure.c
@@ -24,15 +24,15 @@ static void timer_cb(uv_timer_t* handle) {
 TEST_IMPL(loop_configure) {
   uv_timer_t timer_handle;
   uv_loop_t loop;
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 #ifdef _WIN32
-  ASSERT(UV_ENOSYS == uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, 0));
+  ASSERT_EQ(UV_ENOSYS, uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, 0));
 #else
-  ASSERT(0 == uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, SIGPROF));
+  ASSERT_EQ(0, uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, SIGPROF));
 #endif
-  ASSERT(0 == uv_timer_init(&loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 10, 0));
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(0 == uv_loop_close(&loop));
+  ASSERT_EQ(0, uv_timer_init(&loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 10, 0));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_loop_close(&loop));
   return 0;
 }

--- a/test/test-loop-configure.c
+++ b/test/test-loop-configure.c
@@ -24,15 +24,15 @@ static void timer_cb(uv_timer_t* handle) {
 TEST_IMPL(loop_configure) {
   uv_timer_t timer_handle;
   uv_loop_t loop;
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 #ifdef _WIN32
   ASSERT_EQ(UV_ENOSYS, uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, 0));
 #else
-  ASSERT_EQ(0, uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, SIGPROF));
+  ASSERT_OK(uv_loop_configure(&loop, UV_LOOP_BLOCK_SIGNAL, SIGPROF));
 #endif
-  ASSERT_EQ(0, uv_timer_init(&loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 10, 0));
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_OK(uv_timer_init(&loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 10, 0));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_loop_close(&loop));
   return 0;
 }

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -250,7 +250,7 @@ static void prepare_2_cb(uv_prepare_t* handle) {
    * stops itself immediately. A started watcher is not queued until the next
    * round, so when this callback is made (loop_iteration % 2 == 0) cannot be
    * true. */
-  ASSERT_NE(loop_iteration % 2, 0);
+  ASSERT_NE(0, loop_iteration % 2);
 
   r = uv_prepare_stop((uv_prepare_t*)handle);
   ASSERT_OK(r);
@@ -318,13 +318,13 @@ TEST_IMPL(loop_handles) {
   ASSERT_EQ(loop_iteration, ITERATIONS);
 
   ASSERT_EQ(prepare_1_cb_called, ITERATIONS);
-  ASSERT_EQ(prepare_1_close_cb_called, 1);
+  ASSERT_EQ(1, prepare_1_close_cb_called);
 
   ASSERT_EQ(prepare_2_cb_called, ITERATIONS / 2);
-  ASSERT_EQ(prepare_2_close_cb_called, 1);
+  ASSERT_EQ(1, prepare_2_close_cb_called);
 
   ASSERT_EQ(check_cb_called, ITERATIONS);
-  ASSERT_EQ(check_close_cb_called, 1);
+  ASSERT_EQ(1, check_close_cb_called);
 
   /* idle_1_cb should be called a lot */
   ASSERT_EQ(idle_1_close_cb_called, IDLE_COUNT);

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -108,7 +108,7 @@ static int idle_2_is_active = 0;
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_PTR_EQ(handle, &timer_handle);
 }
 
 
@@ -116,7 +116,7 @@ static void idle_2_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "IDLE_2_CLOSE_CB\n");
   fflush(stderr);
 
-  ASSERT(handle == (uv_handle_t*)&idle_2_handle);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&idle_2_handle);
 
   ASSERT(idle_2_is_active);
 
@@ -129,7 +129,7 @@ static void idle_2_cb(uv_idle_t* handle) {
   fprintf(stderr, "%s", "IDLE_2_CB\n");
   fflush(stderr);
 
-  ASSERT(handle == &idle_2_handle);
+  ASSERT_PTR_EQ(handle, &idle_2_handle);
 
   idle_2_cb_called++;
 
@@ -144,14 +144,14 @@ static void idle_1_cb(uv_idle_t* handle) {
   fflush(stderr);
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(idles_1_active > 0);
+  ASSERT_GT(idles_1_active, 0);
 
   /* Init idle_2 and make it active */
   if (!idle_2_is_active && !uv_is_closing((uv_handle_t*)&idle_2_handle)) {
     r = uv_idle_init(uv_default_loop(), &idle_2_handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_idle_start(&idle_2_handle, idle_2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     idle_2_is_active = 1;
     idle_2_cb_started++;
   }
@@ -160,7 +160,7 @@ static void idle_1_cb(uv_idle_t* handle) {
 
   if (idle_1_cb_called % 5 == 0) {
     r = uv_idle_stop((uv_idle_t*)handle);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     idles_1_active--;
   }
 }
@@ -179,7 +179,7 @@ static void idle_1_close_cb(uv_handle_t* handle) {
 static void prepare_1_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "PREPARE_1_CLOSE_CB");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&prepare_1_handle);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&prepare_1_handle);
 
   prepare_1_close_cb_called++;
 }
@@ -188,7 +188,7 @@ static void prepare_1_close_cb(uv_handle_t* handle) {
 static void check_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "CHECK_CLOSE_CB\n");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&check_handle);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&check_handle);
 
   check_close_cb_called++;
 }
@@ -197,7 +197,7 @@ static void check_close_cb(uv_handle_t* handle) {
 static void prepare_2_close_cb(uv_handle_t* handle) {
   fprintf(stderr, "%s", "PREPARE_2_CLOSE_CB\n");
   fflush(stderr);
-  ASSERT(handle == (uv_handle_t*)&prepare_2_handle);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&prepare_2_handle);
 
   prepare_2_close_cb_called++;
 }
@@ -208,13 +208,13 @@ static void check_cb(uv_check_t* handle) {
 
   fprintf(stderr, "%s", "CHECK_CB\n");
   fflush(stderr);
-  ASSERT(handle == &check_handle);
+  ASSERT_PTR_EQ(handle, &check_handle);
 
   if (loop_iteration < ITERATIONS) {
     /* Make some idle watchers active */
     for (i = 0; i < 1 + (loop_iteration % IDLE_COUNT); i++) {
       r = uv_idle_start(&idle_1_handles[i], idle_1_cb);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
       idles_1_active++;
     }
 
@@ -244,16 +244,16 @@ static void prepare_2_cb(uv_prepare_t* handle) {
 
   fprintf(stderr, "%s", "PREPARE_2_CB\n");
   fflush(stderr);
-  ASSERT(handle == &prepare_2_handle);
+  ASSERT_PTR_EQ(handle, &prepare_2_handle);
 
   /* Prepare_2 gets started by prepare_1 when (loop_iteration % 2 == 0), and it
    * stops itself immediately. A started watcher is not queued until the next
    * round, so when this callback is made (loop_iteration % 2 == 0) cannot be
    * true. */
-  ASSERT(loop_iteration % 2 != 0);
+  ASSERT_NE(loop_iteration % 2, 0);
 
   r = uv_prepare_stop((uv_prepare_t*)handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   prepare_2_cb_called++;
 }
@@ -264,11 +264,11 @@ static void prepare_1_cb(uv_prepare_t* handle) {
 
   fprintf(stderr, "%s", "PREPARE_1_CB\n");
   fflush(stderr);
-  ASSERT(handle == &prepare_1_handle);
+  ASSERT_PTR_EQ(handle, &prepare_1_handle);
 
   if (loop_iteration % 2 == 0) {
     r = uv_prepare_start(&prepare_2_handle, prepare_2_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   prepare_1_cb_called++;
@@ -283,23 +283,23 @@ TEST_IMPL(loop_handles) {
   int r;
 
   r = uv_prepare_init(uv_default_loop(), &prepare_1_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare_1_handle, prepare_1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* initialize only, prepare_2 is started by prepare_1_cb */
   r = uv_prepare_init(uv_default_loop(), &prepare_2_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < IDLE_COUNT; i++) {
     /* initialize only, idle_1 handles are started by check_cb */
     r = uv_idle_init(uv_default_loop(), &idle_1_handles[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* don't init or start idle_2, both is done by idle_1_cb */
@@ -307,30 +307,30 @@ TEST_IMPL(loop_handles) {
   /* The timer callback is there to keep the event loop polling unref it as it
    * is not supposed to keep the loop alive */
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&timer_handle, timer_cb, TIMEOUT, TIMEOUT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_unref((uv_handle_t*)&timer_handle);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(loop_iteration == ITERATIONS);
+  ASSERT_EQ(loop_iteration, ITERATIONS);
 
-  ASSERT(prepare_1_cb_called == ITERATIONS);
-  ASSERT(prepare_1_close_cb_called == 1);
+  ASSERT_EQ(prepare_1_cb_called, ITERATIONS);
+  ASSERT_EQ(prepare_1_close_cb_called, 1);
 
-  ASSERT(prepare_2_cb_called == ITERATIONS / 2);
-  ASSERT(prepare_2_close_cb_called == 1);
+  ASSERT_EQ(prepare_2_cb_called, ITERATIONS / 2);
+  ASSERT_EQ(prepare_2_close_cb_called, 1);
 
-  ASSERT(check_cb_called == ITERATIONS);
-  ASSERT(check_close_cb_called == 1);
+  ASSERT_EQ(check_cb_called, ITERATIONS);
+  ASSERT_EQ(check_close_cb_called, 1);
 
   /* idle_1_cb should be called a lot */
-  ASSERT(idle_1_close_cb_called == IDLE_COUNT);
+  ASSERT_EQ(idle_1_close_cb_called, IDLE_COUNT);
 
-  ASSERT(idle_2_close_cb_called == idle_2_cb_started);
-  ASSERT(idle_2_is_active == 0);
+  ASSERT_EQ(idle_2_close_cb_called, idle_2_cb_started);
+  ASSERT_EQ(idle_2_is_active, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-loop-handles.c
+++ b/test/test-loop-handles.c
@@ -149,9 +149,9 @@ static void idle_1_cb(uv_idle_t* handle) {
   /* Init idle_2 and make it active */
   if (!idle_2_is_active && !uv_is_closing((uv_handle_t*)&idle_2_handle)) {
     r = uv_idle_init(uv_default_loop(), &idle_2_handle);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     r = uv_idle_start(&idle_2_handle, idle_2_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     idle_2_is_active = 1;
     idle_2_cb_started++;
   }
@@ -160,7 +160,7 @@ static void idle_1_cb(uv_idle_t* handle) {
 
   if (idle_1_cb_called % 5 == 0) {
     r = uv_idle_stop((uv_idle_t*)handle);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     idles_1_active--;
   }
 }
@@ -214,7 +214,7 @@ static void check_cb(uv_check_t* handle) {
     /* Make some idle watchers active */
     for (i = 0; i < 1 + (loop_iteration % IDLE_COUNT); i++) {
       r = uv_idle_start(&idle_1_handles[i], idle_1_cb);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
       idles_1_active++;
     }
 
@@ -253,7 +253,7 @@ static void prepare_2_cb(uv_prepare_t* handle) {
   ASSERT_NE(loop_iteration % 2, 0);
 
   r = uv_prepare_stop((uv_prepare_t*)handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   prepare_2_cb_called++;
 }
@@ -268,7 +268,7 @@ static void prepare_1_cb(uv_prepare_t* handle) {
 
   if (loop_iteration % 2 == 0) {
     r = uv_prepare_start(&prepare_2_handle, prepare_2_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   prepare_1_cb_called++;
@@ -283,23 +283,23 @@ TEST_IMPL(loop_handles) {
   int r;
 
   r = uv_prepare_init(uv_default_loop(), &prepare_1_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_prepare_start(&prepare_1_handle, prepare_1_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_check_init(uv_default_loop(), &check_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_check_start(&check_handle, check_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* initialize only, prepare_2 is started by prepare_1_cb */
   r = uv_prepare_init(uv_default_loop(), &prepare_2_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   for (i = 0; i < IDLE_COUNT; i++) {
     /* initialize only, idle_1 handles are started by check_cb */
     r = uv_idle_init(uv_default_loop(), &idle_1_handles[i]);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   /* don't init or start idle_2, both is done by idle_1_cb */
@@ -307,13 +307,13 @@ TEST_IMPL(loop_handles) {
   /* The timer callback is there to keep the event loop polling unref it as it
    * is not supposed to keep the loop alive */
   r = uv_timer_init(uv_default_loop(), &timer_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&timer_handle, timer_cb, TIMEOUT, TIMEOUT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_unref((uv_handle_t*)&timer_handle);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(loop_iteration, ITERATIONS);
 
@@ -330,7 +330,7 @@ TEST_IMPL(loop_handles) {
   ASSERT_EQ(idle_1_close_cb_called, IDLE_COUNT);
 
   ASSERT_EQ(idle_2_close_cb_called, idle_2_cb_started);
-  ASSERT_EQ(idle_2_is_active, 0);
+  ASSERT_OK(idle_2_is_active);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -30,7 +30,7 @@ static int num_ticks = 10;
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT(handle == &prepare_handle);
+  ASSERT_PTR_EQ(handle, &prepare_handle);
   prepare_called++;
   if (prepare_called == num_ticks)
     uv_prepare_stop(handle);
@@ -38,7 +38,7 @@ static void prepare_cb(uv_prepare_t* handle) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_PTR_EQ(handle, &timer_handle);
   timer_called++;
   if (timer_called == 1)
     uv_stop(uv_default_loop());
@@ -55,17 +55,17 @@ TEST_IMPL(loop_stop) {
   uv_timer_start(&timer_handle, timer_cb, 100, 100);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r != 0);
-  ASSERT(timer_called == 1);
+  ASSERT(r);
+  ASSERT_EQ(timer_called, 1);
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-  ASSERT(r != 0);
-  ASSERT(prepare_called > 1);
+  ASSERT(r);
+  ASSERT_GT(prepare_called, 1);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(timer_called == 10);
-  ASSERT(prepare_called == 10);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(timer_called, 10);
+  ASSERT_EQ(prepare_called, 10);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -63,7 +63,7 @@ TEST_IMPL(loop_stop) {
   ASSERT_GT(prepare_called, 1);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(timer_called, 10);
   ASSERT_EQ(prepare_called, 10);
 

--- a/test/test-loop-stop.c
+++ b/test/test-loop-stop.c
@@ -56,7 +56,7 @@ TEST_IMPL(loop_stop) {
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT(r);
-  ASSERT_EQ(timer_called, 1);
+  ASSERT_EQ(1, timer_called);
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
   ASSERT(r);
@@ -64,8 +64,8 @@ TEST_IMPL(loop_stop) {
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(timer_called, 10);
-  ASSERT_EQ(prepare_called, 10);
+  ASSERT_EQ(10, timer_called);
+  ASSERT_EQ(10, prepare_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -76,7 +76,7 @@ TEST_IMPL(loop_stop_before_run) {
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, (uv_timer_cb) abort, 0, 0));
   uv_stop(uv_default_loop());
-  ASSERT_NE(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
+  ASSERT_NE(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -28,7 +28,7 @@ TEST_IMPL(loop_update_time) {
 
   start = uv_now(uv_default_loop());
   while (uv_now(uv_default_loop()) - start < 1000)
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -48,21 +48,21 @@ TEST_IMPL(loop_backend_timeout) {
   r = uv_run(loop, UV_RUN_NOWAIT);
   ASSERT_EQ(r, 1);
   loop->active_handles--;
-  ASSERT_EQ(uv_loop_alive(loop), 0);
+  ASSERT_OK(uv_loop_alive(loop));
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(uv_loop_alive(loop), 0);
-  ASSERT_EQ(uv_backend_timeout(loop), 0);
+  ASSERT_OK(uv_loop_alive(loop));
+  ASSERT_OK(uv_backend_timeout(loop));
 
   r = uv_timer_start(&timer, cb, 1000, 0); /* 1 sec */
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(uv_backend_timeout(loop), 1000);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(uv_backend_timeout(loop), 0);
+  ASSERT_OK(r);
+  ASSERT_OK(uv_backend_timeout(loop));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-loop-time.c
+++ b/test/test-loop-time.c
@@ -46,7 +46,7 @@ TEST_IMPL(loop_backend_timeout) {
   /* The default loop has some internal watchers to initialize. */
   loop->active_handles++;
   r = uv_run(loop, UV_RUN_NOWAIT);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
   loop->active_handles--;
   ASSERT_OK(uv_loop_alive(loop));
 
@@ -58,7 +58,7 @@ TEST_IMPL(loop_backend_timeout) {
 
   r = uv_timer_start(&timer, cb, 1000, 0); /* 1 sec */
   ASSERT_OK(r);
-  ASSERT_EQ(uv_backend_timeout(loop), 1000);
+  ASSERT_EQ(1000, uv_backend_timeout(loop));
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);

--- a/test/test-metrics.c
+++ b/test/test-metrics.c
@@ -59,11 +59,11 @@ TEST_IMPL(metrics_idle_time) {
   cntr = 0;
   timer.data = &cntr;
 
-  ASSERT_EQ(0, uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
-  ASSERT_EQ(0, uv_timer_start(&timer, timer_spin_cb, timeout, 0));
+  ASSERT_OK(uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_OK(uv_timer_start(&timer, timer_spin_cb, timeout, 0));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_GT(cntr, 0);
 
   idle_time = uv_metrics_idle_time(uv_default_loop());
@@ -87,12 +87,12 @@ static void metrics_routine_cb(void* arg) {
   cntr = 0;
   timer.data = &cntr;
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_loop_configure(&loop, UV_METRICS_IDLE_TIME));
-  ASSERT_EQ(0, uv_timer_init(&loop, &timer));
-  ASSERT_EQ(0, uv_timer_start(&timer, timer_spin_cb, timeout, 0));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_configure(&loop, UV_METRICS_IDLE_TIME));
+  ASSERT_OK(uv_timer_init(&loop, &timer));
+  ASSERT_OK(uv_timer_start(&timer, timer_spin_cb, timeout, 0));
 
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
   ASSERT_GT(cntr, 0);
 
   idle_time = uv_metrics_idle_time(&loop);
@@ -104,7 +104,7 @@ static void metrics_routine_cb(void* arg) {
   ASSERT_GE(idle_time, (timeout - 500) * UV_NS_TO_MS);
 
   close_loop(&loop);
-  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_OK(uv_loop_close(&loop));
 }
 
 
@@ -113,7 +113,7 @@ TEST_IMPL(metrics_idle_time_thread) {
   int i;
 
   for (i = 0; i < 5; i++) {
-    ASSERT_EQ(0, uv_thread_create(&threads[i], metrics_routine_cb, NULL));
+    ASSERT_OK(uv_thread_create(&threads[i], metrics_routine_cb, NULL));
   }
 
   for (i = 0; i < 5; i++) {
@@ -136,16 +136,16 @@ TEST_IMPL(metrics_idle_time_zero) {
 
   cntr = 0;
   timer.data = &cntr;
-  ASSERT_EQ(0, uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
-  ASSERT_EQ(0, uv_timer_start(&timer, timer_noop_cb, 0, 0));
+  ASSERT_OK(uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_OK(uv_timer_start(&timer, timer_noop_cb, 0, 0));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_GT(cntr, 0);
-  ASSERT_EQ(0, uv_metrics_idle_time(uv_default_loop()));
+  ASSERT_OK(uv_metrics_idle_time(uv_default_loop()));
 
-  ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
+  ASSERT_OK(uv_metrics_info(uv_default_loop(), &metrics));
   ASSERT_UINT64_EQ(cntr, metrics.loop_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -156,7 +156,7 @@ TEST_IMPL(metrics_idle_time_zero) {
 static void close_cb(uv_fs_t* req) {
   uv_metrics_t metrics;
 
-  ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
+  ASSERT_OK(uv_metrics_info(uv_default_loop(), &metrics));
   ASSERT_UINT64_EQ(3, metrics.loop_count);
   ASSERT_UINT64_GT(metrics.events, last_events_count);
 
@@ -168,7 +168,7 @@ static void close_cb(uv_fs_t* req) {
 static void write_cb(uv_fs_t* req) {
   uv_metrics_t metrics;
 
-  ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
+  ASSERT_OK(uv_metrics_info(uv_default_loop(), &metrics));
   ASSERT_UINT64_EQ(2, metrics.loop_count);
   ASSERT_UINT64_GT(metrics.events, last_events_count);
   ASSERT_EQ(req->result, sizeof(test_buf));
@@ -176,17 +176,17 @@ static void write_cb(uv_fs_t* req) {
   uv_fs_req_cleanup(req);
   last_events_count = metrics.events;
 
-  ASSERT_EQ(0, uv_fs_close(uv_default_loop(),
-                           &fs_reqs.close_req,
-                           fs_reqs.open_req.result,
-                           close_cb));
+  ASSERT_OK(uv_fs_close(uv_default_loop(),
+                        &fs_reqs.close_req,
+                        fs_reqs.open_req.result,
+                        close_cb));
 }
 
 
 static void create_cb(uv_fs_t* req) {
   uv_metrics_t metrics;
 
-  ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
+  ASSERT_OK(uv_metrics_info(uv_default_loop(), &metrics));
   /* Event count here is still 0 so not going to check. */
   ASSERT_UINT64_EQ(1, metrics.loop_count);
   ASSERT_GE(req->result, 0);
@@ -195,13 +195,13 @@ static void create_cb(uv_fs_t* req) {
   last_events_count = metrics.events;
 
   uv_buf_t iov = uv_buf_init(test_buf, sizeof(test_buf));
-  ASSERT_EQ(0, uv_fs_write(uv_default_loop(),
-                           &fs_reqs.write_req,
-                           req->result,
-                           &iov,
-                           1,
-                           0,
-                           write_cb));
+  ASSERT_OK(uv_fs_write(uv_default_loop(),
+                        &fs_reqs.write_req,
+                        req->result,
+                        &iov,
+                        1,
+                        0,
+                        write_cb));
 }
 
 
@@ -210,15 +210,15 @@ static void prepare_cb(uv_prepare_t* handle) {
 
   uv_prepare_stop(handle);
 
-  ASSERT_EQ(0, uv_metrics_info(uv_default_loop(), &metrics));
+  ASSERT_OK(uv_metrics_info(uv_default_loop(), &metrics));
   ASSERT_UINT64_EQ(0, metrics.loop_count);
   ASSERT_UINT64_EQ(0, metrics.events);
 
-  ASSERT_EQ(0, uv_fs_open(uv_default_loop(),
-                          &fs_reqs.open_req,
-                          "test_file",
-                          O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR,
-                          create_cb));
+  ASSERT_OK(uv_fs_open(uv_default_loop(),
+                       &fs_reqs.open_req,
+                       "test_file",
+                       O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR,
+                       create_cb));
 }
 
 
@@ -229,10 +229,10 @@ TEST_IMPL(metrics_info_check) {
   uv_fs_unlink(NULL, &unlink_req, "test_file", NULL);
   uv_fs_req_cleanup(&unlink_req);
 
-  ASSERT_EQ(0, uv_prepare_init(uv_default_loop(), &prepare));
-  ASSERT_EQ(0, uv_prepare_start(&prepare, prepare_cb));
+  ASSERT_OK(uv_prepare_init(uv_default_loop(), &prepare));
+  ASSERT_OK(uv_prepare_start(&prepare, prepare_cb));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   uv_fs_unlink(NULL, &unlink_req, "test_file", NULL);
   uv_fs_req_cleanup(&unlink_req);

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*)&server, close_cb);
   connection_cb_called++;
 }
@@ -48,25 +48,25 @@ static void start_server(void) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   free(req);
   uv_close((uv_handle_t*)&client, close_cb);
   connect_cb_called++;
@@ -78,17 +78,17 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -100,9 +100,9 @@ TEST_IMPL(multiple_listen) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -100,9 +100,9 @@ TEST_IMPL(multiple_listen) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connection_cb_called, 1);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, connection_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-multiple-listen.c
+++ b/test/test-multiple-listen.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   uv_close((uv_handle_t*)&server, close_cb);
   connection_cb_called++;
 }
@@ -48,25 +48,25 @@ static void start_server(void) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   free(req);
   uv_close((uv_handle_t*)&client, close_cb);
   connect_cb_called++;
@@ -78,17 +78,17 @@ static void client_connect(void) {
   uv_connect_t* connect_req = malloc(sizeof *connect_req);
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   ASSERT_NOT_NULL(connect_req);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -40,7 +40,7 @@ TEST_IMPL(thread_mutex) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_mutex_lock(&mutex);
   uv_mutex_unlock(&mutex);
@@ -55,11 +55,11 @@ TEST_IMPL(thread_mutex_recursive) {
   int r;
 
   r = uv_mutex_init_recursive(&mutex);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_mutex_lock(&mutex);
   uv_mutex_lock(&mutex);
-  ASSERT(0 == uv_mutex_trylock(&mutex));
+  ASSERT_EQ(0, uv_mutex_trylock(&mutex));
 
   uv_mutex_unlock(&mutex);
   uv_mutex_unlock(&mutex);
@@ -75,7 +75,7 @@ TEST_IMPL(thread_rwlock) {
   int r;
 
   r = uv_rwlock_init(&rwlock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_rwlock_rdlock(&rwlock);
   uv_rwlock_rdunlock(&rwlock);
@@ -101,7 +101,7 @@ static void synchronize(void) {
   synchronize_nowait();
   /* Wait for the other thread.  Guard against spurious wakeups. */
   for (current = step; current == step; uv_cond_wait(&condvar, &mutex));
-  ASSERT(step == current + 1);
+  ASSERT_EQ(step, current + 1);
 }
 
 
@@ -111,23 +111,23 @@ static void thread_rwlock_trylock_peer(void* unused) {
   uv_mutex_lock(&mutex);
 
   /* Write lock held by other thread. */
-  ASSERT(UV_EBUSY == uv_rwlock_tryrdlock(&rwlock));
-  ASSERT(UV_EBUSY == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Read lock held by other thread. */
-  ASSERT(0 == uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
   uv_rwlock_rdunlock(&rwlock);
-  ASSERT(UV_EBUSY == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Acquire write lock. */
-  ASSERT(0 == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Release write lock and acquire read lock. */
   uv_rwlock_wrunlock(&rwlock);
-  ASSERT(0 == uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
   synchronize();
 
   uv_rwlock_rdunlock(&rwlock);
@@ -139,22 +139,22 @@ static void thread_rwlock_trylock_peer(void* unused) {
 TEST_IMPL(thread_rwlock_trylock) {
   uv_thread_t thread;
 
-  ASSERT(0 == uv_cond_init(&condvar));
-  ASSERT(0 == uv_mutex_init(&mutex));
-  ASSERT(0 == uv_rwlock_init(&rwlock));
+  ASSERT_EQ(0, uv_cond_init(&condvar));
+  ASSERT_EQ(0, uv_mutex_init(&mutex));
+  ASSERT_EQ(0, uv_rwlock_init(&rwlock));
 
   uv_mutex_lock(&mutex);
-  ASSERT(0 == uv_thread_create(&thread, thread_rwlock_trylock_peer, NULL));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_rwlock_trylock_peer, NULL));
 
   /* Hold write lock. */
-  ASSERT(0 == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_trywrlock(&rwlock));
   synchronize();  /* Releases the mutex to the other thread. */
 
   /* Release write lock and acquire read lock.  Pthreads doesn't support
    * the notion of upgrading or downgrading rwlocks, so neither do we.
    */
   uv_rwlock_wrunlock(&rwlock);
-  ASSERT(0 == uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
   synchronize();
 
   /* Release read lock. */
@@ -162,17 +162,17 @@ TEST_IMPL(thread_rwlock_trylock) {
   synchronize();
 
   /* Write lock held by other thread. */
-  ASSERT(UV_EBUSY == uv_rwlock_tryrdlock(&rwlock));
-  ASSERT(UV_EBUSY == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Read lock held by other thread. */
-  ASSERT(0 == uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
   uv_rwlock_rdunlock(&rwlock);
-  ASSERT(UV_EBUSY == uv_rwlock_trywrlock(&rwlock));
+  ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   uv_rwlock_destroy(&rwlock);
   uv_mutex_unlock(&mutex);
   uv_mutex_destroy(&mutex);

--- a/test/test-mutexes.c
+++ b/test/test-mutexes.c
@@ -40,7 +40,7 @@ TEST_IMPL(thread_mutex) {
   int r;
 
   r = uv_mutex_init(&mutex);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_mutex_lock(&mutex);
   uv_mutex_unlock(&mutex);
@@ -55,11 +55,11 @@ TEST_IMPL(thread_mutex_recursive) {
   int r;
 
   r = uv_mutex_init_recursive(&mutex);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_mutex_lock(&mutex);
   uv_mutex_lock(&mutex);
-  ASSERT_EQ(0, uv_mutex_trylock(&mutex));
+  ASSERT_OK(uv_mutex_trylock(&mutex));
 
   uv_mutex_unlock(&mutex);
   uv_mutex_unlock(&mutex);
@@ -75,7 +75,7 @@ TEST_IMPL(thread_rwlock) {
   int r;
 
   r = uv_rwlock_init(&rwlock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_rwlock_rdlock(&rwlock);
   uv_rwlock_rdunlock(&rwlock);
@@ -116,18 +116,18 @@ static void thread_rwlock_trylock_peer(void* unused) {
   synchronize();
 
   /* Read lock held by other thread. */
-  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_OK(uv_rwlock_tryrdlock(&rwlock));
   uv_rwlock_rdunlock(&rwlock);
   ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Acquire write lock. */
-  ASSERT_EQ(0, uv_rwlock_trywrlock(&rwlock));
+  ASSERT_OK(uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
   /* Release write lock and acquire read lock. */
   uv_rwlock_wrunlock(&rwlock);
-  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_OK(uv_rwlock_tryrdlock(&rwlock));
   synchronize();
 
   uv_rwlock_rdunlock(&rwlock);
@@ -139,22 +139,22 @@ static void thread_rwlock_trylock_peer(void* unused) {
 TEST_IMPL(thread_rwlock_trylock) {
   uv_thread_t thread;
 
-  ASSERT_EQ(0, uv_cond_init(&condvar));
-  ASSERT_EQ(0, uv_mutex_init(&mutex));
-  ASSERT_EQ(0, uv_rwlock_init(&rwlock));
+  ASSERT_OK(uv_cond_init(&condvar));
+  ASSERT_OK(uv_mutex_init(&mutex));
+  ASSERT_OK(uv_rwlock_init(&rwlock));
 
   uv_mutex_lock(&mutex);
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_rwlock_trylock_peer, NULL));
+  ASSERT_OK(uv_thread_create(&thread, thread_rwlock_trylock_peer, NULL));
 
   /* Hold write lock. */
-  ASSERT_EQ(0, uv_rwlock_trywrlock(&rwlock));
+  ASSERT_OK(uv_rwlock_trywrlock(&rwlock));
   synchronize();  /* Releases the mutex to the other thread. */
 
   /* Release write lock and acquire read lock.  Pthreads doesn't support
    * the notion of upgrading or downgrading rwlocks, so neither do we.
    */
   uv_rwlock_wrunlock(&rwlock);
-  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_OK(uv_rwlock_tryrdlock(&rwlock));
   synchronize();
 
   /* Release read lock. */
@@ -167,12 +167,12 @@ TEST_IMPL(thread_rwlock_trylock) {
   synchronize();
 
   /* Read lock held by other thread. */
-  ASSERT_EQ(0, uv_rwlock_tryrdlock(&rwlock));
+  ASSERT_OK(uv_rwlock_tryrdlock(&rwlock));
   uv_rwlock_rdunlock(&rwlock);
   ASSERT_EQ(UV_EBUSY, uv_rwlock_trywrlock(&rwlock));
   synchronize();
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_rwlock_destroy(&rwlock);
   uv_mutex_unlock(&mutex);
   uv_mutex_destroy(&mutex);

--- a/test/test-not-readable-nor-writable-on-read-error.c
+++ b/test/test-not-readable-nor-writable-on-read-error.c
@@ -35,7 +35,7 @@ static int close_cb_called;
 
 static void write_cb(uv_write_t* req, int status) {
   write_cb_called++;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -54,8 +54,8 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   read_cb_called++;
 
   ASSERT((nread < 0) && (nread != UV_EOF));
-  ASSERT(0 == uv_is_writable(handle));
-  ASSERT(0 == uv_is_readable(handle));
+  ASSERT_EQ(0, uv_is_writable(handle));
+  ASSERT_EQ(0, uv_is_readable(handle));
 
   uv_close((uv_handle_t*) handle, close_cb);
 }
@@ -65,10 +65,10 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_buf_t reset_me;
 
   connect_cb_called++;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_read_start((uv_stream_t*) &tcp_client, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   reset_me = uv_buf_init(reset_me_cmd, sizeof(reset_me_cmd));
 
@@ -78,26 +78,26 @@ static void connect_cb(uv_connect_t* req, int status) {
                1,
                write_cb);
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 TEST_IMPL(not_readable_nor_writable_on_read_error) {
   struct sockaddr_in sa;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
-  ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(0 == uv_tcp_init(&loop, &tcp_client));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_tcp_init(&loop, &tcp_client));
 
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &tcp_client,
-                             (const struct sockaddr*) &sa,
-                             connect_cb));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &tcp_client,
+                              (const struct sockaddr*) &sa,
+                              connect_cb));
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(read_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(read_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-not-readable-nor-writable-on-read-error.c
+++ b/test/test-not-readable-nor-writable-on-read-error.c
@@ -35,7 +35,7 @@ static int close_cb_called;
 
 static void write_cb(uv_write_t* req, int status) {
   write_cb_called++;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -54,8 +54,8 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   read_cb_called++;
 
   ASSERT((nread < 0) && (nread != UV_EOF));
-  ASSERT_EQ(0, uv_is_writable(handle));
-  ASSERT_EQ(0, uv_is_readable(handle));
+  ASSERT_OK(uv_is_writable(handle));
+  ASSERT_OK(uv_is_readable(handle));
 
   uv_close((uv_handle_t*) handle, close_cb);
 }
@@ -65,10 +65,10 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_buf_t reset_me;
 
   connect_cb_called++;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_read_start((uv_stream_t*) &tcp_client, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   reset_me = uv_buf_init(reset_me_cmd, sizeof(reset_me_cmd));
 
@@ -78,21 +78,21 @@ static void connect_cb(uv_connect_t* req, int status) {
                1,
                write_cb);
 
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 TEST_IMPL(not_readable_nor_writable_on_read_error) {
   struct sockaddr_in sa;
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_tcp_init(&loop, &tcp_client));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_tcp_init(&loop, &tcp_client));
 
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &tcp_client,
-                              (const struct sockaddr*) &sa,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &tcp_client,
+                           (const struct sockaddr*) &sa,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(read_cb_called, 1);

--- a/test/test-not-readable-nor-writable-on-read-error.c
+++ b/test/test-not-readable-nor-writable-on-read-error.c
@@ -94,10 +94,10 @@ TEST_IMPL(not_readable_nor_writable_on_read_error) {
 
   ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-not-writable-after-shutdown.c
+++ b/test/test-not-writable-after-shutdown.c
@@ -34,12 +34,12 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_is_writable(req->handle));
+  ASSERT_OK(uv_is_writable(req->handle));
 }
 
 TEST_IMPL(not_writable_after_shutdown) {
@@ -49,20 +49,20 @@ TEST_IMPL(not_writable_after_shutdown) {
   uv_tcp_t socket;
   uv_connect_t connect_req;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &socket);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &socket,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-not-writable-after-shutdown.c
+++ b/test/test-not-writable-after-shutdown.c
@@ -34,12 +34,12 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_is_writable(req->handle));
+  ASSERT_EQ(0, uv_is_writable(req->handle));
 }
 
 TEST_IMPL(not_writable_after_shutdown) {
@@ -49,20 +49,20 @@ TEST_IMPL(not_writable_after_shutdown) {
   uv_tcp_t socket;
   uv_connect_t connect_req;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &socket);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &socket,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -62,7 +62,7 @@ TEST_IMPL(osx_select) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
 
@@ -72,7 +72,7 @@ TEST_IMPL(osx_select) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -97,13 +97,13 @@ TEST_IMPL(osx_select_many_fds) {
   TEST_FILE_LIMIT(ARRAY_SIZE(tcps) + 100);
 
   r = uv_ip4_addr("127.0.0.1", 0, &addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   for (i = 0; i < ARRAY_SIZE(tcps); i++) {
     r = uv_tcp_init(uv_default_loop(), &tcps[i]);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     r = uv_tcp_bind(&tcps[i], (const struct sockaddr *) &addr, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_unref((uv_handle_t*) &tcps[i]);
   }
 
@@ -115,10 +115,10 @@ TEST_IMPL(osx_select_many_fds) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Emulate user-input */
   str = "got some input\n"
@@ -126,7 +126,7 @@ TEST_IMPL(osx_select_many_fds) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -62,7 +62,7 @@ TEST_IMPL(osx_select) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
 
@@ -72,12 +72,12 @@ TEST_IMPL(osx_select) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(read_count == 3);
+  ASSERT_EQ(read_count, 3);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -97,13 +97,13 @@ TEST_IMPL(osx_select_many_fds) {
   TEST_FILE_LIMIT(ARRAY_SIZE(tcps) + 100);
 
   r = uv_ip4_addr("127.0.0.1", 0, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < ARRAY_SIZE(tcps); i++) {
     r = uv_tcp_init(uv_default_loop(), &tcps[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_tcp_bind(&tcps[i], (const struct sockaddr *) &addr, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_unref((uv_handle_t*) &tcps[i]);
   }
 
@@ -115,10 +115,10 @@ TEST_IMPL(osx_select_many_fds) {
   }
 
   r = uv_tty_init(uv_default_loop(), &tty, fd, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &tty, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate user-input */
   str = "got some input\n"
@@ -126,12 +126,12 @@ TEST_IMPL(osx_select_many_fds) {
         "feel pretty happy\n";
   for (i = 0, len = strlen(str); i < len; i++) {
     r = ioctl(fd, TIOCSTI, str + i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(read_count == 3);
+  ASSERT_EQ(read_count, 3);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -77,7 +77,7 @@ TEST_IMPL(osx_select) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(read_count, 3);
+  ASSERT_EQ(3, read_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -131,7 +131,7 @@ TEST_IMPL(osx_select_many_fds) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(read_count, 3);
+  ASSERT_EQ(3, read_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -376,7 +376,7 @@ static void pipe2_pinger_new(int vectored_writes) {
 
 static int run_ping_pong_test(void) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(completed_pingers, 1);
+  ASSERT_EQ(1, completed_pingers);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-ping-pong.c
+++ b/test/test-ping-pong.c
@@ -83,7 +83,7 @@ static void pinger_on_close(uv_handle_t* handle) {
 
 
 static void pinger_after_write(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   free(req->data);
   free(req);
 }
@@ -112,7 +112,7 @@ static void pinger_write_ping(pinger_t* pinger) {
   req = malloc(sizeof(*req));
   ASSERT_NOT_NULL(req);
   req->data = NULL;
-  ASSERT_EQ(0, uv_write(req, stream, bufs, nbufs, pinger_after_write));
+  ASSERT_OK(uv_write(req, stream, bufs, nbufs, pinger_after_write));
 
   puts("PING");
 }
@@ -188,7 +188,7 @@ static void ponger_read_cb(uv_stream_t* stream,
   req = malloc(sizeof(*req));
   ASSERT_NOT_NULL(req);
   req->data = buf->base;
-  ASSERT_EQ(0, uv_write(req, stream, &writebuf, 1, pinger_after_write));
+  ASSERT_OK(uv_write(req, stream, &writebuf, 1, pinger_after_write));
 }
 
 
@@ -197,17 +197,17 @@ static void pinger_on_connect(uv_connect_t* req, int status) {
 
   pinger_on_connect_count++;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   ASSERT_EQ(1, uv_is_readable(req->handle));
   ASSERT_EQ(1, uv_is_writable(req->handle));
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t *) req->handle));
+  ASSERT_OK(uv_is_closing((uv_handle_t *) req->handle));
 
   pinger_write_ping(pinger);
 
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) req->handle,
-                             alloc_cb,
-                             pinger_read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) req->handle,
+                          alloc_cb,
+                          pinger_read_cb));
 }
 
 
@@ -218,7 +218,7 @@ static void tcp_pinger_v6_new(int vectored_writes) {
   pinger_t* pinger;
 
 
-  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip6_addr("::1", TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   ASSERT_NOT_NULL(pinger);
   pinger->vectored_writes = vectored_writes;
@@ -229,7 +229,7 @@ static void tcp_pinger_v6_new(int vectored_writes) {
   /* Try to connect to the server and do NUM_PINGS ping-pongs. */
   r = uv_tcp_init(uv_default_loop(), &pinger->stream.tcp);
   pinger->stream.tcp.data = pinger;
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* We are never doing multiple reads/connects at a time anyway, so these
    * handles can be pre-initialized. */
@@ -237,10 +237,10 @@ static void tcp_pinger_v6_new(int vectored_writes) {
                      &pinger->stream.tcp,
                      (const struct sockaddr*) &server_addr,
                      pinger_on_connect);
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT_EQ(pinger_on_connect_count, 0);
+  ASSERT_OK(pinger_on_connect_count);
 }
 
 
@@ -249,7 +249,7 @@ static void tcp_pinger_new(int vectored_writes) {
   struct sockaddr_in server_addr;
   pinger_t* pinger;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   pinger = malloc(sizeof(*pinger));
   ASSERT_NOT_NULL(pinger);
   pinger->vectored_writes = vectored_writes;
@@ -260,7 +260,7 @@ static void tcp_pinger_new(int vectored_writes) {
   /* Try to connect to the server and do NUM_PINGS ping-pongs. */
   r = uv_tcp_init(uv_default_loop(), &pinger->stream.tcp);
   pinger->stream.tcp.data = pinger;
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* We are never doing multiple reads/connects at a time anyway, so these
    * handles can be pre-initialized. */
@@ -268,10 +268,10 @@ static void tcp_pinger_new(int vectored_writes) {
                      &pinger->stream.tcp,
                      (const struct sockaddr*) &server_addr,
                      pinger_on_connect);
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT_EQ(pinger_on_connect_count, 0);
+  ASSERT_OK(pinger_on_connect_count);
 }
 
 
@@ -289,7 +289,7 @@ static void pipe_pinger_new(int vectored_writes) {
   /* Try to connect to the server and do NUM_PINGS ping-pongs. */
   r = uv_pipe_init(uv_default_loop(), &pinger->stream.pipe, 0);
   pinger->stream.pipe.data = pinger;
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* We are never doing multiple reads/connects at a time anyway, so these
    * handles can be pre-initialized. */
@@ -297,7 +297,7 @@ static void pipe_pinger_new(int vectored_writes) {
       pinger_on_connect);
 
   /* Synchronous connect callbacks are not allowed. */
-  ASSERT_EQ(pinger_on_connect_count, 0);
+  ASSERT_OK(pinger_on_connect_count);
 }
 
 
@@ -315,31 +315,31 @@ static void socketpair_pinger_new(int vectored_writes) {
 
   /* Try to make a socketpair and do NUM_PINGS ping-pongs. */
   (void)uv_default_loop(); /* ensure WSAStartup has been performed */
-  ASSERT_EQ(0, uv_socketpair(SOCK_STREAM, 0, fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
+  ASSERT_OK(uv_socketpair(SOCK_STREAM, 0, fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
 #ifndef _WIN32
   /* On Windows, this is actually a UV_TCP, but libuv doesn't detect that. */
   ASSERT_EQ(uv_guess_handle((uv_file) fds[0]), UV_NAMED_PIPE);
   ASSERT_EQ(uv_guess_handle((uv_file) fds[1]), UV_NAMED_PIPE);
 #endif
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &pinger->stream.tcp));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &pinger->stream.tcp));
   pinger->stream.pipe.data = pinger;
-  ASSERT_EQ(0, uv_tcp_open(&pinger->stream.tcp, fds[1]));
+  ASSERT_OK(uv_tcp_open(&pinger->stream.tcp, fds[1]));
 
   ponger = malloc(sizeof(*ponger));
   ASSERT_NOT_NULL(ponger);
   ponger->data = NULL;
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), ponger));
-  ASSERT_EQ(0, uv_tcp_open(ponger, fds[0]));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), ponger));
+  ASSERT_OK(uv_tcp_open(ponger, fds[0]));
 
   pinger_write_ping(pinger);
 
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &pinger->stream.tcp,
-                             alloc_cb,
-                             pinger_read_cb));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) ponger,
-                             alloc_cb,
-                             ponger_read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &pinger->stream.tcp,
+                          alloc_cb,
+                          pinger_read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) ponger,
+                          alloc_cb,
+                          ponger_read_cb));
 }
 
 
@@ -349,14 +349,14 @@ static void pipe2_pinger_new(int vectored_writes) {
   uv_pipe_t* ponger;
 
   /* Try to make a pipe and do NUM_PINGS pings. */
-  ASSERT_EQ(0, uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
+  ASSERT_OK(uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
   ASSERT_EQ(uv_guess_handle(fds[0]), UV_NAMED_PIPE);
   ASSERT_EQ(uv_guess_handle(fds[1]), UV_NAMED_PIPE);
 
   ponger = malloc(sizeof(*ponger));
   ASSERT_NOT_NULL(ponger);
-  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), ponger, 0));
-  ASSERT_EQ(0, uv_pipe_open(ponger, fds[0]));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), ponger, 0));
+  ASSERT_OK(uv_pipe_open(ponger, fds[0]));
 
   pinger = malloc(sizeof(*pinger));
   ASSERT_NOT_NULL(pinger);
@@ -364,14 +364,14 @@ static void pipe2_pinger_new(int vectored_writes) {
   pinger->state = 0;
   pinger->pongs = 0;
   pinger->pong = PING;
-  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pinger->stream.pipe, 0));
-  ASSERT_EQ(0, uv_pipe_open(&pinger->stream.pipe, fds[1]));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pinger->stream.pipe, 0));
+  ASSERT_OK(uv_pipe_open(&pinger->stream.pipe, fds[1]));
   pinger->stream.pipe.data = pinger; /* record for close_cb */
   ponger->data = pinger; /* record for read_cb */
 
   pinger_write_ping(pinger);
 
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) ponger, alloc_cb, pinger_read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) ponger, alloc_cb, pinger_read_cb));
 }
 
 static int run_ping_pong_test(void) {

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -46,17 +46,17 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_bind(&server1, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_init(uv_default_loop(), &server2, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_bind(&server2, TEST_PIPENAME);
   ASSERT_EQ(r, UV_EADDRINUSE);
 
   r = uv_listen((uv_stream_t*)&server1, SOMAXCONN, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&server2, SOMAXCONN, NULL);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -77,7 +77,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&server, BAD_PIPENAME);
   ASSERT_EQ(r, UV_EACCES);
@@ -98,9 +98,9 @@ TEST_IMPL(pipe_bind_error_inval) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_bind(&server, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_bind(&server, TEST_PIPENAME_2);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -123,7 +123,7 @@ TEST_IMPL(pipe_listen_without_bind) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
   ASSERT_EQ(r, UV_EINVAL);
@@ -141,14 +141,14 @@ TEST_IMPL(pipe_listen_without_bind) {
 TEST_IMPL(pipe_bind_or_listen_error_after_close) {
   uv_pipe_t server;
 
-  ASSERT_EQ(uv_pipe_init(uv_default_loop(), &server, 0), 0);
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &server, 0));
   uv_close((uv_handle_t*) &server, NULL);
 
   ASSERT_EQ(uv_pipe_bind(&server, TEST_PIPENAME), UV_EINVAL);
 
   ASSERT_EQ(uv_listen((uv_stream_t*) &server, SOMAXCONN, NULL), UV_EINVAL);
 
-  ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -65,7 +65,7 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -86,7 +86,7 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -108,7 +108,7 @@ TEST_IMPL(pipe_bind_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -132,7 +132,7 @@ TEST_IMPL(pipe_listen_without_bind) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -46,26 +46,26 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server1, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &server2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server2, TEST_PIPENAME);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   r = uv_listen((uv_stream_t*)&server1, SOMAXCONN, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, SOMAXCONN, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -77,16 +77,16 @@ TEST_IMPL(pipe_bind_error_addrnotavail) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&server, BAD_PIPENAME);
-  ASSERT(r == UV_EACCES);
+  ASSERT_EQ(r, UV_EACCES);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -98,17 +98,17 @@ TEST_IMPL(pipe_bind_error_inval) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_bind(&server, TEST_PIPENAME_2);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -123,16 +123,16 @@ TEST_IMPL(pipe_listen_without_bind) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server, SOMAXCONN, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -61,7 +61,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
   uv_pipe_t stdin_pipe;
 
   r = pipe(fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
     
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   pid = -1;
@@ -77,27 +77,27 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
     close(fd[1]);
     /* block until write end of pipe is closed */
     r = read(fd[0], &buf, 1);
-    ASSERT(-1 <= r && r <= 1);
+    ASSERT_NE(-1 <= r && r <= 1, 0);
     close(0);
     r = dup(fd[0]);
-    ASSERT(r != -1);
+    ASSERT_NE(r, -1);
 
     /* Create a stream that reads from the pipe. */
     r = uv_pipe_init(uv_default_loop(), (uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_pipe_open((uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_read_start((uv_stream_t *)&stdin_pipe, alloc_buffer, read_stdin);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     /*
      * Because the other end of the pipe was closed, there should
      * be no event left to process after one run of the event loop.
      * Otherwise, it means that events were not processed correctly.
      */
-    ASSERT(uv_run(uv_default_loop(), UV_RUN_NOWAIT) == 0);
+    ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_NOWAIT), 0);
   } else {
     /*
      * Close both ends of the pipe so that the child

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -77,7 +77,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
     close(fd[1]);
     /* block until write end of pipe is closed */
     r = read(fd[0], &buf, 1);
-    ASSERT_NE(-1 <= r && r <= 1, 0);
+    ASSERT(-1 <= r && r <= 1);
     close(0);
     r = dup(fd[0]);
     ASSERT_NE(r, -1);

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -61,7 +61,7 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
   uv_pipe_t stdin_pipe;
 
   r = pipe(fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
     
 #if defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)
   pid = -1;
@@ -84,20 +84,20 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
 
     /* Create a stream that reads from the pipe. */
     r = uv_pipe_init(uv_default_loop(), (uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_pipe_open((uv_pipe_t *)&stdin_pipe, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_read_start((uv_stream_t *)&stdin_pipe, alloc_buffer, read_stdin);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     /*
      * Because the other end of the pipe was closed, there should
      * be no event left to process after one run of the event loop.
      * Otherwise, it means that events were not processed correctly.
      */
-    ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_NOWAIT), 0);
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_NOWAIT));
   } else {
     /*
      * Close both ends of the pipe so that the child

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -64,7 +64,7 @@ TEST_IMPL(pipe_connect_bad_name) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_pipe_connect(&req, &client, BAD_PIPENAME, connect_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -84,7 +84,7 @@ TEST_IMPL(pipe_connect_to_file) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &client, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_pipe_connect(&req, &client, path, connect_cb_file);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-pipe-connect-error.c
+++ b/test/test-pipe-connect-error.c
@@ -69,8 +69,8 @@ TEST_IMPL(pipe_connect_bad_name) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -89,8 +89,8 @@ TEST_IMPL(pipe_connect_to_file) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-connect-multiple.c
+++ b/test/test-pipe-connect-multiple.c
@@ -44,14 +44,14 @@ static uv_pipe_t connections[NUM_CLIENTS];
 static void connection_cb(uv_stream_t* server, int status) {
   int r;
   uv_pipe_t* conn;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   conn = &connections[connection_cb_called];
   r = uv_pipe_init(server->loop, conn, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (++connection_cb_called == NUM_CLIENTS &&
       connect_cb_called == NUM_CLIENTS) {
@@ -61,7 +61,7 @@ static void connection_cb(uv_stream_t* server, int status) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   if (++connect_cb_called == NUM_CLIENTS &&
       connection_cb_called == NUM_CLIENTS) {
     uv_stop(connect_req->handle->loop);
@@ -80,17 +80,17 @@ TEST_IMPL(pipe_connect_multiple) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &server_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&server_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server_handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   for (i = 0; i < NUM_CLIENTS; i++) {
     r = uv_pipe_init(loop, &clients[i].pipe_handle, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     uv_pipe_connect(&clients[i].conn_req,
                     &clients[i].pipe_handle,
                     TEST_PIPENAME,
@@ -99,8 +99,8 @@ TEST_IMPL(pipe_connect_multiple) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(connection_cb_called == NUM_CLIENTS);
-  ASSERT(connect_cb_called == NUM_CLIENTS);
+  ASSERT_EQ(connection_cb_called, NUM_CLIENTS);
+  ASSERT_EQ(connect_cb_called, NUM_CLIENTS);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-connect-multiple.c
+++ b/test/test-pipe-connect-multiple.c
@@ -44,14 +44,14 @@ static uv_pipe_t connections[NUM_CLIENTS];
 static void connection_cb(uv_stream_t* server, int status) {
   int r;
   uv_pipe_t* conn;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   conn = &connections[connection_cb_called];
   r = uv_pipe_init(server->loop, conn, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(server, (uv_stream_t*)conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (++connection_cb_called == NUM_CLIENTS &&
       connect_cb_called == NUM_CLIENTS) {
@@ -61,7 +61,7 @@ static void connection_cb(uv_stream_t* server, int status) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   if (++connect_cb_called == NUM_CLIENTS &&
       connection_cb_called == NUM_CLIENTS) {
     uv_stop(connect_req->handle->loop);
@@ -80,17 +80,17 @@ TEST_IMPL(pipe_connect_multiple) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &server_handle, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&server_handle, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server_handle, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   for (i = 0; i < NUM_CLIENTS; i++) {
     r = uv_pipe_init(loop, &clients[i].pipe_handle, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_pipe_connect(&clients[i].conn_req,
                     &clients[i].pipe_handle,
                     TEST_PIPENAME,
@@ -110,14 +110,14 @@ TEST_IMPL(pipe_connect_multiple) {
 static void connection_cb2(uv_stream_t* server, int status) {
   int r;
   uv_pipe_t* conn;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   conn = &connections[connection_cb_called];
   r = uv_pipe_init(server->loop, conn, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(server, (uv_stream_t*)conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*)conn, NULL);
   if (++connection_cb_called == NUM_CLIENTS &&
@@ -146,17 +146,17 @@ TEST_IMPL(pipe_connect_close_multiple) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &server_handle, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&server_handle, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server_handle, 128, connection_cb2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   for (i = 0; i < NUM_CLIENTS; i++) {
     r = uv_pipe_init(loop, &clients[i].pipe_handle, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     uv_pipe_connect(&clients[i].conn_req,
                     &clients[i].pipe_handle,
                     TEST_PIPENAME,

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -65,15 +65,15 @@ TEST_IMPL(pipe_connect_on_prepare) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe_handle, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_prepare_init(uv_default_loop(), &prepare_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_prepare_start(&prepare_handle, prepare_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(close_cb_called, 2);
   ASSERT_EQ(connect_cb_called, 1);

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -75,8 +75,8 @@ TEST_IMPL(pipe_connect_on_prepare) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 2);
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-connect-prepare.c
+++ b/test/test-pipe-connect-prepare.c
@@ -48,7 +48,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* connect_req, int status) {
-  ASSERT(status == UV_ENOENT);
+  ASSERT_EQ(status, UV_ENOENT);
   connect_cb_called++;
   uv_close((uv_handle_t*)&prepare_handle, close_cb);
   uv_close((uv_handle_t*)&pipe_handle, close_cb);
@@ -56,7 +56,7 @@ static void connect_cb(uv_connect_t* connect_req, int status) {
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT(handle == &prepare_handle);
+  ASSERT_PTR_EQ(handle, &prepare_handle);
   uv_pipe_connect(&conn_req, &pipe_handle, BAD_PIPENAME, connect_cb);
 }
 
@@ -65,18 +65,18 @@ TEST_IMPL(pipe_connect_on_prepare) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_prepare_init(uv_default_loop(), &prepare_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_prepare_start(&prepare_handle, prepare_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(connect_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(connect_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -52,11 +52,11 @@ static void pipe_client_connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (*buf == '\0') {  /* Linux abstract socket. */
     const char expected[] = "\0" TEST_PIPENAME;
@@ -82,7 +82,7 @@ static void pipe_server_connection_cb(uv_stream_t* handle, int status) {
   /* This function *may* be called, depending on whether accept or the
    * connection callback is called first.
    */
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -99,7 +99,7 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT_NOT_NULL(loop);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
@@ -110,25 +110,25 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_NE(buf[len - 1], 0);
   ASSERT_EQ(buf[len], '\0');
-  ASSERT_EQ(memcmp(buf, TEST_PIPENAME, len), 0);
+  ASSERT_OK(memcmp(buf, TEST_PIPENAME, len));
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_server, buf, &len);
   ASSERT_EQ(r, UV_ENOTCONN);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_init(loop, &pipe_client, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   len = sizeof buf;
   r = uv_pipe_getsockname(&pipe_client, buf, &len);
@@ -146,13 +146,13 @@ TEST_IMPL(pipe_getsockname) {
 
   len = sizeof buf;
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_NE(buf[len - 1], 0);
-  ASSERT_EQ(memcmp(buf, TEST_PIPENAME, len), 0);
+  ASSERT_OK(memcmp(buf, TEST_PIPENAME, len));
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(pipe_client_connect_cb_called, 1);
   ASSERT_EQ(pipe_close_cb_called, 2);
 
@@ -221,40 +221,40 @@ TEST_IMPL(pipe_getsockname_blocking) {
   ASSERT(r);
 
   r = uv_pipe_init(uv_default_loop(), &pipe_client, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   readfd = _open_osfhandle((intptr_t)readh, _O_RDONLY);
   ASSERT_NE(r, -1);
   r = uv_pipe_open(&pipe_client, readfd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_read_start((uv_stream_t*) &pipe_client,
                     (uv_alloc_cb) abort,
                     (uv_read_cb) abort);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   Sleep(100);
   r = uv_read_stop((uv_stream_t*)&pipe_client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   len1 = sizeof buf1;
   r = uv_pipe_getsockname(&pipe_client, buf1, &len1);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(len1, 0);  /* It's an annonymous pipe. */
+  ASSERT_OK(r);
+  ASSERT_OK(len1);  /* It's an annonymous pipe. */
 
   r = uv_read_start((uv_stream_t*)&pipe_client,
                     (uv_alloc_cb) abort,
                     (uv_read_cb) abort);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   Sleep(100);
 
   len2 = sizeof buf2;
   r = uv_pipe_getsockname(&pipe_client, buf2, &len2);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(len2, 0);  /* It's an annonymous pipe. */
+  ASSERT_OK(r);
+  ASSERT_OK(len2);  /* It's an annonymous pipe. */
 
   r = uv_read_stop((uv_stream_t*)&pipe_client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(len1, len2);
-  ASSERT_EQ(memcmp(buf1, buf2, len1), 0);
+  ASSERT_OK(memcmp(buf1, buf2, len1));
 
   pipe_close_cb_called = 0;
   uv_close((uv_handle_t*)&pipe_client, pipe_close_cb);

--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -116,7 +116,7 @@ TEST_IMPL(pipe_getsockname) {
   r = uv_pipe_getsockname(&pipe_server, buf, &len);
   ASSERT_OK(r);
 
-  ASSERT_NE(buf[len - 1], 0);
+  ASSERT_NE(0, buf[len - 1]);
   ASSERT_EQ(buf[len], '\0');
   ASSERT_OK(memcmp(buf, TEST_PIPENAME, len));
 
@@ -148,13 +148,13 @@ TEST_IMPL(pipe_getsockname) {
   r = uv_pipe_getpeername(&pipe_client, buf, &len);
   ASSERT_OK(r);
 
-  ASSERT_NE(buf[len - 1], 0);
+  ASSERT_NE(0, buf[len - 1]);
   ASSERT_OK(memcmp(buf, TEST_PIPENAME, len));
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(pipe_client_connect_cb_called, 1);
-  ASSERT_EQ(pipe_close_cb_called, 2);
+  ASSERT_EQ(1, pipe_client_connect_cb_called);
+  ASSERT_EQ(2, pipe_close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -261,7 +261,7 @@ TEST_IMPL(pipe_getsockname_blocking) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(pipe_close_cb_called, 1);
+  ASSERT_EQ(1, pipe_close_cb_called);
 
   CloseHandle(writeh);
 #endif

--- a/test/test-pipe-pending-instances.c
+++ b/test/test-pipe-pending-instances.c
@@ -37,22 +37,22 @@ TEST_IMPL(pipe_pending_instances) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_pending_instances(&pipe_handle, 8);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_pending_instances(&pipe_handle, 16);
 
   r = uv_listen((uv_stream_t*)&pipe_handle, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*)&pipe_handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-pending-instances.c
+++ b/test/test-pipe-pending-instances.c
@@ -37,22 +37,22 @@ TEST_IMPL(pipe_pending_instances) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_pending_instances(&pipe_handle, 8);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_pending_instances(&pipe_handle, 16);
 
   r = uv_listen((uv_stream_t*)&pipe_handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&pipe_handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -45,12 +45,12 @@ static void set_nonblocking(uv_os_sock_t sock) {
 #ifdef _WIN32
   unsigned long on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #else
   int flags = fcntl(sock, F_GETFL, 0);
-  ASSERT(flags >= 0);
+  ASSERT_GE(flags, 0);
   r = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-  ASSERT(r >= 0);
+  ASSERT_GE(r, 0);
 #endif
 }
 
@@ -79,22 +79,22 @@ static void read_cb(uv_stream_t* handle,
   unsigned int i;
 
   p = (uv_pipe_t*) handle;
-  ASSERT(nread >= 0);
+  ASSERT_GE(nread, 0);
 
   while (uv_pipe_pending_count(p) != 0) {
     pending = uv_pipe_pending_type(p);
-    ASSERT(pending == UV_NAMED_PIPE);
+    ASSERT_EQ(pending, UV_NAMED_PIPE);
 
-    ASSERT(incoming_count < ARRAY_SIZE(incoming));
+    ASSERT_LT(incoming_count, ARRAY_SIZE(incoming));
     inc = &incoming[incoming_count++];
-    ASSERT(0 == uv_pipe_init(p->loop, inc, 0));
-    ASSERT(0 == uv_accept(handle, (uv_stream_t*) inc));
+    ASSERT_EQ(0, uv_pipe_init(p->loop, inc, 0));
+    ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) inc));
   }
 
   if (incoming_count != ARRAY_SIZE(incoming))
     return;
 
-  ASSERT(0 == uv_read_stop((uv_stream_t*) p));
+  ASSERT_EQ(0, uv_read_stop((uv_stream_t*) p));
   uv_close((uv_handle_t*) p, close_cb);
   for (i = 0; i < ARRAY_SIZE(incoming); i++)
     uv_close((uv_handle_t*) &incoming[i], close_cb);
@@ -115,12 +115,12 @@ TEST_IMPL(pipe_sendmsg) {
   unsigned int i;
   uv_buf_t buf;
 
-  ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
   for (i = 0; i < ARRAY_SIZE(send_fds); i += 2)
-    ASSERT(0 == socketpair(AF_UNIX, SOCK_STREAM, 0, send_fds + i));
-  ASSERT(i == ARRAY_SIZE(send_fds));
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &p, 1));
-  ASSERT(0 == uv_pipe_open(&p, fds[1]));
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, send_fds + i));
+  ASSERT_EQ(i, ARRAY_SIZE(send_fds));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &p, 1));
+  ASSERT_EQ(0, uv_pipe_open(&p, fds[1]));
 
   buf = uv_buf_init("X", 1);
   memset(&msg, 0, sizeof(msg));
@@ -130,7 +130,7 @@ TEST_IMPL(pipe_sendmsg) {
 
   msg.msg_control = (void*) scratch;
   msg.msg_controllen = CMSG_LEN(sizeof(send_fds));
-  ASSERT(sizeof(scratch) >= msg.msg_controllen);
+  ASSERT_GE(sizeof(scratch), msg.msg_controllen);
 
   cmsg = CMSG_FIRSTHDR(&msg);
   cmsg->cmsg_level = SOL_SOCKET;
@@ -146,16 +146,16 @@ TEST_IMPL(pipe_sendmsg) {
   }
 
   set_nonblocking(fds[1]);
-  ASSERT(0 == uv_read_start((uv_stream_t*) &p, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &p, alloc_cb, read_cb));
 
   do
     r = sendmsg(fds[0], &msg, 0);
   while (r == -1 && errno == EINTR);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(ARRAY_SIZE(incoming) == incoming_count);
-  ASSERT(ARRAY_SIZE(incoming) + 1 == close_called);
+  ASSERT_EQ(ARRAY_SIZE(incoming), incoming_count);
+  ASSERT_EQ(ARRAY_SIZE(incoming) + 1, close_called);
   close(fds[0]);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -151,7 +151,7 @@ TEST_IMPL(pipe_sendmsg) {
   do
     r = sendmsg(fds[0], &msg, 0);
   while (r == -1 && errno == EINTR);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(ARRAY_SIZE(incoming), incoming_count);

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -45,7 +45,7 @@ static void set_nonblocking(uv_os_sock_t sock) {
 #ifdef _WIN32
   unsigned long on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #else
   int flags = fcntl(sock, F_GETFL, 0);
   ASSERT_GE(flags, 0);
@@ -87,14 +87,14 @@ static void read_cb(uv_stream_t* handle,
 
     ASSERT_LT(incoming_count, ARRAY_SIZE(incoming));
     inc = &incoming[incoming_count++];
-    ASSERT_EQ(0, uv_pipe_init(p->loop, inc, 0));
-    ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) inc));
+    ASSERT_OK(uv_pipe_init(p->loop, inc, 0));
+    ASSERT_OK(uv_accept(handle, (uv_stream_t*) inc));
   }
 
   if (incoming_count != ARRAY_SIZE(incoming))
     return;
 
-  ASSERT_EQ(0, uv_read_stop((uv_stream_t*) p));
+  ASSERT_OK(uv_read_stop((uv_stream_t*) p));
   uv_close((uv_handle_t*) p, close_cb);
   for (i = 0; i < ARRAY_SIZE(incoming); i++)
     uv_close((uv_handle_t*) &incoming[i], close_cb);
@@ -115,12 +115,12 @@ TEST_IMPL(pipe_sendmsg) {
   unsigned int i;
   uv_buf_t buf;
 
-  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  ASSERT_OK(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
   for (i = 0; i < ARRAY_SIZE(send_fds); i += 2)
-    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, send_fds + i));
+    ASSERT_OK(socketpair(AF_UNIX, SOCK_STREAM, 0, send_fds + i));
   ASSERT_EQ(i, ARRAY_SIZE(send_fds));
-  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &p, 1));
-  ASSERT_EQ(0, uv_pipe_open(&p, fds[1]));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &p, 1));
+  ASSERT_OK(uv_pipe_open(&p, fds[1]));
 
   buf = uv_buf_init("X", 1);
   memset(&msg, 0, sizeof(msg));
@@ -146,7 +146,7 @@ TEST_IMPL(pipe_sendmsg) {
   }
 
   set_nonblocking(fds[1]);
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &p, alloc_cb, read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &p, alloc_cb, read_cb));
 
   do
     r = sendmsg(fds[0], &msg, 0);

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -86,8 +86,8 @@ TEST_IMPL(pipe_server_close) {
 
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(pipe_client_connect_cb_called, 1);
-  ASSERT_EQ(pipe_close_cb_called, 2);
+  ASSERT_EQ(1, pipe_client_connect_cb_called);
+  ASSERT_EQ(2, pipe_close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -35,15 +35,15 @@ static int pipe_client_connect_cb_called = 0;
 
 
 static void pipe_close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &pipe_client ||
-         handle == (uv_handle_t*) &pipe_server);
+  ASSERT_NE(handle == (uv_handle_t*) &pipe_client ||
+            handle == (uv_handle_t*) &pipe_server, 0);
   pipe_close_cb_called++;
 }
 
 
 static void pipe_client_connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   pipe_client_connect_cb_called++;
 
@@ -56,7 +56,7 @@ static void pipe_server_connection_cb(uv_stream_t* handle, int status) {
   /* This function *may* be called, depending on whether accept or the
    * connection callback is called first.
    */
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -71,23 +71,23 @@ TEST_IMPL(pipe_server_close) {
   ASSERT_NOT_NULL(loop);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(loop, &pipe_client, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_connect(&connect_req, &pipe_client, TEST_PIPENAME, pipe_client_connect_cb);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(pipe_client_connect_cb_called == 1);
-  ASSERT(pipe_close_cb_called == 2);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(pipe_client_connect_cb_called, 1);
+  ASSERT_EQ(pipe_close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-server-close.c
+++ b/test/test-pipe-server-close.c
@@ -43,7 +43,7 @@ static void pipe_close_cb(uv_handle_t* handle) {
 
 static void pipe_client_connect_cb(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   pipe_client_connect_cb_called++;
 
@@ -56,7 +56,7 @@ static void pipe_server_connection_cb(uv_stream_t* handle, int status) {
   /* This function *may* be called, depending on whether accept or the
    * connection callback is called first.
    */
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -71,21 +71,21 @@ TEST_IMPL(pipe_server_close) {
   ASSERT_NOT_NULL(loop);
 
   r = uv_pipe_init(loop, &pipe_server, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&pipe_server, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*) &pipe_server, 0, pipe_server_connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_init(loop, &pipe_client, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_connect(&connect_req, &pipe_client, TEST_PIPENAME, pipe_client_connect_cb);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(pipe_client_connect_cb_called, 1);
   ASSERT_EQ(pipe_close_cb_called, 2);
 

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -35,10 +35,10 @@ TEST_IMPL(pipe_set_chmod) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* No easy way to test if this works, we will only make sure that the call is
    * successful. */
@@ -47,17 +47,17 @@ TEST_IMPL(pipe_set_chmod) {
     MAKE_VALGRIND_HAPPY(loop);
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");
   }
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifndef _WIN32
   memset(&stat_buf, 0, sizeof(stat_buf));
-  ASSERT_EQ(0, stat(TEST_PIPENAME, &stat_buf));
+  ASSERT_OK(stat(TEST_PIPENAME, &stat_buf));
   ASSERT(stat_buf.st_mode & S_IRUSR);
   ASSERT(stat_buf.st_mode & S_IRGRP);
   ASSERT(stat_buf.st_mode & S_IROTH);
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IWUSR);
@@ -66,7 +66,7 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IRUSR);

--- a/test/test-pipe-set-fchmod.c
+++ b/test/test-pipe-set-fchmod.c
@@ -35,10 +35,10 @@ TEST_IMPL(pipe_set_chmod) {
   loop = uv_default_loop();
 
   r = uv_pipe_init(loop, &pipe_handle, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_bind(&pipe_handle, TEST_PIPENAME);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* No easy way to test if this works, we will only make sure that the call is
    * successful. */
@@ -47,7 +47,7 @@ TEST_IMPL(pipe_set_chmod) {
     MAKE_VALGRIND_HAPPY(loop);
     RETURN_SKIP("Insufficient privileges to alter pipe fmode");
   }
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   memset(&stat_buf, 0, sizeof(stat_buf));
   ASSERT_EQ(0, stat(TEST_PIPENAME, &stat_buf));
@@ -57,7 +57,7 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IWUSR);
@@ -66,7 +66,7 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifndef _WIN32
   stat(TEST_PIPENAME, &stat_buf);
   ASSERT(stat_buf.st_mode & S_IRUSR);
@@ -78,14 +78,14 @@ TEST_IMPL(pipe_set_chmod) {
 #endif
 
   r = uv_pipe_chmod(NULL, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_pipe_chmod(&pipe_handle, 12345678);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&pipe_handle, NULL);
   r = uv_pipe_chmod(&pipe_handle, UV_WRITABLE | UV_READABLE);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -46,13 +46,13 @@ static void thread_main(void* arg) {
     uv_fs_req_cleanup(&req);
   } while (n > 0 || (n == -1 && uv_errno == UV_EINTR));
 
-  ASSERT(n == 0);
+  ASSERT_EQ(n, 0);
 }
 
 
 #ifdef _WIN32
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   req->handle = NULL; /* signal completion of write_cb */
 }
 #endif
@@ -77,15 +77,15 @@ TEST_IMPL(pipe_set_non_blocking) {
   uv_write_t write_req;
 #endif
 
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT(0 == uv_pipe(fd, 0, 0));
-  ASSERT(0 == uv_pipe_open(&pipe_handle, fd[1]));
-  ASSERT(0 == uv_stream_set_blocking((uv_stream_t*) &pipe_handle, 1));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
+  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[1]));
+  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &pipe_handle, 1));
   fd[1] = -1; /* fd[1] is owned by pipe_handle now. */
 
   ctx.fd = fd[0];
-  ASSERT(0 == uv_barrier_init(&ctx.barrier, 2));
-  ASSERT(0 == uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_EQ(0, uv_barrier_init(&ctx.barrier, 2));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
   uv_barrier_wait(&ctx.barrier);
 
   buf.len = sizeof(data);
@@ -99,25 +99,29 @@ TEST_IMPL(pipe_set_non_blocking) {
      */
     n = uv_try_write((uv_stream_t*) &pipe_handle, &buf, 1);
 #ifdef _WIN32
-    ASSERT(n == UV_EAGAIN); /* E_NOTIMPL */
-    ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &pipe_handle, &buf, 1, write_cb));
+    ASSERT_EQ(n, UV_EAGAIN); /* E_NOTIMPL */
+    ASSERT_EQ(0, uv_write(&write_req,
+                          (uv_stream_t*) &pipe_handle,
+                          &buf,
+                          1,
+                          write_cb));
     ASSERT_NOT_NULL(write_req.handle);
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
     ASSERT_NULL(write_req.handle); /* check for signaled completion of write_cb */
     n = buf.len;
 #endif
-    ASSERT(n == sizeof(data));
+    ASSERT_EQ(n, sizeof(data));
     nwritten += n;
   }
 
   uv_close((uv_handle_t*) &pipe_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 #ifdef _WIN32
-  ASSERT(0 == _close(fd[0]));  /* fd[1] is closed by uv_close(). */
+  ASSERT_EQ(0, _close(fd[0]));  /* fd[1] is closed by uv_close(). */
 #else
-  ASSERT(0 == close(fd[0]));  /* fd[1] is closed by uv_close(). */
+  ASSERT_EQ(0, close(fd[0]));  /* fd[1] is closed by uv_close(). */
 #endif
   fd[0] = -1;
   uv_barrier_destroy(&ctx.barrier);

--- a/test/test-pipe-set-non-blocking.c
+++ b/test/test-pipe-set-non-blocking.c
@@ -46,13 +46,13 @@ static void thread_main(void* arg) {
     uv_fs_req_cleanup(&req);
   } while (n > 0 || (n == -1 && uv_errno == UV_EINTR));
 
-  ASSERT_EQ(n, 0);
+  ASSERT_OK(n);
 }
 
 
 #ifdef _WIN32
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   req->handle = NULL; /* signal completion of write_cb */
 }
 #endif
@@ -77,15 +77,15 @@ TEST_IMPL(pipe_set_non_blocking) {
   uv_write_t write_req;
 #endif
 
-  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
-  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[1]));
-  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &pipe_handle, 1));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_OK(uv_pipe(fd, 0, 0));
+  ASSERT_OK(uv_pipe_open(&pipe_handle, fd[1]));
+  ASSERT_OK(uv_stream_set_blocking((uv_stream_t*) &pipe_handle, 1));
   fd[1] = -1; /* fd[1] is owned by pipe_handle now. */
 
   ctx.fd = fd[0];
-  ASSERT_EQ(0, uv_barrier_init(&ctx.barrier, 2));
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_main, &ctx));
+  ASSERT_OK(uv_barrier_init(&ctx.barrier, 2));
+  ASSERT_OK(uv_thread_create(&thread, thread_main, &ctx));
   uv_barrier_wait(&ctx.barrier);
 
   buf.len = sizeof(data);
@@ -100,13 +100,13 @@ TEST_IMPL(pipe_set_non_blocking) {
     n = uv_try_write((uv_stream_t*) &pipe_handle, &buf, 1);
 #ifdef _WIN32
     ASSERT_EQ(n, UV_EAGAIN); /* E_NOTIMPL */
-    ASSERT_EQ(0, uv_write(&write_req,
-                          (uv_stream_t*) &pipe_handle,
-                          &buf,
-                          1,
-                          write_cb));
+    ASSERT_OK(uv_write(&write_req,
+                       (uv_stream_t*) &pipe_handle,
+                       &buf,
+                       1,
+                       write_cb));
     ASSERT_NOT_NULL(write_req.handle);
-    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
     ASSERT_NULL(write_req.handle); /* check for signaled completion of write_cb */
     n = buf.len;
 #endif
@@ -115,13 +115,13 @@ TEST_IMPL(pipe_set_non_blocking) {
   }
 
   uv_close((uv_handle_t*) &pipe_handle, NULL);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
 #ifdef _WIN32
-  ASSERT_EQ(0, _close(fd[0]));  /* fd[1] is closed by uv_close(). */
+  ASSERT_OK(_close(fd[0]));  /* fd[1] is closed by uv_close(). */
 #else
-  ASSERT_EQ(0, close(fd[0]));  /* fd[1] is closed by uv_close(). */
+  ASSERT_OK(close(fd[0]));  /* fd[1] is closed by uv_close(). */
 #endif
   fd[0] = -1;
   uv_barrier_destroy(&ctx.barrier);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -44,19 +44,19 @@ TEST_IMPL(platform_output) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   printf("uv_get_process_title: %s\n", buffer);
 
   size = sizeof(buffer);
   err = uv_cwd(buffer, &size);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   printf("uv_cwd: %s\n", buffer);
 
   err = uv_resident_set_memory(&rss);
 #if defined(__MSYS__)
   ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   printf("uv_resident_set_memory: %llu\n", (unsigned long long) rss);
 #endif
 
@@ -64,13 +64,13 @@ TEST_IMPL(platform_output) {
 #if defined(__PASE__)
   ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   ASSERT_GT(uptime, 0);
   printf("uv_uptime: %f\n", uptime);
 #endif
 
   err = uv_getrusage(&rusage);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   ASSERT_GE(rusage.ru_utime.tv_sec, 0);
   ASSERT_GE(rusage.ru_utime.tv_usec, 0);
   ASSERT_GE(rusage.ru_stime.tv_sec, 0);
@@ -94,7 +94,7 @@ TEST_IMPL(platform_output) {
 #if defined(__CYGWIN__) || defined(__MSYS__)
   ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   printf("uv_cpu_info:\n");
   for (i = 0; i < count; i++) {
@@ -113,7 +113,7 @@ TEST_IMPL(platform_output) {
   uv_free_cpu_info(cpus, count);
 
   err = uv_interface_addresses(&interfaces, &count);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   printf("uv_interface_addresses:\n");
   for (i = 0; i < count; i++) {
@@ -149,7 +149,7 @@ TEST_IMPL(platform_output) {
   uv_free_interface_addresses(interfaces, count);
 
   err = uv_os_get_passwd(&pwd);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   err = uv_os_get_group(&grp, pwd.gid);
 #if defined(_WIN32)
@@ -159,7 +159,7 @@ TEST_IMPL(platform_output) {
   (void) member;
   grp.groupname = "ENOTSUP";
 #else
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   ASSERT_EQ(pwd.gid, grp.gid);
 #endif
 
@@ -190,7 +190,7 @@ TEST_IMPL(platform_output) {
   printf("uv_os_getppid: %d\n", (int) ppid);
 
   err = uv_os_uname(&uname);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
   printf("uv_os_uname:\n");
   printf("  sysname: %s\n", uname.sysname);
   printf("  release: %s\n", uname.release);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -44,37 +44,37 @@ TEST_IMPL(platform_output) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_get_process_title: %s\n", buffer);
 
   size = sizeof(buffer);
   err = uv_cwd(buffer, &size);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_cwd: %s\n", buffer);
 
   err = uv_resident_set_memory(&rss);
 #if defined(__MSYS__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_resident_set_memory: %llu\n", (unsigned long long) rss);
 #endif
 
   err = uv_uptime(&uptime);
 #if defined(__PASE__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT(err == 0);
-  ASSERT(uptime > 0);
+  ASSERT_EQ(err, 0);
+  ASSERT_GT(uptime, 0);
   printf("uv_uptime: %f\n", uptime);
 #endif
 
   err = uv_getrusage(&rusage);
-  ASSERT(err == 0);
-  ASSERT(rusage.ru_utime.tv_sec >= 0);
-  ASSERT(rusage.ru_utime.tv_usec >= 0);
-  ASSERT(rusage.ru_stime.tv_sec >= 0);
-  ASSERT(rusage.ru_stime.tv_usec >= 0);
+  ASSERT_EQ(err, 0);
+  ASSERT_GE(rusage.ru_utime.tv_sec, 0);
+  ASSERT_GE(rusage.ru_utime.tv_usec, 0);
+  ASSERT_GE(rusage.ru_stime.tv_sec, 0);
+  ASSERT_GE(rusage.ru_stime.tv_usec, 0);
   printf("uv_getrusage:\n");
   printf("  user: %llu sec %llu microsec\n",
          (unsigned long long) rusage.ru_utime.tv_sec,
@@ -92,9 +92,9 @@ TEST_IMPL(platform_output) {
 
   err = uv_cpu_info(&cpus, &count);
 #if defined(__CYGWIN__) || defined(__MSYS__)
-  ASSERT(err == UV_ENOSYS);
+  ASSERT_EQ(err, UV_ENOSYS);
 #else
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   printf("uv_cpu_info:\n");
   for (i = 0; i < count; i++) {
@@ -113,7 +113,7 @@ TEST_IMPL(platform_output) {
   uv_free_cpu_info(cpus, count);
 
   err = uv_interface_addresses(&interfaces, &count);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   printf("uv_interface_addresses:\n");
   for (i = 0; i < count; i++) {
@@ -183,14 +183,14 @@ TEST_IMPL(platform_output) {
 #endif
 
   pid = uv_os_getpid();
-  ASSERT(pid > 0);
+  ASSERT_GT(pid, 0);
   printf("uv_os_getpid: %d\n", (int) pid);
   ppid = uv_os_getppid();
-  ASSERT(ppid > 0);
+  ASSERT_GT(ppid, 0);
   printf("uv_os_getppid: %d\n", (int) ppid);
 
   err = uv_os_uname(&uname);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
   printf("uv_os_uname:\n");
   printf("  sysname: %s\n", uname.sysname);
   printf("  release: %s\n", uname.release);

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -59,7 +59,7 @@ static void NO_INLINE close_socket_and_verify_stack(void) {
     data[i] = MARKER;
 
   r = closesocket(sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_sleep(VERIFY_AFTER);
 
@@ -79,32 +79,32 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
   ASSERT_NE(sock, INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
   ASSERT(r);
   ASSERT_EQ(WSAGetLastError(), WSAEWOULDBLOCK);
 
   r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_poll_start(&handle, UV_READABLE | UV_WRITABLE, poll_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*) &handle, close_cb);
 
   close_socket_and_verify_stack();
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(close_cb_called, 1);
 

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -59,12 +59,12 @@ static void NO_INLINE close_socket_and_verify_stack(void) {
     data[i] = MARKER;
 
   r = closesocket(sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_sleep(VERIFY_AFTER);
 
   for (i = 0; i < ARRAY_SIZE(data); i++)
-    ASSERT(data[i] == MARKER);
+    ASSERT_EQ(data[i], MARKER);
 }
 #endif
 
@@ -79,34 +79,34 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
-  ASSERT(r != 0);
-  ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
+  ASSERT(r);
+  ASSERT_EQ(WSAGetLastError(), WSAEWOULDBLOCK);
 
   r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_poll_start(&handle, UV_READABLE | UV_WRITABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &handle, close_cb);
 
   close_socket_and_verify_stack();
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-close-doesnt-corrupt-stack.c
+++ b/test/test-poll-close-doesnt-corrupt-stack.c
@@ -106,7 +106,7 @@ TEST_IMPL(poll_close_doesnt_corrupt_stack) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -50,7 +50,7 @@ TEST_IMPL(poll_close) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 #endif
 

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -50,7 +50,7 @@ TEST_IMPL(poll_close) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -66,7 +66,7 @@ TEST_IMPL(poll_close) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == NUM_SOCKETS);
+  ASSERT_EQ(close_cb_called, NUM_SOCKETS);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -39,11 +39,11 @@ static void close_cb(uv_handle_t* h) {
 static void poll_cb(uv_poll_t* h, int status, int events) {
   int r;
 
-  ASSERT(status == 0);
-  ASSERT(h == &handle);
+  ASSERT_EQ(status, 0);
+  ASSERT_PTR_EQ(h, &handle);
 
   r = uv_poll_start(&handle, UV_READABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   closesocket(sock);
   uv_close((uv_handle_t*) &handle, close_cb);
@@ -62,29 +62,29 @@ TEST_IMPL(poll_closesocket) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
-  ASSERT(r != 0);
-  ASSERT(WSAGetLastError() == WSAEWOULDBLOCK);
+  ASSERT(r);
+  ASSERT_EQ(WSAGetLastError(), WSAEWOULDBLOCK);
 
   r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_poll_start(&handle, UV_WRITABLE, poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -39,11 +39,11 @@ static void close_cb(uv_handle_t* h) {
 static void poll_cb(uv_poll_t* h, int status, int events) {
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(h, &handle);
 
   r = uv_poll_start(&handle, UV_READABLE, poll_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   closesocket(sock);
   uv_close((uv_handle_t*) &handle, close_cb);
@@ -62,25 +62,25 @@ TEST_IMPL(poll_closesocket) {
   struct sockaddr_in addr;
 
   r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
   ASSERT_NE(sock, INVALID_SOCKET);
   on = 1;
   r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_ip4_addr("127.0.0.1", TEST_PORT, &addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof addr);
   ASSERT(r);
   ASSERT_EQ(WSAGetLastError(), WSAEWOULDBLOCK);
 
   r = uv_poll_init_socket(uv_default_loop(), &handle, sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_poll_start(&handle, UV_WRITABLE, poll_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-poll-closesocket.c
+++ b/test/test-poll-closesocket.c
@@ -84,7 +84,7 @@ TEST_IMPL(poll_closesocket) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -40,7 +40,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void poll_cb(uv_poll_t* handle, int status, int events) {
   /* Not a bound socket, linux immediately reports UV_READABLE, other OS do not */
-  ASSERT(events == UV_READABLE);
+  ASSERT_EQ(events, UV_READABLE);
 }
 
 TEST_IMPL(poll_multiple_handles) {
@@ -51,20 +51,24 @@ TEST_IMPL(poll_multiple_handles) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
 #ifdef _WIN32
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
 #else
-  ASSERT(sock != -1);
+  ASSERT_NE(sock, -1);
 #endif
-  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &first_poll_handle, sock));
-  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &second_poll_handle, sock));
+  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
+                                   &first_poll_handle,
+                                   sock));
+  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
+                                   &second_poll_handle,
+                                   sock));
 
-  ASSERT(0 == uv_poll_start(&first_poll_handle, UV_READABLE, poll_cb));
+  ASSERT_EQ(0, uv_poll_start(&first_poll_handle, UV_READABLE, poll_cb));
 
   /* We may not start polling while another polling handle is active
    * on that fd.
@@ -73,26 +77,27 @@ TEST_IMPL(poll_multiple_handles) {
   /* We do not track handles in an O(1) lookupable way on Windows,
    * so not checking that here.
    */
-  ASSERT(uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb) == UV_EEXIST);
+  ASSERT_EQ(uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb),
+            UV_EEXIST);
 #endif
 
   /* After stopping the other polling handle, we now should be able to poll */
-  ASSERT(0 == uv_poll_stop(&first_poll_handle));
-  ASSERT(0 == uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb));
+  ASSERT_EQ(0, uv_poll_stop(&first_poll_handle));
+  ASSERT_EQ(0, uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb));
 
   /* Closing an already stopped polling handle is safe in any case */
   uv_close((uv_handle_t*) &first_poll_handle, close_cb);
 
   uv_unref((uv_handle_t*) &second_poll_handle);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(close_cb_called, 1);
   uv_ref((uv_handle_t*) &second_poll_handle);
 
   ASSERT(uv_is_active((uv_handle_t*) &second_poll_handle));
   uv_close((uv_handle_t*) &second_poll_handle, close_cb);
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -90,14 +90,14 @@ TEST_IMPL(poll_multiple_handles) {
 
   uv_unref((uv_handle_t*) &second_poll_handle);
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
   uv_ref((uv_handle_t*) &second_poll_handle);
 
   ASSERT(uv_is_active((uv_handle_t*) &second_poll_handle));
   uv_close((uv_handle_t*) &second_poll_handle, close_cb);
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -51,7 +51,7 @@ TEST_IMPL(poll_multiple_handles) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 #endif
 
@@ -61,14 +61,14 @@ TEST_IMPL(poll_multiple_handles) {
 #else
   ASSERT_NE(sock, -1);
 #endif
-  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
-                                   &first_poll_handle,
-                                   sock));
-  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
-                                   &second_poll_handle,
-                                   sock));
+  ASSERT_OK(uv_poll_init_socket(uv_default_loop(),
+                                &first_poll_handle,
+                                sock));
+  ASSERT_OK(uv_poll_init_socket(uv_default_loop(),
+                                &second_poll_handle,
+                                sock));
 
-  ASSERT_EQ(0, uv_poll_start(&first_poll_handle, UV_READABLE, poll_cb));
+  ASSERT_OK(uv_poll_start(&first_poll_handle, UV_READABLE, poll_cb));
 
   /* We may not start polling while another polling handle is active
    * on that fd.
@@ -82,21 +82,21 @@ TEST_IMPL(poll_multiple_handles) {
 #endif
 
   /* After stopping the other polling handle, we now should be able to poll */
-  ASSERT_EQ(0, uv_poll_stop(&first_poll_handle));
-  ASSERT_EQ(0, uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb));
+  ASSERT_OK(uv_poll_stop(&first_poll_handle));
+  ASSERT_OK(uv_poll_start(&second_poll_handle, UV_READABLE, poll_cb));
 
   /* Closing an already stopped polling handle is safe in any case */
   uv_close((uv_handle_t*) &first_poll_handle, close_cb);
 
   uv_unref((uv_handle_t*) &second_poll_handle);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(close_cb_called, 1);
   uv_ref((uv_handle_t*) &second_poll_handle);
 
   ASSERT(uv_is_active((uv_handle_t*) &second_poll_handle));
   uv_close((uv_handle_t*) &second_poll_handle, close_cb);
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -70,7 +70,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
   int n;
   int fd;
 
-  ASSERT_EQ(0, uv_fileno((uv_handle_t*)handle, &fd));
+  ASSERT_OK(uv_fileno((uv_handle_t*)handle, &fd));
   memset(buffer, 0, 5);
 
   if (events & UV_PRIORITIZED) {
@@ -79,10 +79,10 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
     while (n == -1 && errno == EINTR);
     ASSERT(n >= 0 || errno != EINVAL);
     cli_pr_check = 1;
-    ASSERT_EQ(0, uv_poll_stop(&poll_req[0]));
-    ASSERT_EQ(0, uv_poll_start(&poll_req[0],
-                               UV_READABLE | UV_WRITABLE,
-                               poll_cb));
+    ASSERT_OK(uv_poll_stop(&poll_req[0]));
+    ASSERT_OK(uv_poll_start(&poll_req[0],
+                            UV_READABLE | UV_WRITABLE,
+                            poll_cb));
   }
   if (events & UV_READABLE) {
     if (fd == client_fd) {
@@ -91,13 +91,13 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
       if (cli_rd_check == 1) {
-        ASSERT_EQ(strncmp(buffer, "world", n), 0);
+        ASSERT_OK(strncmp(buffer, "world", n));
         ASSERT_EQ(n, 5);
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {
         ASSERT_EQ(n, 4);
-        ASSERT_EQ(strncmp(buffer, "hello", n), 0);
+        ASSERT_OK(strncmp(buffer, "hello", n));
         cli_rd_check = 1;
         do {
           do
@@ -105,7 +105,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
           while (n == -1 && errno == EINTR);
           if (n > 0) {
             ASSERT_EQ(n, 5);
-            ASSERT_EQ(strncmp(buffer, "world", n), 0);
+            ASSERT_OK(strncmp(buffer, "world", n));
             cli_rd_check = 2;
           }
         } while (n > 0);
@@ -119,7 +119,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
       ASSERT_EQ(n, 3);
-      ASSERT_EQ(strncmp(buffer, "foo", n), 0);
+      ASSERT_OK(strncmp(buffer, "foo", n));
       srv_rd_check = 1;
       uv_poll_stop(&poll_req[1]);
     }
@@ -135,21 +135,21 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
 static void connection_cb(uv_stream_t* handle, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT_EQ(0, uv_fileno((uv_handle_t*) &peer_handle, &server_fd));
-  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
-                                   &poll_req[0],
-                                   client_fd));
-  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
-                                   &poll_req[1],
-                                   server_fd));
-  ASSERT_EQ(0, uv_poll_start(&poll_req[0],
-                             UV_PRIORITIZED | UV_READABLE | UV_WRITABLE,
-                             poll_cb));
-  ASSERT_EQ(0, uv_poll_start(&poll_req[1],
-                             UV_READABLE,
-                             poll_cb));
+  ASSERT_OK(status);
+  ASSERT_OK(uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_OK(uv_fileno((uv_handle_t*) &peer_handle, &server_fd));
+  ASSERT_OK(uv_poll_init_socket(uv_default_loop(),
+                                &poll_req[0],
+                                client_fd));
+  ASSERT_OK(uv_poll_init_socket(uv_default_loop(),
+                                &poll_req[1],
+                                server_fd));
+  ASSERT_OK(uv_poll_start(&poll_req[0],
+                          UV_PRIORITIZED | UV_READABLE | UV_WRITABLE,
+                          poll_cb));
+  ASSERT_OK(uv_poll_start(&poll_req[1],
+                          UV_READABLE,
+                          poll_cb));
   do {
     r = send(server_fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
@@ -160,7 +160,7 @@ static void connection_cb(uv_stream_t* handle, int status) {
   } while (r < 0 && errno == EINTR);
   ASSERT_EQ(r, 5);
 
-  ASSERT_EQ(0, uv_idle_start(&idle, idle_cb));
+  ASSERT_OK(uv_idle_start(&idle, idle_cb));
 }
 
 
@@ -169,18 +169,18 @@ TEST_IMPL(poll_oob) {
   int r = 0;
   uv_loop_t* loop;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
-  ASSERT_EQ(0, uv_idle_init(loop, &idle));
-  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_OK(uv_tcp_init(loop, &server_handle));
+  ASSERT_OK(uv_tcp_init(loop, &client_handle));
+  ASSERT_OK(uv_tcp_init(loop, &peer_handle));
+  ASSERT_OK(uv_idle_init(loop, &idle));
+  ASSERT_OK(uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
 
   /* Ensure two separate packets */
-  ASSERT_EQ(0, uv_tcp_nodelay(&client_handle, 1));
+  ASSERT_OK(uv_tcp_nodelay(&client_handle, 1));
 
   client_fd = socket(PF_INET, SOCK_STREAM, 0);
   ASSERT_GE(client_fd, 0);
@@ -188,9 +188,9 @@ TEST_IMPL(poll_oob) {
     errno = 0;
     r = connect(client_fd, (const struct sockaddr*)&addr, sizeof(addr));
   } while (r == -1 && errno == EINTR);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(ticks, kMaxTicks);
 

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -70,7 +70,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
   int n;
   int fd;
 
-  ASSERT(0 == uv_fileno((uv_handle_t*)handle, &fd));
+  ASSERT_EQ(0, uv_fileno((uv_handle_t*)handle, &fd));
   memset(buffer, 0, 5);
 
   if (events & UV_PRIORITIZED) {
@@ -79,10 +79,10 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
     while (n == -1 && errno == EINTR);
     ASSERT(n >= 0 || errno != EINVAL);
     cli_pr_check = 1;
-    ASSERT(0 == uv_poll_stop(&poll_req[0]));
-    ASSERT(0 == uv_poll_start(&poll_req[0],
-                              UV_READABLE | UV_WRITABLE,
-                              poll_cb));
+    ASSERT_EQ(0, uv_poll_stop(&poll_req[0]));
+    ASSERT_EQ(0, uv_poll_start(&poll_req[0],
+                               UV_READABLE | UV_WRITABLE,
+                               poll_cb));
   }
   if (events & UV_READABLE) {
     if (fd == client_fd) {
@@ -91,21 +91,21 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
       if (cli_rd_check == 1) {
-        ASSERT(strncmp(buffer, "world", n) == 0);
-        ASSERT(5 == n);
+        ASSERT_EQ(strncmp(buffer, "world", n), 0);
+        ASSERT_EQ(n, 5);
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {
-        ASSERT(n == 4);
-        ASSERT(strncmp(buffer, "hello", n) == 0);
+        ASSERT_EQ(n, 4);
+        ASSERT_EQ(strncmp(buffer, "hello", n), 0);
         cli_rd_check = 1;
         do {
           do
             n = recv(server_fd, &buffer, 5, 0);
           while (n == -1 && errno == EINTR);
           if (n > 0) {
-            ASSERT(n == 5);
-            ASSERT(strncmp(buffer, "world", n) == 0);
+            ASSERT_EQ(n, 5);
+            ASSERT_EQ(strncmp(buffer, "world", n), 0);
             cli_rd_check = 2;
           }
         } while (n > 0);
@@ -118,8 +118,8 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
         n = recv(server_fd, &buffer, 3, 0);
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
-      ASSERT(3 == n);
-      ASSERT(strncmp(buffer, "foo", n) == 0);
+      ASSERT_EQ(n, 3);
+      ASSERT_EQ(strncmp(buffer, "foo", n), 0);
       srv_rd_check = 1;
       uv_poll_stop(&poll_req[1]);
     }
@@ -128,35 +128,39 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
     do {
       n = send(client_fd, "foo", 3, 0);
     } while (n < 0 && errno == EINTR);
-    ASSERT(3 == n);
+    ASSERT_EQ(n, 3);
   }
 }
 
 static void connection_cb(uv_stream_t* handle, int status) {
   int r;
 
-  ASSERT(0 == status);
-  ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT(0 == uv_fileno((uv_handle_t*) &peer_handle, &server_fd));
-  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &poll_req[0], client_fd));
-  ASSERT(0 == uv_poll_init_socket(uv_default_loop(), &poll_req[1], server_fd));
-  ASSERT(0 == uv_poll_start(&poll_req[0],
-                            UV_PRIORITIZED | UV_READABLE | UV_WRITABLE,
-                            poll_cb));
-  ASSERT(0 == uv_poll_start(&poll_req[1],
-                            UV_READABLE,
-                            poll_cb));
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_EQ(0, uv_fileno((uv_handle_t*) &peer_handle, &server_fd));
+  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
+                                   &poll_req[0],
+                                   client_fd));
+  ASSERT_EQ(0, uv_poll_init_socket(uv_default_loop(),
+                                   &poll_req[1],
+                                   server_fd));
+  ASSERT_EQ(0, uv_poll_start(&poll_req[0],
+                             UV_PRIORITIZED | UV_READABLE | UV_WRITABLE,
+                             poll_cb));
+  ASSERT_EQ(0, uv_poll_start(&poll_req[1],
+                             UV_READABLE,
+                             poll_cb));
   do {
     r = send(server_fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   do {
     r = send(server_fd, "world", 5, 0);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
-  ASSERT(0 == uv_idle_start(&idle, idle_cb));
+  ASSERT_EQ(0, uv_idle_start(&idle, idle_cb));
 }
 
 
@@ -165,39 +169,39 @@ TEST_IMPL(poll_oob) {
   int r = 0;
   uv_loop_t* loop;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_tcp_init(loop, &server_handle));
-  ASSERT(0 == uv_tcp_init(loop, &client_handle));
-  ASSERT(0 == uv_tcp_init(loop, &peer_handle));
-  ASSERT(0 == uv_idle_init(loop, &idle));
-  ASSERT(0 == uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
+  ASSERT_EQ(0, uv_idle_init(loop, &idle));
+  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
 
   /* Ensure two separate packets */
-  ASSERT(0 == uv_tcp_nodelay(&client_handle, 1));
+  ASSERT_EQ(0, uv_tcp_nodelay(&client_handle, 1));
 
   client_fd = socket(PF_INET, SOCK_STREAM, 0);
-  ASSERT(client_fd >= 0);
+  ASSERT_GE(client_fd, 0);
   do {
     errno = 0;
     r = connect(client_fd, (const struct sockaddr*)&addr, sizeof(addr));
   } while (r == -1 && errno == EINTR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(ticks == kMaxTicks);
+  ASSERT_EQ(ticks, kMaxTicks);
 
   /* Did client receive the POLLPRI message */
-  ASSERT(cli_pr_check == 1);
+  ASSERT_EQ(cli_pr_check, 1);
   /* Did client receive the POLLIN message */
-  ASSERT(cli_rd_check == 2);
+  ASSERT_EQ(cli_rd_check, 2);
   /* Could we write with POLLOUT and did the server receive our POLLOUT message
    * through POLLIN.
    */
-  ASSERT(srv_rd_check == 1);
+  ASSERT_EQ(srv_rd_check, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -92,11 +92,11 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       ASSERT(n >= 0 || errno != EINVAL);
       if (cli_rd_check == 1) {
         ASSERT_OK(strncmp(buffer, "world", n));
-        ASSERT_EQ(n, 5);
+        ASSERT_EQ(5, n);
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {
-        ASSERT_EQ(n, 4);
+        ASSERT_EQ(4, n);
         ASSERT_OK(strncmp(buffer, "hello", n));
         cli_rd_check = 1;
         do {
@@ -104,7 +104,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
             n = recv(server_fd, &buffer, 5, 0);
           while (n == -1 && errno == EINTR);
           if (n > 0) {
-            ASSERT_EQ(n, 5);
+            ASSERT_EQ(5, n);
             ASSERT_OK(strncmp(buffer, "world", n));
             cli_rd_check = 2;
           }
@@ -118,7 +118,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
         n = recv(server_fd, &buffer, 3, 0);
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
-      ASSERT_EQ(n, 3);
+      ASSERT_EQ(3, n);
       ASSERT_OK(strncmp(buffer, "foo", n));
       srv_rd_check = 1;
       uv_poll_stop(&poll_req[1]);
@@ -128,7 +128,7 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
     do {
       n = send(client_fd, "foo", 3, 0);
     } while (n < 0 && errno == EINTR);
-    ASSERT_EQ(n, 3);
+    ASSERT_EQ(3, n);
   }
 }
 
@@ -153,12 +153,12 @@ static void connection_cb(uv_stream_t* handle, int status) {
   do {
     r = send(server_fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT_EQ(r, 5);
+  ASSERT_EQ(5, r);
 
   do {
     r = send(server_fd, "world", 5, 0);
   } while (r < 0 && errno == EINTR);
-  ASSERT_EQ(r, 5);
+  ASSERT_EQ(5, r);
 
   ASSERT_OK(uv_idle_start(&idle, idle_cb));
 }
@@ -195,13 +195,13 @@ TEST_IMPL(poll_oob) {
   ASSERT_EQ(ticks, kMaxTicks);
 
   /* Did client receive the POLLPRI message */
-  ASSERT_EQ(cli_pr_check, 1);
+  ASSERT_EQ(1, cli_pr_check);
   /* Did client receive the POLLIN message */
-  ASSERT_EQ(cli_rd_check, 2);
+  ASSERT_EQ(2, cli_rd_check);
   /* Could we write with POLLOUT and did the server receive our POLLOUT message
    * through POLLIN.
    */
-  ASSERT_EQ(srv_rd_check, 1);
+  ASSERT_EQ(1, srv_rd_check);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -106,9 +106,9 @@ static uv_os_sock_t create_bound_socket (struct sockaddr_in bind_addr) {
 
   sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
 #ifdef _WIN32
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
 #else
-  ASSERT(sock >= 0);
+  ASSERT_GE(sock, 0);
 #endif
 
 #ifndef _WIN32
@@ -116,12 +116,12 @@ static uv_os_sock_t create_bound_socket (struct sockaddr_in bind_addr) {
     /* Allow reuse of the port. */
     int yes = 1;
     r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
   r = bind(sock, (const struct sockaddr*) &bind_addr, sizeof bind_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return sock;
 }
@@ -163,12 +163,12 @@ static connection_context_t* create_connection_context(
   r = uv_poll_init_socket(uv_default_loop(), &context->poll_handle, sock);
   context->open_handles++;
   context->poll_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &context->timer_handle);
   context->open_handles++;
   context->timer_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return context;
 }
@@ -179,15 +179,15 @@ static void connection_close_cb(uv_handle_t* handle) {
 
   if (--context->open_handles == 0) {
     if (test_mode == DUPLEX || context->is_server_connection) {
-      ASSERT(context->read == TRANSFER_BYTES);
+      ASSERT_EQ(context->read, TRANSFER_BYTES);
     } else {
-      ASSERT(context->read == 0);
+      ASSERT_EQ(context->read, 0);
     }
 
     if (test_mode == DUPLEX || !context->is_server_connection) {
-      ASSERT(context->sent == TRANSFER_BYTES);
+      ASSERT_EQ(context->sent, TRANSFER_BYTES);
     } else {
-      ASSERT(context->sent == 0);
+      ASSERT_EQ(context->sent, 0);
     }
 
     closed_connections++;
@@ -208,7 +208,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
   unsigned int new_events;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT(events & context->events);
   ASSERT(!(events & ~context->events));
 
@@ -226,7 +226,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
         do
           r = recv(context->sock, buffer, sizeof buffer, 0);
         while (r == -1 && errno == EINTR);
-        ASSERT(r >= 0);
+        ASSERT_GE(r, 0);
 
         if (r > 0) {
           context->read += r;
@@ -306,7 +306,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
           static char buffer[103];
 
           int send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
-          ASSERT(send_bytes > 0);
+          ASSERT_GT(send_bytes, 0);
 
           do
             r = send(context->sock, buffer, send_bytes, 0);
@@ -318,7 +318,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
             break;
           }
 
-          ASSERT(r > 0);
+          ASSERT_GT(r, 0);
           context->sent += r;
           valid_writable_wakeups++;
           break;
@@ -330,7 +330,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
           static char buffer[1234];
 
           int send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
-          ASSERT(send_bytes > 0);
+          ASSERT_GT(send_bytes, 0);
 
           do
             r = send(context->sock, buffer, send_bytes, 0);
@@ -342,18 +342,18 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
             break;
           }
 
-          ASSERT(r > 0);
+          ASSERT_GT(r, 0);
           valid_writable_wakeups++;
           context->sent += r;
 
           while (context->sent < TRANSFER_BYTES) {
             send_bytes = MIN(TRANSFER_BYTES - context->sent, sizeof buffer);
-            ASSERT(send_bytes > 0);
+            ASSERT_GT(send_bytes, 0);
 
             do
               r = send(context->sock, buffer, send_bytes, 0);
             while (r == -1 && errno == EINTR);
-            ASSERT(r != 0);
+            ASSERT(r);
 
             if (r < 0) {
               ASSERT(got_eagain());
@@ -403,7 +403,7 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
 #else
       r = shutdown(context->sock, SHUT_WR);
 #endif
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
       context->sent_fin = 1;
       new_events &= ~UV_WRITABLE;
     }
@@ -432,9 +432,9 @@ static void connection_poll_cb(uv_poll_t* handle, int status, int events) {
 
   /* Assert that uv_is_active works correctly for poll handles. */
   if (context->events != 0) {
-    ASSERT(1 == uv_is_active((uv_handle_t*) handle));
+    ASSERT_EQ(1, uv_is_active((uv_handle_t*) handle));
   } else {
-    ASSERT(0 == uv_is_active((uv_handle_t*) handle));
+    ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
   }
 }
 
@@ -444,7 +444,7 @@ static void delay_timer_cb(uv_timer_t* timer) {
   int r;
 
   /* Timer should auto stop. */
-  ASSERT(0 == uv_is_active((uv_handle_t*) timer));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) timer));
 
   /* Add the requested events to the poll mask. */
   ASSERT(context->delayed_events != 0);
@@ -454,7 +454,7 @@ static void delay_timer_cb(uv_timer_t* timer) {
   r = uv_poll_start(&context->poll_handle,
                     context->events,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -471,7 +471,7 @@ static server_context_t* create_server_context(
 
   r = uv_poll_init_socket(uv_default_loop(), &context->poll_handle, sock);
   context->poll_handle.data = context;
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return context;
 }
@@ -500,9 +500,9 @@ static void server_poll_cb(uv_poll_t* handle, int status, int events) {
   addr_len = sizeof addr;
   sock = accept(server_context->sock, (struct sockaddr*) &addr, &addr_len);
 #ifdef _WIN32
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
 #else
-  ASSERT(sock >= 0);
+  ASSERT_GE(sock, 0);
 #endif
 
   connection_context = create_connection_context(sock, 1);
@@ -510,7 +510,7 @@ static void server_poll_cb(uv_poll_t* handle, int status, int events) {
   r = uv_poll_start(&connection_context->poll_handle,
                     UV_READABLE | UV_WRITABLE | UV_DISCONNECT,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (++server_context->connections == NUM_CLIENTS) {
     close_socket(server_context->sock);
@@ -525,15 +525,15 @@ static void start_server(void) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   sock = create_bound_socket(addr);
   context = create_server_context(sock);
 
   r = listen(sock, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_poll_start(&context->poll_handle, UV_READABLE, server_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -544,8 +544,8 @@ static void start_client(void) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &addr));
 
   sock = create_bound_socket(addr);
   context = create_connection_context(sock, 0);
@@ -554,7 +554,7 @@ static void start_client(void) {
   r = uv_poll_start(&context->poll_handle,
                     UV_READABLE | UV_WRITABLE | UV_DISCONNECT,
                     connection_poll_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (struct sockaddr*) &server_addr, sizeof server_addr);
   ASSERT(r == 0 || got_eagain());
@@ -568,7 +568,7 @@ static void start_poll_test(void) {
   {
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -578,16 +578,16 @@ static void start_poll_test(void) {
     start_client();
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Assert that at most five percent of the writable wakeups was spurious. */
-  ASSERT(spurious_writable_wakeups == 0 ||
-         (valid_writable_wakeups + spurious_writable_wakeups) /
-         spurious_writable_wakeups > 20);
+  ASSERT_NE(spurious_writable_wakeups == 0 ||
+            (valid_writable_wakeups + spurious_writable_wakeups) /
+            spurious_writable_wakeups > 20, 0);
 
-  ASSERT(closed_connections == NUM_CLIENTS * 2);
+  ASSERT_EQ(closed_connections, NUM_CLIENTS * 2);
 #if !defined(__sun) && !defined(_AIX) && !defined(__MVS__)
-  ASSERT(disconnects == NUM_CLIENTS * 2);
+  ASSERT_EQ(disconnects, NUM_CLIENTS * 2);
 #endif
   MAKE_VALGRIND_HAPPY(uv_default_loop());
 }
@@ -642,9 +642,9 @@ TEST_IMPL(poll_bad_fdtype) {
 #else
   fd = open(".", O_RDONLY);
 #endif
-  ASSERT(fd != -1);
-  ASSERT(0 != uv_poll_init(uv_default_loop(), &poll_handle, fd));
-  ASSERT(0 == close(fd));
+  ASSERT_NE(fd, -1);
+  ASSERT_NE(0, uv_poll_init(uv_default_loop(), &poll_handle, fd));
+  ASSERT_EQ(0, close(fd));
 #endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -658,15 +658,15 @@ TEST_IMPL(poll_nested_epoll) {
   int fd;
 
   fd = epoll_create(1);
-  ASSERT(fd != -1);
+  ASSERT_NE(fd, -1);
 
-  ASSERT(0 == uv_poll_init(uv_default_loop(), &poll_handle, fd));
-  ASSERT(0 == uv_poll_start(&poll_handle, UV_READABLE, (uv_poll_cb) abort));
-  ASSERT(0 != uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, fd));
+  ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, (uv_poll_cb) abort));
+  ASSERT_NE(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
   uv_close((uv_handle_t*) &poll_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == close(fd));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, close(fd));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -680,15 +680,15 @@ TEST_IMPL(poll_nested_kqueue) {
   int fd;
 
   fd = kqueue();
-  ASSERT(fd != -1);
+  ASSERT_NE(fd, -1);
 
-  ASSERT(0 == uv_poll_init(uv_default_loop(), &poll_handle, fd));
-  ASSERT(0 == uv_poll_start(&poll_handle, UV_READABLE, (uv_poll_cb) abort));
-  ASSERT(0 != uv_run(uv_default_loop(), UV_RUN_NOWAIT));
+  ASSERT_EQ(0, uv_poll_init(uv_default_loop(), &poll_handle, fd));
+  ASSERT_EQ(0, uv_poll_start(&poll_handle, UV_READABLE, (uv_poll_cb) abort));
+  ASSERT_NE(0, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
 
   uv_close((uv_handle_t*) &poll_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == close(fd));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, close(fd));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-process-priority.c
+++ b/test/test-process-priority.c
@@ -46,8 +46,8 @@ TEST_IMPL(process_priority) {
     if (r == UV_EACCES)
       continue;
 
-    ASSERT_EQ(r, 0);
-    ASSERT_EQ(uv_os_getpriority(0, &priority), 0);
+    ASSERT_OK(r);
+    ASSERT_OK(uv_os_getpriority(0, &priority));
 
     /* Verify that the priority values match on Unix, and are range mapped
        on Windows. */
@@ -71,7 +71,7 @@ TEST_IMPL(process_priority) {
 #endif
 
     /* Verify that the current PID and 0 are equivalent. */
-    ASSERT_EQ(uv_os_getpriority(uv_os_getpid(), &r), 0);
+    ASSERT_OK(uv_os_getpriority(uv_os_getpid(), &r));
     ASSERT_EQ(priority, r);
   }
 

--- a/test/test-process-priority.c
+++ b/test/test-process-priority.c
@@ -35,7 +35,7 @@ TEST_IMPL(process_priority) {
 
   /* Verify that passing a NULL pointer returns UV_EINVAL. */
   r = uv_os_getpriority(0, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Verify that all valid values work. */
   for (i = UV_PRIORITY_HIGHEST; i <= UV_PRIORITY_LOW; i++) {
@@ -46,38 +46,38 @@ TEST_IMPL(process_priority) {
     if (r == UV_EACCES)
       continue;
 
-    ASSERT(r == 0);
-    ASSERT(uv_os_getpriority(0, &priority) == 0);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(uv_os_getpriority(0, &priority), 0);
 
     /* Verify that the priority values match on Unix, and are range mapped
        on Windows. */
 #ifndef _WIN32
-    ASSERT(priority == i);
+    ASSERT_EQ(priority, i);
 #else
     /* On Windows, only elevated users can set UV_PRIORITY_HIGHEST. Other
        users will silently be set to UV_PRIORITY_HIGH. */
     if (i < UV_PRIORITY_HIGH)
       ASSERT(priority == UV_PRIORITY_HIGHEST || priority == UV_PRIORITY_HIGH);
     else if (i < UV_PRIORITY_ABOVE_NORMAL)
-      ASSERT(priority == UV_PRIORITY_HIGH);
+      ASSERT_EQ(priority, UV_PRIORITY_HIGH);
     else if (i < UV_PRIORITY_NORMAL)
-      ASSERT(priority == UV_PRIORITY_ABOVE_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_ABOVE_NORMAL);
     else if (i < UV_PRIORITY_BELOW_NORMAL)
-      ASSERT(priority == UV_PRIORITY_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_NORMAL);
     else if (i < UV_PRIORITY_LOW)
-      ASSERT(priority == UV_PRIORITY_BELOW_NORMAL);
+      ASSERT_EQ(priority, UV_PRIORITY_BELOW_NORMAL);
     else
-      ASSERT(priority == UV_PRIORITY_LOW);
+      ASSERT_EQ(priority, UV_PRIORITY_LOW);
 #endif
 
     /* Verify that the current PID and 0 are equivalent. */
-    ASSERT(uv_os_getpriority(uv_os_getpid(), &r) == 0);
-    ASSERT(priority == r);
+    ASSERT_EQ(uv_os_getpriority(uv_os_getpid(), &r), 0);
+    ASSERT_EQ(priority, r);
   }
 
   /* Verify that invalid priorities return UV_EINVAL. */
-  ASSERT(uv_os_setpriority(0, UV_PRIORITY_HIGHEST - 1) == UV_EINVAL);
-  ASSERT(uv_os_setpriority(0, UV_PRIORITY_LOW + 1) == UV_EINVAL);
+  ASSERT_EQ(uv_os_setpriority(0, UV_PRIORITY_HIGHEST - 1), UV_EINVAL);
+  ASSERT_EQ(uv_os_setpriority(0, UV_PRIORITY_LOW + 1), UV_EINVAL);
 
   return 0;
 }

--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -46,7 +46,7 @@ static void getter_thread_body(void* arg) {
   getter_sem = arg;
 
   while (UV_EAGAIN == uv_sem_trywait(getter_sem)) {
-    ASSERT(0 == uv_get_process_title(buffer, sizeof(buffer)));
+    ASSERT_EQ(0, uv_get_process_title(buffer, sizeof(buffer)));
 
     /* The maximum size of the process title on some platforms depends on
      * the total size of the argv vector. It's therefore possible to read
@@ -70,10 +70,10 @@ static void setter_thread_body(void* arg) {
   int i;
 
   for (i = 0; i < NUM_ITERATIONS; i++) {
-    ASSERT(0 == uv_set_process_title(titles[0]));
-    ASSERT(0 == uv_set_process_title(titles[1]));
-    ASSERT(0 == uv_set_process_title(titles[2]));
-    ASSERT(0 == uv_set_process_title(titles[3]));
+    ASSERT_EQ(0, uv_set_process_title(titles[0]));
+    ASSERT_EQ(0, uv_set_process_title(titles[1]));
+    ASSERT_EQ(0, uv_set_process_title(titles[2]));
+    ASSERT_EQ(0, uv_set_process_title(titles[3]));
   }
 }
 
@@ -89,17 +89,17 @@ TEST_IMPL(process_title_threadsafe) {
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #endif
 
-  ASSERT(0 == uv_set_process_title(titles[0]));
+  ASSERT_EQ(0, uv_set_process_title(titles[0]));
 
   ASSERT_EQ(0, uv_sem_init(&getter_sem, 0));
   ASSERT_EQ(0,
             uv_thread_create(&getter_thread, getter_thread_body, &getter_sem));
 
   for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
-    ASSERT(0 == uv_thread_create(&setter_threads[i], setter_thread_body, NULL));
+    ASSERT_EQ(0, uv_thread_create(&setter_threads[i], setter_thread_body, NULL));
 
   for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
-    ASSERT(0 == uv_thread_join(&setter_threads[i]));
+    ASSERT_EQ(0, uv_thread_join(&setter_threads[i]));
 
   uv_sem_post(&getter_sem);
   ASSERT_EQ(0, uv_thread_join(&getter_thread));

--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -46,7 +46,7 @@ static void getter_thread_body(void* arg) {
   getter_sem = arg;
 
   while (UV_EAGAIN == uv_sem_trywait(getter_sem)) {
-    ASSERT_EQ(0, uv_get_process_title(buffer, sizeof(buffer)));
+    ASSERT_OK(uv_get_process_title(buffer, sizeof(buffer)));
 
     /* The maximum size of the process title on some platforms depends on
      * the total size of the argv vector. It's therefore possible to read
@@ -70,10 +70,10 @@ static void setter_thread_body(void* arg) {
   int i;
 
   for (i = 0; i < NUM_ITERATIONS; i++) {
-    ASSERT_EQ(0, uv_set_process_title(titles[0]));
-    ASSERT_EQ(0, uv_set_process_title(titles[1]));
-    ASSERT_EQ(0, uv_set_process_title(titles[2]));
-    ASSERT_EQ(0, uv_set_process_title(titles[3]));
+    ASSERT_OK(uv_set_process_title(titles[0]));
+    ASSERT_OK(uv_set_process_title(titles[1]));
+    ASSERT_OK(uv_set_process_title(titles[2]));
+    ASSERT_OK(uv_set_process_title(titles[3]));
   }
 }
 
@@ -89,20 +89,19 @@ TEST_IMPL(process_title_threadsafe) {
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #endif
 
-  ASSERT_EQ(0, uv_set_process_title(titles[0]));
+  ASSERT_OK(uv_set_process_title(titles[0]));
 
-  ASSERT_EQ(0, uv_sem_init(&getter_sem, 0));
-  ASSERT_EQ(0,
-            uv_thread_create(&getter_thread, getter_thread_body, &getter_sem));
-
-  for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
-    ASSERT_EQ(0, uv_thread_create(&setter_threads[i], setter_thread_body, NULL));
+  ASSERT_OK(uv_sem_init(&getter_sem, 0));
+  ASSERT_OK(uv_thread_create(&getter_thread, getter_thread_body, &getter_sem));
 
   for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
-    ASSERT_EQ(0, uv_thread_join(&setter_threads[i]));
+    ASSERT_OK(uv_thread_create(&setter_threads[i], setter_thread_body, NULL));
+
+  for (i = 0; i < (int) ARRAY_SIZE(setter_threads); i++)
+    ASSERT_OK(uv_thread_join(&setter_threads[i]));
 
   uv_sem_post(&getter_sem);
-  ASSERT_EQ(0, uv_thread_join(&getter_thread));
+  ASSERT_OK(uv_thread_join(&getter_thread));
   uv_sem_destroy(&getter_sem);
 
   return 0;

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -29,15 +29,15 @@ static void set_title(const char* title) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   err = uv_set_process_title(title);
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT_EQ(err, 0);
+  ASSERT_OK(err);
 
-  ASSERT_EQ(strcmp(buffer, title), 0);
+  ASSERT_OK(strcmp(buffer, title));
 }
 
 
@@ -77,8 +77,8 @@ TEST_IMPL(process_title) {
 
 
 static void exit_cb(uv_process_t* process, int64_t status, int signo) {
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(signo, 0);
+  ASSERT_OK(status);
+  ASSERT_OK(signo);
   uv_close((uv_handle_t*) process, NULL);
 }
 
@@ -97,7 +97,7 @@ TEST_IMPL(process_title_big_argv) {
 #endif
 
   exepath_size = sizeof(exepath) - 1;
-  ASSERT_EQ(0, uv_exepath(exepath, &exepath_size));
+  ASSERT_OK(uv_exepath(exepath, &exepath_size));
   exepath[exepath_size] = '\0';
 
   memset(jumbo, 'x', sizeof(jumbo) - 1);
@@ -117,8 +117,8 @@ TEST_IMPL(process_title_big_argv) {
   options.args = args;
   options.exit_cb = exit_cb;
 
-  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-process-title.c
+++ b/test/test-process-title.c
@@ -29,15 +29,15 @@ static void set_title(const char* title) {
   int err;
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   err = uv_set_process_title(title);
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
   err = uv_get_process_title(buffer, sizeof(buffer));
-  ASSERT(err == 0);
+  ASSERT_EQ(err, 0);
 
-  ASSERT(strcmp(buffer, title) == 0);
+  ASSERT_EQ(strcmp(buffer, title), 0);
 }
 
 
@@ -47,15 +47,15 @@ static void uv_get_process_title_edge_cases(void) {
 
   /* Test a NULL buffer */
   r = uv_get_process_title(NULL, 100);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Test size of zero */
   r = uv_get_process_title(buffer, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Test for insufficient buffer size */
   r = uv_get_process_title(buffer, 1);
-  ASSERT(r == UV_ENOBUFS);
+  ASSERT_EQ(r, UV_ENOBUFS);
 }
 
 
@@ -77,8 +77,8 @@ TEST_IMPL(process_title) {
 
 
 static void exit_cb(uv_process_t* process, int64_t status, int signo) {
-  ASSERT(status == 0);
-  ASSERT(signo == 0);
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(signo, 0);
   uv_close((uv_handle_t*) process, NULL);
 }
 
@@ -97,7 +97,7 @@ TEST_IMPL(process_title_big_argv) {
 #endif
 
   exepath_size = sizeof(exepath) - 1;
-  ASSERT(0 == uv_exepath(exepath, &exepath_size));
+  ASSERT_EQ(0, uv_exepath(exepath, &exepath_size));
   exepath[exepath_size] = '\0';
 
   memset(jumbo, 'x', sizeof(jumbo) - 1);
@@ -117,8 +117,8 @@ TEST_IMPL(process_title_big_argv) {
   options.args = args;
   options.exit_cb = exit_cb;
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -131,5 +131,5 @@ void process_title_big_argv(void) {
 
   /* Return value deliberately ignored. */
   uv_get_process_title(buf, sizeof(buf));
-  ASSERT(0 != strcmp(buf, "fail"));
+  ASSERT_NE(0, strcmp(buf, "fail"));
 }

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -71,7 +71,7 @@ static const unsigned first_handle_number_fs_event = 0;
   static unsigned name##_cb_calls[3];                                         \
                                                                               \
   static void name##2_cb(__VA_ARGS__) {                                       \
-    ASSERT(handle == &(name)[2]);                                             \
+    ASSERT_PTR_EQ(handle, &(name)[2]);                                        \
     if (first_handle_number_##name == 2) {                                    \
       uv_close((uv_handle_t*)&(name)[2], NULL);                               \
       uv_close((uv_handle_t*)&(name)[1], NULL);                               \
@@ -80,12 +80,12 @@ static const unsigned first_handle_number_fs_event = 0;
   }                                                                           \
                                                                               \
   static void name##1_cb(__VA_ARGS__) {                                       \
-    ASSERT(handle == &(name)[1]);                                             \
+    ASSERT_PTR_EQ(handle, &(name)[1]);                                        \
     ASSERT(0 && "Shouldn't be called" && (&name[0]));                         \
   }                                                                           \
                                                                               \
   static void name##0_cb(__VA_ARGS__) {                                       \
-    ASSERT(handle == &(name)[0]);                                             \
+    ASSERT_PTR_EQ(handle, &(name)[0]);                                        \
     if (first_handle_number_##name == 0) {                                    \
       uv_close((uv_handle_t*)&(name)[0], NULL);                               \
       uv_close((uv_handle_t*)&(name)[1], NULL);                               \
@@ -105,18 +105,18 @@ static const unsigned first_handle_number_fs_event = 0;
     for (i = 0; i < ARRAY_SIZE(name); i++) {                                  \
       int r;                                                                  \
       r = uv_##name##_init((loop), &(name)[i]);                               \
-      ASSERT(r == 0);                                                         \
+      ASSERT_EQ(r, 0);                                                        \
                                                                               \
       r = uv_##name##_start(&(name)[i], name##_cbs[i]);                       \
-      ASSERT(r == 0);                                                         \
+      ASSERT_EQ(r, 0);                                                        \
     }                                                                         \
   } while (0)
 
 #define END_ASSERTS(name)                                                     \
   do {                                                                        \
-    ASSERT(name##_cb_calls[0] == 1);                                          \
-    ASSERT(name##_cb_calls[1] == 0);                                          \
-    ASSERT(name##_cb_calls[2] == 1);                                          \
+    ASSERT_EQ(name##_cb_calls[0], 1);                                         \
+    ASSERT_EQ(name##_cb_calls[1], 0);                                         \
+    ASSERT_EQ(name##_cb_calls[2], 1);                                         \
   } while (0)
 
 DEFINE_GLOBALS_AND_CBS(idle, uv_idle_t* handle)
@@ -140,13 +140,13 @@ static void init_and_start_fs_events(uv_loop_t* loop) {
   for (i = 0; i < ARRAY_SIZE(fs_event); i++) {
     int r;
     r = uv_fs_event_init(loop, &fs_event[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_fs_event_start(&fs_event[i],
                           (uv_fs_event_cb)fs_event_cbs[i],
                           watched_dir,
                           0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -156,10 +156,10 @@ static void helper_timer_cb(uv_timer_t* thandle) {
 
   /* fire all fs_events */
   r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
-  ASSERT(r == 0);
-  ASSERT(fs_req.result == 0);
-  ASSERT(fs_req.fs_type == UV_FS_UTIME);
-  ASSERT(strcmp(fs_req.path, watched_dir) == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(fs_req.result, 0);
+  ASSERT_EQ(fs_req.fs_type, UV_FS_UTIME);
+  ASSERT_EQ(strcmp(fs_req.path, watched_dir), 0);
   uv_fs_req_cleanup(&fs_req);
 
   helper_timer_cb_calls++;
@@ -182,21 +182,21 @@ TEST_IMPL(queue_foreach_delete) {
 
   /* helper timer to trigger async and fs_event callbacks */
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, helper_timer_cb, 0, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   r = uv_run(loop, UV_RUN_NOWAIT);
-  ASSERT(r == 1);
+  ASSERT_EQ(r, 1);
 
   END_ASSERTS(idle);
   END_ASSERTS(prepare);
   END_ASSERTS(check);
 
 #ifdef __linux__
-  ASSERT(helper_timer_cb_calls == 1);
+  ASSERT_EQ(helper_timer_cb_calls, 1);
 #endif
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -105,17 +105,17 @@ static const unsigned first_handle_number_fs_event = 0;
     for (i = 0; i < ARRAY_SIZE(name); i++) {                                  \
       int r;                                                                  \
       r = uv_##name##_init((loop), &(name)[i]);                               \
-      ASSERT_EQ(r, 0);                                                        \
+      ASSERT_OK(r);                                                           \
                                                                               \
       r = uv_##name##_start(&(name)[i], name##_cbs[i]);                       \
-      ASSERT_EQ(r, 0);                                                        \
+      ASSERT_OK(r);                                                           \
     }                                                                         \
   } while (0)
 
 #define END_ASSERTS(name)                                                     \
   do {                                                                        \
     ASSERT_EQ(name##_cb_calls[0], 1);                                         \
-    ASSERT_EQ(name##_cb_calls[1], 0);                                         \
+    ASSERT_OK(name##_cb_calls[1]);                                            \
     ASSERT_EQ(name##_cb_calls[2], 1);                                         \
   } while (0)
 
@@ -140,13 +140,13 @@ static void init_and_start_fs_events(uv_loop_t* loop) {
   for (i = 0; i < ARRAY_SIZE(fs_event); i++) {
     int r;
     r = uv_fs_event_init(loop, &fs_event[i]);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_fs_event_start(&fs_event[i],
                           (uv_fs_event_cb)fs_event_cbs[i],
                           watched_dir,
                           0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
@@ -156,10 +156,10 @@ static void helper_timer_cb(uv_timer_t* thandle) {
 
   /* fire all fs_events */
   r = uv_fs_utime(thandle->loop, &fs_req, watched_dir, 0, 0, NULL);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(fs_req.result, 0);
+  ASSERT_OK(r);
+  ASSERT_OK(fs_req.result);
   ASSERT_EQ(fs_req.fs_type, UV_FS_UTIME);
-  ASSERT_EQ(strcmp(fs_req.path, watched_dir), 0);
+  ASSERT_OK(strcmp(fs_req.path, watched_dir));
   uv_fs_req_cleanup(&fs_req);
 
   helper_timer_cb_calls++;
@@ -182,10 +182,10 @@ TEST_IMPL(queue_foreach_delete) {
 
   /* helper timer to trigger async and fs_event callbacks */
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, helper_timer_cb, 0, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #endif
 
   r = uv_run(loop, UV_RUN_NOWAIT);

--- a/test/test-queue-foreach-delete.c
+++ b/test/test-queue-foreach-delete.c
@@ -114,9 +114,9 @@ static const unsigned first_handle_number_fs_event = 0;
 
 #define END_ASSERTS(name)                                                     \
   do {                                                                        \
-    ASSERT_EQ(name##_cb_calls[0], 1);                                         \
+    ASSERT_EQ(1, name##_cb_calls[0]);                                         \
     ASSERT_OK(name##_cb_calls[1]);                                            \
-    ASSERT_EQ(name##_cb_calls[2], 1);                                         \
+    ASSERT_EQ(1, name##_cb_calls[2]);                                         \
   } while (0)
 
 DEFINE_GLOBALS_AND_CBS(idle, uv_idle_t* handle)
@@ -189,14 +189,14 @@ TEST_IMPL(queue_foreach_delete) {
 #endif
 
   r = uv_run(loop, UV_RUN_NOWAIT);
-  ASSERT_EQ(r, 1);
+  ASSERT_EQ(1, r);
 
   END_ASSERTS(idle);
   END_ASSERTS(prepare);
   END_ASSERTS(check);
 
 #ifdef __linux__
-  ASSERT_EQ(helper_timer_cb_calls, 1);
+  ASSERT_EQ(1, helper_timer_cb_calls);
 #endif
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -62,13 +62,13 @@ TEST_IMPL(random_async) {
   ASSERT_OK(random_cb_called);
 
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(random_cb_called, 1);
+  ASSERT_EQ(1, random_cb_called);
 
   ASSERT_OK(uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
-  ASSERT_EQ(random_cb_called, 1);
+  ASSERT_EQ(1, random_cb_called);
 
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(random_cb_called, 2);
+  ASSERT_EQ(2, random_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -33,16 +33,16 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
 
   memset(zero, 0, sizeof(zero));
 
-  ASSERT(0 == status);
-  ASSERT(buf == (void*) scratch);
+  ASSERT_EQ(status, 0);
+  ASSERT_PTR_EQ(buf, (void*) scratch);
 
   if (random_cb_called == 0) {
-    ASSERT(buflen == 0);
-    ASSERT(0 == memcmp(scratch, zero, sizeof(zero)));
+    ASSERT_EQ(buflen, 0);
+    ASSERT_EQ(0, memcmp(scratch, zero, sizeof(zero)));
   } else {
-    ASSERT(buflen == sizeof(scratch));
+    ASSERT_EQ(buflen, sizeof(scratch));
     /* Buy a lottery ticket if you manage to trip this assertion. */
-    ASSERT(0 != memcmp(scratch, zero, sizeof(zero)));
+    ASSERT_NE(0, memcmp(scratch, zero, sizeof(zero)));
   }
 
   random_cb_called++;
@@ -54,21 +54,21 @@ TEST_IMPL(random_async) {
   uv_loop_t* loop;
 
   loop = uv_default_loop();
-  ASSERT(UV_EINVAL == uv_random(loop, &req, scratch, sizeof(scratch), -1,
-                                random_cb));
-  ASSERT(UV_E2BIG == uv_random(loop, &req, scratch, -1, -1, random_cb));
+  ASSERT_EQ(UV_EINVAL, uv_random(loop, &req, scratch, sizeof(scratch), -1,
+                                 random_cb));
+  ASSERT_EQ(UV_E2BIG, uv_random(loop, &req, scratch, -1, -1, random_cb));
 
-  ASSERT(0 == uv_random(loop, &req, scratch, 0, 0, random_cb));
-  ASSERT(0 == random_cb_called);
+  ASSERT_EQ(0, uv_random(loop, &req, scratch, 0, 0, random_cb));
+  ASSERT_EQ(random_cb_called, 0);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == random_cb_called);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(random_cb_called, 1);
 
-  ASSERT(0 == uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
-  ASSERT(1 == random_cb_called);
+  ASSERT_EQ(0, uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
+  ASSERT_EQ(random_cb_called, 1);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(2 == random_cb_called);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(random_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -79,15 +79,15 @@ TEST_IMPL(random_sync) {
   char zero[256];
   char buf[256];
 
-  ASSERT(UV_EINVAL == uv_random(NULL, NULL, buf, sizeof(buf), -1, NULL));
-  ASSERT(UV_E2BIG == uv_random(NULL, NULL, buf, -1, -1, NULL));
+  ASSERT_EQ(UV_EINVAL, uv_random(NULL, NULL, buf, sizeof(buf), -1, NULL));
+  ASSERT_EQ(UV_E2BIG, uv_random(NULL, NULL, buf, -1, -1, NULL));
 
   memset(buf, 0, sizeof(buf));
-  ASSERT(0 == uv_random(NULL, NULL, buf, sizeof(buf), 0, NULL));
+  ASSERT_EQ(0, uv_random(NULL, NULL, buf, sizeof(buf), 0, NULL));
 
   /* Buy a lottery ticket if you manage to trip this assertion. */
   memset(zero, 0, sizeof(zero));
-  ASSERT(0 != memcmp(buf, zero, sizeof(zero)));
+  ASSERT_NE(0, memcmp(buf, zero, sizeof(zero)));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-random.c
+++ b/test/test-random.c
@@ -33,12 +33,12 @@ static void random_cb(uv_random_t* req, int status, void* buf, size_t buflen) {
 
   memset(zero, 0, sizeof(zero));
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(buf, (void*) scratch);
 
   if (random_cb_called == 0) {
-    ASSERT_EQ(buflen, 0);
-    ASSERT_EQ(0, memcmp(scratch, zero, sizeof(zero)));
+    ASSERT_OK(buflen);
+    ASSERT_OK(memcmp(scratch, zero, sizeof(zero)));
   } else {
     ASSERT_EQ(buflen, sizeof(scratch));
     /* Buy a lottery ticket if you manage to trip this assertion. */
@@ -58,16 +58,16 @@ TEST_IMPL(random_async) {
                                  random_cb));
   ASSERT_EQ(UV_E2BIG, uv_random(loop, &req, scratch, -1, -1, random_cb));
 
-  ASSERT_EQ(0, uv_random(loop, &req, scratch, 0, 0, random_cb));
-  ASSERT_EQ(random_cb_called, 0);
+  ASSERT_OK(uv_random(loop, &req, scratch, 0, 0, random_cb));
+  ASSERT_OK(random_cb_called);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(random_cb_called, 1);
 
-  ASSERT_EQ(0, uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
+  ASSERT_OK(uv_random(loop, &req, scratch, sizeof(scratch), 0, random_cb));
   ASSERT_EQ(random_cb_called, 1);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(random_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -83,7 +83,7 @@ TEST_IMPL(random_sync) {
   ASSERT_EQ(UV_E2BIG, uv_random(NULL, NULL, buf, -1, -1, NULL));
 
   memset(buf, 0, sizeof(buf));
-  ASSERT_EQ(0, uv_random(NULL, NULL, buf, sizeof(buf), 0, NULL));
+  ASSERT_OK(uv_random(NULL, NULL, buf, sizeof(buf), 0, NULL));
 
   /* Buy a lottery ticket if you manage to trip this assertion. */
   memset(zero, 0, sizeof(zero));

--- a/test/test-readable-on-eof.c
+++ b/test/test-readable-on-eof.c
@@ -54,8 +54,8 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   int r;
 
   ASSERT_EQ(nread, UV_EOF);
-  ASSERT_EQ(uv_is_readable(handle), 1);
-  ASSERT_EQ(uv_is_writable(handle), 1);
+  ASSERT_EQ(1, uv_is_readable(handle));
+  ASSERT_EQ(1, uv_is_writable(handle));
 
   if (++read_cb_called == 3) {
       uv_close((uv_handle_t*) handle, close_cb);
@@ -100,10 +100,10 @@ TEST_IMPL(readable_on_eof) {
 
   ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(read_cb_called, 3);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(3, read_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-readable-on-eof.c
+++ b/test/test-readable-on-eof.c
@@ -35,7 +35,7 @@ static int close_cb_called;
 
 static void write_cb(uv_write_t* req, int status) {
   write_cb_called++;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -59,11 +59,11 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
   if (++read_cb_called == 3) {
       uv_close((uv_handle_t*) handle, close_cb);
-      ASSERT_EQ(uv_is_readable(handle), 0);
-      ASSERT_EQ(uv_is_writable(handle), 0);
+      ASSERT_OK(uv_is_readable(handle));
+      ASSERT_OK(uv_is_writable(handle));
   } else {
       r = uv_read_start((uv_stream_t*) &tcp_client, alloc_cb, read_cb);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
   }
 }
 
@@ -72,7 +72,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_buf_t close_me;
 
   connect_cb_called++;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   read_cb((uv_stream_t*) &tcp_client, UV_EOF, NULL);
 
@@ -84,22 +84,21 @@ static void connect_cb(uv_connect_t* req, int status) {
                1,
                write_cb);
 
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 TEST_IMPL(readable_on_eof) {
   struct sockaddr_in sa;
-  ASSERT_EQ(uv_ip4_addr("127.0.0.1", TEST_PORT, &sa), 0);
-  ASSERT_EQ(uv_loop_init(&loop), 0);
-  ASSERT_EQ(uv_tcp_init(&loop, &tcp_client), 0);
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_tcp_init(&loop, &tcp_client));
 
-  ASSERT_EQ(uv_tcp_connect(&connect_req,
+  ASSERT_OK(uv_tcp_connect(&connect_req,
                            &tcp_client,
                            (const struct sockaddr*) &sa,
-                           connect_cb),
-            0);
+                           connect_cb));
 
-  ASSERT_EQ(uv_run(&loop, UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(read_cb_called, 3);

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -47,9 +47,9 @@ static void close_cb(uv_handle_t* handle) {
 static void do_close(void* handle) {
   close_cb_called = 0;
   uv_close((uv_handle_t*)handle, close_cb);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 }
 
 
@@ -69,13 +69,13 @@ static void req_cb(uv_handle_t* req, int status) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_PTR_EQ(req, &shutdown_req);
   shutdown_cb_called++;
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req == &write_req);
+  ASSERT_PTR_EQ(req, &write_req);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   write_cb_called++;
 }
@@ -83,8 +83,8 @@ static void write_cb(uv_write_t* req, int status) {
 
 static void connect_and_write(uv_connect_t* req, int status) {
   uv_buf_t buf = uv_buf_init(buffer, sizeof buffer);
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
   uv_write(&write_req, req->handle, &buf, 1, write_cb);
   connect_cb_called++;
 }
@@ -92,8 +92,8 @@ static void connect_and_write(uv_connect_t* req, int status) {
 
 
 static void connect_and_shutdown(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   connect_cb_called++;
 }
@@ -250,7 +250,7 @@ TEST_IMPL(tcp_ref2b) {
   uv_unref((uv_handle_t*)&h);
   uv_close((uv_handle_t*)&h, close_cb);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -259,7 +259,7 @@ TEST_IMPL(tcp_ref2b) {
 TEST_IMPL(tcp_ref3) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -267,8 +267,8 @@ TEST_IMPL(tcp_ref3) {
                  connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -278,7 +278,7 @@ TEST_IMPL(tcp_ref3) {
 TEST_IMPL(tcp_ref4) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -286,9 +286,9 @@ TEST_IMPL(tcp_ref4) {
                  connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -309,7 +309,7 @@ TEST_IMPL(udp_ref) {
 TEST_IMPL(udp_ref2) {
   struct sockaddr_in addr;
   uv_udp_t h;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_bind(&h, (const struct sockaddr*) &addr, 0);
   uv_udp_recv_start(&h, (uv_alloc_cb)fail_cb, (uv_udp_recv_cb)fail_cb);
@@ -327,7 +327,7 @@ TEST_IMPL(udp_ref3) {
   uv_udp_send_t req;
   uv_udp_t h;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_send(&req,
               &h,
@@ -337,7 +337,7 @@ TEST_IMPL(udp_ref3) {
               (uv_udp_send_cb) req_cb);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(req_cb_called == 1);
+  ASSERT_EQ(req_cb_called, 1);
   do_close(&h);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -374,8 +374,8 @@ TEST_IMPL(pipe_ref3) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -388,9 +388,9 @@ TEST_IMPL(pipe_ref4) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -410,7 +410,7 @@ TEST_IMPL(process_ref) {
   exepath_size = sizeof(exepath);
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   argv[0] = exepath;
   options.file = exepath;
@@ -418,13 +418,13 @@ TEST_IMPL(process_ref) {
   options.exit_cb = NULL;
 
   r = uv_spawn(uv_default_loop(), &h, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   r = uv_process_kill(&h, /* SIGTERM */ 15);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   do_close(&h);
 
@@ -437,9 +437,9 @@ TEST_IMPL(has_ref) {
   uv_idle_t h;
   uv_idle_init(uv_default_loop(), &h);
   uv_ref((uv_handle_t*)&h);
-  ASSERT(uv_has_ref((uv_handle_t*)&h) == 1);
+  ASSERT_EQ(uv_has_ref((uv_handle_t*)&h), 1);
   uv_unref((uv_handle_t*)&h);
-  ASSERT(uv_has_ref((uv_handle_t*)&h) == 0);
+  ASSERT_EQ(uv_has_ref((uv_handle_t*)&h), 0);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -49,7 +49,7 @@ static void do_close(void* handle) {
   uv_close((uv_handle_t*)handle, close_cb);
   ASSERT_OK(close_cb_called);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 }
 
 
@@ -250,7 +250,7 @@ TEST_IMPL(tcp_ref2b) {
   uv_unref((uv_handle_t*)&h);
   uv_close((uv_handle_t*)&h, close_cb);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -267,8 +267,8 @@ TEST_IMPL(tcp_ref3) {
                  connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -286,9 +286,9 @@ TEST_IMPL(tcp_ref4) {
                  connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -337,7 +337,7 @@ TEST_IMPL(udp_ref3) {
               (uv_udp_send_cb) req_cb);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(req_cb_called, 1);
+  ASSERT_EQ(1, req_cb_called);
   do_close(&h);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -374,8 +374,8 @@ TEST_IMPL(pipe_ref3) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_shutdown);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -388,9 +388,9 @@ TEST_IMPL(pipe_ref4) {
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_and_write);
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
   do_close(&h);
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -437,7 +437,7 @@ TEST_IMPL(has_ref) {
   uv_idle_t h;
   uv_idle_init(uv_default_loop(), &h);
   uv_ref((uv_handle_t*)&h);
-  ASSERT_EQ(uv_has_ref((uv_handle_t*)&h), 1);
+  ASSERT_EQ(1, uv_has_ref((uv_handle_t*)&h));
   uv_unref((uv_handle_t*)&h);
   ASSERT_OK(uv_has_ref((uv_handle_t*)&h));
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-ref.c
+++ b/test/test-ref.c
@@ -47,7 +47,7 @@ static void close_cb(uv_handle_t* handle) {
 static void do_close(void* handle) {
   close_cb_called = 0;
   uv_close((uv_handle_t*)handle, close_cb);
-  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_OK(close_cb_called);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(close_cb_called, 1);
 }
@@ -84,7 +84,7 @@ static void write_cb(uv_write_t* req, int status) {
 static void connect_and_write(uv_connect_t* req, int status) {
   uv_buf_t buf = uv_buf_init(buffer, sizeof buffer);
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   uv_write(&write_req, req->handle, &buf, 1, write_cb);
   connect_cb_called++;
 }
@@ -93,7 +93,7 @@ static void connect_and_write(uv_connect_t* req, int status) {
 
 static void connect_and_shutdown(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
   connect_cb_called++;
 }
@@ -259,7 +259,7 @@ TEST_IMPL(tcp_ref2b) {
 TEST_IMPL(tcp_ref3) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -278,7 +278,7 @@ TEST_IMPL(tcp_ref3) {
 TEST_IMPL(tcp_ref4) {
   struct sockaddr_in addr;
   uv_tcp_t h;
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_tcp_init(uv_default_loop(), &h);
   uv_tcp_connect(&connect_req,
                  &h,
@@ -309,7 +309,7 @@ TEST_IMPL(udp_ref) {
 TEST_IMPL(udp_ref2) {
   struct sockaddr_in addr;
   uv_udp_t h;
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_bind(&h, (const struct sockaddr*) &addr, 0);
   uv_udp_recv_start(&h, (uv_alloc_cb)fail_cb, (uv_udp_recv_cb)fail_cb);
@@ -327,7 +327,7 @@ TEST_IMPL(udp_ref3) {
   uv_udp_send_t req;
   uv_udp_t h;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   uv_udp_init(uv_default_loop(), &h);
   uv_udp_send(&req,
               &h,
@@ -410,7 +410,7 @@ TEST_IMPL(process_ref) {
   exepath_size = sizeof(exepath);
 
   r = uv_exepath(exepath, &exepath_size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   argv[0] = exepath;
   options.file = exepath;
@@ -418,13 +418,13 @@ TEST_IMPL(process_ref) {
   options.exit_cb = NULL;
 
   r = uv_spawn(uv_default_loop(), &h, &options);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_unref((uv_handle_t*)&h);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   r = uv_process_kill(&h, /* SIGTERM */ 15);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   do_close(&h);
 
@@ -439,7 +439,7 @@ TEST_IMPL(has_ref) {
   uv_ref((uv_handle_t*)&h);
   ASSERT_EQ(uv_has_ref((uv_handle_t*)&h), 1);
   uv_unref((uv_handle_t*)&h);
-  ASSERT_EQ(uv_has_ref((uv_handle_t*)&h), 0);
+  ASSERT_OK(uv_has_ref((uv_handle_t*)&h));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -39,7 +39,7 @@ TEST_IMPL(run_nowait) {
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
   ASSERT(r);
-  ASSERT_EQ(timer_called, 0);
+  ASSERT_OK(timer_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-run-nowait.c
+++ b/test/test-run-nowait.c
@@ -27,7 +27,7 @@ static int timer_called = 0;
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer_handle);
+  ASSERT_PTR_EQ(handle, &timer_handle);
   timer_called = 1;
 }
 
@@ -38,8 +38,8 @@ TEST_IMPL(run_nowait) {
   uv_timer_start(&timer_handle, timer_cb, 100, 100);
 
   r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-  ASSERT(r != 0);
-  ASSERT(timer_called == 0);
+  ASSERT(r);
+  ASSERT_EQ(timer_called, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-run-once.c
+++ b/test/test-run-once.c
@@ -29,7 +29,7 @@ static int idle_counter;
 
 
 static void idle_cb(uv_idle_t* handle) {
-  ASSERT(handle == &idle_handle);
+  ASSERT_PTR_EQ(handle, &idle_handle);
 
   if (++idle_counter == NUM_TICKS)
     uv_idle_stop(handle);
@@ -41,7 +41,7 @@ TEST_IMPL(run_once) {
   uv_idle_start(&idle_handle, idle_cb);
 
   while (uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(idle_counter == NUM_TICKS);
+  ASSERT_EQ(idle_counter, NUM_TICKS);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-semaphore.c
+++ b/test/test-semaphore.c
@@ -59,7 +59,7 @@ TEST_IMPL(semaphore_1) {
 
   uv_sleep(100);
   uv_mutex_lock(&wc.mutex);
-  ASSERT_EQ(wc.posted, 1);
+  ASSERT_EQ(1, wc.posted);
   uv_sem_wait(&wc.sem); /* should not block */
   uv_mutex_unlock(&wc.mutex); /* ergo, it should be ok to unlock after wait */
 

--- a/test/test-semaphore.c
+++ b/test/test-semaphore.c
@@ -40,7 +40,7 @@ static void worker(void* arg) {
     uv_sleep(c->delay);
 
   uv_mutex_lock(&c->mutex);
-  ASSERT(c->posted == 0);
+  ASSERT_EQ(c->posted, 0);
   uv_sem_post(&c->sem);
   c->posted = 1;
   uv_mutex_unlock(&c->mutex);
@@ -53,17 +53,17 @@ TEST_IMPL(semaphore_1) {
 
   memset(&wc, 0, sizeof(wc));
 
-  ASSERT(0 == uv_sem_init(&wc.sem, 0));
-  ASSERT(0 == uv_mutex_init(&wc.mutex));
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_sem_init(&wc.sem, 0));
+  ASSERT_EQ(0, uv_mutex_init(&wc.mutex));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   uv_sleep(100);
   uv_mutex_lock(&wc.mutex);
-  ASSERT(wc.posted == 1);
+  ASSERT_EQ(wc.posted, 1);
   uv_sem_wait(&wc.sem); /* should not block */
   uv_mutex_unlock(&wc.mutex); /* ergo, it should be ok to unlock after wait */
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
   uv_sem_destroy(&wc.sem);
 
@@ -78,13 +78,13 @@ TEST_IMPL(semaphore_2) {
   memset(&wc, 0, sizeof(wc));
   wc.delay = 100;
 
-  ASSERT(0 == uv_sem_init(&wc.sem, 0));
-  ASSERT(0 == uv_mutex_init(&wc.mutex));
-  ASSERT(0 == uv_thread_create(&thread, worker, &wc));
+  ASSERT_EQ(0, uv_sem_init(&wc.sem, 0));
+  ASSERT_EQ(0, uv_mutex_init(&wc.mutex));
+  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
 
   uv_sem_wait(&wc.sem);
 
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
   uv_sem_destroy(&wc.sem);
 
@@ -95,15 +95,15 @@ TEST_IMPL(semaphore_2) {
 TEST_IMPL(semaphore_3) {
   uv_sem_t sem;
 
-  ASSERT(0 == uv_sem_init(&sem, 3));
+  ASSERT_EQ(0, uv_sem_init(&sem, 3));
   uv_sem_wait(&sem); /* should not block */
   uv_sem_wait(&sem); /* should not block */
-  ASSERT(0 == uv_sem_trywait(&sem));
-  ASSERT(UV_EAGAIN == uv_sem_trywait(&sem));
+  ASSERT_EQ(0, uv_sem_trywait(&sem));
+  ASSERT_EQ(UV_EAGAIN, uv_sem_trywait(&sem));
 
   uv_sem_post(&sem);
-  ASSERT(0 == uv_sem_trywait(&sem));
-  ASSERT(UV_EAGAIN == uv_sem_trywait(&sem));
+  ASSERT_EQ(0, uv_sem_trywait(&sem));
+  ASSERT_EQ(UV_EAGAIN, uv_sem_trywait(&sem));
 
   uv_sem_destroy(&sem);
 

--- a/test/test-semaphore.c
+++ b/test/test-semaphore.c
@@ -40,7 +40,7 @@ static void worker(void* arg) {
     uv_sleep(c->delay);
 
   uv_mutex_lock(&c->mutex);
-  ASSERT_EQ(c->posted, 0);
+  ASSERT_OK(c->posted);
   uv_sem_post(&c->sem);
   c->posted = 1;
   uv_mutex_unlock(&c->mutex);
@@ -53,9 +53,9 @@ TEST_IMPL(semaphore_1) {
 
   memset(&wc, 0, sizeof(wc));
 
-  ASSERT_EQ(0, uv_sem_init(&wc.sem, 0));
-  ASSERT_EQ(0, uv_mutex_init(&wc.mutex));
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_sem_init(&wc.sem, 0));
+  ASSERT_OK(uv_mutex_init(&wc.mutex));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   uv_sleep(100);
   uv_mutex_lock(&wc.mutex);
@@ -63,7 +63,7 @@ TEST_IMPL(semaphore_1) {
   uv_sem_wait(&wc.sem); /* should not block */
   uv_mutex_unlock(&wc.mutex); /* ergo, it should be ok to unlock after wait */
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
   uv_sem_destroy(&wc.sem);
 
@@ -78,13 +78,13 @@ TEST_IMPL(semaphore_2) {
   memset(&wc, 0, sizeof(wc));
   wc.delay = 100;
 
-  ASSERT_EQ(0, uv_sem_init(&wc.sem, 0));
-  ASSERT_EQ(0, uv_mutex_init(&wc.mutex));
-  ASSERT_EQ(0, uv_thread_create(&thread, worker, &wc));
+  ASSERT_OK(uv_sem_init(&wc.sem, 0));
+  ASSERT_OK(uv_mutex_init(&wc.mutex));
+  ASSERT_OK(uv_thread_create(&thread, worker, &wc));
 
   uv_sem_wait(&wc.sem);
 
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_join(&thread));
   uv_mutex_destroy(&wc.mutex);
   uv_sem_destroy(&wc.sem);
 
@@ -95,14 +95,14 @@ TEST_IMPL(semaphore_2) {
 TEST_IMPL(semaphore_3) {
   uv_sem_t sem;
 
-  ASSERT_EQ(0, uv_sem_init(&sem, 3));
+  ASSERT_OK(uv_sem_init(&sem, 3));
   uv_sem_wait(&sem); /* should not block */
   uv_sem_wait(&sem); /* should not block */
-  ASSERT_EQ(0, uv_sem_trywait(&sem));
+  ASSERT_OK(uv_sem_trywait(&sem));
   ASSERT_EQ(UV_EAGAIN, uv_sem_trywait(&sem));
 
   uv_sem_post(&sem);
-  ASSERT_EQ(0, uv_sem_trywait(&sem));
+  ASSERT_OK(uv_sem_trywait(&sem));
   ASSERT_EQ(UV_EAGAIN, uv_sem_trywait(&sem));
 
   uv_sem_destroy(&sem);

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -52,11 +52,11 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) req->handle));
+  ASSERT_OK(r);
+  ASSERT_OK(uv_is_closing((uv_handle_t*) req->handle));
   uv_close((uv_handle_t*) req->handle, close_cb);
   ASSERT_EQ(1, uv_is_closing((uv_handle_t*) req->handle));
 
@@ -69,16 +69,16 @@ TEST_IMPL(shutdown_close_tcp) {
   uv_tcp_t h;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &h);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(shutdown_cb_called, 1);
@@ -94,10 +94,10 @@ TEST_IMPL(shutdown_close_pipe) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &h, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_cb);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(shutdown_cb_called, 1);

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -80,9 +80,9 @@ TEST_IMPL(shutdown_close_tcp) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -99,9 +99,9 @@ TEST_IMPL(shutdown_close_pipe) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-shutdown-close.c
+++ b/test/test-shutdown-close.c
@@ -37,7 +37,7 @@ static int close_cb_called = 0;
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_PTR_EQ(req, &shutdown_req);
   ASSERT(status == 0 || status == UV_ECANCELED);
   shutdown_cb_called++;
 }
@@ -51,14 +51,14 @@ static void close_cb(uv_handle_t* handle) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&shutdown_req, req->handle, shutdown_cb);
-  ASSERT(r == 0);
-  ASSERT(0 == uv_is_closing((uv_handle_t*) req->handle));
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) req->handle));
   uv_close((uv_handle_t*) req->handle, close_cb);
-  ASSERT(1 == uv_is_closing((uv_handle_t*) req->handle));
+  ASSERT_EQ(1, uv_is_closing((uv_handle_t*) req->handle));
 
   connect_cb_called++;
 }
@@ -69,20 +69,20 @@ TEST_IMPL(shutdown_close_tcp) {
   uv_tcp_t h;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -94,14 +94,14 @@ TEST_IMPL(shutdown_close_pipe) {
   int r;
 
   r = uv_pipe_init(uv_default_loop(), &h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_pipe_connect(&connect_req, &h, TEST_PIPENAME, connect_cb);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -76,20 +76,20 @@ static void shutdown_cb(uv_shutdown_t *req, int status) {
 
   ASSERT_EQ(called_connect_cb, 1);
   ASSERT(!got_eof);
-  ASSERT_EQ(called_tcp_close_cb, 0);
-  ASSERT_EQ(called_timer_close_cb, 0);
-  ASSERT_EQ(called_timer_cb, 0);
+  ASSERT_OK(called_tcp_close_cb);
+  ASSERT_OK(called_timer_close_cb);
+  ASSERT_OK(called_timer_cb);
 
   called_shutdown_cb++;
 }
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(req, &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
 
   /* Check error handling. */
   ASSERT_EQ(UV_EALREADY, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
@@ -107,7 +107,7 @@ static void connect_cb(uv_connect_t *req, int status) {
   uv_shutdown(&shutdown_req, (uv_stream_t*) &tcp, shutdown_cb);
 
   called_connect_cb++;
-  ASSERT_EQ(called_shutdown_cb, 0);
+  ASSERT_OK(called_shutdown_cb);
 }
 
 
@@ -137,7 +137,7 @@ static void timer_cb(uv_timer_t* handle) {
    * The most important assert of the test: we have not received
    * tcp_close_cb yet.
    */
-  ASSERT_EQ(called_tcp_close_cb, 0);
+  ASSERT_OK(called_tcp_close_cb);
   uv_close((uv_handle_t*) &tcp, tcp_close_cb);
 
   called_timer_cb++;
@@ -158,11 +158,11 @@ TEST_IMPL(shutdown_eof) {
   qbuf.len = 1;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   r = uv_tcp_init(uv_default_loop(), &tcp);
   ASSERT(!r);
 

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -46,7 +46,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 
 static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)t == &tcp);
+  ASSERT_PTR_EQ((uv_tcp_t*)t, &tcp);
 
   if (nread == 0) {
     free(buf->base);
@@ -54,14 +54,14 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (!got_q) {
-    ASSERT(nread == 1);
+    ASSERT_EQ(nread, 1);
     ASSERT(!got_eof);
-    ASSERT(buf->base[0] == 'Q');
+    ASSERT_EQ(buf->base[0], 'Q');
     free(buf->base);
     got_q = 1;
     puts("got Q");
   } else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     if (buf->base) {
       free(buf->base);
     }
@@ -72,21 +72,21 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void shutdown_cb(uv_shutdown_t *req, int status) {
-  ASSERT(req == &shutdown_req);
+  ASSERT_PTR_EQ(req, &shutdown_req);
 
-  ASSERT(called_connect_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
   ASSERT(!got_eof);
-  ASSERT(called_tcp_close_cb == 0);
-  ASSERT(called_timer_close_cb == 0);
-  ASSERT(called_timer_cb == 0);
+  ASSERT_EQ(called_tcp_close_cb, 0);
+  ASSERT_EQ(called_timer_close_cb, 0);
+  ASSERT_EQ(called_timer_cb, 0);
 
   called_shutdown_cb++;
 }
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT(status == 0);
-  ASSERT(req == &connect_req);
+  ASSERT_EQ(status, 0);
+  ASSERT_PTR_EQ(req, &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
   ASSERT_EQ(0, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
@@ -107,37 +107,37 @@ static void connect_cb(uv_connect_t *req, int status) {
   uv_shutdown(&shutdown_req, (uv_stream_t*) &tcp, shutdown_cb);
 
   called_connect_cb++;
-  ASSERT(called_shutdown_cb == 0);
+  ASSERT_EQ(called_shutdown_cb, 0);
 }
 
 
 static void tcp_close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &tcp);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*) &tcp);
 
-  ASSERT(called_connect_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
   ASSERT(got_q);
   ASSERT(got_eof);
-  ASSERT(called_timer_cb == 1);
+  ASSERT_EQ(called_timer_cb, 1);
 
   called_tcp_close_cb++;
 }
 
 
 static void timer_close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &timer);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*) &timer);
   called_timer_close_cb++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_PTR_EQ(handle, &timer);
   uv_close((uv_handle_t*) handle, timer_close_cb);
 
   /*
    * The most important assert of the test: we have not received
    * tcp_close_cb yet.
    */
-  ASSERT(called_tcp_close_cb == 0);
+  ASSERT_EQ(called_tcp_close_cb, 0);
   uv_close((uv_handle_t*) &tcp, tcp_close_cb);
 
   called_timer_cb++;
@@ -158,11 +158,11 @@ TEST_IMPL(shutdown_eof) {
   qbuf.len = 1;
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_timer_start(&timer, timer_cb, 100, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   r = uv_tcp_init(uv_default_loop(), &tcp);
   ASSERT(!r);
 
@@ -174,13 +174,13 @@ TEST_IMPL(shutdown_eof) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(called_connect_cb == 1);
-  ASSERT(called_shutdown_cb == 1);
+  ASSERT_EQ(called_connect_cb, 1);
+  ASSERT_EQ(called_shutdown_cb, 1);
   ASSERT(got_eof);
   ASSERT(got_q);
-  ASSERT(called_tcp_close_cb == 1);
-  ASSERT(called_timer_close_cb == 1);
-  ASSERT(called_timer_cb == 1);
+  ASSERT_EQ(called_tcp_close_cb, 1);
+  ASSERT_EQ(called_timer_close_cb, 1);
+  ASSERT_EQ(called_timer_cb, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-shutdown-eof.c
+++ b/test/test-shutdown-eof.c
@@ -54,7 +54,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (!got_q) {
-    ASSERT_EQ(nread, 1);
+    ASSERT_EQ(1, nread);
     ASSERT(!got_eof);
     ASSERT_EQ(buf->base[0], 'Q');
     free(buf->base);
@@ -74,7 +74,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 static void shutdown_cb(uv_shutdown_t *req, int status) {
   ASSERT_PTR_EQ(req, &shutdown_req);
 
-  ASSERT_EQ(called_connect_cb, 1);
+  ASSERT_EQ(1, called_connect_cb);
   ASSERT(!got_eof);
   ASSERT_OK(called_tcp_close_cb);
   ASSERT_OK(called_timer_close_cb);
@@ -114,10 +114,10 @@ static void connect_cb(uv_connect_t *req, int status) {
 static void tcp_close_cb(uv_handle_t* handle) {
   ASSERT_PTR_EQ(handle, (uv_handle_t*) &tcp);
 
-  ASSERT_EQ(called_connect_cb, 1);
+  ASSERT_EQ(1, called_connect_cb);
   ASSERT(got_q);
   ASSERT(got_eof);
-  ASSERT_EQ(called_timer_cb, 1);
+  ASSERT_EQ(1, called_timer_cb);
 
   called_tcp_close_cb++;
 }
@@ -174,13 +174,13 @@ TEST_IMPL(shutdown_eof) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(called_connect_cb, 1);
-  ASSERT_EQ(called_shutdown_cb, 1);
+  ASSERT_EQ(1, called_connect_cb);
+  ASSERT_EQ(1, called_shutdown_cb);
   ASSERT(got_eof);
   ASSERT(got_q);
-  ASSERT_EQ(called_tcp_close_cb, 1);
-  ASSERT_EQ(called_timer_close_cb, 1);
-  ASSERT_EQ(called_timer_cb, 1);
+  ASSERT_EQ(1, called_tcp_close_cb);
+  ASSERT_EQ(1, called_timer_close_cb);
+  ASSERT_EQ(1, called_timer_cb);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-shutdown-simultaneous.c
+++ b/test/test-shutdown-simultaneous.c
@@ -45,7 +45,7 @@ static void shutdown_cb(uv_shutdown_t *req, int status) {
   ASSERT_PTR_EQ(req, &shutdown_req);
 
   ASSERT_EQ(called_connect_cb, 1);
-  ASSERT_EQ(called_tcp_close_cb, 0);
+  ASSERT_OK(called_tcp_close_cb);
 }
 
 
@@ -59,7 +59,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 
   if (!got_q) {
     ASSERT_EQ(nread, 4);
-    ASSERT_EQ(got_eof, 0);
+    ASSERT_OK(got_eof);
     ASSERT_MEM_EQ(buf->base, "QQSS", 4);
     free(buf->base);
     got_q = 1;
@@ -79,11 +79,11 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(req, &connect_req);
 
   /* Start reading from our connection so we can receive the EOF.  */
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
 
   /* Check error handling. */
   ASSERT_EQ(UV_EALREADY, uv_read_start((uv_stream_t*)&tcp, alloc_cb, read_cb));
@@ -98,7 +98,7 @@ static void connect_cb(uv_connect_t *req, int status) {
   ASSERT_EQ(qbuf.len, uv_try_write((uv_stream_t*) &tcp, &qbuf, 1));
 
   called_connect_cb++;
-  ASSERT_EQ(called_shutdown_cb, 0);
+  ASSERT_OK(called_shutdown_cb);
 }
 
 
@@ -113,15 +113,15 @@ TEST_IMPL(shutdown_simultaneous) {
   qbuf.base = "QQSS";
   qbuf.len = 4;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   r = uv_tcp_init(uv_default_loop(), &tcp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp,
                      (const struct sockaddr*) &server_addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-shutdown-simultaneous.c
+++ b/test/test-shutdown-simultaneous.c
@@ -44,7 +44,7 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void shutdown_cb(uv_shutdown_t *req, int status) {
   ASSERT_PTR_EQ(req, &shutdown_req);
 
-  ASSERT_EQ(called_connect_cb, 1);
+  ASSERT_EQ(1, called_connect_cb);
   ASSERT_OK(called_tcp_close_cb);
 }
 
@@ -58,7 +58,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   }
 
   if (!got_q) {
-    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(4, nread);
     ASSERT_OK(got_eof);
     ASSERT_MEM_EQ(buf->base, "QQSS", 4);
     free(buf->base);
@@ -125,10 +125,10 @@ TEST_IMPL(shutdown_simultaneous) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(called_connect_cb, 1);
-  ASSERT_EQ(called_shutdown_cb, 1);
-  ASSERT_EQ(got_eof, 1);
-  ASSERT_EQ(got_q, 1);
+  ASSERT_EQ(1, called_connect_cb);
+  ASSERT_EQ(1, called_shutdown_cb);
+  ASSERT_EQ(1, got_eof);
+  ASSERT_EQ(1, got_q);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -37,8 +37,8 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &req1);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &req1);
+  ASSERT_EQ(status, 0);
   shutdown_cb_called++;
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
@@ -46,12 +46,12 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   r = uv_shutdown(&req1, req->handle, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_shutdown(&req2, req->handle, shutdown_cb);
-  ASSERT(r != 0);
+  ASSERT(r);
 
 }
 
@@ -63,22 +63,22 @@ TEST_IMPL(shutdown_twice) {
 
   uv_connect_t connect_req;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -38,7 +38,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT_PTR_EQ(req, &req1);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   shutdown_cb_called++;
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
@@ -46,10 +46,10 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_shutdown(&req1, req->handle, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_shutdown(&req2, req->handle, shutdown_cb);
   ASSERT(r);
 
@@ -63,20 +63,20 @@ TEST_IMPL(shutdown_twice) {
 
   uv_connect_t connect_req;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &h);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &h,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(shutdown_cb_called, 1);
 

--- a/test/test-shutdown-twice.c
+++ b/test/test-shutdown-twice.c
@@ -78,7 +78,7 @@ TEST_IMPL(shutdown_twice) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -66,14 +66,14 @@ static void increment_counter(int* counter) {
 
 
 static void signal1_cb(uv_signal_t* handle, int signum) {
-  ASSERT(signum == SIGUSR1);
+  ASSERT_EQ(signum, SIGUSR1);
   increment_counter(&signal1_cb_counter);
   uv_signal_stop(handle);
 }
 
 
 static void signal2_cb(uv_signal_t* handle, int signum) {
-  ASSERT(signum == SIGUSR2);
+  ASSERT_EQ(signum, SIGUSR2);
   increment_counter(&signal2_cb_counter);
   uv_signal_stop(handle);
 }
@@ -89,25 +89,25 @@ static void signal_handling_worker(void* context) {
 
   action = (enum signal_action) (uintptr_t) context;
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   /* Setup the signal watchers and start them. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_init(&loop, &signal1a);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1a, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_init(&loop, &signal1b);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1b, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   if (action == ONLY_SIGUSR2 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_init(&loop, &signal2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal2, signal2_cb, SIGUSR2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Signal watchers are now set up. */
@@ -117,26 +117,26 @@ static void signal_handling_worker(void* context) {
    * will return when all signal watchers caught a signal.
    */
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Restart the signal watchers. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_start(&signal1a, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_signal_start(&signal1b, signal1_cb, SIGUSR1);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   if (action == ONLY_SIGUSR2 || action == SIGUSR1_AND_SIGUSR2) {
     r = uv_signal_start(&signal2, signal2_cb, SIGUSR2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Wait for signals once more. */
   uv_sem_post(&sem);
 
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Close the watchers. */
   if (action == ONLY_SIGUSR1 || action == SIGUSR1_AND_SIGUSR2) {
@@ -150,7 +150,7 @@ static void signal_handling_worker(void* context) {
 
   /* Wait for the signal watchers to close. */
   r = uv_run(&loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_loop_close(&loop);
 }
@@ -173,18 +173,18 @@ static void loop_creating_worker(void* context) {
 
     loop = malloc(sizeof(*loop));
     ASSERT_NOT_NULL(loop);
-    ASSERT(0 == uv_loop_init(loop));
+    ASSERT_EQ(0, uv_loop_init(loop));
 
     r = uv_signal_init(loop, &signal);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_signal_start(&signal, signal_unexpected_cb, SIGTERM);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_close((uv_handle_t*) &signal, NULL);
 
     r = uv_run(loop, UV_RUN_DEFAULT);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_loop_close(loop);
     free(loop);
@@ -229,17 +229,17 @@ TEST_IMPL(signal_multiple_loops) {
   int r;
 
   r = uv_sem_init(&sem, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_mutex_init(&lock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Create a couple of threads that create a destroy loops continuously. */
   for (i = 0; i < NUM_LOOP_CREATING_THREADS; i++) {
     r = uv_thread_create(&loop_creating_threads[i],
                          loop_creating_worker,
                          NULL);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Create a couple of threads that actually handle signals. */
@@ -253,7 +253,7 @@ TEST_IMPL(signal_multiple_loops) {
     r = uv_thread_create(&signal_handling_threads[i],
                          signal_handling_worker,
                          (void*) (uintptr_t) action);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Wait until all threads have started and set up their signal watchers. */
@@ -261,9 +261,9 @@ TEST_IMPL(signal_multiple_loops) {
     uv_sem_wait(&sem);
 
   r = kill(getpid(), SIGUSR1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = kill(getpid(), SIGUSR2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Wait for all threads to handle these signals. */
   for (i = 0; i < NUM_SIGNAL_HANDLING_THREADS; i++)
@@ -277,14 +277,14 @@ TEST_IMPL(signal_multiple_loops) {
   pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
   r = kill(getpid(), SIGUSR1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = kill(getpid(), SIGUSR2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Wait for all signal handling threads to exit. */
   for (i = 0; i < NUM_SIGNAL_HANDLING_THREADS; i++) {
     r = uv_thread_join(&signal_handling_threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Tell all loop creating threads to stop. */
@@ -295,7 +295,7 @@ TEST_IMPL(signal_multiple_loops) {
   /* Wait for all loop creating threads to exit. */
   for (i = 0; i < NUM_LOOP_CREATING_THREADS; i++) {
     r = uv_thread_join(&loop_creating_threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_sem_destroy(&sem);
@@ -306,13 +306,13 @@ TEST_IMPL(signal_multiple_loops) {
   /* The division by three reflects the fact that we spawn three different
    * thread groups of (NUM_SIGNAL_HANDLING_THREADS / 3) threads each.
    */
-  ASSERT(signal1_cb_counter == 8 * (NUM_SIGNAL_HANDLING_THREADS / 3));
-  ASSERT(signal2_cb_counter == 4 * (NUM_SIGNAL_HANDLING_THREADS / 3));
+  ASSERT_EQ(signal1_cb_counter, 8 * (NUM_SIGNAL_HANDLING_THREADS / 3));
+  ASSERT_EQ(signal2_cb_counter, 4 * (NUM_SIGNAL_HANDLING_THREADS / 3));
 
   /* We don't know exactly how much loops will be created and destroyed, but at
    * least there should be 1 for every loop creating thread.
    */
-  ASSERT(loop_creation_counter >= NUM_LOOP_CREATING_THREADS);
+  ASSERT_GE(loop_creation_counter, NUM_LOOP_CREATING_THREADS);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -62,17 +62,17 @@ TEST_IMPL(signal_pending_on_close) {
   uv_buf_t buffer;
   int r;
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
-  ASSERT_EQ(0, uv_signal_init(&loop, &signal_hdl));
+  ASSERT_OK(uv_signal_init(&loop, &signal_hdl));
 
-  ASSERT_EQ(0, uv_signal_start(&signal_hdl, signal_cb, SIGPIPE));
+  ASSERT_OK(uv_signal_start(&signal_hdl, signal_cb, SIGPIPE));
 
-  ASSERT_EQ(0, pipe(pipefds));
+  ASSERT_OK(pipe(pipefds));
 
-  ASSERT_EQ(0, uv_pipe_init(&loop, &pipe_hdl, 0));
+  ASSERT_OK(uv_pipe_init(&loop, &pipe_hdl, 0));
 
-  ASSERT_EQ(0, uv_pipe_open(&pipe_hdl, pipefds[1]));
+  ASSERT_OK(uv_pipe_open(&pipe_hdl, pipefds[1]));
 
   /* Write data large enough so it needs loop iteration */
   buf = malloc(1<<24);
@@ -81,12 +81,12 @@ TEST_IMPL(signal_pending_on_close) {
   buffer = uv_buf_init(buf, 1<<24);
 
   r = uv_write(&write_req, (uv_stream_t *) &pipe_hdl, &buffer, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* cause a SIGPIPE on write in next iteration */
   close(pipefds[0]);
 
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(close_cb_called, 2);
 
@@ -96,17 +96,17 @@ TEST_IMPL(signal_pending_on_close) {
 
 
 TEST_IMPL(signal_close_loop_alive) {
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_signal_init(&loop, &signal_hdl));
-  ASSERT_EQ(0, uv_signal_start(&signal_hdl, stop_loop_cb, SIGPIPE));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_signal_init(&loop, &signal_hdl));
+  ASSERT_OK(uv_signal_start(&signal_hdl, stop_loop_cb, SIGPIPE));
   uv_unref((uv_handle_t*) &signal_hdl);
 
-  ASSERT_EQ(0, uv_kill(uv_os_getpid(), SIGPIPE));
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_kill(uv_os_getpid(), SIGPIPE));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &signal_hdl, close_cb);
   ASSERT_EQ(1, uv_loop_alive(&loop));
 
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
   ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -88,7 +88,7 @@ TEST_IMPL(signal_pending_on_close) {
 
   ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -107,7 +107,7 @@ TEST_IMPL(signal_close_loop_alive) {
   ASSERT_EQ(1, uv_loop_alive(&loop));
 
   ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -35,7 +35,7 @@ static int close_cb_called;
 
 
 static void stop_loop_cb(uv_signal_t* signal, int signum) {
-  ASSERT(signum == SIGPIPE);
+  ASSERT_EQ(signum, SIGPIPE);
   uv_stop(signal->loop);
 }
 
@@ -50,7 +50,7 @@ static void close_cb(uv_handle_t *handle) {
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == UV_EPIPE);
+  ASSERT_EQ(status, UV_EPIPE);
   free(buf);
   uv_close((uv_handle_t *) &pipe_hdl, close_cb);
   uv_close((uv_handle_t *) &signal_hdl, close_cb);
@@ -62,17 +62,17 @@ TEST_IMPL(signal_pending_on_close) {
   uv_buf_t buffer;
   int r;
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
-  ASSERT(0 == uv_signal_init(&loop, &signal_hdl));
+  ASSERT_EQ(0, uv_signal_init(&loop, &signal_hdl));
 
-  ASSERT(0 == uv_signal_start(&signal_hdl, signal_cb, SIGPIPE));
+  ASSERT_EQ(0, uv_signal_start(&signal_hdl, signal_cb, SIGPIPE));
 
-  ASSERT(0 == pipe(pipefds));
+  ASSERT_EQ(0, pipe(pipefds));
 
-  ASSERT(0 == uv_pipe_init(&loop, &pipe_hdl, 0));
+  ASSERT_EQ(0, uv_pipe_init(&loop, &pipe_hdl, 0));
 
-  ASSERT(0 == uv_pipe_open(&pipe_hdl, pipefds[1]));
+  ASSERT_EQ(0, uv_pipe_open(&pipe_hdl, pipefds[1]));
 
   /* Write data large enough so it needs loop iteration */
   buf = malloc(1<<24);
@@ -81,14 +81,14 @@ TEST_IMPL(signal_pending_on_close) {
   buffer = uv_buf_init(buf, 1<<24);
 
   r = uv_write(&write_req, (uv_stream_t *) &pipe_hdl, &buffer, 1, write_cb);
-  ASSERT(0 == r);
+  ASSERT_EQ(r, 0);
 
   /* cause a SIGPIPE on write in next iteration */
   close(pipefds[0]);
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
 
-  ASSERT(2 == close_cb_called);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;
@@ -96,18 +96,18 @@ TEST_IMPL(signal_pending_on_close) {
 
 
 TEST_IMPL(signal_close_loop_alive) {
-  ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(0 == uv_signal_init(&loop, &signal_hdl));
-  ASSERT(0 == uv_signal_start(&signal_hdl, stop_loop_cb, SIGPIPE));
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_signal_init(&loop, &signal_hdl));
+  ASSERT_EQ(0, uv_signal_start(&signal_hdl, stop_loop_cb, SIGPIPE));
   uv_unref((uv_handle_t*) &signal_hdl);
 
-  ASSERT(0 == uv_kill(uv_os_getpid(), SIGPIPE));
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_kill(uv_os_getpid(), SIGPIPE));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &signal_hdl, close_cb);
-  ASSERT(1 == uv_loop_alive(&loop));
+  ASSERT_EQ(1, uv_loop_alive(&loop));
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(1 == close_cb_called);
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(&loop);
   return 0;

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -56,16 +56,16 @@ TEST_IMPL(win32_signum_number) {
   uv_signal_init(loop, &signal);
 
   ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, 0), UV_EINVAL);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGINT), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGBREAK), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGHUP), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGWINCH), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGILL), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGABRT_COMPAT), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGFPE), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGSEGV), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGTERM), 0);
-  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGABRT), 0);
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGINT));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGBREAK));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGHUP));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGWINCH));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGILL));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGABRT_COMPAT));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGFPE));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGSEGV));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGTERM));
+  ASSERT_OK(uv_signal_start(&signal, signum_test_cb, SIGABRT));
   ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, -1), UV_EINVAL);
   ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, NSIG), UV_EINVAL);
   ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, 1024), UV_EINVAL);
@@ -138,18 +138,18 @@ static void start_watcher(uv_loop_t* loop,
   ctx->signum = signum;
   ctx->stop_or_close = CLOSE;
   ctx->one_shot = one_shot;
-  ASSERT_EQ(0, uv_signal_init(loop, &ctx->handle));
+  ASSERT_OK(uv_signal_init(loop, &ctx->handle));
   if (one_shot)
-    ASSERT_EQ(0, uv_signal_start_oneshot(&ctx->handle, signal_cb_one_shot, signum));
+    ASSERT_OK(uv_signal_start_oneshot(&ctx->handle, signal_cb_one_shot, signum));
   else
-    ASSERT_EQ(0, uv_signal_start(&ctx->handle, signal_cb, signum));
+    ASSERT_OK(uv_signal_start(&ctx->handle, signal_cb, signum));
 }
 
 static void start_timer(uv_loop_t* loop, int signum, struct timer_ctx* ctx) {
   ctx->ncalls = 0;
   ctx->signum = signum;
-  ASSERT_EQ(0, uv_timer_init(loop, &ctx->handle));
-  ASSERT_EQ(0, uv_timer_start(&ctx->handle, timer_cb, 5, 5));
+  ASSERT_OK(uv_timer_init(loop, &ctx->handle));
+  ASSERT_OK(uv_timer_start(&ctx->handle, timer_cb, 5, 5));
 }
 
 
@@ -162,12 +162,12 @@ TEST_IMPL(we_get_signal) {
   start_timer(loop, SIGCHLD, &tc);
   start_watcher(loop, SIGCHLD, &sc, 0);
   sc.stop_or_close = STOP; /* stop, don't close the signal handle */
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, NSIGNALS);
 
@@ -176,7 +176,7 @@ TEST_IMPL(we_get_signal) {
   uv_signal_start(&sc.handle, signal_cb, SIGCHLD);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, NSIGNALS);
 
@@ -198,7 +198,7 @@ TEST_IMPL(we_get_signals) {
   start_watcher(loop, SIGUSR2, sc + 3, 0);
   start_timer(loop, SIGUSR1, tc + 0);
   start_timer(loop, SIGUSR2, tc + 1);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   for (i = 0; i < ARRAY_SIZE(sc); i++)
     ASSERT_EQ(sc[i].ncalls, NSIGNALS);
@@ -219,19 +219,19 @@ TEST_IMPL(we_get_signal_one_shot) {
   start_timer(loop, SIGCHLD, &tc);
   start_watcher(loop, SIGCHLD, &sc, 1);
   sc.stop_or_close = NOOP;
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, 1);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(sc.ncalls, 1);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
   uv_signal_start_oneshot(&sc.handle, signal_cb_one_shot, SIGCHLD);
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc.ncalls, 1);
 
@@ -252,7 +252,7 @@ TEST_IMPL(we_get_signals_mixed) {
   start_watcher(loop, SIGCHLD, sc + 1, 1);
   sc[0].stop_or_close = CLOSE;
   sc[1].stop_or_close = CLOSE;
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 1);
   ASSERT_EQ(sc[1].ncalls, 1);
@@ -265,11 +265,11 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   start_watcher(loop, SIGCHLD, sc + 2, 0);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, 1);
   ASSERT_EQ(sc[1].ncalls, 1);
-  ASSERT_EQ(sc[2].ncalls, 0);
+  ASSERT_OK(sc[2].ncalls);
 
   /* 2 normal, 1 one-shot then remove one-shot */
   start_timer(loop, SIGCHLD, &tc);
@@ -279,11 +279,11 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   start_watcher(loop, SIGCHLD, sc + 2, 1);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_EQ(sc[0].ncalls, NSIGNALS);
   ASSERT_EQ(sc[1].ncalls, NSIGNALS);
-  ASSERT_EQ(sc[2].ncalls, 0);
+  ASSERT_OK(sc[2].ncalls);
 
   /* 2 normal, 2 one-shot then remove 2 normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -295,10 +295,10 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[3].stop_or_close = CLOSE;
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[1]).handle, NULL);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc[0].ncalls, 0);
-  ASSERT_EQ(sc[1].ncalls, 0);
+  ASSERT_OK(sc[0].ncalls);
+  ASSERT_OK(sc[1].ncalls);
   ASSERT_EQ(sc[2].ncalls, 1);
   ASSERT_EQ(sc[2].ncalls, 1);
 
@@ -311,11 +311,11 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[3].stop_or_close = CLOSE;
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc[0].ncalls, 0);
+  ASSERT_OK(sc[0].ncalls);
   ASSERT_EQ(sc[1].ncalls, 1);
-  ASSERT_EQ(sc[2].ncalls, 0);
+  ASSERT_OK(sc[2].ncalls);
   ASSERT_EQ(sc[3].ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -114,7 +114,7 @@ static void signal_cb(uv_signal_t* handle, int signum) {
 static void signal_cb_one_shot(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
   ASSERT_EQ(signum, ctx->signum);
-  ASSERT_EQ(++ctx->ncalls, 1);
+  ASSERT_EQ(1, ++ctx->ncalls);
   if (ctx->stop_or_close == CLOSE)
     uv_close((uv_handle_t*)handle, NULL);
 }
@@ -221,11 +221,11 @@ TEST_IMPL(we_get_signal_one_shot) {
   sc.stop_or_close = NOOP;
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc.ncalls, 1);
+  ASSERT_EQ(1, sc.ncalls);
 
   start_timer(loop, SIGCHLD, &tc);
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(sc.ncalls, 1);
+  ASSERT_EQ(1, sc.ncalls);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
@@ -233,7 +233,7 @@ TEST_IMPL(we_get_signal_one_shot) {
   start_timer(loop, SIGCHLD, &tc);
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc.ncalls, 1);
+  ASSERT_EQ(1, sc.ncalls);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -254,8 +254,8 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc[0].ncalls, 1);
-  ASSERT_EQ(sc[1].ncalls, 1);
+  ASSERT_EQ(1, sc[0].ncalls);
+  ASSERT_EQ(1, sc[1].ncalls);
 
   /* 2 one-shot, 1 normal then remove normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -267,8 +267,8 @@ TEST_IMPL(we_get_signals_mixed) {
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
-  ASSERT_EQ(sc[0].ncalls, 1);
-  ASSERT_EQ(sc[1].ncalls, 1);
+  ASSERT_EQ(1, sc[0].ncalls);
+  ASSERT_EQ(1, sc[1].ncalls);
   ASSERT_OK(sc[2].ncalls);
 
   /* 2 normal, 1 one-shot then remove one-shot */
@@ -299,8 +299,8 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_OK(sc[0].ncalls);
   ASSERT_OK(sc[1].ncalls);
-  ASSERT_EQ(sc[2].ncalls, 1);
-  ASSERT_EQ(sc[2].ncalls, 1);
+  ASSERT_EQ(1, sc[2].ncalls);
+  ASSERT_EQ(1, sc[2].ncalls);
 
   /* 1 normal, 1 one-shot, 2 normal then remove 1st normal, 2nd normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -314,7 +314,7 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(tc.ncalls, NSIGNALS);
   ASSERT_OK(sc[0].ncalls);
-  ASSERT_EQ(sc[1].ncalls, 1);
+  ASSERT_EQ(1, sc[1].ncalls);
   ASSERT_OK(sc[2].ncalls);
   ASSERT_EQ(sc[3].ncalls, NSIGNALS);
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -31,12 +31,12 @@ TEST_IMPL(kill_invalid_signum) {
 
   pid = uv_os_getpid();
 
-  ASSERT(uv_kill(pid, -1) == UV_EINVAL);
+  ASSERT_EQ(uv_kill(pid, -1), UV_EINVAL);
 #ifdef _WIN32
   /* NSIG is not available on all platforms. */
-  ASSERT(uv_kill(pid, NSIG) == UV_EINVAL);
+  ASSERT_EQ(uv_kill(pid, NSIG), UV_EINVAL);
 #endif
-  ASSERT(uv_kill(pid, 4096) == UV_EINVAL);
+  ASSERT_EQ(uv_kill(pid, 4096), UV_EINVAL);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -55,20 +55,20 @@ TEST_IMPL(win32_signum_number) {
   loop = uv_default_loop();
   uv_signal_init(loop, &signal);
 
-  ASSERT(uv_signal_start(&signal, signum_test_cb, 0) == UV_EINVAL);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGINT) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGBREAK) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGHUP) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGWINCH) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGILL) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGABRT_COMPAT) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGFPE) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGSEGV) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGTERM) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, SIGABRT) == 0);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, -1) == UV_EINVAL);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, NSIG) == UV_EINVAL);
-  ASSERT(uv_signal_start(&signal, signum_test_cb, 1024) == UV_EINVAL);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, 0), UV_EINVAL);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGINT), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGBREAK), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGHUP), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGWINCH), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGILL), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGABRT_COMPAT), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGFPE), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGSEGV), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGTERM), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, SIGABRT), 0);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, -1), UV_EINVAL);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, NSIG), UV_EINVAL);
+  ASSERT_EQ(uv_signal_start(&signal, signum_test_cb, 1024), UV_EINVAL);
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
@@ -100,7 +100,7 @@ struct signal_ctx {
 
 static void signal_cb(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
-  ASSERT(signum == ctx->signum);
+  ASSERT_EQ(signum, ctx->signum);
   if (++ctx->ncalls == NSIGNALS) {
     if (ctx->stop_or_close == STOP)
       uv_signal_stop(handle);
@@ -113,8 +113,8 @@ static void signal_cb(uv_signal_t* handle, int signum) {
 
 static void signal_cb_one_shot(uv_signal_t* handle, int signum) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
-  ASSERT(signum == ctx->signum);
-  ASSERT(++ctx->ncalls == 1);
+  ASSERT_EQ(signum, ctx->signum);
+  ASSERT_EQ(++ctx->ncalls, 1);
   if (ctx->stop_or_close == CLOSE)
     uv_close((uv_handle_t*)handle, NULL);
 }
@@ -138,18 +138,18 @@ static void start_watcher(uv_loop_t* loop,
   ctx->signum = signum;
   ctx->stop_or_close = CLOSE;
   ctx->one_shot = one_shot;
-  ASSERT(0 == uv_signal_init(loop, &ctx->handle));
+  ASSERT_EQ(0, uv_signal_init(loop, &ctx->handle));
   if (one_shot)
-    ASSERT(0 == uv_signal_start_oneshot(&ctx->handle, signal_cb_one_shot, signum));
+    ASSERT_EQ(0, uv_signal_start_oneshot(&ctx->handle, signal_cb_one_shot, signum));
   else
-    ASSERT(0 == uv_signal_start(&ctx->handle, signal_cb, signum));
+    ASSERT_EQ(0, uv_signal_start(&ctx->handle, signal_cb, signum));
 }
 
 static void start_timer(uv_loop_t* loop, int signum, struct timer_ctx* ctx) {
   ctx->ncalls = 0;
   ctx->signum = signum;
-  ASSERT(0 == uv_timer_init(loop, &ctx->handle));
-  ASSERT(0 == uv_timer_start(&ctx->handle, timer_cb, 5, 5));
+  ASSERT_EQ(0, uv_timer_init(loop, &ctx->handle));
+  ASSERT_EQ(0, uv_timer_start(&ctx->handle, timer_cb, 5, 5));
 }
 
 
@@ -162,23 +162,23 @@ TEST_IMPL(we_get_signal) {
   start_timer(loop, SIGCHLD, &tc);
   start_watcher(loop, SIGCHLD, &sc, 0);
   sc.stop_or_close = STOP; /* stop, don't close the signal handle */
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
   uv_signal_start(&sc.handle, signal_cb, SIGCHLD);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == NSIGNALS);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -198,13 +198,13 @@ TEST_IMPL(we_get_signals) {
   start_watcher(loop, SIGUSR2, sc + 3, 0);
   start_timer(loop, SIGUSR1, tc + 0);
   start_timer(loop, SIGUSR2, tc + 1);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
   for (i = 0; i < ARRAY_SIZE(sc); i++)
-    ASSERT(sc[i].ncalls == NSIGNALS);
+    ASSERT_EQ(sc[i].ncalls, NSIGNALS);
 
   for (i = 0; i < ARRAY_SIZE(tc); i++)
-    ASSERT(tc[i].ncalls == NSIGNALS);
+    ASSERT_EQ(tc[i].ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -219,21 +219,21 @@ TEST_IMPL(we_get_signal_one_shot) {
   start_timer(loop, SIGCHLD, &tc);
   start_watcher(loop, SIGCHLD, &sc, 1);
   sc.stop_or_close = NOOP;
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, 1);
 
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(sc.ncalls, 1);
 
   sc.ncalls = 0;
   sc.stop_or_close = CLOSE; /* now close it when it's done */
   uv_signal_start_oneshot(&sc.handle, signal_cb_one_shot, SIGCHLD);
   start_timer(loop, SIGCHLD, &tc);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc.ncalls == 1);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc.ncalls, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -252,10 +252,10 @@ TEST_IMPL(we_get_signals_mixed) {
   start_watcher(loop, SIGCHLD, sc + 1, 1);
   sc[0].stop_or_close = CLOSE;
   sc[1].stop_or_close = CLOSE;
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 1);
-  ASSERT(sc[1].ncalls == 1);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, 1);
+  ASSERT_EQ(sc[1].ncalls, 1);
 
   /* 2 one-shot, 1 normal then remove normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -265,11 +265,11 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   start_watcher(loop, SIGCHLD, sc + 2, 0);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 1);
-  ASSERT(sc[1].ncalls == 1);
-  ASSERT(sc[2].ncalls == 0);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, 1);
+  ASSERT_EQ(sc[1].ncalls, 1);
+  ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 1 one-shot then remove one-shot */
   start_timer(loop, SIGCHLD, &tc);
@@ -279,11 +279,11 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[1].stop_or_close = CLOSE;
   start_watcher(loop, SIGCHLD, sc + 2, 1);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == NSIGNALS);
-  ASSERT(sc[1].ncalls == NSIGNALS);
-  ASSERT(sc[2].ncalls == 0);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, NSIGNALS);
+  ASSERT_EQ(sc[1].ncalls, NSIGNALS);
+  ASSERT_EQ(sc[2].ncalls, 0);
 
   /* 2 normal, 2 one-shot then remove 2 normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -295,12 +295,12 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[3].stop_or_close = CLOSE;
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[1]).handle, NULL);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 0);
-  ASSERT(sc[1].ncalls == 0);
-  ASSERT(sc[2].ncalls == 1);
-  ASSERT(sc[2].ncalls == 1);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, 0);
+  ASSERT_EQ(sc[1].ncalls, 0);
+  ASSERT_EQ(sc[2].ncalls, 1);
+  ASSERT_EQ(sc[2].ncalls, 1);
 
   /* 1 normal, 1 one-shot, 2 normal then remove 1st normal, 2nd normal */
   start_timer(loop, SIGCHLD, &tc);
@@ -311,12 +311,12 @@ TEST_IMPL(we_get_signals_mixed) {
   sc[3].stop_or_close = CLOSE;
   uv_close((uv_handle_t*)&(sc[0]).handle, NULL);
   uv_close((uv_handle_t*)&(sc[2]).handle, NULL);
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(tc.ncalls == NSIGNALS);
-  ASSERT(sc[0].ncalls == 0);
-  ASSERT(sc[1].ncalls == 1);
-  ASSERT(sc[2].ncalls == 0);
-  ASSERT(sc[3].ncalls == NSIGNALS);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(tc.ncalls, NSIGNALS);
+  ASSERT_EQ(sc[0].ncalls, 0);
+  ASSERT_EQ(sc[1].ncalls, 1);
+  ASSERT_EQ(sc[2].ncalls, 0);
+  ASSERT_EQ(sc[3].ncalls, NSIGNALS);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -40,14 +40,14 @@ static void check_buffer_size(uv_handle_t* handle) {
   int value;
 
   value = 0;
-  ASSERT(0 == uv_recv_buffer_size(handle, &value));
-  ASSERT(value > 0);
+  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
+  ASSERT_GT(value, 0);
 
   value = 10000;
-  ASSERT(0 == uv_recv_buffer_size(handle, &value));
+  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
 
   value = 0;
-  ASSERT(0 == uv_recv_buffer_size(handle, &value));
+  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
   /* linux sets double the value */
   ASSERT(value == 10000 || value == 20000);
 }
@@ -56,21 +56,21 @@ static void check_buffer_size(uv_handle_t* handle) {
 TEST_IMPL(socket_buffer_size) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &tcp));
-  ASSERT(0 == uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &tcp));
+  ASSERT_EQ(0, uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0));
   check_buffer_size((uv_handle_t*) &tcp);
   uv_close((uv_handle_t*) &tcp, close_cb);
 
-  ASSERT(0 == uv_udp_init(uv_default_loop(), &udp));
-  ASSERT(0 == uv_udp_bind(&udp, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &udp));
+  ASSERT_EQ(0, uv_udp_bind(&udp, (struct sockaddr*) &addr, 0));
   check_buffer_size((uv_handle_t*) &udp);
   uv_close((uv_handle_t*) &udp, close_cb);
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -40,14 +40,14 @@ static void check_buffer_size(uv_handle_t* handle) {
   int value;
 
   value = 0;
-  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
+  ASSERT_OK(uv_recv_buffer_size(handle, &value));
   ASSERT_GT(value, 0);
 
   value = 10000;
-  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
+  ASSERT_OK(uv_recv_buffer_size(handle, &value));
 
   value = 0;
-  ASSERT_EQ(0, uv_recv_buffer_size(handle, &value));
+  ASSERT_OK(uv_recv_buffer_size(handle, &value));
   /* linux sets double the value */
   ASSERT(value == 10000 || value == 20000);
 }
@@ -56,19 +56,19 @@ static void check_buffer_size(uv_handle_t* handle) {
 TEST_IMPL(socket_buffer_size) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &tcp));
-  ASSERT_EQ(0, uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &tcp));
+  ASSERT_OK(uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0));
   check_buffer_size((uv_handle_t*) &tcp);
   uv_close((uv_handle_t*) &tcp, close_cb);
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &udp));
-  ASSERT_EQ(0, uv_udp_bind(&udp, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &udp));
+  ASSERT_OK(uv_udp_bind(&udp, (struct sockaddr*) &addr, 0));
   check_buffer_size((uv_handle_t*) &udp);
   uv_close((uv_handle_t*) &udp, close_cb);
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(close_cb_called, 2);
 

--- a/test/test-socket-buffer-size.c
+++ b/test/test-socket-buffer-size.c
@@ -70,7 +70,7 @@ TEST_IMPL(socket_buffer_size) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -65,8 +65,8 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT(exit_status == 1);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(exit_status, 1);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*) process, close_cb);
 }
 
@@ -86,9 +86,9 @@ static void kill_cb(uv_process_t* process,
   printf("exit_cb\n");
   exit_cb_called++;
 #ifdef _WIN32
-  ASSERT(exit_status == 1);
+  ASSERT_EQ(exit_status, 1);
 #else
-  ASSERT(exit_status == 0);
+  ASSERT_EQ(exit_status, 0);
 #endif
 #if defined(__APPLE__) || defined(__MVS__)
   /*
@@ -108,7 +108,7 @@ static void kill_cb(uv_process_t* process,
    * This process should be dead.
    */
   err = uv_kill(process->pid, 0);
-  ASSERT(err == UV_ESRCH);
+  ASSERT_EQ(err, UV_ESRCH);
 }
 
 static void detach_failure_cb(uv_process_t* process,
@@ -130,7 +130,7 @@ static void on_read(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
     output_used += nread;
   } else if (nread < 0) {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*) tcp, close_cb);
   }
 }
@@ -143,20 +143,20 @@ static void on_read_once(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*) req->handle, close_cb);
 }
 
 
 static void write_null_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
 static void init_process_options(char* test, uv_exit_cb exit_cb) {
   /* Note spawn_helper1 defined in test/run-tests.c */
   int r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
   args[0] = exepath;
   args[1] = test;
@@ -189,9 +189,9 @@ TEST_IMPL(spawn_fails) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == UV_ENOENT || r == UV_EACCES);
-  ASSERT(0 == uv_is_active((uv_handle_t*) &process));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &process));
   uv_close((uv_handle_t*) &process, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -209,19 +209,19 @@ TEST_IMPL(spawn_fails_check_for_waitpid_cleanup) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == UV_ENOENT || r == UV_EACCES);
-  ASSERT(0 == uv_is_active((uv_handle_t*) &process));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &process));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   /* verify the child is successfully cleaned up within libuv */
   do
     err = waitpid(process.pid, &status, 0);
   while (err == -1 && errno == EINTR);
 
-  ASSERT(err == -1);
-  ASSERT(errno == ECHILD);
+  ASSERT_EQ(err, -1);
+  ASSERT_EQ(errno, ECHILD);
 
   uv_close((uv_handle_t*) &process, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -247,11 +247,11 @@ TEST_IMPL(spawn_empty_env) {
   options.env = env;
   env[0] = NULL;
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -264,13 +264,13 @@ TEST_IMPL(spawn_exit_code) {
   init_process_options("spawn_helper1", exit_cb);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -292,18 +292,18 @@ TEST_IMPL(spawn_stdout) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output is: %s", output);
-  ASSERT(strcmp("hello world\n", output) == 0);
+  ASSERT_EQ(strcmp("hello world\n", output), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -324,7 +324,7 @@ TEST_IMPL(spawn_stdout_to_file) {
 
   r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
 
   file = r;
@@ -336,25 +336,25 @@ TEST_IMPL(spawn_stdout_to_file) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 12);
+  ASSERT_EQ(r, 12);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
-  ASSERT(strcmp("hello world\n", output) == 0);
+  ASSERT_EQ(strcmp("hello world\n", output), 0);
 
   /* Cleanup. */
   unlink("stdout_file");
@@ -378,7 +378,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
 
   r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
 
   file = r;
@@ -392,25 +392,25 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 27);
+  ASSERT_EQ(r, 27);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
-  ASSERT(strcmp("hello world\nhello errworld\n", output) == 0);
+  ASSERT_EQ(strcmp("hello world\nhello errworld\n", output), 0);
 
   /* Cleanup. */
   unlink("stdout_file");
@@ -440,10 +440,10 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
                  O_CREAT | O_RDWR,
                  S_IRUSR | S_IWUSR,
                  NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
   file = dup2(r, STDERR_FILENO);
-  ASSERT(file != -1);
+  ASSERT_NE(file, -1);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_IGNORE;
@@ -454,25 +454,25 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT(r == 27);
+  ASSERT_EQ(r, 27);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
-  ASSERT(strcmp("hello world\nhello errworld\n", output) == 0);
+  ASSERT_EQ(strcmp("hello world\nhello errworld\n", output), 0);
 
   /* Cleanup. */
   unlink("stdout_file");
@@ -507,18 +507,18 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
                  O_CREAT | O_RDWR,
                  S_IRUSR | S_IWUSR,
                  NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
   stdout_file = dup2(r, STDOUT_FILENO);
-  ASSERT(stdout_file != -1);
+  ASSERT_NE(stdout_file, -1);
 
   /* open 'stderr_file' and replace STDERR_FILENO with it */
   r = uv_fs_open(NULL, &fs_req, "stderr_file", O_CREAT | O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
   stderr_file = dup2(r, STDERR_FILENO);
-  ASSERT(stderr_file != -1);
+  ASSERT_NE(stderr_file, -1);
 
   /* now we're going to swap them: the child process' stdout will be our
    * stderr_file and vice versa */
@@ -531,39 +531,39 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   buf = uv_buf_init(output, sizeof(output));
 
   /* check the content of stdout_file */
   r = uv_fs_read(NULL, &fs_req, stdout_file, &buf, 1, 0, NULL);
-  ASSERT(r >= 15);
+  ASSERT_GE(r, 15);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, stdout_file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
-  ASSERT(strncmp("hello errworld\n", output, 15) == 0);
+  ASSERT_EQ(strncmp("hello errworld\n", output, 15), 0);
 
   /* check the content of stderr_file */
   r = uv_fs_read(NULL, &fs_req, stderr_file, &buf, 1, 0, NULL);
-  ASSERT(r >= 12);
+  ASSERT_GE(r, 12);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, stderr_file, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_fs_req_cleanup(&fs_req);
 
   printf("output is: %s", output);
-  ASSERT(strncmp("hello world\n", output, 12) == 0);
+  ASSERT_EQ(strncmp("hello world\n", output, 12), 0);
 
   /* Cleanup. */
   unlink("stdout_file");
@@ -598,22 +598,22 @@ TEST_IMPL(spawn_stdin) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = buffer;
   buf.len = sizeof(buffer);
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3); /* Once for process twice for the pipe. */
-  ASSERT(strcmp(buffer, output) == 0);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3); /* Once for process twice for the pipe. */
+  ASSERT_EQ(strcmp(buffer, output), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -637,18 +637,18 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   options.stdio_count = 4;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &pipe, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output from stdio[3] is: %s", output);
-  ASSERT(strcmp("fourth stdio!\n", output) == 0);
+  ASSERT_EQ(strcmp("fourth stdio!\n", output), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -661,7 +661,7 @@ int spawn_tcp_server_helper(void) {
   int r;
 
   r = uv_tcp_init(uv_default_loop(), &tcp);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifdef _WIN32
   handle = _get_osfhandle(3);
@@ -669,13 +669,13 @@ int spawn_tcp_server_helper(void) {
   handle = 3;
 #endif
   r = uv_tcp_open(&tcp, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Make sure that we can listen on a socket that was
    * passed down from the parent process
    */
   r = uv_listen((uv_stream_t*) &tcp, SOMAXCONN, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   return 1;
 }
@@ -692,21 +692,21 @@ TEST_IMPL(spawn_tcp_server) {
 
   init_process_options("spawn_tcp_server_helper", exit_cb);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   fd = -1;
   r = uv_tcp_init_ex(uv_default_loop(), &tcp_server, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   r = uv_fileno((uv_handle_t*) &tcp_server, &handle);
   fd = _open_osfhandle((intptr_t) handle, 0);
 #else
   r = uv_fileno((uv_handle_t*) &tcp_server, &fd);
  #endif
-  ASSERT(r == 0);
-  ASSERT(fd > 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_GT(fd, 0);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_INHERIT_FD;
@@ -720,13 +720,13 @@ TEST_IMPL(spawn_tcp_server) {
   options.stdio_count = 4;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -742,13 +742,13 @@ TEST_IMPL(spawn_ignored_stdio) {
   options.stdio_count = 0;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -761,19 +761,19 @@ TEST_IMPL(spawn_and_kill) {
   init_process_options("spawn_helper4", kill_cb);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process and once for timer. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process and once for timer. */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -795,25 +795,25 @@ TEST_IMPL(spawn_preserve_env) {
   options.stdio_count = 2;
 
   r = putenv("ENV_TEST=testval");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Explicitly set options.env to NULL to test for env clobbering. */
   options.env = NULL;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   printf("output is: %s", output);
-  ASSERT(strcmp("testval", output) == 0);
+  ASSERT_EQ(strcmp("testval", output), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -828,22 +828,22 @@ TEST_IMPL(spawn_detached) {
   options.flags |= UV_PROCESS_DETACHED;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*) &process);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
-  ASSERT(process.pid == uv_process_get_pid(&process));
+  ASSERT_EQ(process.pid, uv_process_get_pid(&process));
 
   r = uv_kill(process.pid, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_kill(process.pid, SIGTERM);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -861,13 +861,13 @@ TEST_IMPL(spawn_and_kill_with_std) {
   init_process_options("spawn_helper4", kill_cb);
 
   r = uv_pipe_init(uv_default_loop(), &in, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &out, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_pipe_init(uv_default_loop(), &err, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
@@ -879,29 +879,29 @@ TEST_IMPL(spawn_and_kill_with_std) {
   options.stdio_count = 3;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(message, sizeof message);
   r = uv_write(&write, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &err, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 500, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 5); /* process x 1, timer x 1, stdio x 3. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 5); /* process x 1, timer x 1, stdio x 3. */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -928,27 +928,27 @@ TEST_IMPL(spawn_and_ping) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.
    */
   r = uv_process_kill(&process, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(strcmp(output, "TEST") == 0);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(strcmp(output, "TEST"), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -975,27 +975,27 @@ TEST_IMPL(spawn_same_stdout_stderr) {
   options.stdio_count = 2;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.
    */
   r = uv_process_kill(&process, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 0);
+  ASSERT_EQ(exit_cb_called, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(strcmp(output, "TEST") == 0);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(strcmp(output, "TEST"), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1019,15 +1019,15 @@ TEST_IMPL(spawn_closed_process_io) {
 
   close(0); /* Close process stdin. */
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
 
   buf = uv_buf_init(buffer, sizeof(buffer));
-  ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb));
+  ASSERT_EQ(0, uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_cb));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* process, child stdin */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* process, child stdin */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1049,39 +1049,39 @@ TEST_IMPL(kill) {
     sigset_t set;
     sigemptyset(&set);
     sigaddset(&set, SIGTERM);
-    ASSERT(0 == pthread_sigmask(SIG_BLOCK, &set, NULL));
+    ASSERT_EQ(0, pthread_sigmask(SIG_BLOCK, &set, NULL));
   }
-  ASSERT(SIG_ERR != signal(SIGTERM, SIG_IGN));
+  ASSERT_NE(SIG_ERR, signal(SIGTERM, SIG_IGN));
 #endif
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
     sigset_t set;
     sigemptyset(&set);
     sigaddset(&set, SIGTERM);
-    ASSERT(0 == pthread_sigmask(SIG_UNBLOCK, &set, NULL));
+    ASSERT_EQ(0, pthread_sigmask(SIG_UNBLOCK, &set, NULL));
   }
-  ASSERT(SIG_ERR != signal(SIGTERM, SIG_DFL));
+  ASSERT_NE(SIG_ERR, signal(SIGTERM, SIG_DFL));
 #endif
 
   /* Sending signum == 0 should check if the
    * child process is still alive, not kill it.
    */
   r = uv_kill(process.pid, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Kill the process. */
   r = uv_kill(process.pid, SIGTERM);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1119,21 +1119,21 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
                                 65536,
                                 0,
                                 NULL);
-  ASSERT(pipe_handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(pipe_handle, INVALID_HANDLE_VALUE);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
   printf("output is: %s", output);
-  ASSERT(strcmp("hello world\n", output) == 0);
+  ASSERT_EQ(strcmp("hello world\n", output), 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1197,7 +1197,7 @@ TEST_IMPL(argument_escaping) {
   cracked = CommandLineToArgvW(command_line, &num_args);
   for (i = 0; i < num_args; ++i) {
     wprintf(L"%d: %s\t%s\n", i, test_str[i], cracked[i]);
-    ASSERT(wcscmp(test_str[i], cracked[i]) == 0);
+    ASSERT_EQ(wcscmp(test_str[i], cracked[i]), 0);
   }
 
   LocalFree(cracked);
@@ -1207,19 +1207,19 @@ TEST_IMPL(argument_escaping) {
   free(test_output);
 
   result = make_program_args(verbatim, 1, &verbatim_output);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
   result = make_program_args(verbatim, 0, &non_verbatim_output);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
 
   wprintf(L"    verbatim_output: %s\n", verbatim_output);
   wprintf(L"non_verbatim_output: %s\n", non_verbatim_output);
 
-  ASSERT(wcscmp(verbatim_output,
-                L"cmd.exe /c c:\\path\\to\\node.exe --eval "
-                L"\"require('c:\\\\path\\\\to\\\\test.js')\"") == 0);
-  ASSERT(wcscmp(non_verbatim_output,
-                L"cmd.exe /c \"c:\\path\\to\\node.exe --eval "
-                L"\\\"require('c:\\\\path\\\\to\\\\test.js')\\\"\"") == 0);
+  ASSERT_EQ(wcscmp(verbatim_output,
+                   L"cmd.exe /c c:\\path\\to\\node.exe --eval "
+                   L"\"require('c:\\\\path\\\\to\\\\test.js')\""), 0);
+  ASSERT_EQ(wcscmp(non_verbatim_output,
+                   L"cmd.exe /c \"c:\\path\\to\\node.exe --eval "
+                   L"\\\"require('c:\\\\path\\\\to\\\\test.js')\\\"\""), 0);
 
   free(verbatim_output);
   free(non_verbatim_output);
@@ -1303,7 +1303,7 @@ TEST_IMPL(environment_creation) {
   }
 
   result = make_program_env(environment, &env);
-  ASSERT(result == 0);
+  ASSERT_EQ(result, 0);
 
   for (str = env, prev = NULL; *str; prev = str, str += wcslen(str) + 1) {
     int found = 0;
@@ -1327,7 +1327,7 @@ TEST_IMPL(environment_creation) {
     }
     if (prev) { /* verify sort order */
 #if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
-      ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
+      ASSERT_EQ(CompareStringOrdinal(prev, -1, str, -1, TRUE), 1);
 #endif
     }
     ASSERT(found); /* verify that we expected this variable */
@@ -1359,9 +1359,9 @@ TEST_IMPL(spawn_with_an_odd_path) {
   options.file = options.args[0] = "program-that-had-better-not-exist";
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT(r == UV_ENOENT || r == UV_EACCES);
-  ASSERT(0 == uv_is_active((uv_handle_t*) &process));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &process));
   uv_close((uv_handle_t*) &process, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1383,11 +1383,11 @@ TEST_IMPL(spawn_no_path) {
   options.env = env;
   env[0] = NULL;
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   SetEnvironmentVariableW(L"PATH", old_path);
 
@@ -1426,13 +1426,13 @@ TEST_IMPL(spawn_setuid_setgid) {
   if (r == UV_EACCES)
     RETURN_SKIP("user 'nobody' cannot access the test runner");
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1452,8 +1452,8 @@ TEST_IMPL(spawn_setuid_fails) {
     struct passwd* pw;
     pw = getpwnam("nobody");
     ASSERT_NOT_NULL(pw);
-    ASSERT(0 == setgid(pw->pw_gid));
-    ASSERT(0 == setuid(pw->pw_uid));
+    ASSERT_EQ(0, setgid(pw->pw_gid));
+    ASSERT_EQ(0, setuid(pw->pw_uid));
   }
 #endif  /* !__PASE__ */
 
@@ -1477,15 +1477,15 @@ TEST_IMPL(spawn_setuid_fails) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
 #if defined(__CYGWIN__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EPERM);
+  ASSERT_EQ(r, UV_EPERM);
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1503,8 +1503,8 @@ TEST_IMPL(spawn_setgid_fails) {
     struct passwd* pw;
     pw = getpwnam("nobody");
     ASSERT_NOT_NULL(pw);
-    ASSERT(0 == setgid(pw->pw_gid));
-    ASSERT(0 == setuid(pw->pw_uid));
+    ASSERT_EQ(0, setgid(pw->pw_gid));
+    ASSERT_EQ(0, setuid(pw->pw_uid));
   }
 #endif  /* !__PASE__ */
 
@@ -1522,15 +1522,15 @@ TEST_IMPL(spawn_setgid_fails) {
 
   r = uv_spawn(uv_default_loop(), &process, &options);
 #if defined(__CYGWIN__) || defined(__MVS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EPERM);
+  ASSERT_EQ(r, UV_EPERM);
 #endif
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1556,12 +1556,12 @@ TEST_IMPL(spawn_setuid_fails) {
   options.uid = (uv_uid_t) -42424242;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == UV_ENOTSUP);
+  ASSERT_EQ(r, UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1577,12 +1577,12 @@ TEST_IMPL(spawn_setgid_fails) {
   options.gid = (uv_gid_t) -42424242;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == UV_ENOTSUP);
+  ASSERT_EQ(r, UV_ENOTSUP);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1592,12 +1592,12 @@ TEST_IMPL(spawn_setgid_fails) {
 
 TEST_IMPL(spawn_auto_unref) {
   init_process_options("spawn_helper1", NULL);
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == uv_is_closing((uv_handle_t*) &process));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_is_closing((uv_handle_t*) &process));
   uv_close((uv_handle_t*) &process, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == uv_is_closing((uv_handle_t*) &process));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, uv_is_closing((uv_handle_t*) &process));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -1622,13 +1622,13 @@ TEST_IMPL(spawn_fs_open) {
 #endif
 
   r = uv_fs_open(NULL, &fs_req, dev_null, O_RDWR, 0, NULL);
-  ASSERT(r != -1);
+  ASSERT_NE(r, -1);
   fd = uv_get_osfhandle((uv_file) fs_req.result);
   uv_fs_req_cleanup(&fs_req);
 
   init_process_options("spawn_helper8", exit_cb);
 
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &in, 0));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &in, 0));
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
@@ -1637,29 +1637,35 @@ TEST_IMPL(spawn_fs_open) {
 
   /* make an inheritable copy */
 #ifdef _WIN32
-  ASSERT(0 != DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &dup_fd,
-                              0, /* inherit */ TRUE, DUPLICATE_SAME_ACCESS));
+  ASSERT_NE(0, DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &dup_fd,
+                               0, /* inherit */ TRUE, DUPLICATE_SAME_ACCESS));
   kernelbase_module = GetModuleHandleA("kernelbase.dll");
   pCompareObjectHandles = (sCompareObjectHandles)
       GetProcAddress(kernelbase_module, "CompareObjectHandles");
-  ASSERT(pCompareObjectHandles == NULL || pCompareObjectHandles(fd, dup_fd));
+  ASSERT_NE(pCompareObjectHandles == NULL ||
+            pCompareObjectHandles(fd, dup_fd),
+            0);
 #else
   dup_fd = dup(fd);
 #endif
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
 
   buf = uv_buf_init((char*) &fd, sizeof(fd));
-  ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &in, &buf, 1, write_null_cb));
+  ASSERT_EQ(0, uv_write(&write_req,
+                        (uv_stream_t*) &in,
+                        &buf,
+                        1,
+                        write_null_cb));
 
   buf = uv_buf_init((char*) &dup_fd, sizeof(fd));
-  ASSERT(0 == uv_write(&write_req2, (uv_stream_t*) &in, &buf, 1, write_cb));
+  ASSERT_EQ(0, uv_write(&write_req2, (uv_stream_t*) &in, &buf, 1, write_cb));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(0 == uv_fs_close(NULL, &fs_req, r, NULL));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_fs_close(NULL, &fs_req, r, NULL));
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 2);  /* One for `in`, one for process */
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);  /* One for `in`, one for process */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1675,9 +1681,9 @@ TEST_IMPL(closed_fd_events) {
   bufs[0] = uv_buf_init("", 1);
 
   /* create a pipe and share it with a child process */
-  ASSERT(0 == uv_pipe(fd, 0, 0));
-  ASSERT(fd[0] > 2);
-  ASSERT(fd[1] > 2);
+  ASSERT_EQ(0, uv_pipe(fd, 0, 0));
+  ASSERT_GT(fd[0], 2);
+  ASSERT_GT(fd[1], 2);
 
   /* spawn_helper4 blocks indefinitely. */
   init_process_options("spawn_helper4", exit_cb);
@@ -1688,49 +1694,51 @@ TEST_IMPL(closed_fd_events) {
   options.stdio[1].flags = UV_IGNORE;
   options.stdio[2].flags = UV_IGNORE;
 
-  ASSERT(0 == uv_spawn(uv_default_loop(), &process, &options));
+  ASSERT_EQ(0, uv_spawn(uv_default_loop(), &process, &options));
   uv_unref((uv_handle_t*) &process);
 
   /* read from the pipe with uv */
-  ASSERT(0 == uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
-  ASSERT(0 == uv_pipe_open(&pipe_handle, fd[0]));
+  ASSERT_EQ(0, uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_EQ(0, uv_pipe_open(&pipe_handle, fd[0]));
   /* uv_pipe_open() takes ownership of the file descriptor. */
   fd[0] = -1;
 
-  ASSERT(0 == uv_read_start((uv_stream_t*) &pipe_handle, on_alloc, on_read_once));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &pipe_handle,
+                             on_alloc,
+                             on_read_once));
 
-  ASSERT(1 == uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT(req.result == 1);
+  ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
+  ASSERT_EQ(req.result, 1);
   uv_fs_req_cleanup(&req);
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
 
   /* should have received just one byte */
-  ASSERT(output_used == 1);
+  ASSERT_EQ(output_used, 1);
 
   /* close the pipe and see if we still get events */
   uv_close((uv_handle_t*) &pipe_handle, close_cb);
 
-  ASSERT(1 == uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT(req.result == 1);
+  ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
+  ASSERT_EQ(req.result, 1);
   uv_fs_req_cleanup(&req);
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer));
-  ASSERT(0 == uv_timer_start(&timer, timer_counter_cb, 10, 0));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_EQ(0, uv_timer_start(&timer, timer_counter_cb, 10, 0));
 
   /* see if any spurious events interrupt the timer */
   if (1 == uv_run(uv_default_loop(), UV_RUN_ONCE))
     /* have to run again to really trigger the timer */
-    ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+    ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
 
-  ASSERT(timer_counter == 1);
+  ASSERT_EQ(timer_counter, 1);
 
   /* cleanup */
-  ASSERT(0 == uv_process_kill(&process, SIGTERM));
+  ASSERT_EQ(0, uv_process_kill(&process, SIGTERM));
 #ifdef _WIN32
-  ASSERT(0 == _close(fd[1]));
+  ASSERT_EQ(0, _close(fd[1]));
 #else
-  ASSERT(0 == close(fd[1]));
+  ASSERT_EQ(0, close(fd[1]));
 #endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -1795,13 +1803,13 @@ TEST_IMPL(spawn_reads_child_path) {
   options.env = env;
 
   r = uv_spawn(uv_default_loop(), &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1827,27 +1835,27 @@ TEST_IMPL(spawn_inherit_streams) {
   init_process_options("spawn_helper9", exit_cb);
 
   loop = uv_default_loop();
-  ASSERT(uv_pipe_init(loop, &pipe_stdin_child, 0) == 0);
-  ASSERT(uv_pipe_init(loop, &pipe_stdout_child, 0) == 0);
-  ASSERT(uv_pipe_init(loop, &pipe_stdin_parent, 0) == 0);
-  ASSERT(uv_pipe_init(loop, &pipe_stdout_parent, 0) == 0);
+  ASSERT_EQ(uv_pipe_init(loop, &pipe_stdin_child, 0), 0);
+  ASSERT_EQ(uv_pipe_init(loop, &pipe_stdout_child, 0), 0);
+  ASSERT_EQ(uv_pipe_init(loop, &pipe_stdin_parent, 0), 0);
+  ASSERT_EQ(uv_pipe_init(loop, &pipe_stdout_parent, 0), 0);
 
-  ASSERT(uv_pipe(fds_stdin, 0, 0) == 0);
-  ASSERT(uv_pipe(fds_stdout, 0, 0) == 0);
+  ASSERT_EQ(uv_pipe(fds_stdin, 0, 0), 0);
+  ASSERT_EQ(uv_pipe(fds_stdout, 0, 0), 0);
 
-  ASSERT(uv_pipe_open(&pipe_stdin_child, fds_stdin[0]) == 0);
-  ASSERT(uv_pipe_open(&pipe_stdout_child, fds_stdout[1]) == 0);
-  ASSERT(uv_pipe_open(&pipe_stdin_parent, fds_stdin[1]) == 0);
-  ASSERT(uv_pipe_open(&pipe_stdout_parent, fds_stdout[0]) == 0);
+  ASSERT_EQ(uv_pipe_open(&pipe_stdin_child, fds_stdin[0]), 0);
+  ASSERT_EQ(uv_pipe_open(&pipe_stdout_child, fds_stdout[1]), 0);
+  ASSERT_EQ(uv_pipe_open(&pipe_stdin_parent, fds_stdin[1]), 0);
+  ASSERT_EQ(uv_pipe_open(&pipe_stdout_parent, fds_stdout[0]), 0);
   ASSERT(uv_is_readable((uv_stream_t*) &pipe_stdin_child));
   ASSERT(uv_is_writable((uv_stream_t*) &pipe_stdout_child));
   ASSERT(uv_is_writable((uv_stream_t*) &pipe_stdin_parent));
   ASSERT(uv_is_readable((uv_stream_t*) &pipe_stdout_parent));
   /* Some systems (SVR4) open a bidirectional pipe, most don't. */
   bidir = uv_is_writable((uv_stream_t*) &pipe_stdin_child);
-  ASSERT(uv_is_readable((uv_stream_t*) &pipe_stdout_child) == bidir);
-  ASSERT(uv_is_readable((uv_stream_t*) &pipe_stdin_parent) == bidir);
-  ASSERT(uv_is_writable((uv_stream_t*) &pipe_stdout_parent) == bidir);
+  ASSERT_EQ(uv_is_readable((uv_stream_t*) &pipe_stdout_child), bidir);
+  ASSERT_EQ(uv_is_readable((uv_stream_t*) &pipe_stdin_parent), bidir);
+  ASSERT_EQ(uv_is_writable((uv_stream_t*) &pipe_stdout_parent), bidir);
 
   child_stdio[0].flags = UV_INHERIT_STREAM;
   child_stdio[0].data.stream = (uv_stream_t *) &pipe_stdin_child;
@@ -1858,7 +1866,7 @@ TEST_IMPL(spawn_inherit_streams) {
   options.stdio = child_stdio;
   options.stdio_count = 2;
 
-  ASSERT(uv_spawn(loop, &child_req, &options) == 0);
+  ASSERT_EQ(uv_spawn(loop, &child_req, &options), 0);
 
   uv_close((uv_handle_t*) &pipe_stdin_child, NULL);
   uv_close((uv_handle_t*) &pipe_stdout_child, NULL);
@@ -1873,19 +1881,19 @@ TEST_IMPL(spawn_inherit_streams) {
                &buf,
                1,
                write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &pipe_stdout_parent, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   r = memcmp(ubuf, output, sizeof ubuf);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -1967,14 +1975,14 @@ void spawn_stdin_stdout(void) {
     if (r == 0) {
       return;
     }
-    ASSERT(r > 0);
+    ASSERT_GT(r, 0);
     c = r;
     pbuf = buf;
     while (c) {
       do {
         w = write(1, pbuf, (size_t)c);
       } while (w == -1 && errno == EINTR);
-      ASSERT(w >= 0);
+      ASSERT_GE(w, 0);
       pbuf = pbuf + w;
       c = c - w;
     }
@@ -1986,14 +1994,14 @@ void spawn_stdin_stdout(void) {
   char* pbuf;
   HANDLE h_stdin = GetStdHandle(STD_INPUT_HANDLE);
   HANDLE h_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-  ASSERT(h_stdin != INVALID_HANDLE_VALUE);
-  ASSERT(h_stdout != INVALID_HANDLE_VALUE);
+  ASSERT_NE(h_stdin, INVALID_HANDLE_VALUE);
+  ASSERT_NE(h_stdout, INVALID_HANDLE_VALUE);
   for (;;) {
     DWORD n_read;
     DWORD n_written;
     DWORD to_write;
     if (!ReadFile(h_stdin, buf, sizeof buf, &n_read, NULL)) {
-      ASSERT(GetLastError() == ERROR_BROKEN_PIPE);
+      ASSERT_EQ(GetLastError(), ERROR_BROKEN_PIPE);
       return;
     }
     to_write = n_read;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -65,7 +65,7 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT_EQ(exit_status, 1);
+  ASSERT_EQ(1, exit_status);
   ASSERT_OK(term_signal);
   uv_close((uv_handle_t*) process, close_cb);
 }
@@ -86,7 +86,7 @@ static void kill_cb(uv_process_t* process,
   printf("exit_cb\n");
   exit_cb_called++;
 #ifdef _WIN32
-  ASSERT_EQ(exit_status, 1);
+  ASSERT_EQ(1, exit_status);
 #else
   ASSERT_OK(exit_status);
 #endif
@@ -250,8 +250,8 @@ TEST_IMPL(spawn_empty_env) {
   ASSERT_OK(uv_spawn(uv_default_loop(), &process, &options));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -269,8 +269,8 @@ TEST_IMPL(spawn_exit_code) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -300,8 +300,8 @@ TEST_IMPL(spawn_stdout) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* Once for process once for the pipe. */
   printf("output is: %s", output);
   ASSERT_OK(strcmp("hello world\n", output));
 
@@ -341,12 +341,12 @@ TEST_IMPL(spawn_stdout_to_file) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT_EQ(r, 12);
+  ASSERT_EQ(12, r);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -397,12 +397,12 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT_EQ(r, 27);
+  ASSERT_EQ(27, r);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -459,12 +459,12 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   buf = uv_buf_init(output, sizeof(output));
   r = uv_fs_read(NULL, &fs_req, file, &buf, 1, 0, NULL);
-  ASSERT_EQ(r, 27);
+  ASSERT_EQ(27, r);
   uv_fs_req_cleanup(&fs_req);
 
   r = uv_fs_close(NULL, &fs_req, file, NULL);
@@ -536,8 +536,8 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   buf = uv_buf_init(output, sizeof(output));
 
@@ -611,8 +611,8 @@ TEST_IMPL(spawn_stdin) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3); /* Once for process twice for the pipe. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(3, close_cb_called); /* Once for process twice for the pipe. */
   ASSERT_OK(strcmp(buffer, output));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -645,8 +645,8 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* Once for process once for the pipe. */
   printf("output from stdio[3] is: %s", output);
   ASSERT_OK(strcmp("fourth stdio!\n", output));
 
@@ -725,8 +725,8 @@ TEST_IMPL(spawn_tcp_server) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -747,8 +747,8 @@ TEST_IMPL(spawn_ignored_stdio) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -772,8 +772,8 @@ TEST_IMPL(spawn_and_kill) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2); /* Once for process and once for timer. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* Once for process and once for timer. */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -809,8 +809,8 @@ TEST_IMPL(spawn_preserve_env) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   printf("output is: %s", output);
   ASSERT_OK(strcmp("testval", output));
@@ -900,8 +900,8 @@ TEST_IMPL(spawn_and_kill_with_std) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 5); /* process x 1, timer x 1, stdio x 3. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(5, close_cb_called); /* process x 1, timer x 1, stdio x 3. */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -947,7 +947,7 @@ TEST_IMPL(spawn_and_ping) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
   ASSERT_OK(strcmp(output, "TEST"));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -994,7 +994,7 @@ TEST_IMPL(spawn_same_stdout_stderr) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
   ASSERT_OK(strcmp(output, "TEST"));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -1026,8 +1026,8 @@ TEST_IMPL(spawn_closed_process_io) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2); /* process, child stdin */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* process, child stdin */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1080,8 +1080,8 @@ TEST_IMPL(kill) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1130,8 +1130,8 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2); /* Once for process once for the pipe. */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* Once for process once for the pipe. */
   printf("output is: %s", output);
   ASSERT_OK(strcmp("hello world\n", output));
 
@@ -1327,7 +1327,7 @@ TEST_IMPL(environment_creation) {
     }
     if (prev) { /* verify sort order */
 #if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
-      ASSERT_EQ(CompareStringOrdinal(prev, -1, str, -1, TRUE), 1);
+      ASSERT_EQ(1, CompareStringOrdinal(prev, -1, str, -1, TRUE));
 #endif
     }
     ASSERT(found); /* verify that we expected this variable */
@@ -1386,8 +1386,8 @@ TEST_IMPL(spawn_no_path) {
   ASSERT_OK(uv_spawn(uv_default_loop(), &process, &options));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   SetEnvironmentVariableW(L"PATH", old_path);
 
@@ -1431,8 +1431,8 @@ TEST_IMPL(spawn_setuid_setgid) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1664,8 +1664,8 @@ TEST_IMPL(spawn_fs_open) {
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_OK(uv_fs_close(NULL, &fs_req, r, NULL));
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);  /* One for `in`, one for process */
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called);  /* One for `in`, one for process */
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1708,19 +1708,19 @@ TEST_IMPL(closed_fd_events) {
                           on_read_once));
 
   ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT_EQ(req.result, 1);
+  ASSERT_EQ(1, req.result);
   uv_fs_req_cleanup(&req);
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
 
   /* should have received just one byte */
-  ASSERT_EQ(output_used, 1);
+  ASSERT_EQ(1, output_used);
 
   /* close the pipe and see if we still get events */
   uv_close((uv_handle_t*) &pipe_handle, close_cb);
 
   ASSERT_EQ(1, uv_fs_write(NULL, &req, fd[1], bufs, 1, -1, NULL));
-  ASSERT_EQ(req.result, 1);
+  ASSERT_EQ(1, req.result);
   uv_fs_req_cleanup(&req);
 
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer));
@@ -1731,7 +1731,7 @@ TEST_IMPL(closed_fd_events) {
     /* have to run again to really trigger the timer */
     ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
 
-  ASSERT_EQ(timer_counter, 1);
+  ASSERT_EQ(1, timer_counter);
 
   /* cleanup */
   ASSERT_OK(uv_process_kill(&process, SIGTERM));
@@ -1808,8 +1808,8 @@ TEST_IMPL(spawn_reads_child_path) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -1889,8 +1889,8 @@ TEST_IMPL(spawn_inherit_streams) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(3, close_cb_called);
 
   r = memcmp(ubuf, output, sizeof ubuf);
   ASSERT_OK(r);
@@ -1955,8 +1955,8 @@ TEST_IMPL(spawn_exercise_sigchld_issue) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 101);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(101, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -52,8 +52,8 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT(exit_status == 0);
-  ASSERT(term_signal == 0);
+  ASSERT_EQ(exit_status, 0);
+  ASSERT_EQ(term_signal, 0);
   uv_close((uv_handle_t*)process, close_cb);
   uv_close((uv_handle_t*)&in, close_cb);
   uv_close((uv_handle_t*)&out, close_cb);
@@ -62,7 +62,7 @@ static void exit_cb(uv_process_t* process,
 
 static void init_process_options(char* test, uv_exit_cb exit_cb) {
   int r = uv_exepath(exepath, &exepath_size);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   exepath[exepath_size] = '\0';
   args[0] = exepath;
   args[1] = test;
@@ -104,11 +104,11 @@ static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* rdbuf) {
   if (nread > 0) {
     output_used += nread;
     if (output_used % 12 == 0) {
-      ASSERT(memcmp("hello world\n", output, 12) == 0);
+      ASSERT_EQ(memcmp("hello world\n", output, 12), 0);
       wrbuf = uv_buf_init(output, 12);
       req = malloc(sizeof(*req));
       r = uv_write(req, (uv_stream_t*) &in, &wrbuf, 1, after_write);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
   }
 
@@ -140,20 +140,20 @@ static void test_stdio_over_pipes(int overlapped) {
   options.stdio_count = 3;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(on_read_cb_called > 1);
-  ASSERT(after_write_cb_called == 2);
-  ASSERT(exit_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(memcmp("hello world\nhello world\n", output, 24) == 0);
-  ASSERT(output_used == 24);
+  ASSERT_GT(on_read_cb_called, 1);
+  ASSERT_EQ(after_write_cb_called, 2);
+  ASSERT_EQ(exit_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(memcmp("hello world\nhello world\n", output, 24), 0);
+  ASSERT_EQ(output_used, 24);
 
   MAKE_VALGRIND_HAPPY(loop);
 }
@@ -179,8 +179,8 @@ static uv_pipe_t stdin_pipe2;
 static uv_pipe_t stdout_pipe2;
 
 static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT(nread > 0);
-  ASSERT(memcmp("hello world\n", buf->base, nread) == 0);
+  ASSERT_GT(nread, 0);
+  ASSERT_EQ(memcmp("hello world\n", buf->base, nread), 0);
   on_pipe_read_called++;
 
   free(buf->base);
@@ -190,7 +190,7 @@ static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) 
 
 
 static void after_pipe_write(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   after_write_called++;
 }
 
@@ -222,17 +222,17 @@ int stdio_over_pipes_helper(void) {
   int r;
   uv_loop_t* loop = uv_default_loop();
 
-  ASSERT(UV_NAMED_PIPE == uv_guess_handle(0));
-  ASSERT(UV_NAMED_PIPE == uv_guess_handle(1));
+  ASSERT_EQ(UV_NAMED_PIPE, uv_guess_handle(0));
+  ASSERT_EQ(UV_NAMED_PIPE, uv_guess_handle(1));
 
   r = uv_pipe_init(loop, &stdin_pipe1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdout_pipe1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdin_pipe2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_pipe_init(loop, &stdout_pipe2, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_pipe_open(&stdin_pipe1, 0);
   uv_pipe_open(&stdout_pipe1, 1);
@@ -256,15 +256,15 @@ int stdio_over_pipes_helper(void) {
                    &buf[i],
                    1,
                    after_pipe_write);
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     }
 
     notify_parent_process();
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(after_write_called == 7 * (j + 1));
-    ASSERT(on_pipe_read_called == j);
-    ASSERT(close_cb_called == 0);
+    ASSERT_EQ(after_write_called, 7 * (j + 1));
+    ASSERT_EQ(on_pipe_read_called, j);
+    ASSERT_EQ(close_cb_called, 0);
 
     uv_ref((uv_handle_t*) &stdout_pipe1);
     uv_ref((uv_handle_t*) &stdin_pipe1);
@@ -274,13 +274,13 @@ int stdio_over_pipes_helper(void) {
     r = uv_read_start((uv_stream_t*) (j == 0 ? &stdin_pipe1 : &stdin_pipe2),
                       on_read_alloc,
                       on_pipe_read);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     uv_run(loop, UV_RUN_DEFAULT);
 
-    ASSERT(after_write_called == 7 * (j + 1));
-    ASSERT(on_pipe_read_called == j + 1);
-    ASSERT(close_cb_called == 0);
+    ASSERT_EQ(after_write_called, 7 * (j + 1));
+    ASSERT_EQ(on_pipe_read_called, j + 1);
+    ASSERT_EQ(close_cb_called, 0);
   }
 
   uv_close((uv_handle_t*)&stdin_pipe1, close_cb);
@@ -290,9 +290,9 @@ int stdio_over_pipes_helper(void) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(after_write_called == 14);
-  ASSERT(on_pipe_read_called == 2);
-  ASSERT(close_cb_called == 4);
+  ASSERT_EQ(after_write_called, 14);
+  ASSERT_EQ(on_pipe_read_called, 2);
+  ASSERT_EQ(close_cb_called, 4);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -149,11 +149,11 @@ static void test_stdio_over_pipes(int overlapped) {
   ASSERT_OK(r);
 
   ASSERT_GT(on_read_cb_called, 1);
-  ASSERT_EQ(after_write_cb_called, 2);
-  ASSERT_EQ(exit_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(2, after_write_cb_called);
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(3, close_cb_called);
   ASSERT_OK(memcmp("hello world\nhello world\n", output, 24));
-  ASSERT_EQ(output_used, 24);
+  ASSERT_EQ(24, output_used);
 
   MAKE_VALGRIND_HAPPY(loop);
 }
@@ -290,9 +290,9 @@ int stdio_over_pipes_helper(void) {
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT_EQ(after_write_called, 14);
-  ASSERT_EQ(on_pipe_read_called, 2);
-  ASSERT_EQ(close_cb_called, 4);
+  ASSERT_EQ(14, after_write_called);
+  ASSERT_EQ(2, on_pipe_read_called);
+  ASSERT_EQ(4, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -52,8 +52,8 @@ static void exit_cb(uv_process_t* process,
                     int term_signal) {
   printf("exit_cb\n");
   exit_cb_called++;
-  ASSERT_EQ(exit_status, 0);
-  ASSERT_EQ(term_signal, 0);
+  ASSERT_OK(exit_status);
+  ASSERT_OK(term_signal);
   uv_close((uv_handle_t*)process, close_cb);
   uv_close((uv_handle_t*)&in, close_cb);
   uv_close((uv_handle_t*)&out, close_cb);
@@ -62,7 +62,7 @@ static void exit_cb(uv_process_t* process,
 
 static void init_process_options(char* test, uv_exit_cb exit_cb) {
   int r = uv_exepath(exepath, &exepath_size);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   exepath[exepath_size] = '\0';
   args[0] = exepath;
   args[1] = test;
@@ -104,11 +104,11 @@ static void on_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* rdbuf) {
   if (nread > 0) {
     output_used += nread;
     if (output_used % 12 == 0) {
-      ASSERT_EQ(memcmp("hello world\n", output, 12), 0);
+      ASSERT_OK(memcmp("hello world\n", output, 12));
       wrbuf = uv_buf_init(output, 12);
       req = malloc(sizeof(*req));
       r = uv_write(req, (uv_stream_t*) &in, &wrbuf, 1, after_write);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
     }
   }
 
@@ -140,19 +140,19 @@ static void test_stdio_over_pipes(int overlapped) {
   options.stdio_count = 3;
 
   r = uv_spawn(loop, &process, &options);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_GT(on_read_cb_called, 1);
   ASSERT_EQ(after_write_cb_called, 2);
   ASSERT_EQ(exit_cb_called, 1);
   ASSERT_EQ(close_cb_called, 3);
-  ASSERT_EQ(memcmp("hello world\nhello world\n", output, 24), 0);
+  ASSERT_OK(memcmp("hello world\nhello world\n", output, 24));
   ASSERT_EQ(output_used, 24);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -180,7 +180,7 @@ static uv_pipe_t stdout_pipe2;
 
 static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) {
   ASSERT_GT(nread, 0);
-  ASSERT_EQ(memcmp("hello world\n", buf->base, nread), 0);
+  ASSERT_OK(memcmp("hello world\n", buf->base, nread));
   on_pipe_read_called++;
 
   free(buf->base);
@@ -190,7 +190,7 @@ static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf) 
 
 
 static void after_pipe_write(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   after_write_called++;
 }
 
@@ -226,13 +226,13 @@ int stdio_over_pipes_helper(void) {
   ASSERT_EQ(UV_NAMED_PIPE, uv_guess_handle(1));
 
   r = uv_pipe_init(loop, &stdin_pipe1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_init(loop, &stdout_pipe1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_init(loop, &stdin_pipe2, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_pipe_init(loop, &stdout_pipe2, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_pipe_open(&stdin_pipe1, 0);
   uv_pipe_open(&stdout_pipe1, 1);
@@ -256,7 +256,7 @@ int stdio_over_pipes_helper(void) {
                    &buf[i],
                    1,
                    after_pipe_write);
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
     }
 
     notify_parent_process();
@@ -264,7 +264,7 @@ int stdio_over_pipes_helper(void) {
 
     ASSERT_EQ(after_write_called, 7 * (j + 1));
     ASSERT_EQ(on_pipe_read_called, j);
-    ASSERT_EQ(close_cb_called, 0);
+    ASSERT_OK(close_cb_called);
 
     uv_ref((uv_handle_t*) &stdout_pipe1);
     uv_ref((uv_handle_t*) &stdin_pipe1);
@@ -274,13 +274,13 @@ int stdio_over_pipes_helper(void) {
     r = uv_read_start((uv_stream_t*) (j == 0 ? &stdin_pipe1 : &stdin_pipe2),
                       on_read_alloc,
                       on_pipe_read);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     uv_run(loop, UV_RUN_DEFAULT);
 
     ASSERT_EQ(after_write_called, 7 * (j + 1));
     ASSERT_EQ(on_pipe_read_called, j + 1);
-    ASSERT_EQ(close_cb_called, 0);
+    ASSERT_OK(close_cb_called);
   }
 
   uv_close((uv_handle_t*)&stdin_pipe1, close_cb);

--- a/test/test-strscpy.c
+++ b/test/test-strscpy.c
@@ -29,25 +29,25 @@
 TEST_IMPL(strscpy) {
   char d[4];
 
-  ASSERT(0 == uv__strscpy(d, "", 0));
-  ASSERT(0 == uv__strscpy(d, "x", 0));
+  ASSERT_EQ(0, uv__strscpy(d, "", 0));
+  ASSERT_EQ(0, uv__strscpy(d, "x", 0));
 
   memset(d, 0, sizeof(d));
-  ASSERT(1 == uv__strscpy(d, "x", sizeof(d)));
-  ASSERT(0 == memcmp(d, "x\0\0", sizeof(d)));
+  ASSERT_EQ(1, uv__strscpy(d, "x", sizeof(d)));
+  ASSERT_EQ(0, memcmp(d, "x\0\0", sizeof(d)));
 
   memset(d, 0, sizeof(d));
-  ASSERT(2 == uv__strscpy(d, "xy", sizeof(d)));
-  ASSERT(0 == memcmp(d, "xy\0", sizeof(d)));
+  ASSERT_EQ(2, uv__strscpy(d, "xy", sizeof(d)));
+  ASSERT_EQ(0, memcmp(d, "xy\0", sizeof(d)));
 
-  ASSERT(3 == uv__strscpy(d, "xyz", sizeof(d)));
-  ASSERT(0 == memcmp(d, "xyz", sizeof(d)));
+  ASSERT_EQ(3, uv__strscpy(d, "xyz", sizeof(d)));
+  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
 
-  ASSERT(UV_E2BIG == uv__strscpy(d, "xyzz", sizeof(d)));
-  ASSERT(0 == memcmp(d, "xyz", sizeof(d)));
+  ASSERT_EQ(UV_E2BIG, uv__strscpy(d, "xyzz", sizeof(d)));
+  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
 
-  ASSERT(UV_E2BIG == uv__strscpy(d, "xyzzy", sizeof(d)));
-  ASSERT(0 == memcmp(d, "xyz", sizeof(d)));
+  ASSERT_EQ(UV_E2BIG, uv__strscpy(d, "xyzzy", sizeof(d)));
+  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
 
   return 0;
 }

--- a/test/test-strscpy.c
+++ b/test/test-strscpy.c
@@ -29,25 +29,25 @@
 TEST_IMPL(strscpy) {
   char d[4];
 
-  ASSERT_EQ(0, uv__strscpy(d, "", 0));
-  ASSERT_EQ(0, uv__strscpy(d, "x", 0));
+  ASSERT_OK(uv__strscpy(d, "", 0));
+  ASSERT_OK(uv__strscpy(d, "x", 0));
 
   memset(d, 0, sizeof(d));
   ASSERT_EQ(1, uv__strscpy(d, "x", sizeof(d)));
-  ASSERT_EQ(0, memcmp(d, "x\0\0", sizeof(d)));
+  ASSERT_OK(memcmp(d, "x\0\0", sizeof(d)));
 
   memset(d, 0, sizeof(d));
   ASSERT_EQ(2, uv__strscpy(d, "xy", sizeof(d)));
-  ASSERT_EQ(0, memcmp(d, "xy\0", sizeof(d)));
+  ASSERT_OK(memcmp(d, "xy\0", sizeof(d)));
 
   ASSERT_EQ(3, uv__strscpy(d, "xyz", sizeof(d)));
-  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
+  ASSERT_OK(memcmp(d, "xyz", sizeof(d)));
 
   ASSERT_EQ(UV_E2BIG, uv__strscpy(d, "xyzz", sizeof(d)));
-  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
+  ASSERT_OK(memcmp(d, "xyz", sizeof(d)));
 
   ASSERT_EQ(UV_E2BIG, uv__strscpy(d, "xyzzy", sizeof(d)));
-  ASSERT_EQ(0, memcmp(d, "xyz", sizeof(d)));
+  ASSERT_OK(memcmp(d, "xyz", sizeof(d)));
 
   return 0;
 }

--- a/test/test-strtok.c
+++ b/test/test-strtok.c
@@ -56,7 +56,7 @@ const char* tokens[] = {
 };
 
 #define ASSERT_STRCMP(x, y) \
-  ASSERT((x != NULL && y != NULL && strcmp(x, y) == 0) || (x == y && x == NULL))
+  ASSERT_NE((x != NULL && y != NULL && strcmp(x, y) == 0) || (x == y && x == NULL), 0)
 
 TEST_IMPL(strtok) {
   struct strtok_test_case tests[] = {
@@ -74,13 +74,13 @@ TEST_IMPL(strtok) {
   char current_test[2048];
 
   for (i = 0, j = 0; i < tests_len; i += 1) {
-    ASSERT(j < tokens_len);
+    ASSERT_LT(j, tokens_len);
     snprintf(current_test, sizeof(current_test), "%s", tests[i].str);
     tok_r = uv__strtok(current_test, tests[i].sep, &itr);
     ASSERT_STRCMP(tok_r, tokens[j]);
     j++;
     while (tok_r) {
-      ASSERT(j < tokens_len);
+      ASSERT_LT(j, tokens_len);
       tok_r = uv__strtok(NULL, tests[i].sep, &itr);
       ASSERT_STRCMP(tok_r, tokens[j]);
       j++;

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -42,7 +42,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 static void conn_alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
@@ -52,9 +52,9 @@ static void conn_alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void conn_read_cb(uv_stream_t* stream,
                          ssize_t nread,
                          const uv_buf_t* buf) {
-  ASSERT(nread == UV_ENOBUFS);
+  ASSERT_EQ(nread, UV_ENOBUFS);
   ASSERT_NULL(buf->base);
-  ASSERT(buf->len == 0);
+  ASSERT_EQ(buf->len, 0);
 
   uv_close((uv_handle_t*) &incoming, close_cb);
   uv_close((uv_handle_t*) &client, close_cb);
@@ -65,23 +65,23 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   buf = uv_buf_init(hello, sizeof(hello));
   r = uv_write(&write_req, req->handle, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
-  ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
-  ASSERT(0 == uv_read_start((uv_stream_t*) &incoming,
-                            conn_alloc_cb,
-                            conn_read_cb));
+  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &incoming,
+                             conn_alloc_cb,
+                             conn_read_cb));
 
   connection_cb_called++;
 }
@@ -90,11 +90,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
-  ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -104,19 +104,19 @@ TEST_IMPL(tcp_alloc_cb_fail) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client,
-                             (struct sockaddr*) &addr,
-                             connect_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client,
+                              (struct sockaddr*) &addr,
+                              connect_cb));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(connection_cb_called == 1);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -114,9 +114,9 @@ TEST_IMPL(tcp_alloc_cb_fail) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(connection_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, connection_cb_called);
+  ASSERT_EQ(3, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-alloc-cb-fail.c
+++ b/test/test-tcp-alloc-cb-fail.c
@@ -42,7 +42,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 static void conn_alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
@@ -54,7 +54,7 @@ static void conn_read_cb(uv_stream_t* stream,
                          const uv_buf_t* buf) {
   ASSERT_EQ(nread, UV_ENOBUFS);
   ASSERT_NULL(buf->base);
-  ASSERT_EQ(buf->len, 0);
+  ASSERT_OK(buf->len);
 
   uv_close((uv_handle_t*) &incoming, close_cb);
   uv_close((uv_handle_t*) &client, close_cb);
@@ -65,23 +65,23 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called++;
 
   buf = uv_buf_init(hello, sizeof(hello));
   r = uv_write(&write_req, req->handle, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
-  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
-  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &incoming,
-                             conn_alloc_cb,
-                             conn_read_cb));
+  ASSERT_OK(uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &incoming,
+                          conn_alloc_cb,
+                          conn_read_cb));
 
   connection_cb_called++;
 }
@@ -90,11 +90,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -104,15 +104,15 @@ TEST_IMPL(tcp_alloc_cb_fail) {
 
   start_server();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client,
-                              (struct sockaddr*) &addr,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client,
+                           (struct sockaddr*) &addr,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(connection_cb_called, 1);

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -36,7 +36,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == UV_EADDRINUSE);
+  ASSERT_EQ(status, UV_EADDRINUSE);
   uv_close((uv_handle_t*) req->handle, close_cb);
   connect_cb_called++;
 }
@@ -53,24 +53,24 @@ TEST_IMPL(tcp_bind_error_addrinuse_connect) {
    * (greatest common denominator across platforms) but the connect callback
    * should receive an UV_EADDRINUSE error.
    */
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &conn));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_tcp_bind(&conn, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &conn));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_tcp_bind(&conn, (const struct sockaddr*) &addr, 0));
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT + 1, &addr));
-  ASSERT(0 == uv_tcp_connect(&req,
-                             &conn,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT + 1, &addr));
+  ASSERT_EQ(0, uv_tcp_connect(&req,
+                              &conn,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
 
   addrlen = sizeof(addr);
-  ASSERT(UV_EADDRINUSE == uv_tcp_getsockname(&conn,
-                                             (struct sockaddr*) &addr,
-                                             &addrlen));
+  ASSERT_EQ(UV_EADDRINUSE, uv_tcp_getsockname(&conn,
+                                              (struct sockaddr*) &addr,
+                                              &addrlen));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -82,28 +82,28 @@ TEST_IMPL(tcp_bind_error_addrinuse_listen) {
   uv_tcp_t server1, server2;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -115,10 +115,10 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.255.255.255", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.255.255.255", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* It seems that Linux is broken here - bind succeeds. */
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
@@ -128,7 +128,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -140,18 +140,18 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("4.4.4.4", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("4.4.4.4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRNOTAVAIL);
+  ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -168,15 +168,15 @@ TEST_IMPL(tcp_bind_error_fault) {
   garbage_addr = (struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -190,21 +190,21 @@ TEST_IMPL(tcp_bind_error_inval) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr1));
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT_2, &addr2));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr1));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -216,12 +216,12 @@ TEST_IMPL(tcp_bind_localhost_ok) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -233,12 +233,12 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   uv_tcp_t server;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, UV_TCP_IPV6ONLY);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -250,9 +250,9 @@ TEST_IMPL(tcp_listen_without_bind) {
   uv_tcp_t server;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -267,32 +267,32 @@ TEST_IMPL(tcp_bind_writable_flags) {
   uv_shutdown_t shutdown_req;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_is_writable((uv_stream_t*) &server));
-  ASSERT(0 == uv_is_readable((uv_stream_t*) &server));
+  ASSERT_EQ(0, uv_is_writable((uv_stream_t*) &server));
+  ASSERT_EQ(0, uv_is_readable((uv_stream_t*) &server));
 
   buf = uv_buf_init("PING", 4);
   r = uv_write(&write_req, (uv_stream_t*) &server, &buf, 1, NULL);
-  ASSERT(r == UV_EPIPE);
+  ASSERT_EQ(r, UV_EPIPE);
   r = uv_shutdown(&shutdown_req, (uv_stream_t*) &server, NULL);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
   r = uv_read_start((uv_stream_t*) &server,
                     (uv_alloc_cb) abort,
                     (uv_read_cb) abort);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -53,22 +53,22 @@ TEST_IMPL(tcp_bind_error_addrinuse_connect) {
    * (greatest common denominator across platforms) but the connect callback
    * should receive an UV_EADDRINUSE error.
    */
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &conn));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_tcp_bind(&conn, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &conn));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_tcp_bind(&conn, (const struct sockaddr*) &addr, 0));
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT + 1, &addr));
-  ASSERT_EQ(0, uv_tcp_connect(&req,
-                              &conn,
-                              (const struct sockaddr*) &addr,
-                              connect_cb));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT + 1, &addr));
+  ASSERT_OK(uv_tcp_connect(&req,
+                           &conn,
+                           (const struct sockaddr*) &addr,
+                           connect_cb));
 
   addrlen = sizeof(addr);
   ASSERT_EQ(UV_EADDRINUSE, uv_tcp_getsockname(&conn,
                                               (struct sockaddr*) &addr,
                                               &addrlen));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(close_cb_called, 1);
 
@@ -82,19 +82,19 @@ TEST_IMPL(tcp_bind_error_addrinuse_listen) {
   uv_tcp_t server1, server2;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT_EQ(r, UV_EADDRINUSE);
 
@@ -115,10 +115,10 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
   uv_tcp_t server;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.255.255.255", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.255.255.255", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* It seems that Linux is broken here - bind succeeds. */
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
@@ -140,10 +140,10 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
   uv_tcp_t server;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("4.4.4.4", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("4.4.4.4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
@@ -168,7 +168,7 @@ TEST_IMPL(tcp_bind_error_fault) {
   garbage_addr = (struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -190,13 +190,13 @@ TEST_IMPL(tcp_bind_error_inval) {
   uv_tcp_t server;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr1));
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT_2, &addr2));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr1));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -216,12 +216,12 @@ TEST_IMPL(tcp_bind_localhost_ok) {
   uv_tcp_t server;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -233,10 +233,10 @@ TEST_IMPL(tcp_bind_invalid_flags) {
   uv_tcp_t server;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, UV_TCP_IPV6ONLY);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -250,9 +250,9 @@ TEST_IMPL(tcp_listen_without_bind) {
   uv_tcp_t server;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -267,16 +267,16 @@ TEST_IMPL(tcp_bind_writable_flags) {
   uv_shutdown_t shutdown_req;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&server, 128, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_is_writable((uv_stream_t*) &server));
-  ASSERT_EQ(0, uv_is_readable((uv_stream_t*) &server));
+  ASSERT_OK(uv_is_writable((uv_stream_t*) &server));
+  ASSERT_OK(uv_is_readable((uv_stream_t*) &server));
 
   buf = uv_buf_init("PING", 4);
   r = uv_write(&write_req, (uv_stream_t*) &server, &buf, 1, NULL);
@@ -307,11 +307,11 @@ TEST_IMPL(tcp_bind_or_listen_error_after_close) {
   addr.sin_port = htons(9999);
   addr.sin_family = AF_INET;
 
-  ASSERT_EQ(uv_tcp_init(uv_default_loop(), &tcp), 0);
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &tcp));
   uv_close((uv_handle_t*) &tcp, NULL);
   ASSERT_EQ(uv_tcp_bind(&tcp, (struct sockaddr*) &addr, 0), UV_EINVAL);
   ASSERT_EQ(uv_listen((uv_stream_t*) &tcp, 5, NULL), UV_EINVAL);
-  ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-tcp-bind-error.c
+++ b/test/test-tcp-bind-error.c
@@ -69,8 +69,8 @@ TEST_IMPL(tcp_bind_error_addrinuse_connect) {
                                               &addrlen));
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -103,7 +103,7 @@ TEST_IMPL(tcp_bind_error_addrinuse_listen) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -128,7 +128,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_1) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -151,7 +151,7 @@ TEST_IMPL(tcp_bind_error_addrnotavail_2) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -176,7 +176,7 @@ TEST_IMPL(tcp_bind_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -204,7 +204,7 @@ TEST_IMPL(tcp_bind_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -292,7 +292,7 @@ TEST_IMPL(tcp_bind_writable_flags) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -42,29 +42,29 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*)&server1, close_cb);
   uv_close((uv_handle_t*)&server2, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -79,18 +79,18 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRNOTAVAIL);
+  ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -110,15 +110,15 @@ TEST_IMPL(tcp_bind6_error_fault) {
   garbage_addr = (struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -135,21 +135,21 @@ TEST_IMPL(tcp_bind6_error_inval) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr1));
-  ASSERT(0 == uv_ip6_addr("::", TEST_PORT_2, &addr2));
+  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr1));
+  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -164,12 +164,12 @@ TEST_IMPL(tcp_bind6_localhost_ok) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("::1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -64,7 +64,7 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -90,7 +90,7 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -118,7 +118,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -149,7 +149,7 @@ TEST_IMPL(tcp_bind6_error_inval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-bind6-error.c
+++ b/test/test-tcp-bind6-error.c
@@ -42,20 +42,20 @@ TEST_IMPL(tcp_bind6_error_addrinuse) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server1, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &server2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server2, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&server1, 128, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_listen((uv_stream_t*)&server2, 128, NULL);
   ASSERT_EQ(r, UV_EADDRINUSE);
 
@@ -79,10 +79,10 @@ TEST_IMPL(tcp_bind6_error_addrnotavail) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip6_addr("4:4:4:4:4:4:4:4", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
   ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 
@@ -110,7 +110,7 @@ TEST_IMPL(tcp_bind6_error_fault) {
   garbage_addr = (struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) garbage_addr, 0);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -135,13 +135,13 @@ TEST_IMPL(tcp_bind6_error_inval) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr1));
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT_2, &addr2));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &addr1));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT_2, &addr2));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr2, 0);
   ASSERT_EQ(r, UV_EINVAL);
 
@@ -164,12 +164,12 @@ TEST_IMPL(tcp_bind6_localhost_ok) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -91,7 +91,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   pending_incoming = (uv_tcp_t*) stream - &tcp_incoming[0];
   ASSERT_LT(pending_incoming, got_connections);
   ASSERT_OK(uv_read_stop(stream));
-  ASSERT_EQ(nread, 1);
+  ASSERT_EQ(1, nread);
 
   loop = stream->loop;
   read_cb_called++;
@@ -185,7 +185,7 @@ TEST_IMPL(tcp_close_accept) {
   ASSERT_EQ(ARRAY_SIZE(tcp_outgoing), got_connections);
   ASSERT_EQ((ARRAY_SIZE(tcp_outgoing) + 2), close_cb_called);
   ASSERT_EQ(ARRAY_SIZE(tcp_outgoing), write_cb_called);
-  ASSERT_EQ(read_cb_called, 1);
+  ASSERT_EQ(1, read_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-close-accept.c
+++ b/test/test-tcp-close-accept.c
@@ -47,7 +47,7 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
@@ -57,7 +57,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* outgoing;
 
   if (req == &tcp_check_req) {
-    ASSERT(status != 0);
+    ASSERT(status);
 
     /*
      * Time to finish the test: close both the check and pending incoming
@@ -68,14 +68,14 @@ static void connect_cb(uv_connect_t* req, int status) {
     return;
   }
 
-  ASSERT(status == 0);
-  ASSERT(connect_reqs <= req);
-  ASSERT(req <= connect_reqs + ARRAY_SIZE(connect_reqs));
+  ASSERT_EQ(status, 0);
+  ASSERT_LE(connect_reqs, req);
+  ASSERT_LE(req, connect_reqs + ARRAY_SIZE(connect_reqs));
   i = req - connect_reqs;
 
   buf = uv_buf_init("x", 1);
   outgoing = (uv_stream_t*) &tcp_outgoing[i];
-  ASSERT(0 == uv_write(&write_reqs[i], outgoing, &buf, 1, write_cb));
+  ASSERT_EQ(0, uv_write(&write_reqs[i], outgoing, &buf, 1, write_cb));
 }
 
 static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
@@ -89,9 +89,9 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   unsigned int i;
 
   pending_incoming = (uv_tcp_t*) stream - &tcp_incoming[0];
-  ASSERT(pending_incoming < got_connections);
-  ASSERT(0 == uv_read_stop(stream));
-  ASSERT(1 == nread);
+  ASSERT_LT(pending_incoming, got_connections);
+  ASSERT_EQ(0, uv_read_stop(stream));
+  ASSERT_EQ(nread, 1);
 
   loop = stream->loop;
   read_cb_called++;
@@ -106,19 +106,19 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   uv_close((uv_handle_t*) &tcp_server, close_cb);
 
   /* Create new fd that should be one of the closed incomings */
-  ASSERT(0 == uv_tcp_init(loop, &tcp_check));
-  ASSERT(0 == uv_tcp_connect(&tcp_check_req,
-                             &tcp_check,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_read_start((uv_stream_t*) &tcp_check, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_check));
+  ASSERT_EQ(0, uv_tcp_connect(&tcp_check_req,
+                              &tcp_check,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &tcp_check, alloc_cb, read_cb));
 }
 
 static void connection_cb(uv_stream_t* server, int status) {
   unsigned int i;
   uv_tcp_t* incoming;
 
-  ASSERT(server == (uv_stream_t*) &tcp_server);
+  ASSERT_PTR_EQ(server, (uv_stream_t*) &tcp_server);
 
   /* Ignore tcp_check connection */
   if (got_connections == ARRAY_SIZE(tcp_incoming))
@@ -126,8 +126,8 @@ static void connection_cb(uv_stream_t* server, int status) {
 
   /* Accept everyone */
   incoming = &tcp_incoming[got_connections++];
-  ASSERT(0 == uv_tcp_init(server->loop, incoming));
-  ASSERT(0 == uv_accept(server, (uv_stream_t*) incoming));
+  ASSERT_EQ(0, uv_tcp_init(server->loop, incoming));
+  ASSERT_EQ(0, uv_accept(server, (uv_stream_t*) incoming));
 
   if (got_connections != ARRAY_SIZE(tcp_incoming))
     return;
@@ -135,7 +135,7 @@ static void connection_cb(uv_stream_t* server, int status) {
   /* Once all clients are accepted - start reading */
   for (i = 0; i < ARRAY_SIZE(tcp_incoming); i++) {
     incoming = &tcp_incoming[i];
-    ASSERT(0 == uv_read_start((uv_stream_t*) incoming, alloc_cb, read_cb));
+    ASSERT_EQ(0, uv_read_start((uv_stream_t*) incoming, alloc_cb, read_cb));
   }
 }
 
@@ -162,30 +162,30 @@ TEST_IMPL(tcp_close_accept) {
    */
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(loop, &tcp_server));
-  ASSERT(0 == uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &tcp_server,
+  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_server));
+  ASSERT_EQ(0, uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &tcp_server,
                         ARRAY_SIZE(tcp_outgoing),
                         connection_cb));
 
   for (i = 0; i < ARRAY_SIZE(tcp_outgoing); i++) {
     client = tcp_outgoing + i;
 
-    ASSERT(0 == uv_tcp_init(loop, client));
-    ASSERT(0 == uv_tcp_connect(&connect_reqs[i],
-                               client,
-                               (const struct sockaddr*) &addr,
-                               connect_cb));
+    ASSERT_EQ(0, uv_tcp_init(loop, client));
+    ASSERT_EQ(0, uv_tcp_connect(&connect_reqs[i],
+                                client,
+                                (const struct sockaddr*) &addr,
+                                connect_cb));
   }
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(ARRAY_SIZE(tcp_outgoing) == got_connections);
-  ASSERT((ARRAY_SIZE(tcp_outgoing) + 2) == close_cb_called);
-  ASSERT(ARRAY_SIZE(tcp_outgoing) == write_cb_called);
-  ASSERT(1 == read_cb_called);
+  ASSERT_EQ(ARRAY_SIZE(tcp_outgoing), got_connections);
+  ASSERT_EQ((ARRAY_SIZE(tcp_outgoing) + 2), close_cb_called);
+  ASSERT_EQ(ARRAY_SIZE(tcp_outgoing), write_cb_called);
+  ASSERT_EQ(read_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-close-after-read-timeout.c
+++ b/test/test-tcp-close-after-read-timeout.c
@@ -175,8 +175,8 @@ TEST_IMPL(tcp_close_after_read_timeout) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(read_cb_called, 1);
-  ASSERT_EQ(on_close_called, 3);
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(3, on_close_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-close-after-read-timeout.c
+++ b/test/test-tcp-close-after-read-timeout.c
@@ -112,9 +112,9 @@ static void on_connection(uv_stream_t* server, int status) {
 
 
 static void on_close(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &client ||
-         handle == (uv_handle_t*) &connection ||
-         handle == (uv_handle_t*) &timer);
+  ASSERT_NE(handle == (uv_handle_t*) &client ||
+            handle == (uv_handle_t*) &connection ||
+            handle == (uv_handle_t*) &timer, 0);
   on_close_called++;
 }
 

--- a/test/test-tcp-close-after-read-timeout.c
+++ b/test/test-tcp-close-after-read-timeout.c
@@ -48,10 +48,10 @@ static void on_client_connect(uv_connect_t* conn_req, int status) {
   int r;
 
   r = uv_read_start((uv_stream_t*) &client, on_client_alloc, on_client_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, on_client_timeout, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -73,7 +73,7 @@ static void on_client_read(uv_stream_t* stream, ssize_t nread,
 
 static void on_client_timeout(uv_timer_t* handle) {
   ASSERT_EQ(handle, &timer);
-  ASSERT_EQ(read_cb_called, 0);
+  ASSERT_OK(read_cb_called);
   uv_read_stop((uv_stream_t*) &client);
   uv_close((uv_handle_t*) &client, on_close);
   uv_close((uv_handle_t*) &timer, on_close);
@@ -101,13 +101,13 @@ static void on_connection_read(uv_stream_t* stream,
 static void on_connection(uv_stream_t* server, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(uv_accept(server, (uv_stream_t*) &connection), 0);
+  ASSERT_OK(status);
+  ASSERT_OK(uv_accept(server, (uv_stream_t*) &connection));
 
   r = uv_read_start((uv_stream_t*) &connection,
                     on_connection_alloc,
                     on_connection_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -123,16 +123,16 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr), 0);
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*) handle, 128, on_connection);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_unref((uv_handle_t*) handle);
 }
@@ -147,7 +147,7 @@ TEST_IMPL(tcp_close_after_read_timeout) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT_EQ(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr), 0);
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
@@ -155,25 +155,25 @@ TEST_IMPL(tcp_close_after_read_timeout) {
   start_server(loop, &tcp_server);
 
   r = uv_tcp_init(loop, &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      on_client_connect);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(loop, &connection);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(read_cb_called, 0);
-  ASSERT_EQ(on_close_called, 0);
+  ASSERT_OK(read_cb_called);
+  ASSERT_OK(on_close_called);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(read_cb_called, 1);
   ASSERT_EQ(on_close_called, 3);

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -62,7 +62,7 @@ static void do_write(uv_tcp_t* handle) {
   buf = uv_buf_init("PING", 4);
   for (i = 0; i < ARRAY_SIZE(write_reqs); i++) {
     r = uv_write(&write_reqs[i], (uv_stream_t*) handle, &buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -72,8 +72,10 @@ static void do_close(uv_tcp_t* handle) {
   int r;
 
   if (shutdown_before_close == 1) {
-    ASSERT(0 == uv_shutdown(&shutdown_req, (uv_stream_t*) handle, shutdown_cb));
-    ASSERT(UV_EINVAL == uv_tcp_close_reset(handle, close_cb));
+    ASSERT_EQ(0, uv_shutdown(&shutdown_req,
+                             (uv_stream_t*) handle,
+                             shutdown_cb));
+    ASSERT_EQ(UV_EINVAL, uv_tcp_close_reset(handle, close_cb));
   } else if (shutdown_before_close == 2) {
     r = uv_fileno((const uv_handle_t*) handle, &fd);
     ASSERT_EQ(r, 0);
@@ -85,8 +87,9 @@ static void do_close(uv_tcp_t* handle) {
 #endif
     ASSERT_EQ(0, uv_tcp_close_reset(handle, close_cb));
   } else {
-    ASSERT(0 == uv_tcp_close_reset(handle, close_cb));
-    ASSERT(UV_ENOTCONN == uv_shutdown(&shutdown_req, (uv_stream_t*) handle, shutdown_cb));
+    ASSERT_EQ(0, uv_tcp_close_reset(handle, close_cb));
+    ASSERT_EQ(UV_ENOTCONN, uv_shutdown(&shutdown_req, (uv_stream_t*) handle,
+              shutdown_cb));
   }
 
   uv_close((uv_handle_t*) &tcp_server, NULL);
@@ -99,14 +102,14 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 }
 
 static void read_cb2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)stream == &tcp_client);
+  ASSERT_PTR_EQ((uv_tcp_t*)stream, &tcp_client);
   if (nread == UV_EOF)
     uv_close((uv_handle_t*) stream, NULL);
 }
 
 
 static void connect_cb(uv_connect_t* conn_req, int status) {
-  ASSERT(conn_req == &connect_req);
+  ASSERT_PTR_EQ(conn_req, &connect_req);
   uv_read_start((uv_stream_t*) &tcp_client, alloc_cb, read_cb2);
   do_write(&tcp_client);
   if (client_close)
@@ -116,33 +119,33 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
-  ASSERT(close_cb_called == 0);
-  ASSERT(req->handle == (uv_stream_t*)&tcp_client);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_client);
   write_cb_called++;
 }
 
 
 static void close_cb(uv_handle_t* handle) {
   if (client_close)
-    ASSERT(handle == (uv_handle_t*) &tcp_client);
+    ASSERT_PTR_EQ(handle, (uv_handle_t*) &tcp_client);
   else
-    ASSERT(handle == (uv_handle_t*) &tcp_accepted);
+    ASSERT_PTR_EQ(handle, (uv_handle_t*) &tcp_accepted);
 
   close_cb_called++;
 }
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   if (client_close)
-    ASSERT(req->handle == (uv_stream_t*) &tcp_client);
+    ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &tcp_client);
   else
-    ASSERT(req->handle == (uv_stream_t*) &tcp_accepted);
+    ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &tcp_accepted);
 
   shutdown_cb_called++;
 }
 
 
 static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT((uv_tcp_t*)stream == &tcp_accepted);
+  ASSERT_PTR_EQ((uv_tcp_t*)stream, &tcp_accepted);
   if (nread < 0) {
     uv_close((uv_handle_t*) stream, NULL);
   } else {
@@ -154,10 +157,10 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connection_cb(uv_stream_t* server, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(loop, &tcp_accepted));
-  ASSERT(0 == uv_accept(server, (uv_stream_t*) &tcp_accepted));
+  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_accepted));
+  ASSERT_EQ(0, uv_accept(server, (uv_stream_t*) &tcp_accepted));
 
   uv_read_start((uv_stream_t*) &tcp_accepted, alloc_cb, read_cb);
 }
@@ -167,16 +170,16 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -184,16 +187,16 @@ static void do_connect(uv_loop_t* loop, uv_tcp_t* tcp_client) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -212,16 +215,16 @@ TEST_IMPL(tcp_close_reset_client) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 1);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -239,16 +242,16 @@ TEST_IMPL(tcp_close_reset_client_after_shutdown) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -266,16 +269,16 @@ TEST_IMPL(tcp_close_reset_accepted) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 1);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -293,16 +296,16 @@ TEST_IMPL(tcp_close_reset_accepted_after_shutdown) {
 
   do_connect(loop, &tcp_client);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 4);
-  ASSERT(close_cb_called == 0);
-  ASSERT(shutdown_cb_called == 1);
+  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(shutdown_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -222,8 +222,8 @@ TEST_IMPL(tcp_close_reset_client) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 4);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(4, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
   ASSERT_OK(shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -249,9 +249,9 @@ TEST_IMPL(tcp_close_reset_client_after_shutdown) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(4, write_cb_called);
   ASSERT_OK(close_cb_called);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -276,8 +276,8 @@ TEST_IMPL(tcp_close_reset_accepted) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 4);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(4, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
   ASSERT_OK(shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -303,9 +303,9 @@ TEST_IMPL(tcp_close_reset_accepted_after_shutdown) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 4);
+  ASSERT_EQ(4, write_cb_called);
   ASSERT_OK(close_cb_called);
-  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -330,8 +330,8 @@ TEST_IMPL(tcp_close_reset_accepted_after_socket_shutdown) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 4);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(4, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
   ASSERT_OK(shutdown_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -69,24 +69,24 @@ TEST_IMPL(tcp_close_while_connecting) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT(0 == uv_ip4_addr("1.2.3.4", TEST_PORT, &addr));
-  ASSERT(0 == uv_tcp_init(loop, &tcp_handle));
+  ASSERT_EQ(0, uv_ip4_addr("1.2.3.4", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_handle));
   r = uv_tcp_connect(&connect_req,
                      &tcp_handle,
                      (const struct sockaddr*) &addr,
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT(r == 0);
-  ASSERT(0 == uv_timer_init(loop, &timer1_handle));
-  ASSERT(0 == uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
-  ASSERT(0 == uv_timer_init(loop, &timer2_handle));
-  ASSERT(0 == uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(0, uv_timer_init(loop, &timer1_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
+  ASSERT_EQ(0, uv_timer_init(loop, &timer2_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(timer1_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(timer1_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
 

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -69,20 +69,20 @@ TEST_IMPL(tcp_close_while_connecting) {
   int r;
 
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_ip4_addr("1.2.3.4", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_tcp_init(loop, &tcp_handle));
+  ASSERT_OK(uv_ip4_addr("1.2.3.4", TEST_PORT, &addr));
+  ASSERT_OK(uv_tcp_init(loop, &tcp_handle));
   r = uv_tcp_connect(&connect_req,
                      &tcp_handle,
                      (const struct sockaddr*) &addr,
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(0, uv_timer_init(loop, &timer1_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
-  ASSERT_EQ(0, uv_timer_init(loop, &timer2_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(r);
+  ASSERT_OK(uv_timer_init(loop, &timer1_handle));
+  ASSERT_OK(uv_timer_start(&timer1_handle, timer1_cb, 1, 0));
+  ASSERT_OK(uv_timer_init(loop, &timer2_handle));
+  ASSERT_OK(uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(timer1_cb_called, 1);

--- a/test/test-tcp-close-while-connecting.c
+++ b/test/test-tcp-close-while-connecting.c
@@ -84,9 +84,9 @@ TEST_IMPL(tcp_close_while_connecting) {
   ASSERT_OK(uv_timer_start(&timer2_handle, timer2_cb, 86400 * 1000, 0));
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(timer1_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, timer1_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
 

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -49,7 +49,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
     ASSERT_NOT_NULL(req);
 
     r = uv_write(req, (uv_stream_t*)&tcp_handle, &buf, 1, write_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_close((uv_handle_t*)&tcp_handle, close_cb);
@@ -58,7 +58,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
-  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_OK(close_cb_called);
   ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_handle);
   write_cb_called++;
   free(req);
@@ -72,7 +72,7 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connection_cb(uv_stream_t* server, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -80,16 +80,16 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)handle, 128, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_unref((uv_handle_t*)handle);
 }
@@ -104,7 +104,7 @@ TEST_IMPL(tcp_close) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
@@ -112,19 +112,19 @@ TEST_IMPL(tcp_close) {
   start_server(loop, &tcp_server);
 
   r = uv_tcp_init(loop, &tcp_handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_handle,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(write_cb_called, 0);
-  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_OK(write_cb_called);
+  ASSERT_OK(close_cb_called);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -129,7 +129,7 @@ TEST_IMPL(tcp_close) {
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 
   ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-close.c
+++ b/test/test-tcp-close.c
@@ -49,7 +49,7 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
     ASSERT_NOT_NULL(req);
 
     r = uv_write(req, (uv_stream_t*)&tcp_handle, &buf, 1, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   uv_close((uv_handle_t*)&tcp_handle, close_cb);
@@ -58,21 +58,21 @@ static void connect_cb(uv_connect_t* conn_req, int status) {
 
 static void write_cb(uv_write_t* req, int status) {
   /* write callbacks should run before the close callback */
-  ASSERT(close_cb_called == 0);
-  ASSERT(req->handle == (uv_stream_t*)&tcp_handle);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*)&tcp_handle);
   write_cb_called++;
   free(req);
 }
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*)&tcp_handle);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*)&tcp_handle);
   close_cb_called++;
 }
 
 
 static void connection_cb(uv_stream_t* server, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -80,16 +80,16 @@ static void start_server(uv_loop_t* loop, uv_tcp_t* handle) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(handle, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)handle, 128, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)handle);
 }
@@ -104,7 +104,7 @@ TEST_IMPL(tcp_close) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
@@ -112,24 +112,24 @@ TEST_IMPL(tcp_close) {
   start_server(loop, &tcp_server);
 
   r = uv_tcp_init(loop, &tcp_handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_handle,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called == 0);
-  ASSERT(close_cb_called == 0);
+  ASSERT_EQ(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   printf("%d of %d write reqs seen\n", write_cb_called, NUM_WRITE_REQS);
 
-  ASSERT(write_cb_called == NUM_WRITE_REQS);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(write_cb_called, NUM_WRITE_REQS);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -37,14 +37,14 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status < 0);
+  ASSERT_LT(status, 0);
   connect_cb_called++;
   uv_close((uv_handle_t*)req->handle, close_cb);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status < 0);
+  ASSERT_LT(status, 0);
   write_cb_called++;
 }
 
@@ -67,30 +67,30 @@ TEST_IMPL(tcp_connect_error_after_write) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   buf = uv_buf_init("TEST", 4);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == UV_EBADF);
+  ASSERT_EQ(r, UV_EBADF);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -88,9 +88,9 @@ TEST_IMPL(tcp_connect_error_after_write) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -67,11 +67,11 @@ TEST_IMPL(tcp_connect_error_after_write) {
   uv_buf_t buf;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   buf = uv_buf_init("TEST", 4);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
   ASSERT_EQ(r, UV_EBADF);
@@ -80,13 +80,13 @@ TEST_IMPL(tcp_connect_error_after_write) {
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(write_cb_called, 1);

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -54,19 +54,19 @@ TEST_IMPL(tcp_connect_error_fault) {
   garbage_addr = (const struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
                      connect_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -66,7 +66,7 @@ TEST_IMPL(tcp_connect_error_fault) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_OK(connect_cb_called);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect-error.c
+++ b/test/test-tcp-connect-error.c
@@ -54,7 +54,7 @@ TEST_IMPL(tcp_connect_error_fault) {
   garbage_addr = (const struct sockaddr_in*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
@@ -65,7 +65,7 @@ TEST_IMPL(tcp_connect_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connect_cb_called, 0);
+  ASSERT_OK(connect_cb_called);
   ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -38,14 +38,14 @@ static void close_cb(uv_handle_t* handle);
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, UV_ECANCELED);
   connect_cb_called++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_PTR_EQ(handle, &timer);
   uv_close((uv_handle_t*)&conn, close_cb);
   uv_close((uv_handle_t*)&timer, close_cb);
 }
@@ -64,16 +64,16 @@ TEST_IMPL(tcp_connect_timeout) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("8.8.8.8", 9999, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("8.8.8.8", 9999, &addr));
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 50, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -81,10 +81,10 @@ TEST_IMPL(tcp_connect_timeout) {
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -151,7 +151,7 @@ TEST_IMPL(tcp_local_connect_timeout) {
   ASSERT_EQ(r, 0);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -64,16 +64,16 @@ TEST_IMPL(tcp_connect_timeout) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("8.8.8.8", 9999, &addr));
+  ASSERT_OK(uv_ip4_addr("8.8.8.8", 9999, &addr));
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, timer_cb, 50, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -81,10 +81,10 @@ TEST_IMPL(tcp_connect_timeout) {
                      connect_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -105,7 +105,7 @@ static int is_supported_system(void) {
   int min_semver[3] = {10, 0, 16299};
   int cnt;
   uv_utsname_t uname;
-  ASSERT_EQ(uv_os_uname(&uname), 0);
+  ASSERT_OK(uv_os_uname(&uname));
   if (strcmp(uname.sysname, "Windows_NT") == 0) {
     cnt = sscanf(uname.release, "%d.%d.%d", &semver[0], &semver[1], &semver[2]);
     if (cnt != 3) {
@@ -130,17 +130,17 @@ TEST_IMPL(tcp_local_connect_timeout) {
   if (!is_supported_system()) {
     RETURN_SKIP("Unsupported system");
   }
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Give it 1s to timeout. */
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -148,10 +148,10 @@ TEST_IMPL(tcp_local_connect_timeout) {
                      connect_local_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -168,17 +168,17 @@ TEST_IMPL(tcp6_local_connect_timeout) {
     RETURN_SKIP("IPv6 not supported");
   }
 
-  ASSERT_EQ(0, uv_ip6_addr("::1", 9999, &addr));
+  ASSERT_OK(uv_ip6_addr("::1", 9999, &addr));
 
   r = uv_timer_init(uv_default_loop(), &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Give it 1s to timeout. */
   r = uv_timer_start(&timer, timer_cb, 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(uv_default_loop(), &conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
@@ -186,10 +186,10 @@ TEST_IMPL(tcp6_local_connect_timeout) {
                      connect_local_cb);
   if (r == UV_ENETUNREACH)
     RETURN_SKIP("Network unreachable.");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -55,7 +55,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
   garbage_addr = (const struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
@@ -66,7 +66,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connect_cb_called, 0);
+  ASSERT_OK(connect_cb_called);
   ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -67,7 +67,7 @@ TEST_IMPL(tcp_connect6_error_fault) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_OK(connect_cb_called);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-connect6-error.c
+++ b/test/test-tcp-connect6-error.c
@@ -55,19 +55,19 @@ TEST_IMPL(tcp_connect6_error_fault) {
   garbage_addr = (const struct sockaddr_in6*) &garbage;
 
   r = uv_tcp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tcp_connect(&req,
                      &server,
                      (const struct sockaddr*) garbage_addr,
                      connect_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_close((uv_handle_t*)&server, close_cb);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -32,7 +32,7 @@
 
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
@@ -41,13 +41,13 @@ static void on_connection(uv_stream_t* server, int status) {
   uv_tcp_t* handle;
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   handle = malloc(sizeof(*handle));
   ASSERT_NOT_NULL(handle);
 
   r = uv_tcp_init_ex(server->loop, handle, AF_INET);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(server, (uv_stream_t*)handle);
   ASSERT_EQ(r, UV_EBUSY);
@@ -61,16 +61,16 @@ static void tcp_listener(uv_loop_t* loop, uv_tcp_t* server) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*) server, 128, on_connection);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -78,16 +78,16 @@ static void tcp_connector(uv_loop_t* loop, uv_tcp_t* client, uv_connect_t* req) 
   struct sockaddr_in server_addr;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
 
   r = uv_tcp_init(loop, client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(req,
                      client,
                      (const struct sockaddr*) &server_addr,
                      on_connect);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -98,32 +98,32 @@ TEST_IMPL(tcp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(memcmp(&addr.sin_addr,
+  ASSERT_OK(r);
+  ASSERT_OK(memcmp(&addr.sin_addr,
                    &sockname.sin_addr,
-                   sizeof(addr.sin_addr)), 0);
+                   sizeof(addr.sin_addr)));
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -142,13 +142,13 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
@@ -158,7 +158,7 @@ TEST_IMPL(tcp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -32,7 +32,7 @@
 
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
@@ -41,16 +41,16 @@ static void on_connection(uv_stream_t* server, int status) {
   uv_tcp_t* handle;
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   handle = malloc(sizeof(*handle));
   ASSERT_NOT_NULL(handle);
 
   r = uv_tcp_init_ex(server->loop, handle, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)handle);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
 
   uv_close((uv_handle_t*) server, NULL);
   uv_close((uv_handle_t*) handle, (uv_close_cb)free);
@@ -61,16 +61,16 @@ static void tcp_listener(uv_loop_t* loop, uv_tcp_t* server) {
   struct sockaddr_in addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_tcp_init(loop, server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*) server, 128, on_connection);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -78,16 +78,16 @@ static void tcp_connector(uv_loop_t* loop, uv_tcp_t* client, uv_connect_t* req) 
   struct sockaddr_in server_addr;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
 
   r = uv_tcp_init(loop, client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(req,
                      client,
                      (const struct sockaddr*) &server_addr,
                      on_connect);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -98,32 +98,32 @@ TEST_IMPL(tcp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
-  ASSERT(fd != INVALID_FD);
+  ASSERT_EQ(r, 0);
+  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
-  ASSERT(sockname.sin_family == AF_INET);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
-  ASSERT(memcmp(&addr.sin_addr,
-                &sockname.sin_addr,
-                sizeof(addr.sin_addr)) == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(memcmp(&addr.sin_addr,
+                   &sockname.sin_addr,
+                   sizeof(addr.sin_addr)), 0);
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -142,14 +142,14 @@ TEST_IMPL(tcp_create_early_bad_bind) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
-  ASSERT(fd != INVALID_FD);
+  ASSERT_EQ(r, 0);
+  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
@@ -158,16 +158,16 @@ TEST_IMPL(tcp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT(r == 0);
-    ASSERT(sockname.sin6_family == AF_INET6);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
 #if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MSYS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EFAULT);
+  ASSERT_EQ(r, UV_EFAULT);
 #endif
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -183,10 +183,10 @@ TEST_IMPL(tcp_create_early_bad_domain) {
   int r;
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, 47);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_tcp_init_ex(uv_default_loop(), &client, 1024);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -34,18 +34,18 @@ TEST_IMPL(tcp_flags) {
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_nodelay(&handle, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_keepalive(&handle, 1, 60);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -34,18 +34,18 @@ TEST_IMPL(tcp_flags) {
   loop = uv_default_loop();
 
   r = uv_tcp_init(loop, &handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_nodelay(&handle, 1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_keepalive(&handle, 1, 60);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*)&handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -62,8 +62,8 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   uv_os_fd_t fd;
 
   ASSERT_GE(nread, 0);
-  ASSERT_EQ(0, uv_fileno((uv_handle_t*)handle, &fd));
-  ASSERT_EQ(0, uv_idle_start(&idle, idle_cb));
+  ASSERT_OK(uv_fileno((uv_handle_t*)handle, &fd));
+  ASSERT_OK(uv_idle_start(&idle, idle_cb));
 
 #ifdef __MVS__
   /* Need to flush out the OOB data. Otherwise, this callback will get
@@ -76,7 +76,7 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &client_handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -84,14 +84,14 @@ static void connection_cb(uv_stream_t* handle, int status) {
   int r;
   uv_os_fd_t fd;
 
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
+  ASSERT_OK(status);
+  ASSERT_OK(uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
 
   /* Send some OOB data */
-  ASSERT_EQ(0, uv_fileno((uv_handle_t*) &client_handle, &fd));
+  ASSERT_OK(uv_fileno((uv_handle_t*) &client_handle, &fd));
 
-  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &client_handle, 1));
+  ASSERT_OK(uv_stream_set_blocking((uv_stream_t*) &client_handle, 1));
 
   /* The problem triggers only on a second message, it seem that xnu is not
    * triggering `kevent()` for the first one
@@ -106,7 +106,7 @@ static void connection_cb(uv_stream_t* handle, int status) {
   } while (r < 0 && errno == EINTR);
   ASSERT_EQ(r, 5);
 
-  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
+  ASSERT_OK(uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
 }
 
 
@@ -114,24 +114,24 @@ TEST_IMPL(tcp_oob) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
-  ASSERT_EQ(0, uv_idle_init(loop, &idle));
-  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_OK(uv_tcp_init(loop, &server_handle));
+  ASSERT_OK(uv_tcp_init(loop, &client_handle));
+  ASSERT_OK(uv_tcp_init(loop, &peer_handle));
+  ASSERT_OK(uv_idle_init(loop, &idle));
+  ASSERT_OK(uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
 
   /* Ensure two separate packets */
-  ASSERT_EQ(0, uv_tcp_nodelay(&client_handle, 1));
+  ASSERT_OK(uv_tcp_nodelay(&client_handle, 1));
 
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client_handle,
-                              (const struct sockaddr*) &addr,
-                              connect_cb));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client_handle,
+                           (const struct sockaddr*) &addr,
+                           connect_cb));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_EQ(ticks, kMaxTicks);
 

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -61,22 +61,22 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 #endif
   uv_os_fd_t fd;
 
-  ASSERT(nread >= 0);
-  ASSERT(0 == uv_fileno((uv_handle_t*)handle, &fd));
-  ASSERT(0 == uv_idle_start(&idle, idle_cb));
+  ASSERT_GE(nread, 0);
+  ASSERT_EQ(0, uv_fileno((uv_handle_t*)handle, &fd));
+  ASSERT_EQ(0, uv_idle_start(&idle, idle_cb));
 
 #ifdef __MVS__
   /* Need to flush out the OOB data. Otherwise, this callback will get
    * triggered on every poll with nread = 0.
    */
-  ASSERT(-1 != recv(fd, lbuf, sizeof(lbuf), MSG_OOB));
+  ASSERT_NE(-1, recv(fd, lbuf, sizeof(lbuf), MSG_OOB));
 #endif
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &client_handle);
-  ASSERT(0 == status);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &client_handle);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -84,14 +84,14 @@ static void connection_cb(uv_stream_t* handle, int status) {
   int r;
   uv_os_fd_t fd;
 
-  ASSERT(0 == status);
-  ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT(0 == uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
 
   /* Send some OOB data */
-  ASSERT(0 == uv_fileno((uv_handle_t*) &client_handle, &fd));
+  ASSERT_EQ(0, uv_fileno((uv_handle_t*) &client_handle, &fd));
 
-  ASSERT(0 == uv_stream_set_blocking((uv_stream_t*) &client_handle, 1));
+  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &client_handle, 1));
 
   /* The problem triggers only on a second message, it seem that xnu is not
    * triggering `kevent()` for the first one
@@ -99,14 +99,14 @@ static void connection_cb(uv_stream_t* handle, int status) {
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT(5 == r);
+  ASSERT_EQ(r, 5);
 
-  ASSERT(0 == uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
+  ASSERT_EQ(0, uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
 }
 
 
@@ -114,26 +114,26 @@ TEST_IMPL(tcp_oob) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_tcp_init(loop, &server_handle));
-  ASSERT(0 == uv_tcp_init(loop, &client_handle));
-  ASSERT(0 == uv_tcp_init(loop, &peer_handle));
-  ASSERT(0 == uv_idle_init(loop, &idle));
-  ASSERT(0 == uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
+  ASSERT_EQ(0, uv_idle_init(loop, &idle));
+  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
 
   /* Ensure two separate packets */
-  ASSERT(0 == uv_tcp_nodelay(&client_handle, 1));
+  ASSERT_EQ(0, uv_tcp_nodelay(&client_handle, 1));
 
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client_handle,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client_handle,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(ticks == kMaxTicks);
+  ASSERT_EQ(ticks, kMaxTicks);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-oob.c
+++ b/test/test-tcp-oob.c
@@ -99,12 +99,12 @@ static void connection_cb(uv_stream_t* handle, int status) {
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT_EQ(r, 5);
+  ASSERT_EQ(5, r);
 
   do {
     r = send(fd, "hello", 5, MSG_OOB);
   } while (r < 0 && errno == EINTR);
-  ASSERT_EQ(r, 5);
+  ASSERT_EQ(5, r);
 
   ASSERT_OK(uv_stream_set_blocking((uv_stream_t*) &client_handle, 0));
 }

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -114,7 +114,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   ASSERT_NOT_NULL(tcp);
 
   if (nread >= 0) {
-    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(4, nread);
     ASSERT_OK(memcmp("PING", buf->base, nread));
   }
   else {
@@ -272,10 +272,10 @@ TEST_IMPL(tcp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -363,9 +363,9 @@ TEST_IMPL(tcp_open_connected) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -396,11 +396,11 @@ TEST_IMPL(tcp_write_ready) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(shutdown_requested, 1);
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, shutdown_requested);
+  ASSERT_EQ(1, connect_cb_called);
   ASSERT_GT(write_cb_called, 0);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-open.c
+++ b/test/test-tcp-open.c
@@ -46,7 +46,7 @@ static void startup(void) {
 #ifdef _WIN32
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 }
 
@@ -56,9 +56,9 @@ static uv_os_sock_t create_tcp_socket(void) {
 
   sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
 #ifdef _WIN32
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
 #else
-  ASSERT(sock >= 0);
+  ASSERT_GE(sock, 0);
 #endif
 
 #ifndef _WIN32
@@ -66,7 +66,7 @@ static uv_os_sock_t create_tcp_socket(void) {
     /* Allow reuse of the port. */
     int yes = 1;
     int r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -81,7 +81,7 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -89,7 +89,7 @@ static void alloc_cb(uv_handle_t* handle,
                      size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -102,8 +102,8 @@ static void close_cb(uv_handle_t* handle) {
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(req == &shutdown_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &shutdown_req);
+  ASSERT_EQ(status, 0);
 
   /* Now we wait for the EOF */
   shutdown_cb_called++;
@@ -114,11 +114,11 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
   ASSERT_NOT_NULL(tcp);
 
   if (nread >= 0) {
-    ASSERT(nread == 4);
-    ASSERT(memcmp("PING", buf->base, nread) == 0);
+    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(memcmp("PING", buf->base, nread), 0);
   }
   else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     uv_close((uv_handle_t*)tcp, close_cb);
   }
 }
@@ -130,9 +130,9 @@ static void read1_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
   if (nread >= 0) {
     for (i = 0; i < nread; ++i)
-      ASSERT(buf->base[i] == 'P');
+      ASSERT_EQ(buf->base[i], 'P');
   } else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     printf("GOT EOF\n");
     uv_close((uv_handle_t*)tcp, close_cb);
   }
@@ -166,7 +166,7 @@ static void write1_cb(uv_write_t* req, int status) {
 
   buf = uv_buf_init("P", 1);
   r = uv_write(&write_req, req->handle, &buf, 1, write1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   write_cb_called++;
 }
@@ -177,7 +177,7 @@ static void timer_cb(uv_timer_t* handle) {
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, (uv_stream_t*) &client, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   shutdown_requested++;
 }
 
@@ -187,22 +187,22 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
 
   r = uv_write(&write_req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -211,25 +211,25 @@ static void connect1_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
 
   r = uv_timer_init(uv_default_loop(), &tm);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&tm, timer_cb, 2000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("P", 1);
   r = uv_write(&write_req, stream, &buf, 1, write1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -239,30 +239,30 @@ TEST_IMPL(tcp_open) {
   int r;
   uv_tcp_t client2;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
     r = uv_tcp_init(uv_default_loop(), &client2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_tcp_open(&client2, sock);
-    ASSERT(r == UV_EEXIST);
+    ASSERT_EQ(r, UV_EEXIST);
 
     uv_close((uv_handle_t*) &client2, NULL);
   }
@@ -272,10 +272,10 @@ TEST_IMPL(tcp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -292,13 +292,13 @@ TEST_IMPL(tcp_open_twice) {
   sock2 = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock2);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
   close_socket(sock2);
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -317,15 +317,15 @@ TEST_IMPL(tcp_open_bound) {
   startup();
   sock = create_tcp_socket();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
 
-  ASSERT(0 == bind(sock, (struct sockaddr*) &addr, sizeof(addr)));
+  ASSERT_EQ(0, bind(sock, (struct sockaddr*) &addr, sizeof(addr)));
 
-  ASSERT(0 == uv_tcp_open(&server, sock));
+  ASSERT_EQ(0, uv_tcp_open(&server, sock));
 
-  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, NULL));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, NULL));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -338,28 +338,34 @@ TEST_IMPL(tcp_open_connected) {
   uv_os_sock_t sock;
   uv_buf_t buf = uv_buf_init("PING", 4);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_tcp_socket();
 
-  ASSERT(0 == connect(sock, (struct sockaddr*) &addr,  sizeof(addr)));
+  ASSERT_EQ(0, connect(sock, (struct sockaddr*) &addr,  sizeof(addr)));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
 
-  ASSERT(0 == uv_tcp_open(&client, sock));
+  ASSERT_EQ(0, uv_tcp_open(&client, sock));
 
-  ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &client, &buf, 1, write_cb));
+  ASSERT_EQ(0, uv_write(&write_req,
+                        (uv_stream_t*) &client,
+                        &buf,
+                        1,
+                        write_cb));
 
-  ASSERT(0 == uv_shutdown(&shutdown_req, (uv_stream_t*) &client, shutdown_cb));
+  ASSERT_EQ(0, uv_shutdown(&shutdown_req,
+                           (uv_stream_t*) &client,
+                           shutdown_cb));
 
-  ASSERT(0 == uv_read_start((uv_stream_t*) &client, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &client, alloc_cb, read_cb));
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -371,30 +377,30 @@ TEST_IMPL(tcp_write_ready) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_tcp_socket();
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect1_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(shutdown_requested == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called > 0);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(shutdown_requested, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_GT(write_cb_called, 0);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-read-stop-start.c
+++ b/test/test-tcp-read-stop-start.c
@@ -33,14 +33,14 @@ static uv_connect_t connect_req;
 static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
 
 static void on_write_close_immediately(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   uv_close((uv_handle_t*)req->handle, NULL); /* Close immediately */
   free(req);
 }
 
 static void on_write(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   free(req);
 }
@@ -50,7 +50,7 @@ static void do_write(uv_stream_t* stream, uv_write_cb cb) {
   uv_buf_t buf;
   buf.base = "1234578";
   buf.len = 8;
-  ASSERT_EQ(0, uv_write(req, stream, &buf, 1, cb));
+  ASSERT_OK(uv_write(req, stream, &buf, 1, cb));
 }
 
 static void on_alloc(uv_handle_t* handle,
@@ -69,9 +69,9 @@ static void on_read1(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
    */
   do_write(stream, on_write);
 
-  ASSERT_EQ(0, uv_read_stop(stream));
+  ASSERT_OK(uv_read_stop(stream));
 
-  ASSERT_EQ(0, uv_read_start(stream, on_alloc, on_read2));
+  ASSERT_OK(uv_read_start(stream, on_alloc, on_read2));
 
   read_cb_called++;
 }
@@ -86,17 +86,17 @@ static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 }
 
 static void on_connection(uv_stream_t* server, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
-  ASSERT_EQ(0, uv_tcp_init(server->loop, &connection));
+  ASSERT_OK(uv_tcp_init(server->loop, &connection));
 
-  ASSERT_EQ(0, uv_accept(server, (uv_stream_t* )&connection));
+  ASSERT_OK(uv_accept(server, (uv_stream_t* )&connection));
 
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*)&connection, on_alloc, on_read1));
+  ASSERT_OK(uv_read_start((uv_stream_t*)&connection, on_alloc, on_read1));
 }
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   do_write((uv_stream_t*)&client, on_write_close_immediately);
 }
@@ -107,27 +107,27 @@ TEST_IMPL(tcp_read_stop_start) {
   { /* Server */
     struct sockaddr_in addr;
 
-    ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+    ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-    ASSERT_EQ(0, uv_tcp_init(loop, &server));
+    ASSERT_OK(uv_tcp_init(loop, &server));
 
-    ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) & addr, 0));
+    ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) & addr, 0));
 
-    ASSERT_EQ(0, uv_listen((uv_stream_t*)&server, 10, on_connection));
+    ASSERT_OK(uv_listen((uv_stream_t*)&server, 10, on_connection));
   }
 
   { /* Client */
     struct sockaddr_in addr;
 
-    ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+    ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-    ASSERT_EQ(0, uv_tcp_init(loop, &client));
+    ASSERT_OK(uv_tcp_init(loop, &client));
 
-    ASSERT_EQ(0, uv_tcp_connect(&connect_req, &client,
-                                (const struct sockaddr*) & addr, on_connect));
+    ASSERT_OK(uv_tcp_connect(&connect_req, &client,
+                             (const struct sockaddr*) & addr, on_connect));
   }
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   ASSERT_GE(read_cb_called, 2);
 

--- a/test/test-tcp-read-stop-start.c
+++ b/test/test-tcp-read-stop-start.c
@@ -33,14 +33,14 @@ static uv_connect_t connect_req;
 static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
 
 static void on_write_close_immediately(uv_write_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   uv_close((uv_handle_t*)req->handle, NULL); /* Close immediately */
   free(req);
 }
 
 static void on_write(uv_write_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   free(req);
 }
@@ -50,7 +50,7 @@ static void do_write(uv_stream_t* stream, uv_write_cb cb) {
   uv_buf_t buf;
   buf.base = "1234578";
   buf.len = 8;
-  ASSERT(0 == uv_write(req, stream, &buf, 1, cb));
+  ASSERT_EQ(0, uv_write(req, stream, &buf, 1, cb));
 }
 
 static void on_alloc(uv_handle_t* handle,
@@ -62,22 +62,22 @@ static void on_alloc(uv_handle_t* handle,
 }
 
 static void on_read1(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT(nread >= 0);
+  ASSERT_GE(nread, 0);
 
   /* Do write on a half open connection to force WSAECONNABORTED (on Windows)
    * in the subsequent uv_read_start()
    */
   do_write(stream, on_write);
 
-  ASSERT(0 == uv_read_stop(stream));
+  ASSERT_EQ(0, uv_read_stop(stream));
 
-  ASSERT(0 == uv_read_start(stream, on_alloc, on_read2));
+  ASSERT_EQ(0, uv_read_start(stream, on_alloc, on_read2));
 
   read_cb_called++;
 }
 
 static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
-  ASSERT(nread < 0);
+  ASSERT_LT(nread, 0);
 
   uv_close((uv_handle_t*)stream, NULL);
   uv_close((uv_handle_t*)&server, NULL);
@@ -86,17 +86,17 @@ static void on_read2(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 }
 
 static void on_connection(uv_stream_t* server, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(server->loop, &connection));
+  ASSERT_EQ(0, uv_tcp_init(server->loop, &connection));
 
-  ASSERT(0 == uv_accept(server, (uv_stream_t* )&connection));
+  ASSERT_EQ(0, uv_accept(server, (uv_stream_t* )&connection));
 
-  ASSERT(0 == uv_read_start((uv_stream_t*)&connection, on_alloc, on_read1));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*)&connection, on_alloc, on_read1));
 }
 
 static void on_connect(uv_connect_t* req, int status) {
-  ASSERT(0 == status);
+  ASSERT_EQ(status, 0);
 
   do_write((uv_stream_t*)&client, on_write_close_immediately);
 }
@@ -107,29 +107,29 @@ TEST_IMPL(tcp_read_stop_start) {
   { /* Server */
     struct sockaddr_in addr;
 
-    ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+    ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-    ASSERT(0 == uv_tcp_init(loop, &server));
+    ASSERT_EQ(0, uv_tcp_init(loop, &server));
 
-    ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) & addr, 0));
+    ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) & addr, 0));
 
-    ASSERT(0 == uv_listen((uv_stream_t*)&server, 10, on_connection));
+    ASSERT_EQ(0, uv_listen((uv_stream_t*)&server, 10, on_connection));
   }
 
   { /* Client */
     struct sockaddr_in addr;
 
-    ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+    ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-    ASSERT(0 == uv_tcp_init(loop, &client));
+    ASSERT_EQ(0, uv_tcp_init(loop, &client));
 
-    ASSERT(0 == uv_tcp_connect(&connect_req, &client,
-                               (const struct sockaddr*) & addr, on_connect));
+    ASSERT_EQ(0, uv_tcp_connect(&connect_req, &client,
+                                (const struct sockaddr*) & addr, on_connect));
   }
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
-  ASSERT(read_cb_called >= 2);
+  ASSERT_GE(read_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -40,21 +40,21 @@ static void write_cb(uv_write_t* req, int status) {
 
 static void timer_cb(uv_timer_t* handle) {
   uv_buf_t buf = uv_buf_init("PING", 4);
-  ASSERT_EQ(0, uv_write(&write_req,
-                        (uv_stream_t*) &tcp_handle,
-                        &buf,
-                        1,
-                        write_cb));
-  ASSERT_EQ(0, uv_read_stop((uv_stream_t*) &tcp_handle));
+  ASSERT_OK(uv_write(&write_req,
+                     (uv_stream_t*) &tcp_handle,
+                     &buf,
+                     1,
+                     write_cb));
+  ASSERT_OK(uv_read_stop((uv_stream_t*) &tcp_handle));
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &tcp_handle,
-                             (uv_alloc_cb) fail_cb,
-                             (uv_read_cb) fail_cb));
+  ASSERT_OK(status);
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &tcp_handle,
+                          (uv_alloc_cb) fail_cb,
+                          (uv_read_cb) fail_cb));
 }
 
 
@@ -62,14 +62,14 @@ TEST_IMPL(tcp_read_stop) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &tcp_handle));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &tcp_handle,
-                              (const struct sockaddr*) &addr,
-                              connect_cb));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &tcp_handle));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &tcp_handle,
+                           (const struct sockaddr*) &addr,
+                           connect_cb));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
 
   return 0;

--- a/test/test-tcp-read-stop.c
+++ b/test/test-tcp-read-stop.c
@@ -40,21 +40,21 @@ static void write_cb(uv_write_t* req, int status) {
 
 static void timer_cb(uv_timer_t* handle) {
   uv_buf_t buf = uv_buf_init("PING", 4);
-  ASSERT(0 == uv_write(&write_req,
-                       (uv_stream_t*) &tcp_handle,
-                       &buf,
-                       1,
-                       write_cb));
-  ASSERT(0 == uv_read_stop((uv_stream_t*) &tcp_handle));
+  ASSERT_EQ(0, uv_write(&write_req,
+                        (uv_stream_t*) &tcp_handle,
+                        &buf,
+                        1,
+                        write_cb));
+  ASSERT_EQ(0, uv_read_stop((uv_stream_t*) &tcp_handle));
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(0 == status);
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT(0 == uv_read_start((uv_stream_t*) &tcp_handle,
-                            (uv_alloc_cb) fail_cb,
-                            (uv_read_cb) fail_cb));
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &tcp_handle,
+                             (uv_alloc_cb) fail_cb,
+                             (uv_read_cb) fail_cb));
 }
 
 
@@ -62,14 +62,14 @@ TEST_IMPL(tcp_read_stop) {
   uv_connect_t connect_req;
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &tcp_handle));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &tcp_handle,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &tcp_handle));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &tcp_handle,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
 
   return 0;

--- a/test/test-tcp-rst.c
+++ b/test/test-tcp-rst.c
@@ -98,9 +98,9 @@ TEST_IMPL(tcp_rst) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(called_alloc_cb, 1);
-  ASSERT_EQ(called_connect_cb, 1);
-  ASSERT_EQ(called_close_cb, 1);
+  ASSERT_EQ(1, called_alloc_cb);
+  ASSERT_EQ(1, called_connect_cb);
+  ASSERT_EQ(1, called_close_cb);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-rst.c
+++ b/test/test-tcp-rst.c
@@ -31,7 +31,7 @@ static int called_close_cb;
 
 
 static void close_cb(uv_handle_t* handle) {
-  ASSERT(handle == (uv_handle_t*) &tcp);
+  ASSERT_PTR_EQ(handle, (uv_handle_t*) &tcp);
   called_close_cb++;
 }
 

--- a/test/test-tcp-rst.c
+++ b/test/test-tcp-rst.c
@@ -48,7 +48,7 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
   ASSERT_EQ(nread, UV_ECONNRESET);
 
   int fd;
-  ASSERT_EQ(0, uv_fileno((uv_handle_t*) t, &fd));
+  ASSERT_OK(uv_fileno((uv_handle_t*) t, &fd));
   uv_handle_type type = uv_guess_handle(fd);
   ASSERT_EQ(type, UV_TCP);
 
@@ -58,11 +58,11 @@ static void read_cb(uv_stream_t* t, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(req, &connect_req);
 
   /* Start reading from the connection so we receive the RST in uv__read. */
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &tcp, alloc_cb, read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &tcp, alloc_cb, read_cb));
 
   /* Write 'QSH' to receive RST from the echo server. */
   ASSERT_EQ(qbuf.len, uv_try_write((uv_stream_t*) &tcp, &qbuf, 1));
@@ -86,15 +86,15 @@ TEST_IMPL(tcp_rst) {
   qbuf.base = "QSH";
   qbuf.len = 3;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   r = uv_tcp_init(uv_default_loop(), &tcp);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp,
                      (const struct sockaddr*) &server_addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -66,10 +66,10 @@ static void timer_cb(uv_timer_t* handle) {
 
   buf = uv_buf_init("TEST", 4);
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_shutdown(&shutdown_req, (uv_stream_t*)&conn, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -80,22 +80,22 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called++;
 
   r = uv_read_start((uv_stream_t*)&conn, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   write_cb_called++;
 }
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   shutdown_cb_called++;
   uv_close((uv_handle_t*)&conn, close_cb);
 }
@@ -106,26 +106,26 @@ TEST_IMPL(tcp_shutdown_after_write) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, timer_cb, 125, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(loop, &conn);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(write_cb_called, 1);

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -127,11 +127,11 @@ TEST_IMPL(tcp_shutdown_after_write) {
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(conn_close_cb_called, 1);
-  ASSERT_EQ(timer_close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, conn_close_cb_called);
+  ASSERT_EQ(1, timer_close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -66,10 +66,10 @@ static void timer_cb(uv_timer_t* handle) {
 
   buf = uv_buf_init("TEST", 4);
   r = uv_write(&write_req, (uv_stream_t*)&conn, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_shutdown(&shutdown_req, (uv_stream_t*)&conn, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -80,22 +80,22 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   r = uv_read_start((uv_stream_t*)&conn, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
 
 static void shutdown_cb(uv_shutdown_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   shutdown_cb_called++;
   uv_close((uv_handle_t*)&conn, close_cb);
 }
@@ -106,32 +106,32 @@ TEST_IMPL(tcp_shutdown_after_write) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 125, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(loop, &conn);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &conn,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(conn_close_cb_called == 1);
-  ASSERT(timer_close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(conn_close_cb_called, 1);
+  ASSERT_EQ(timer_close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -100,9 +100,9 @@ TEST_IMPL(tcp_try_write_error) {
   uv_close((uv_handle_t*) &client, close_cb);
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
-  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(3, close_cb_called);
+  ASSERT_EQ(1, connection_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -49,21 +49,21 @@ static void incoming_close_cb(uv_handle_t* handle) {
     r = uv_try_write((uv_stream_t*) &client, &buf, 1);
   fprintf(stderr, "uv_try_write error: %d %s\n", r, uv_strerror(r));
   ASSERT(r == UV_EPIPE || r == UV_ECONNABORTED || r == UV_ECONNRESET);
-  ASSERT(client.write_queue_size == 0);
+  ASSERT_EQ(client.write_queue_size, 0);
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
-  ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
 
   connection_cb_called++;
   uv_close((uv_handle_t*) &incoming, incoming_close_cb);
@@ -74,11 +74,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
-  ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -88,21 +88,21 @@ TEST_IMPL(tcp_try_write_error) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client,
-                             (struct sockaddr*) &addr,
-                             connect_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client,
+                              (struct sockaddr*) &addr,
+                              connect_cb));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &client, close_cb);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(connection_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(connection_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-try-write-error.c
+++ b/test/test-tcp-try-write-error.c
@@ -49,21 +49,21 @@ static void incoming_close_cb(uv_handle_t* handle) {
     r = uv_try_write((uv_stream_t*) &client, &buf, 1);
   fprintf(stderr, "uv_try_write error: %d %s\n", r, uv_strerror(r));
   ASSERT(r == UV_EPIPE || r == UV_ECONNABORTED || r == UV_ECONNRESET);
-  ASSERT_EQ(client.write_queue_size, 0);
+  ASSERT_OK(client.write_queue_size);
 }
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called++;
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
-  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
-  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_OK(uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &incoming));
 
   connection_cb_called++;
   uv_close((uv_handle_t*) &incoming, incoming_close_cb);
@@ -74,11 +74,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -88,17 +88,17 @@ TEST_IMPL(tcp_try_write_error) {
 
   start_server();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client,
-                              (struct sockaddr*) &addr,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client,
+                           (struct sockaddr*) &addr,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   uv_close((uv_handle_t*) &client, close_cb);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(close_cb_called, 3);

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -46,7 +46,7 @@ static void close_cb(uv_handle_t* handle) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   do {
@@ -87,24 +87,24 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
-  ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
 
   connection_cb_called++;
-  ASSERT(0 == uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
 }
 
 
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
-  ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -114,21 +114,21 @@ TEST_IMPL(tcp_try_write) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client,
-                             (struct sockaddr*) &addr,
-                             connect_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client,
+                              (struct sockaddr*) &addr,
+                              connect_cb));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(close_cb_called == 3);
-  ASSERT(connection_cb_called == 1);
-  ASSERT(bytes_read == bytes_written);
-  ASSERT(bytes_written > 0);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(bytes_read, bytes_written);
+  ASSERT_GT(bytes_written, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -46,7 +46,7 @@ static void close_cb(uv_handle_t* handle) {
 static void connect_cb(uv_connect_t* req, int status) {
   int r;
   uv_buf_t buf;
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called++;
 
   do {
@@ -87,24 +87,24 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
-  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
-  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_OK(uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &incoming));
 
   connection_cb_called++;
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
 }
 
 
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -114,15 +114,15 @@ TEST_IMPL(tcp_try_write) {
 
   start_server();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client,
-                              (struct sockaddr*) &addr,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client,
+                           (struct sockaddr*) &addr,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(close_cb_called, 3);

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -124,9 +124,9 @@ TEST_IMPL(tcp_try_write) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 3);
-  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(3, close_cb_called);
+  ASSERT_EQ(1, connection_cb_called);
   ASSERT_EQ(bytes_read, bytes_written);
   ASSERT_GT(bytes_written, 0);
 

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -61,13 +61,13 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &client_handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
   ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &peer_handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 }
 
 
@@ -76,11 +76,11 @@ static void connection_cb(uv_stream_t* handle, int status) {
 
   buf = uv_buf_init("PING", 4);
 
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
-  ASSERT_EQ(0, uv_write(&write_req, (uv_stream_t*) &peer_handle,
-                        &buf, 1, write_cb));
+  ASSERT_OK(status);
+  ASSERT_OK(uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
+  ASSERT_OK(uv_write(&write_req, (uv_stream_t*) &peer_handle,
+                     &buf, 1, write_cb));
 }
 
 
@@ -88,23 +88,23 @@ TEST_IMPL(tcp_unexpected_read) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1000, 0));
-  ASSERT_EQ(0, uv_check_init(loop, &check_handle));
-  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
-  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
-  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
-  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client_handle,
-                              (const struct sockaddr*) &addr,
-                              connect_cb));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 1000, 0));
+  ASSERT_OK(uv_check_init(loop, &check_handle));
+  ASSERT_OK(uv_check_start(&check_handle, check_cb));
+  ASSERT_OK(uv_tcp_init(loop, &server_handle));
+  ASSERT_OK(uv_tcp_init(loop, &client_handle));
+  ASSERT_OK(uv_tcp_init(loop, &peer_handle));
+  ASSERT_OK(uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client_handle,
+                           (const struct sockaddr*) &addr,
+                           connect_cb));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   /* This is somewhat inexact but the idea is that the event loop should not
    * start busy looping when the server sends a message and the client isn't

--- a/test/test-tcp-unexpected-read.c
+++ b/test/test-tcp-unexpected-read.c
@@ -60,14 +60,14 @@ static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &client_handle);
-  ASSERT(0 == status);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &client_handle);
+  ASSERT_EQ(status, 0);
 }
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(req->handle == (uv_stream_t*) &peer_handle);
-  ASSERT(0 == status);
+  ASSERT_PTR_EQ(req->handle, (uv_stream_t*) &peer_handle);
+  ASSERT_EQ(status, 0);
 }
 
 
@@ -76,11 +76,11 @@ static void connection_cb(uv_stream_t* handle, int status) {
 
   buf = uv_buf_init("PING", 4);
 
-  ASSERT(0 == status);
-  ASSERT(0 == uv_accept(handle, (uv_stream_t*) &peer_handle));
-  ASSERT(0 == uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
-  ASSERT(0 == uv_write(&write_req, (uv_stream_t*) &peer_handle,
-                       &buf, 1, write_cb));
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(0, uv_accept(handle, (uv_stream_t*) &peer_handle));
+  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &peer_handle, alloc_cb, read_cb));
+  ASSERT_EQ(0, uv_write(&write_req, (uv_stream_t*) &peer_handle,
+                        &buf, 1, write_cb));
 }
 
 
@@ -88,29 +88,29 @@ TEST_IMPL(tcp_unexpected_read) {
   struct sockaddr_in addr;
   uv_loop_t* loop;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   loop = uv_default_loop();
 
-  ASSERT(0 == uv_timer_init(loop, &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 1000, 0));
-  ASSERT(0 == uv_check_init(loop, &check_handle));
-  ASSERT(0 == uv_check_start(&check_handle, check_cb));
-  ASSERT(0 == uv_tcp_init(loop, &server_handle));
-  ASSERT(0 == uv_tcp_init(loop, &client_handle));
-  ASSERT(0 == uv_tcp_init(loop, &peer_handle));
-  ASSERT(0 == uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client_handle,
-                             (const struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_init(loop, &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 1000, 0));
+  ASSERT_EQ(0, uv_check_init(loop, &check_handle));
+  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+  ASSERT_EQ(0, uv_tcp_init(loop, &server_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &client_handle));
+  ASSERT_EQ(0, uv_tcp_init(loop, &peer_handle));
+  ASSERT_EQ(0, uv_tcp_bind(&server_handle, (const struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server_handle, 1, connection_cb));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client_handle,
+                              (const struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
   /* This is somewhat inexact but the idea is that the event loop should not
    * start busy looping when the server sends a message and the client isn't
    * reading.
    */
-  ASSERT(ticks <= 20);
+  ASSERT_LE(ticks, 20);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -49,20 +49,20 @@ TEST_IMPL(tcp_write_after_connect) {
 #endif
 
   struct sockaddr_in sa;
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
-  ASSERT_EQ(0, uv_loop_init(&loop));
-  ASSERT_EQ(0, uv_tcp_init(&loop, &tcp_client));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT_OK(uv_loop_init(&loop));
+  ASSERT_OK(uv_tcp_init(&loop, &tcp_client));
 
-  ASSERT_EQ(0, uv_tcp_connect(&connection_request,
-                              &tcp_client,
-                              (const struct sockaddr *)
-                              &sa,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_connect(&connection_request,
+                           &tcp_client,
+                           (const struct sockaddr *)
+                           &sa,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_write(&write_request,
-                        (uv_stream_t *)&tcp_client,
-                        &buf, 1,
-                        write_cb));
+  ASSERT_OK(uv_write(&write_request,
+                     (uv_stream_t *)&tcp_client,
+                     &buf, 1,
+                     write_cb));
 
   uv_run(&loop, UV_RUN_DEFAULT);
 

--- a/test/test-tcp-write-after-connect.c
+++ b/test/test-tcp-write-after-connect.c
@@ -32,13 +32,13 @@ uv_buf_t buf = { "HELLO", 4 };
 
 
 static void write_cb(uv_write_t *req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
 
 static void connect_cb(uv_connect_t *req, int status) {
-  ASSERT(status == UV_ECONNREFUSED);
+  ASSERT_EQ(status, UV_ECONNREFUSED);
 }
 
 
@@ -49,20 +49,20 @@ TEST_IMPL(tcp_write_after_connect) {
 #endif
 
   struct sockaddr_in sa;
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
-  ASSERT(0 == uv_loop_init(&loop));
-  ASSERT(0 == uv_tcp_init(&loop, &tcp_client));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &sa));
+  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_tcp_init(&loop, &tcp_client));
 
-  ASSERT(0 == uv_tcp_connect(&connection_request,
-                             &tcp_client,
-                             (const struct sockaddr *)
-                             &sa,
-                             connect_cb));
+  ASSERT_EQ(0, uv_tcp_connect(&connection_request,
+                              &tcp_client,
+                              (const struct sockaddr *)
+                              &sa,
+                              connect_cb));
 
-  ASSERT(0 == uv_write(&write_request,
-                       (uv_stream_t *)&tcp_client,
-                       &buf, 1,
-                       write_cb));
+  ASSERT_EQ(0, uv_write(&write_request,
+                        (uv_stream_t *)&tcp_client,
+                        &buf, 1,
+                        write_cb));
 
   uv_run(&loop, UV_RUN_DEFAULT);
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -41,13 +41,13 @@ static void close_socket(uv_tcp_t* sock) {
   int r;
 
   r = uv_fileno((uv_handle_t*)sock, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #ifdef _WIN32
   r = closesocket((uv_os_sock_t)fd);
 #else
   r = close(fd);
 #endif
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -74,7 +74,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int r;
 
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   stream = req->handle;
   connect_cb_called++;
@@ -84,7 +84,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   buf = uv_buf_init("hello\n", 6);
   r = uv_write(&write_req, stream, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -93,16 +93,16 @@ TEST_IMPL(tcp_write_fail) {
   uv_tcp_t client;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -106,9 +106,9 @@ TEST_IMPL(tcp_write_fail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(write_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -41,13 +41,13 @@ static void close_socket(uv_tcp_t* sock) {
   int r;
 
   r = uv_fileno((uv_handle_t*)sock, &fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #ifdef _WIN32
   r = closesocket((uv_os_sock_t)fd);
 #else
   r = close(fd);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -60,7 +60,7 @@ static void close_cb(uv_handle_t* handle) {
 static void write_cb(uv_write_t* req, int status) {
   ASSERT_NOT_NULL(req);
 
-  ASSERT(status != 0);
+  ASSERT(status);
   fprintf(stderr, "uv_write error: %s\n", uv_strerror(status));
   write_cb_called++;
 
@@ -73,8 +73,8 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
@@ -84,7 +84,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
   buf = uv_buf_init("hello\n", 6);
   r = uv_write(&write_req, stream, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -93,22 +93,22 @@ TEST_IMPL(tcp_write_fail) {
   uv_tcp_t client;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-write-in-a-row.c
+++ b/test/test-tcp-write-in-a-row.c
@@ -45,7 +45,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void write_cb(uv_write_t* w, int status) {
   /* the small write should finish immediately after the big write */
-  ASSERT_EQ(0, uv_stream_get_write_queue_size((uv_stream_t*) &client));
+  ASSERT_OK(uv_stream_get_write_queue_size((uv_stream_t*) &client));
 
   write_cb_called++;
 
@@ -62,13 +62,13 @@ static void connect_cb(uv_connect_t* _, int status) {
   uv_buf_t buf;
   size_t write_queue_size0, write_queue_size1;
 
-  ASSERT_EQ(0, status);
+  ASSERT_OK(status);
   connect_cb_called++;
 
   /* fire a big write */
   buf = uv_buf_init(data, sizeof(data));
   r = uv_write(&small_write, (uv_stream_t*) &client, &buf, 1, write_cb);
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* check that the write process gets stuck */
   write_queue_size0 = uv_stream_get_write_queue_size((uv_stream_t*) &client);
@@ -77,7 +77,7 @@ static void connect_cb(uv_connect_t* _, int status) {
   /* fire a small write, which should be queued */
   buf = uv_buf_init("A", 1);
   r = uv_write(&big_write, (uv_stream_t*) &client, &buf, 1, write_cb);
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   write_queue_size1 = uv_stream_get_write_queue_size((uv_stream_t*) &client);
   ASSERT_EQ(write_queue_size1, write_queue_size0 + 1);
@@ -93,22 +93,22 @@ static void alloc_cb(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {}
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(0, status);
+  ASSERT_OK(status);
   connection_cb_called++;
 
-  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
-  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
-  ASSERT_EQ(0, uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
+  ASSERT_OK(uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &incoming, alloc_cb, read_cb));
 }
 
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 TEST_IMPL(tcp_write_in_a_row) {
@@ -121,15 +121,15 @@ TEST_IMPL(tcp_write_in_a_row) {
 
   start_server();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client,
-                              (struct sockaddr*) &addr,
-                              connect_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client,
+                           (struct sockaddr*) &addr,
+                           connect_cb));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(1, connect_cb_called);
   ASSERT_EQ(3, close_cb_called);

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -125,14 +125,14 @@ TEST_IMPL(tcp_write_queue_order) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(connect_cb_called, 1);
-  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_EQ(1, connect_cb_called);
+  ASSERT_EQ(1, connection_cb_called);
   ASSERT_GT(write_callbacks, 0);
   ASSERT_GT(write_cancelled_callbacks, 0);
   ASSERT_EQ(write_callbacks +
             write_error_callbacks +
             write_cancelled_callbacks, REQ_COUNT);
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(3, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -67,7 +67,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i;
   uv_buf_t buf;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   connect_cb_called++;
 
   buf = uv_buf_init(base, sizeof(base));
@@ -78,19 +78,19 @@ static void connect_cb(uv_connect_t* req, int status) {
                  &buf,
                  1,
                  write_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
-  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
-  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_OK(uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &incoming));
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
-  ASSERT_EQ(0, uv_timer_start(&timer, timer_cb, 1000, 0));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_OK(uv_timer_start(&timer, timer_cb, 1000, 0));
 
   connection_cb_called++;
 }
@@ -99,11 +99,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -114,16 +114,16 @@ TEST_IMPL(tcp_write_queue_order) {
 
   start_server();
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
-                              &client,
-                              (struct sockaddr*) &addr,
-                              connect_cb));
-  ASSERT_EQ(0, uv_send_buffer_size((uv_handle_t*) &client, &buffer_size));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &client,
+                           (struct sockaddr*) &addr,
+                           connect_cb));
+  ASSERT_OK(uv_send_buffer_size((uv_handle_t*) &client, &buffer_size));
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(connect_cb_called, 1);
   ASSERT_EQ(connection_cb_called, 1);

--- a/test/test-tcp-write-queue-order.c
+++ b/test/test-tcp-write-queue-order.c
@@ -67,7 +67,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i;
   uv_buf_t buf;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 
   buf = uv_buf_init(base, sizeof(base));
@@ -78,19 +78,19 @@ static void connect_cb(uv_connect_t* req, int status) {
                  &buf,
                  1,
                  write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
 
 static void connection_cb(uv_stream_t* tcp, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
-  ASSERT(0 == uv_tcp_init(tcp->loop, &incoming));
-  ASSERT(0 == uv_accept(tcp, (uv_stream_t*) &incoming));
+  ASSERT_EQ(0, uv_tcp_init(tcp->loop, &incoming));
+  ASSERT_EQ(0, uv_accept(tcp, (uv_stream_t*) &incoming));
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer));
-  ASSERT(0 == uv_timer_start(&timer, timer_cb, 1000, 0));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer));
+  ASSERT_EQ(0, uv_timer_start(&timer, timer_cb, 1000, 0));
 
   connection_cb_called++;
 }
@@ -99,11 +99,11 @@ static void connection_cb(uv_stream_t* tcp, int status) {
 static void start_server(void) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &server));
-  ASSERT(0 == uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
-  ASSERT(0 == uv_listen((uv_stream_t*) &server, 128, connection_cb));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &server));
+  ASSERT_EQ(0, uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
+  ASSERT_EQ(0, uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
 
 
@@ -114,25 +114,25 @@ TEST_IMPL(tcp_write_queue_order) {
 
   start_server();
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_tcp_init(uv_default_loop(), &client));
-  ASSERT(0 == uv_tcp_connect(&connect_req,
-                             &client,
-                             (struct sockaddr*) &addr,
-                             connect_cb));
-  ASSERT(0 == uv_send_buffer_size((uv_handle_t*) &client, &buffer_size));
+  ASSERT_EQ(0, uv_tcp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_tcp_connect(&connect_req,
+                              &client,
+                              (struct sockaddr*) &addr,
+                              connect_cb));
+  ASSERT_EQ(0, uv_send_buffer_size((uv_handle_t*) &client, &buffer_size));
 
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(connect_cb_called == 1);
-  ASSERT(connection_cb_called == 1);
-  ASSERT(write_callbacks > 0);
-  ASSERT(write_cancelled_callbacks > 0);
-  ASSERT(write_callbacks +
-         write_error_callbacks +
-         write_cancelled_callbacks == REQ_COUNT);
-  ASSERT(close_cb_called == 3);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(connection_cb_called, 1);
+  ASSERT_GT(write_callbacks, 0);
+  ASSERT_GT(write_cancelled_callbacks, 0);
+  ASSERT_EQ(write_callbacks +
+            write_error_callbacks +
+            write_cancelled_callbacks, REQ_COUNT);
+  ASSERT_EQ(close_cb_called, 3);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -45,23 +45,23 @@ static void connection_cb(uv_stream_t* server, int status) {
   int r;
   uv_buf_t buf;
 
-  ASSERT(server == (uv_stream_t*)&tcp_server);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(server, (uv_stream_t*)&tcp_server);
+  ASSERT_EQ(status, 0);
 
   r = uv_tcp_init(server->loop, &tcp_peer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_accept(server, (uv_stream_t*)&tcp_peer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_start((uv_stream_t*)&tcp_peer, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf.base = "hello\n";
   buf.len = 6;
 
   r = uv_write(&write_req, (uv_stream_t*)&tcp_peer, &buf, 1, write_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -88,8 +88,8 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 
 static void connect_cb(uv_connect_t* req, int status) {
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   /* Close the client. */
   uv_close((uv_handle_t*)&tcp_client, NULL);
@@ -97,7 +97,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   write_cb_called++;
 }
 
@@ -107,34 +107,34 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 1, connection_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(write_cb_called > 0);
-  ASSERT(read_cb_called > 0);
+  ASSERT_GT(write_cb_called, 0);
+  ASSERT_GT(read_cb_called, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-tcp-write-to-half-open-connection.c
+++ b/test/test-tcp-write-to-half-open-connection.c
@@ -46,22 +46,22 @@ static void connection_cb(uv_stream_t* server, int status) {
   uv_buf_t buf;
 
   ASSERT_PTR_EQ(server, (uv_stream_t*)&tcp_server);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   r = uv_tcp_init(server->loop, &tcp_peer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_accept(server, (uv_stream_t*)&tcp_peer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_read_start((uv_stream_t*)&tcp_peer, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf.base = "hello\n";
   buf.len = 6;
 
   r = uv_write(&write_req, (uv_stream_t*)&tcp_peer, &buf, 1, write_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -89,7 +89,7 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   /* Close the client. */
   uv_close((uv_handle_t*)&tcp_client, NULL);
@@ -97,7 +97,7 @@ static void connect_cb(uv_connect_t* req, int status) {
 
 
 static void write_cb(uv_write_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   write_cb_called++;
 }
 
@@ -107,31 +107,31 @@ TEST_IMPL(tcp_write_to_half_open_connection) {
   uv_loop_t* loop;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   loop = uv_default_loop();
   ASSERT_NOT_NULL(loop);
 
   r = uv_tcp_init(loop, &tcp_server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_bind(&tcp_server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_listen((uv_stream_t*)&tcp_server, 1, connection_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_init(loop, &tcp_client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &tcp_client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_GT(write_cb_called, 0);
   ASSERT_GT(read_cb_called, 0);

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -169,10 +169,10 @@ TEST_IMPL(tcp_writealot) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(shutdown_cb_called, 1);
-  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(1, shutdown_cb_called);
+  ASSERT_EQ(1, connect_cb_called);
   ASSERT_EQ(write_cb_called, WRITES);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, close_cb_called);
   ASSERT_EQ(bytes_sent, TOTAL_BYTES);
   ASSERT_EQ(bytes_sent_done, TOTAL_BYTES);
   ASSERT_EQ(bytes_received_done, TOTAL_BYTES);

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -66,12 +66,12 @@ static void shutdown_cb(uv_shutdown_t* req, int status) {
   uv_tcp_t* tcp;
 
   ASSERT_PTR_EQ(req, &shutdown_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   tcp = (uv_tcp_t*)(req->handle);
 
   /* The write buffer should be empty by now. */
-  ASSERT_EQ(tcp->write_queue_size, 0);
+  ASSERT_OK(tcp->write_queue_size);
 
   /* Now we wait for the EOF */
   shutdown_cb_called++;
@@ -116,7 +116,7 @@ static void connect_cb(uv_connect_t* req, int status) {
   int i, j, r;
 
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   stream = req->handle;
   connect_cb_called++;
@@ -131,16 +131,16 @@ static void connect_cb(uv_connect_t* req, int status) {
     }
 
     r = uv_write(write_req, stream, send_bufs, CHUNKS_PER_WRITE, write_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, stream, shutdown_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -153,19 +153,19 @@ TEST_IMPL(tcp_writealot) {
   RETURN_SKIP("Test is too slow to run under ThreadSanitizer");
 #endif
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   send_buffer = calloc(1, TOTAL_BYTES);
   ASSERT_NOT_NULL(send_buffer);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-tcp-writealot.c
+++ b/test/test-tcp-writealot.c
@@ -65,19 +65,19 @@ static void close_cb(uv_handle_t* handle) {
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   uv_tcp_t* tcp;
 
-  ASSERT(req == &shutdown_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &shutdown_req);
+  ASSERT_EQ(status, 0);
 
   tcp = (uv_tcp_t*)(req->handle);
 
   /* The write buffer should be empty by now. */
-  ASSERT(tcp->write_queue_size == 0);
+  ASSERT_EQ(tcp->write_queue_size, 0);
 
   /* Now we wait for the EOF */
   shutdown_cb_called++;
 
   /* We should have had all the writes called already. */
-  ASSERT(write_cb_called == WRITES);
+  ASSERT_EQ(write_cb_called, WRITES);
 }
 
 
@@ -88,7 +88,7 @@ static void read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
     bytes_received_done += nread;
   }
   else {
-    ASSERT(nread == UV_EOF);
+    ASSERT_EQ(nread, UV_EOF);
     printf("GOT EOF\n");
     uv_close((uv_handle_t*)tcp, close_cb);
   }
@@ -115,8 +115,8 @@ static void connect_cb(uv_connect_t* req, int status) {
   uv_stream_t* stream;
   int i, j, r;
 
-  ASSERT(req == &connect_req);
-  ASSERT(status == 0);
+  ASSERT_PTR_EQ(req, &connect_req);
+  ASSERT_EQ(status, 0);
 
   stream = req->handle;
   connect_cb_called++;
@@ -131,16 +131,16 @@ static void connect_cb(uv_connect_t* req, int status) {
     }
 
     r = uv_write(write_req, stream, send_bufs, CHUNKS_PER_WRITE, write_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* Shutdown on drain. */
   r = uv_shutdown(&shutdown_req, stream, shutdown_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start reading */
   r = uv_read_start(stream, alloc_cb, read_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -153,29 +153,29 @@ TEST_IMPL(tcp_writealot) {
   RETURN_SKIP("Test is too slow to run under ThreadSanitizer");
 #endif
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   send_buffer = calloc(1, TOTAL_BYTES);
   ASSERT_NOT_NULL(send_buffer);
 
   r = uv_tcp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_tcp_connect(&connect_req,
                      &client,
                      (const struct sockaddr*) &addr,
                      connect_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(shutdown_cb_called == 1);
-  ASSERT(connect_cb_called == 1);
-  ASSERT(write_cb_called == WRITES);
-  ASSERT(close_cb_called == 1);
-  ASSERT(bytes_sent == TOTAL_BYTES);
-  ASSERT(bytes_sent_done == TOTAL_BYTES);
-  ASSERT(bytes_received_done == TOTAL_BYTES);
+  ASSERT_EQ(shutdown_cb_called, 1);
+  ASSERT_EQ(connect_cb_called, 1);
+  ASSERT_EQ(write_cb_called, WRITES);
+  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(bytes_sent, TOTAL_BYTES);
+  ASSERT_EQ(bytes_sent_done, TOTAL_BYTES);
+  ASSERT_EQ(bytes_received_done, TOTAL_BYTES);
 
   free(send_buffer);
 

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -34,12 +34,12 @@ static void check_affinity(void* arg) {
 
   cpumask = (char*)arg;
   cpumasksize = uv_cpumask_size();
-  ASSERT(cpumasksize > 0);
+  ASSERT_GT(cpumasksize, 0);
   tid = uv_thread_self();
   r = uv_thread_setaffinity(&tid, cpumask, NULL, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_thread_setaffinity(&tid, cpumask + cpumasksize, cpumask, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -63,13 +63,13 @@ TEST_IMPL(thread_affinity) {
   threads[0] = uv_thread_self();
 #endif
   cpumasksize = uv_cpumask_size();
-  ASSERT(cpumasksize > 0);
+  ASSERT_GT(cpumasksize, 0);
 
   cpumask = calloc(4 * cpumasksize, 1);
   ASSERT(cpumask);
 
   r = uv_thread_getaffinity(&threads[0], cpumask, cpumasksize);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(cpumask[0] && "test must be run with cpu 0 affinity");
   ncpus = 0;
   while (cpumask[++ncpus]) { }
@@ -100,24 +100,24 @@ TEST_IMPL(thread_affinity) {
   }
 #endif
 
-  ASSERT(0 == uv_thread_create(threads + 1,
-                               check_affinity,
-                               &cpumask[t1first]));
-  ASSERT(0 == uv_thread_create(threads + 2,
-                               check_affinity,
-                               &cpumask[t2first]));
-  ASSERT(0 == uv_thread_join(threads + 1));
-  ASSERT(0 == uv_thread_join(threads + 2));
+  ASSERT_EQ(0, uv_thread_create(threads + 1,
+                                check_affinity,
+                                &cpumask[t1first]));
+  ASSERT_EQ(0, uv_thread_create(threads + 2,
+                                check_affinity,
+                                &cpumask[t2first]));
+  ASSERT_EQ(0, uv_thread_join(threads + 1));
+  ASSERT_EQ(0, uv_thread_join(threads + 2));
 
   ASSERT(cpumask[t1first + 0] == (ncpus == 1));
   ASSERT(cpumask[t1first + 1] == (ncpus >= 2));
-  ASSERT(cpumask[t1first + 2] == 0);
+  ASSERT_EQ(cpumask[t1first + 2], 0);
   ASSERT(cpumask[t1first + 3] == (ncpus >= 4));
 
-  ASSERT(cpumask[t2first + 0] == 1);
-  ASSERT(cpumask[t2first + 1] == 0);
+  ASSERT_EQ(cpumask[t2first + 0], 1);
+  ASSERT_EQ(cpumask[t2first + 1], 0);
   ASSERT(cpumask[t2first + 2] == (ncpus >= 3));
-  ASSERT(cpumask[t2first + 3] == 0);
+  ASSERT_EQ(cpumask[t2first + 3], 0);
 
   c = uv_thread_getcpu();
   ASSERT_GE(c, 0);
@@ -147,7 +147,7 @@ TEST_IMPL(thread_affinity) {
 TEST_IMPL(thread_affinity) {
   int cpumasksize;
   cpumasksize = uv_cpumask_size();
-  ASSERT(cpumasksize == UV_ENOTSUP);
+  ASSERT_EQ(cpumasksize, UV_ENOTSUP);
   return 0;
 }
 

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -114,7 +114,7 @@ TEST_IMPL(thread_affinity) {
   ASSERT_OK(cpumask[t1first + 2]);
   ASSERT(cpumask[t1first + 3] == (ncpus >= 4));
 
-  ASSERT_EQ(cpumask[t2first + 0], 1);
+  ASSERT_EQ(1, cpumask[t2first + 0]);
   ASSERT_OK(cpumask[t2first + 1]);
   ASSERT(cpumask[t2first + 2] == (ncpus >= 3));
   ASSERT_OK(cpumask[t2first + 3]);

--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -37,9 +37,9 @@ static void check_affinity(void* arg) {
   ASSERT_GT(cpumasksize, 0);
   tid = uv_thread_self();
   r = uv_thread_setaffinity(&tid, cpumask, NULL, cpumasksize);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_thread_setaffinity(&tid, cpumask + cpumasksize, cpumask, cpumasksize);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -69,7 +69,7 @@ TEST_IMPL(thread_affinity) {
   ASSERT(cpumask);
 
   r = uv_thread_getaffinity(&threads[0], cpumask, cpumasksize);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(cpumask[0] && "test must be run with cpu 0 affinity");
   ncpus = 0;
   while (cpumask[++ncpus]) { }
@@ -100,24 +100,24 @@ TEST_IMPL(thread_affinity) {
   }
 #endif
 
-  ASSERT_EQ(0, uv_thread_create(threads + 1,
-                                check_affinity,
-                                &cpumask[t1first]));
-  ASSERT_EQ(0, uv_thread_create(threads + 2,
-                                check_affinity,
-                                &cpumask[t2first]));
-  ASSERT_EQ(0, uv_thread_join(threads + 1));
-  ASSERT_EQ(0, uv_thread_join(threads + 2));
+  ASSERT_OK(uv_thread_create(threads + 1,
+                             check_affinity,
+                             &cpumask[t1first]));
+  ASSERT_OK(uv_thread_create(threads + 2,
+                             check_affinity,
+                             &cpumask[t2first]));
+  ASSERT_OK(uv_thread_join(threads + 1));
+  ASSERT_OK(uv_thread_join(threads + 2));
 
   ASSERT(cpumask[t1first + 0] == (ncpus == 1));
   ASSERT(cpumask[t1first + 1] == (ncpus >= 2));
-  ASSERT_EQ(cpumask[t1first + 2], 0);
+  ASSERT_OK(cpumask[t1first + 2]);
   ASSERT(cpumask[t1first + 3] == (ncpus >= 4));
 
   ASSERT_EQ(cpumask[t2first + 0], 1);
-  ASSERT_EQ(cpumask[t2first + 1], 0);
+  ASSERT_OK(cpumask[t2first + 1]);
   ASSERT(cpumask[t2first + 2] == (ncpus >= 3));
-  ASSERT_EQ(cpumask[t2first + 3], 0);
+  ASSERT_OK(cpumask[t2first + 3]);
 
   c = uv_thread_getcpu();
   ASSERT_GE(c, 0);
@@ -125,16 +125,16 @@ TEST_IMPL(thread_affinity) {
   memset(cpumask, 0, cpumasksize);
   cpumask[c] = 1;
   r = uv_thread_setaffinity(&threads[0], cpumask, NULL, cpumasksize);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   memset(cpumask, 0, cpumasksize);
   r = uv_thread_getaffinity(&threads[0], cpumask, cpumasksize);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   for (i = 0; i < cpumasksize; i++) {
     if (i == c)
       ASSERT_EQ(1, cpumask[i]);
     else
-      ASSERT_EQ(0, cpumask[i]);
+      ASSERT_OK(cpumask[i]);
   }
 
   free(cpumask);

--- a/test/test-thread-equal.c
+++ b/test/test-thread-equal.c
@@ -31,7 +31,7 @@ static void check_thread(void* arg) {
 #ifdef _WIN32
   ASSERT_NOT_NULL(self_id);
 #endif
-  ASSERT_EQ(uv_thread_equal(&main_thread_id, &self_id), 0);
+  ASSERT_OK(uv_thread_equal(&main_thread_id, &self_id));
   *thread_id = uv_thread_self();
 }
 
@@ -42,10 +42,10 @@ TEST_IMPL(thread_equal) {
   ASSERT_NOT_NULL(main_thread_id);
 #endif
   ASSERT_NE(0, uv_thread_equal(&main_thread_id, &main_thread_id));
-  ASSERT_EQ(0, uv_thread_create(threads + 0, check_thread, subthreads + 0));
-  ASSERT_EQ(0, uv_thread_create(threads + 1, check_thread, subthreads + 1));
-  ASSERT_EQ(0, uv_thread_join(threads + 0));
-  ASSERT_EQ(0, uv_thread_join(threads + 1));
-  ASSERT_EQ(0, uv_thread_equal(subthreads + 0, subthreads + 1));
+  ASSERT_OK(uv_thread_create(threads + 0, check_thread, subthreads + 0));
+  ASSERT_OK(uv_thread_create(threads + 1, check_thread, subthreads + 1));
+  ASSERT_OK(uv_thread_join(threads + 0));
+  ASSERT_OK(uv_thread_join(threads + 1));
+  ASSERT_OK(uv_thread_equal(subthreads + 0, subthreads + 1));
   return 0;
 }

--- a/test/test-thread-equal.c
+++ b/test/test-thread-equal.c
@@ -31,7 +31,7 @@ static void check_thread(void* arg) {
 #ifdef _WIN32
   ASSERT_NOT_NULL(self_id);
 #endif
-  ASSERT(uv_thread_equal(&main_thread_id, &self_id) == 0);
+  ASSERT_EQ(uv_thread_equal(&main_thread_id, &self_id), 0);
   *thread_id = uv_thread_self();
 }
 
@@ -41,11 +41,11 @@ TEST_IMPL(thread_equal) {
 #ifdef _WIN32
   ASSERT_NOT_NULL(main_thread_id);
 #endif
-  ASSERT(0 != uv_thread_equal(&main_thread_id, &main_thread_id));
-  ASSERT(0 == uv_thread_create(threads + 0, check_thread, subthreads + 0));
-  ASSERT(0 == uv_thread_create(threads + 1, check_thread, subthreads + 1));
-  ASSERT(0 == uv_thread_join(threads + 0));
-  ASSERT(0 == uv_thread_join(threads + 1));
-  ASSERT(0 == uv_thread_equal(subthreads + 0, subthreads + 1));
+  ASSERT_NE(0, uv_thread_equal(&main_thread_id, &main_thread_id));
+  ASSERT_EQ(0, uv_thread_create(threads + 0, check_thread, subthreads + 0));
+  ASSERT_EQ(0, uv_thread_create(threads + 1, check_thread, subthreads + 1));
+  ASSERT_EQ(0, uv_thread_join(threads + 0));
+  ASSERT_EQ(0, uv_thread_join(threads + 1));
+  ASSERT_EQ(0, uv_thread_equal(subthreads + 0, subthreads + 1));
   return 0;
 }

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -71,7 +71,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
                      "localhost",
                      NULL,
                      NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -80,7 +80,7 @@ static void getaddrinfo_cb(uv_getaddrinfo_t* handle,
                            struct addrinfo* res) {
   struct getaddrinfo_req* req;
 
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   req = container_of(handle, struct getaddrinfo_req, handle);
   uv_freeaddrinfo(res);
@@ -94,7 +94,7 @@ static void fs_do(struct fs_req* req) {
   int r;
 
   r = uv_fs_stat(req->loop, &req->handle, ".", fs_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -115,7 +115,7 @@ static void do_work(void* arg) {
   size_t i;
   struct test_thread* thread = arg;
 
-  ASSERT_EQ(0, uv_loop_init(&loop));
+  ASSERT_OK(uv_loop_init(&loop));
 
   for (i = 0; i < ARRAY_SIZE(getaddrinfo_reqs); i++) {
     struct getaddrinfo_req* req = getaddrinfo_reqs + i;
@@ -131,8 +131,8 @@ static void do_work(void* arg) {
     fs_do(req);
   }
 
-  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT_EQ(0, uv_loop_close(&loop));
+  ASSERT_OK(uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_loop_close(&loop));
   thread->thread_called = 1;
 }
 
@@ -148,10 +148,10 @@ TEST_IMPL(thread_create) {
   int r;
 
   r = uv_thread_create(&tid, thread_entry, (void *) 42);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_thread_join(&tid);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(thread_called, 1);
 
@@ -176,12 +176,12 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_create(&threads[i].thread_id, do_work, &threads[i]);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_join(&threads[i].thread_id);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     ASSERT_EQ(threads[i].thread_called, 1);
   }
 
@@ -201,14 +201,14 @@ static void tls_thread(void* arg) {
 TEST_IMPL(thread_local_storage) {
   char name[] = "main";
   uv_thread_t threads[2];
-  ASSERT_EQ(0, uv_key_create(&tls_key));
+  ASSERT_OK(uv_key_create(&tls_key));
   ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, name);
   ASSERT_EQ(name, uv_key_get(&tls_key));
-  ASSERT_EQ(0, uv_thread_create(threads + 0, tls_thread, threads + 0));
-  ASSERT_EQ(0, uv_thread_create(threads + 1, tls_thread, threads + 1));
-  ASSERT_EQ(0, uv_thread_join(threads + 0));
-  ASSERT_EQ(0, uv_thread_join(threads + 1));
+  ASSERT_OK(uv_thread_create(threads + 0, tls_thread, threads + 0));
+  ASSERT_OK(uv_thread_create(threads + 1, tls_thread, threads + 1));
+  ASSERT_OK(uv_thread_join(threads + 0));
+  ASSERT_OK(uv_thread_join(threads + 1));
   uv_key_delete(&tls_key);
   return 0;
 }
@@ -228,24 +228,24 @@ static void thread_check_stack(void* arg) {
   struct rlimit lim;
   size_t stack_size;
   pthread_attr_t attr;
-  ASSERT_EQ(0, getrlimit(RLIMIT_STACK, &lim));
+  ASSERT_OK(getrlimit(RLIMIT_STACK, &lim));
   if (lim.rlim_cur == RLIM_INFINITY)
     lim.rlim_cur = 2 << 20;  /* glibc default. */
-  ASSERT_EQ(0, pthread_getattr_np(pthread_self(), &attr));
-  ASSERT_EQ(0, pthread_attr_getstacksize(&attr, &stack_size));
+  ASSERT_OK(pthread_getattr_np(pthread_self(), &attr));
+  ASSERT_OK(pthread_attr_getstacksize(&attr, &stack_size));
   expected = arg == NULL ? 0 : ((uv_thread_options_t*)arg)->stack_size;
   if (expected == 0)
     expected = (size_t)lim.rlim_cur;
   ASSERT_GE(stack_size, expected);
-  ASSERT_EQ(0, pthread_attr_destroy(&attr));
+  ASSERT_OK(pthread_attr_destroy(&attr));
 #endif
 }
 
 
 TEST_IMPL(thread_stack_size) {
   uv_thread_t thread;
-  ASSERT_EQ(0, uv_thread_create(&thread, thread_check_stack, NULL));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create(&thread, thread_check_stack, NULL));
+  ASSERT_OK(uv_thread_join(&thread));
   return 0;
 }
 
@@ -255,42 +255,42 @@ TEST_IMPL(thread_stack_size_explicit) {
 
   options.flags = UV_THREAD_HAS_STACK_SIZE;
   options.stack_size = 1024 * 1024;
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
   options.stack_size = 8 * 1024 * 1024;  /* larger than most default os sizes */
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
   options.stack_size = 0;
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
   options.stack_size = 42;
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
 #ifdef PTHREAD_STACK_MIN
   options.stack_size = PTHREAD_STACK_MIN - 42;  /* unaligned size */
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
   options.stack_size = PTHREAD_STACK_MIN / 2 - 42;  /* unaligned size */
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                   thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 #endif
 
   /* unaligned size, should be larger than PTHREAD_STACK_MIN */
   options.stack_size = 1234567;
-  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT_EQ(0, uv_thread_join(&thread));
+  ASSERT_OK(uv_thread_create_ex(&thread, &options,
+                                thread_check_stack, &options));
+  ASSERT_OK(uv_thread_join(&thread));
 
   return 0;
 }

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -71,7 +71,7 @@ static void getaddrinfo_do(struct getaddrinfo_req* req) {
                      "localhost",
                      NULL,
                      NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -80,7 +80,7 @@ static void getaddrinfo_cb(uv_getaddrinfo_t* handle,
                            struct addrinfo* res) {
   struct getaddrinfo_req* req;
 
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   req = container_of(handle, struct getaddrinfo_req, handle);
   uv_freeaddrinfo(res);
@@ -94,7 +94,7 @@ static void fs_do(struct fs_req* req) {
   int r;
 
   r = uv_fs_stat(req->loop, &req->handle, ".", fs_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -115,7 +115,7 @@ static void do_work(void* arg) {
   size_t i;
   struct test_thread* thread = arg;
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   for (i = 0; i < ARRAY_SIZE(getaddrinfo_reqs); i++) {
     struct getaddrinfo_req* req = getaddrinfo_reqs + i;
@@ -131,14 +131,14 @@ static void do_work(void* arg) {
     fs_do(req);
   }
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
-  ASSERT(0 == uv_loop_close(&loop));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_loop_close(&loop));
   thread->thread_called = 1;
 }
 
 
 static void thread_entry(void* arg) {
-  ASSERT(arg == (void *) 42);
+  ASSERT_PTR_EQ(arg, (void *) 42);
   thread_called++;
 }
 
@@ -148,12 +148,12 @@ TEST_IMPL(thread_create) {
   int r;
 
   r = uv_thread_create(&tid, thread_entry, (void *) 42);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_thread_join(&tid);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(thread_called == 1);
+  ASSERT_EQ(thread_called, 1);
 
   return 0;
 }
@@ -176,13 +176,13 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_create(&threads[i].thread_id, do_work, &threads[i]);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_join(&threads[i].thread_id);
-    ASSERT(r == 0);
-    ASSERT(threads[i].thread_called == 1);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(threads[i].thread_called, 1);
   }
 
   return 0;
@@ -192,7 +192,7 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 static void tls_thread(void* arg) {
   ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, arg);
-  ASSERT(arg == uv_key_get(&tls_key));
+  ASSERT_EQ(arg, uv_key_get(&tls_key));
   uv_key_set(&tls_key, NULL);
   ASSERT_NULL(uv_key_get(&tls_key));
 }
@@ -201,14 +201,14 @@ static void tls_thread(void* arg) {
 TEST_IMPL(thread_local_storage) {
   char name[] = "main";
   uv_thread_t threads[2];
-  ASSERT(0 == uv_key_create(&tls_key));
+  ASSERT_EQ(0, uv_key_create(&tls_key));
   ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, name);
-  ASSERT(name == uv_key_get(&tls_key));
-  ASSERT(0 == uv_thread_create(threads + 0, tls_thread, threads + 0));
-  ASSERT(0 == uv_thread_create(threads + 1, tls_thread, threads + 1));
-  ASSERT(0 == uv_thread_join(threads + 0));
-  ASSERT(0 == uv_thread_join(threads + 1));
+  ASSERT_EQ(name, uv_key_get(&tls_key));
+  ASSERT_EQ(0, uv_thread_create(threads + 0, tls_thread, threads + 0));
+  ASSERT_EQ(0, uv_thread_create(threads + 1, tls_thread, threads + 1));
+  ASSERT_EQ(0, uv_thread_join(threads + 0));
+  ASSERT_EQ(0, uv_thread_join(threads + 1));
   uv_key_delete(&tls_key);
   return 0;
 }
@@ -222,30 +222,30 @@ static void thread_check_stack(void* arg) {
    * on MacOS. */
   if (expected == 0)
     expected = 512 * 1024;
-  ASSERT(pthread_get_stacksize_np(pthread_self()) >= expected);
+  ASSERT_GE(pthread_get_stacksize_np(pthread_self()), expected);
 #elif defined(__linux__) && defined(__GLIBC__)
   size_t expected;
   struct rlimit lim;
   size_t stack_size;
   pthread_attr_t attr;
-  ASSERT(0 == getrlimit(RLIMIT_STACK, &lim));
+  ASSERT_EQ(0, getrlimit(RLIMIT_STACK, &lim));
   if (lim.rlim_cur == RLIM_INFINITY)
     lim.rlim_cur = 2 << 20;  /* glibc default. */
-  ASSERT(0 == pthread_getattr_np(pthread_self(), &attr));
-  ASSERT(0 == pthread_attr_getstacksize(&attr, &stack_size));
+  ASSERT_EQ(0, pthread_getattr_np(pthread_self(), &attr));
+  ASSERT_EQ(0, pthread_attr_getstacksize(&attr, &stack_size));
   expected = arg == NULL ? 0 : ((uv_thread_options_t*)arg)->stack_size;
   if (expected == 0)
     expected = (size_t)lim.rlim_cur;
-  ASSERT(stack_size >= expected);
-  ASSERT(0 == pthread_attr_destroy(&attr));
+  ASSERT_GE(stack_size, expected);
+  ASSERT_EQ(0, pthread_attr_destroy(&attr));
 #endif
 }
 
 
 TEST_IMPL(thread_stack_size) {
   uv_thread_t thread;
-  ASSERT(0 == uv_thread_create(&thread, thread_check_stack, NULL));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create(&thread, thread_check_stack, NULL));
+  ASSERT_EQ(0, uv_thread_join(&thread));
   return 0;
 }
 
@@ -255,42 +255,42 @@ TEST_IMPL(thread_stack_size_explicit) {
 
   options.flags = UV_THREAD_HAS_STACK_SIZE;
   options.stack_size = 1024 * 1024;
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   options.stack_size = 8 * 1024 * 1024;  /* larger than most default os sizes */
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   options.stack_size = 0;
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   options.stack_size = 42;
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
 #ifdef PTHREAD_STACK_MIN
   options.stack_size = PTHREAD_STACK_MIN - 42;  /* unaligned size */
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   options.stack_size = PTHREAD_STACK_MIN / 2 - 42;  /* unaligned size */
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
-                                  thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
+                                   thread_check_stack, &options));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 #endif
 
   /* unaligned size, should be larger than PTHREAD_STACK_MIN */
   options.stack_size = 1234567;
-  ASSERT(0 == uv_thread_create_ex(&thread, &options,
+  ASSERT_EQ(0, uv_thread_create_ex(&thread, &options,
                                   thread_check_stack, &options));
-  ASSERT(0 == uv_thread_join(&thread));
+  ASSERT_EQ(0, uv_thread_join(&thread));
 
   return 0;
 }

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -153,7 +153,7 @@ TEST_IMPL(thread_create) {
   r = uv_thread_join(&tid);
   ASSERT_OK(r);
 
-  ASSERT_EQ(thread_called, 1);
+  ASSERT_EQ(1, thread_called);
 
   return 0;
 }
@@ -182,7 +182,7 @@ TEST_IMPL(threadpool_multiple_event_loops) {
   for (i = 0; i < ARRAY_SIZE(threads); i++) {
     r = uv_thread_join(&threads[i].thread_id);
     ASSERT_OK(r);
-    ASSERT_EQ(threads[i].thread_called, 1);
+    ASSERT_EQ(1, threads[i].thread_called);
   }
 
   return 0;

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -73,8 +73,8 @@ static void saturate_threadpool(void) {
 
   loop = uv_default_loop();
   for (i = 0; i < ARRAY_SIZE(pause_reqs); i += 1) {
-    ASSERT(0 == uv_sem_init(pause_sems + i, 0));
-    ASSERT(0 == uv_queue_work(loop, pause_reqs + i, work_cb, done_cb));
+    ASSERT_EQ(0, uv_sem_init(pause_sems + i, 0));
+    ASSERT_EQ(0, uv_queue_work(loop, pause_reqs + i, work_cb, done_cb));
   }
 }
 
@@ -119,7 +119,8 @@ static int known_broken(uv_req_t* req) {
 
 
 static void fs_cb(uv_fs_t* req) {
-  ASSERT(known_broken((uv_req_t*) req) || req->result == UV_ECANCELED);
+  ASSERT_NE(known_broken((uv_req_t*) req) || \
+      req->result == UV_ECANCELED, 0);
   uv_fs_req_cleanup(req);
   fs_cb_called++;
 }
@@ -128,7 +129,7 @@ static void fs_cb(uv_fs_t* req) {
 static void getaddrinfo_cb(uv_getaddrinfo_t* req,
                            int status,
                            struct addrinfo* res) {
-  ASSERT(status == UV_EAI_CANCELED);
+  ASSERT_EQ(status, UV_EAI_CANCELED);
   ASSERT_NULL(res);
   uv_freeaddrinfo(res);  /* Should not crash. */
 }
@@ -138,7 +139,7 @@ static void getnameinfo_cb(uv_getnameinfo_t* handle,
                            int status,
                            const char* hostname,
                            const char* service) {
-  ASSERT(status == UV_EAI_CANCELED);
+  ASSERT_EQ(status, UV_EAI_CANCELED);
   ASSERT_NULL(hostname);
   ASSERT_NULL(service);
 }
@@ -150,7 +151,7 @@ static void work2_cb(uv_work_t* req) {
 
 
 static void done2_cb(uv_work_t* req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   done2_cb_called++;
 }
 
@@ -174,7 +175,7 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void nop_done_cb(uv_work_t* req, int status) {
-  ASSERT(status == UV_ECANCELED);
+  ASSERT_EQ(status, UV_ECANCELED);
   done_cb_called++;
 }
 
@@ -184,9 +185,9 @@ static void nop_random_cb(uv_random_t* req, int status, void* buf, size_t len) {
 
   ri = container_of(req, struct random_info, random_req);
 
-  ASSERT(status == UV_ECANCELED);
-  ASSERT(buf == (void*) ri->buf);
-  ASSERT(len == sizeof(ri->buf));
+  ASSERT_EQ(status, UV_ECANCELED);
+  ASSERT_PTR_EQ(buf, (void*) ri->buf);
+  ASSERT_EQ(len, sizeof(ri->buf));
 
   done_cb_called++;
 }
@@ -204,21 +205,21 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   saturate_threadpool();
 
   r = uv_getaddrinfo(loop, reqs + 0, getaddrinfo_cb, "fail", NULL, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 1, getaddrinfo_cb, NULL, "fail", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 2, getaddrinfo_cb, "fail", "fail", NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getaddrinfo(loop, reqs + 3, getaddrinfo_cb, "fail", NULL, &hints);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -233,28 +234,28 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   int r;
 
   r = uv_ip4_addr("127.0.0.1", 80, &addr4);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   INIT_CANCEL_INFO(&ci, reqs);
   loop = uv_default_loop();
   saturate_threadpool();
 
   r = uv_getnameinfo(loop, reqs + 0, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 1, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 2, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_getnameinfo(loop, reqs + 3, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -267,17 +268,17 @@ TEST_IMPL(threadpool_cancel_random) {
 
   saturate_threadpool();
   loop = uv_default_loop();
-  ASSERT(0 == uv_random(loop,
-                        &req.random_req,
-                        &req.buf,
-                        sizeof(req.buf),
-                        0,
-                        nop_random_cb));
-  ASSERT(0 == uv_cancel((uv_req_t*) &req));
-  ASSERT(0 == done_cb_called);
+  ASSERT_EQ(0, uv_random(loop,
+                         &req.random_req,
+                         &req.buf,
+                         sizeof(req.buf),
+                         0,
+                         nop_random_cb));
+  ASSERT_EQ(0, uv_cancel((uv_req_t*) &req));
+  ASSERT_EQ(0, done_cb_called);
   unblock_threadpool();
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == done_cb_called);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, done_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -295,13 +296,13 @@ TEST_IMPL(threadpool_cancel_work) {
   saturate_threadpool();
 
   for (i = 0; i < ARRAY_SIZE(reqs); i++)
-    ASSERT(0 == uv_queue_work(loop, reqs + i, work2_cb, done2_cb));
+    ASSERT_EQ(0, uv_queue_work(loop, reqs + i, work2_cb, done2_cb));
 
-  ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == timer_cb_called);
-  ASSERT(ARRAY_SIZE(reqs) == done2_cb_called);
+  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, timer_cb_called);
+  ASSERT_EQ(ARRAY_SIZE(reqs), done2_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -322,39 +323,39 @@ TEST_IMPL(threadpool_cancel_fs) {
 
   /* Needs to match ARRAY_SIZE(fs_reqs). */
   n = 0;
-  ASSERT(0 == uv_fs_chmod(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT(0 == uv_fs_chown(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_close(loop, reqs + n++, 0, fs_cb));
-  ASSERT(0 == uv_fs_fchmod(loop, reqs + n++, 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_fchown(loop, reqs + n++, 0, 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_fdatasync(loop, reqs + n++, 0, fs_cb));
-  ASSERT(0 == uv_fs_fstat(loop, reqs + n++, 0, fs_cb));
-  ASSERT(0 == uv_fs_fsync(loop, reqs + n++, 0, fs_cb));
-  ASSERT(0 == uv_fs_ftruncate(loop, reqs + n++, 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_futime(loop, reqs + n++, 0, 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_link(loop, reqs + n++, "/", "/", fs_cb));
-  ASSERT(0 == uv_fs_lstat(loop, reqs + n++, "/", fs_cb));
-  ASSERT(0 == uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT(0 == uv_fs_open(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_read(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
-  ASSERT(0 == uv_fs_scandir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT(0 == uv_fs_readlink(loop, reqs + n++, "/", fs_cb));
-  ASSERT(0 == uv_fs_realpath(loop, reqs + n++, "/", fs_cb));
-  ASSERT(0 == uv_fs_rename(loop, reqs + n++, "/", "/", fs_cb));
-  ASSERT(0 == uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT(0 == uv_fs_sendfile(loop, reqs + n++, 0, 0, 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_stat(loop, reqs + n++, "/", fs_cb));
-  ASSERT(0 == uv_fs_symlink(loop, reqs + n++, "/", "/", 0, fs_cb));
-  ASSERT(0 == uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
-  ASSERT(0 == uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT(0 == uv_fs_write(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
-  ASSERT(n == ARRAY_SIZE(reqs));
+  ASSERT_EQ(0, uv_fs_chmod(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_chown(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_close(loop, reqs + n++, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_fchmod(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_fchown(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_fdatasync(loop, reqs + n++, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_fstat(loop, reqs + n++, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_fsync(loop, reqs + n++, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_ftruncate(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_futime(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_link(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_lstat(loop, reqs + n++, "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_open(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_read(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_scandir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_readlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_realpath(loop, reqs + n++, "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_rename(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_sendfile(loop, reqs + n++, 0, 0, 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_stat(loop, reqs + n++, "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_symlink(loop, reqs + n++, "/", "/", 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT_EQ(0, uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_EQ(0, uv_fs_write(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
+  ASSERT_EQ(n, ARRAY_SIZE(reqs));
 
-  ASSERT(0 == uv_timer_init(loop, &ci.timer_handle));
-  ASSERT(0 == uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(n == fs_cb_called);
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(n, fs_cb_called);
+  ASSERT_EQ(1, timer_cb_called);
 
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -368,12 +369,12 @@ TEST_IMPL(threadpool_cancel_single) {
 
   saturate_threadpool();
   loop = uv_default_loop();
-  ASSERT(0 == uv_queue_work(loop, &req, (uv_work_cb) abort, nop_done_cb));
-  ASSERT(0 == uv_cancel((uv_req_t*) &req));
-  ASSERT(0 == done_cb_called);
+  ASSERT_EQ(0, uv_queue_work(loop, &req, (uv_work_cb) abort, nop_done_cb));
+  ASSERT_EQ(0, uv_cancel((uv_req_t*) &req));
+  ASSERT_EQ(0, done_cb_called);
   unblock_threadpool();
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
-  ASSERT(1 == done_cb_called);
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(1, done_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -405,7 +405,7 @@ TEST_IMPL(threadpool_cancel_when_busy) {
 
   ASSERT_EQ(uv_cancel((uv_req_t*) &req), UV_EBUSY);
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(done_cb_called, 1);
+  ASSERT_EQ(1, done_cb_called);
 
   uv_sem_destroy(&sem_lock);
 

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -73,8 +73,8 @@ static void saturate_threadpool(void) {
 
   loop = uv_default_loop();
   for (i = 0; i < ARRAY_SIZE(pause_reqs); i += 1) {
-    ASSERT_EQ(0, uv_sem_init(pause_sems + i, 0));
-    ASSERT_EQ(0, uv_queue_work(loop, pause_reqs + i, work_cb, done_cb));
+    ASSERT_OK(uv_sem_init(pause_sems + i, 0));
+    ASSERT_OK(uv_queue_work(loop, pause_reqs + i, work_cb, done_cb));
   }
 }
 
@@ -205,20 +205,20 @@ TEST_IMPL(threadpool_cancel_getaddrinfo) {
   saturate_threadpool();
 
   r = uv_getaddrinfo(loop, reqs + 0, getaddrinfo_cb, "fail", NULL, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getaddrinfo(loop, reqs + 1, getaddrinfo_cb, NULL, "fail", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getaddrinfo(loop, reqs + 2, getaddrinfo_cb, "fail", "fail", NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getaddrinfo(loop, reqs + 3, getaddrinfo_cb, "fail", NULL, &hints);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_OK(uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(1, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -234,27 +234,27 @@ TEST_IMPL(threadpool_cancel_getnameinfo) {
   int r;
 
   r = uv_ip4_addr("127.0.0.1", 80, &addr4);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   INIT_CANCEL_INFO(&ci, reqs);
   loop = uv_default_loop();
   saturate_threadpool();
 
   r = uv_getnameinfo(loop, reqs + 0, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getnameinfo(loop, reqs + 1, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getnameinfo(loop, reqs + 2, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_getnameinfo(loop, reqs + 3, getnameinfo_cb, (const struct sockaddr*)&addr4, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_OK(uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(1, timer_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -268,16 +268,16 @@ TEST_IMPL(threadpool_cancel_random) {
 
   saturate_threadpool();
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_random(loop,
-                         &req.random_req,
-                         &req.buf,
-                         sizeof(req.buf),
-                         0,
-                         nop_random_cb));
-  ASSERT_EQ(0, uv_cancel((uv_req_t*) &req));
-  ASSERT_EQ(0, done_cb_called);
+  ASSERT_OK(uv_random(loop,
+                      &req.random_req,
+                      &req.buf,
+                      sizeof(req.buf),
+                      0,
+                      nop_random_cb));
+  ASSERT_OK(uv_cancel((uv_req_t*) &req));
+  ASSERT_OK(done_cb_called);
   unblock_threadpool();
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(1, done_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
@@ -296,11 +296,11 @@ TEST_IMPL(threadpool_cancel_work) {
   saturate_threadpool();
 
   for (i = 0; i < ARRAY_SIZE(reqs); i++)
-    ASSERT_EQ(0, uv_queue_work(loop, reqs + i, work2_cb, done2_cb));
+    ASSERT_OK(uv_queue_work(loop, reqs + i, work2_cb, done2_cb));
 
-  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_OK(uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(1, timer_cb_called);
   ASSERT_EQ(ARRAY_SIZE(reqs), done2_cb_called);
 
@@ -323,37 +323,37 @@ TEST_IMPL(threadpool_cancel_fs) {
 
   /* Needs to match ARRAY_SIZE(fs_reqs). */
   n = 0;
-  ASSERT_EQ(0, uv_fs_chmod(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_chown(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_close(loop, reqs + n++, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_fchmod(loop, reqs + n++, 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_fchown(loop, reqs + n++, 0, 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_fdatasync(loop, reqs + n++, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_fstat(loop, reqs + n++, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_fsync(loop, reqs + n++, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_ftruncate(loop, reqs + n++, 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_futime(loop, reqs + n++, 0, 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_link(loop, reqs + n++, "/", "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_lstat(loop, reqs + n++, "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_open(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_read(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_scandir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_readlink(loop, reqs + n++, "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_realpath(loop, reqs + n++, "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_rename(loop, reqs + n++, "/", "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_sendfile(loop, reqs + n++, 0, 0, 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_stat(loop, reqs + n++, "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_symlink(loop, reqs + n++, "/", "/", 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
-  ASSERT_EQ(0, uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
-  ASSERT_EQ(0, uv_fs_write(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
+  ASSERT_OK(uv_fs_chmod(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_OK(uv_fs_chown(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_close(loop, reqs + n++, 0, fs_cb));
+  ASSERT_OK(uv_fs_fchmod(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_fchown(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_fdatasync(loop, reqs + n++, 0, fs_cb));
+  ASSERT_OK(uv_fs_fstat(loop, reqs + n++, 0, fs_cb));
+  ASSERT_OK(uv_fs_fsync(loop, reqs + n++, 0, fs_cb));
+  ASSERT_OK(uv_fs_ftruncate(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_futime(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_link(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT_OK(uv_fs_lstat(loop, reqs + n++, "/", fs_cb));
+  ASSERT_OK(uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_OK(uv_fs_open(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_read(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
+  ASSERT_OK(uv_fs_scandir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_OK(uv_fs_readlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT_OK(uv_fs_realpath(loop, reqs + n++, "/", fs_cb));
+  ASSERT_OK(uv_fs_rename(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT_OK(uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT_OK(uv_fs_sendfile(loop, reqs + n++, 0, 0, 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_stat(loop, reqs + n++, "/", fs_cb));
+  ASSERT_OK(uv_fs_symlink(loop, reqs + n++, "/", "/", 0, fs_cb));
+  ASSERT_OK(uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT_OK(uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT_OK(uv_fs_write(loop, reqs + n++, -1, &iov, 1, 0, fs_cb));
   ASSERT_EQ(n, ARRAY_SIZE(reqs));
 
-  ASSERT_EQ(0, uv_timer_init(loop, &ci.timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(loop, &ci.timer_handle));
+  ASSERT_OK(uv_timer_start(&ci.timer_handle, timer_cb, 10, 0));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(n, fs_cb_called);
   ASSERT_EQ(1, timer_cb_called);
 
@@ -369,11 +369,11 @@ TEST_IMPL(threadpool_cancel_single) {
 
   saturate_threadpool();
   loop = uv_default_loop();
-  ASSERT_EQ(0, uv_queue_work(loop, &req, (uv_work_cb) abort, nop_done_cb));
-  ASSERT_EQ(0, uv_cancel((uv_req_t*) &req));
-  ASSERT_EQ(0, done_cb_called);
+  ASSERT_OK(uv_queue_work(loop, &req, (uv_work_cb) abort, nop_done_cb));
+  ASSERT_OK(uv_cancel((uv_req_t*) &req));
+  ASSERT_OK(done_cb_called);
   unblock_threadpool();
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
   ASSERT_EQ(1, done_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -36,7 +36,7 @@ static void work_cb(uv_work_t* req) {
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   ASSERT_PTR_EQ(req, &work_req);
   ASSERT_PTR_EQ(req->data, &data);
   after_work_cb_count++;
@@ -48,7 +48,7 @@ TEST_IMPL(threadpool_queue_work_simple) {
 
   work_req.data = &data;
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(work_cb_count, 1);
@@ -68,8 +68,8 @@ TEST_IMPL(threadpool_queue_work_einval) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(work_cb_count, 0);
-  ASSERT_EQ(after_work_cb_count, 0);
+  ASSERT_OK(work_cb_count);
+  ASSERT_OK(after_work_cb_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -51,8 +51,8 @@ TEST_IMPL(threadpool_queue_work_simple) {
   ASSERT_OK(r);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(work_cb_count, 1);
-  ASSERT_EQ(after_work_cb_count, 1);
+  ASSERT_EQ(1, work_cb_count);
+  ASSERT_EQ(1, after_work_cb_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-threadpool.c
+++ b/test/test-threadpool.c
@@ -29,16 +29,16 @@ static char data;
 
 
 static void work_cb(uv_work_t* req) {
-  ASSERT(req == &work_req);
-  ASSERT(req->data == &data);
+  ASSERT_PTR_EQ(req, &work_req);
+  ASSERT_PTR_EQ(req->data, &data);
   work_cb_count++;
 }
 
 
 static void after_work_cb(uv_work_t* req, int status) {
-  ASSERT(status == 0);
-  ASSERT(req == &work_req);
-  ASSERT(req->data == &data);
+  ASSERT_EQ(status, 0);
+  ASSERT_PTR_EQ(req, &work_req);
+  ASSERT_PTR_EQ(req->data, &data);
   after_work_cb_count++;
 }
 
@@ -48,11 +48,11 @@ TEST_IMPL(threadpool_queue_work_simple) {
 
   work_req.data = &data;
   r = uv_queue_work(uv_default_loop(), &work_req, work_cb, after_work_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 1);
-  ASSERT(after_work_cb_count == 1);
+  ASSERT_EQ(work_cb_count, 1);
+  ASSERT_EQ(after_work_cb_count, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -64,12 +64,12 @@ TEST_IMPL(threadpool_queue_work_einval) {
 
   work_req.data = &data;
   r = uv_queue_work(uv_default_loop(), &work_req, NULL, after_work_cb);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(work_cb_count == 0);
-  ASSERT(after_work_cb_count == 0);
+  ASSERT_EQ(work_cb_count, 0);
+  ASSERT_EQ(after_work_cb_count, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -44,8 +44,8 @@ static void close_cb(uv_handle_t* handle) {
 static void repeat_1_cb(uv_timer_t* handle) {
   int r;
 
-  ASSERT(handle == &repeat_1);
-  ASSERT(uv_timer_get_repeat((uv_timer_t*)handle) == 50);
+  ASSERT_PTR_EQ(handle, &repeat_1);
+  ASSERT_EQ(uv_timer_get_repeat((uv_timer_t*)handle), 50);
 
   fprintf(stderr, "repeat_1_cb called after %ld ms\n",
           (long int)(uv_now(uv_default_loop()) - start_time));
@@ -54,7 +54,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
   repeat_1_cb_called++;
 
   r = uv_timer_again(&repeat_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   if (repeat_1_cb_called == 10) {
     uv_close((uv_handle_t*)handle, close_cb);
@@ -67,7 +67,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
 
 
 static void repeat_2_cb(uv_timer_t* handle) {
-  ASSERT(handle == &repeat_2);
+  ASSERT_PTR_EQ(handle, &repeat_2);
   ASSERT(repeat_2_cb_allowed);
 
   fprintf(stderr, "repeat_2_cb called after %ld ms\n",
@@ -77,7 +77,7 @@ static void repeat_2_cb(uv_timer_t* handle) {
   repeat_2_cb_called++;
 
   if (uv_timer_get_repeat(&repeat_2) == 0) {
-    ASSERT(0 == uv_is_active((uv_handle_t*) handle));
+    ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
     uv_close((uv_handle_t*)handle, close_cb);
     return;
   }
@@ -85,7 +85,7 @@ static void repeat_2_cb(uv_timer_t* handle) {
   fprintf(stderr, "uv_timer_get_repeat %ld ms\n",
           (long int)uv_timer_get_repeat(&repeat_2));
   fflush(stderr);
-  ASSERT(uv_timer_get_repeat(&repeat_2) == 100);
+  ASSERT_EQ(uv_timer_get_repeat(&repeat_2), 100);
 
   /* This shouldn't take effect immediately. */
   uv_timer_set_repeat(&repeat_2, 0);
@@ -96,41 +96,41 @@ TEST_IMPL(timer_again) {
   int r;
 
   start_time = uv_now(uv_default_loop());
-  ASSERT(0 < start_time);
+  ASSERT_LT(0, start_time);
 
   /* Verify that it is not possible to uv_timer_again a never-started timer. */
   r = uv_timer_init(uv_default_loop(), &dummy);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_again(&dummy);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   uv_unref((uv_handle_t*)&dummy);
 
   /* Start timer repeat_1. */
   r = uv_timer_init(uv_default_loop(), &repeat_1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat_1, repeat_1_cb, 50, 0);
-  ASSERT(r == 0);
-  ASSERT(uv_timer_get_repeat(&repeat_1) == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(uv_timer_get_repeat(&repeat_1), 0);
 
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);
-  ASSERT(uv_timer_get_repeat(&repeat_1) == 50);
+  ASSERT_EQ(uv_timer_get_repeat(&repeat_1), 50);
 
   /*
    * Start another repeating timer. It'll be again()ed by the repeat_1 so
    * it should not time out until repeat_1 stops.
    */
   r = uv_timer_init(uv_default_loop(), &repeat_2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat_2, repeat_2_cb, 100, 100);
-  ASSERT(r == 0);
-  ASSERT(uv_timer_get_repeat(&repeat_2) == 100);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(uv_timer_get_repeat(&repeat_2), 100);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(repeat_1_cb_called == 10);
-  ASSERT(repeat_2_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(repeat_1_cb_called, 10);
+  ASSERT_EQ(repeat_2_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   fprintf(stderr, "Test took %ld ms (expected ~700 ms)\n",
           (long int)(uv_now(uv_default_loop()) - start_time));

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -45,7 +45,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
   int r;
 
   ASSERT_PTR_EQ(handle, &repeat_1);
-  ASSERT_EQ(uv_timer_get_repeat((uv_timer_t*)handle), 50);
+  ASSERT_EQ(50, uv_timer_get_repeat((uv_timer_t*)handle));
 
   fprintf(stderr, "repeat_1_cb called after %ld ms\n",
           (long int)(uv_now(uv_default_loop()) - start_time));
@@ -85,7 +85,7 @@ static void repeat_2_cb(uv_timer_t* handle) {
   fprintf(stderr, "uv_timer_get_repeat %ld ms\n",
           (long int)uv_timer_get_repeat(&repeat_2));
   fflush(stderr);
-  ASSERT_EQ(uv_timer_get_repeat(&repeat_2), 100);
+  ASSERT_EQ(100, uv_timer_get_repeat(&repeat_2));
 
   /* This shouldn't take effect immediately. */
   uv_timer_set_repeat(&repeat_2, 0);
@@ -114,7 +114,7 @@ TEST_IMPL(timer_again) {
 
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);
-  ASSERT_EQ(uv_timer_get_repeat(&repeat_1), 50);
+  ASSERT_EQ(50, uv_timer_get_repeat(&repeat_1));
 
   /*
    * Start another repeating timer. It'll be again()ed by the repeat_1 so
@@ -124,13 +124,13 @@ TEST_IMPL(timer_again) {
   ASSERT_OK(r);
   r = uv_timer_start(&repeat_2, repeat_2_cb, 100, 100);
   ASSERT_OK(r);
-  ASSERT_EQ(uv_timer_get_repeat(&repeat_2), 100);
+  ASSERT_EQ(100, uv_timer_get_repeat(&repeat_2));
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(repeat_1_cb_called, 10);
-  ASSERT_EQ(repeat_2_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(10, repeat_1_cb_called);
+  ASSERT_EQ(2, repeat_2_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   fprintf(stderr, "Test took %ld ms (expected ~700 ms)\n",
           (long int)(uv_now(uv_default_loop()) - start_time));

--- a/test/test-timer-again.c
+++ b/test/test-timer-again.c
@@ -54,7 +54,7 @@ static void repeat_1_cb(uv_timer_t* handle) {
   repeat_1_cb_called++;
 
   r = uv_timer_again(&repeat_2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (repeat_1_cb_called == 10) {
     uv_close((uv_handle_t*)handle, close_cb);
@@ -77,7 +77,7 @@ static void repeat_2_cb(uv_timer_t* handle) {
   repeat_2_cb_called++;
 
   if (uv_timer_get_repeat(&repeat_2) == 0) {
-    ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
+    ASSERT_OK(uv_is_active((uv_handle_t*) handle));
     uv_close((uv_handle_t*)handle, close_cb);
     return;
   }
@@ -100,17 +100,17 @@ TEST_IMPL(timer_again) {
 
   /* Verify that it is not possible to uv_timer_again a never-started timer. */
   r = uv_timer_init(uv_default_loop(), &dummy);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_again(&dummy);
   ASSERT_EQ(r, UV_EINVAL);
   uv_unref((uv_handle_t*)&dummy);
 
   /* Start timer repeat_1. */
   r = uv_timer_init(uv_default_loop(), &repeat_1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&repeat_1, repeat_1_cb, 50, 0);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(uv_timer_get_repeat(&repeat_1), 0);
+  ASSERT_OK(r);
+  ASSERT_OK(uv_timer_get_repeat(&repeat_1));
 
   /* Actually make repeat_1 repeating. */
   uv_timer_set_repeat(&repeat_1, 50);
@@ -121,9 +121,9 @@ TEST_IMPL(timer_again) {
    * it should not time out until repeat_1 stops.
    */
   r = uv_timer_init(uv_default_loop(), &repeat_2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&repeat_2, repeat_2_cb, 100, 100);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(uv_timer_get_repeat(&repeat_2), 100);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -32,49 +32,49 @@ static int timer_cb_called;
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT(0 == uv_prepare_stop(&prepare_handle));
-  ASSERT(0 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(0, uv_prepare_stop(&prepare_handle));
+  ASSERT_EQ(prepare_cb_called, 0);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 0);
   prepare_cb_called++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(0 == uv_timer_stop(&timer_handle));
-  ASSERT(1 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(0, uv_timer_stop(&timer_handle));
+  ASSERT_EQ(prepare_cb_called, 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 0);
   timer_cb_called++;
 }
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT(0 == uv_check_stop(&check_handle));
-  ASSERT(0 == uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT(0 == uv_prepare_start(&prepare_handle, prepare_cb));
-  ASSERT(0 == prepare_cb_called);
-  ASSERT(0 == check_cb_called);
-  ASSERT(0 == timer_cb_called);
+  ASSERT_EQ(0, uv_check_stop(&check_handle));
+  ASSERT_EQ(0, uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_EQ(0, uv_prepare_start(&prepare_handle, prepare_cb));
+  ASSERT_EQ(prepare_cb_called, 0);
+  ASSERT_EQ(check_cb_called, 0);
+  ASSERT_EQ(timer_cb_called, 0);
   check_cb_called++;
 }
 
 
 TEST_IMPL(timer_from_check) {
-  ASSERT(0 == uv_prepare_init(uv_default_loop(), &prepare_handle));
-  ASSERT(0 == uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT(0 == uv_check_start(&check_handle, check_cb));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT(1 == prepare_cb_called);
-  ASSERT(1 == check_cb_called);
-  ASSERT(1 == timer_cb_called);
+  ASSERT_EQ(0, uv_prepare_init(uv_default_loop(), &prepare_handle));
+  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(prepare_cb_called, 1);
+  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(timer_cb_called, 1);
   uv_close((uv_handle_t*) &prepare_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -34,7 +34,7 @@ static int timer_cb_called;
 static void prepare_cb(uv_prepare_t* handle) {
   ASSERT_OK(uv_prepare_stop(&prepare_handle));
   ASSERT_OK(prepare_cb_called);
-  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(1, check_cb_called);
   ASSERT_OK(timer_cb_called);
   prepare_cb_called++;
 }
@@ -42,8 +42,8 @@ static void prepare_cb(uv_prepare_t* handle) {
 
 static void timer_cb(uv_timer_t* handle) {
   ASSERT_OK(uv_timer_stop(&timer_handle));
-  ASSERT_EQ(prepare_cb_called, 1);
-  ASSERT_EQ(check_cb_called, 1);
+  ASSERT_EQ(1, prepare_cb_called);
+  ASSERT_EQ(1, check_cb_called);
   ASSERT_OK(timer_cb_called);
   timer_cb_called++;
 }
@@ -68,9 +68,9 @@ TEST_IMPL(timer_from_check) {
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 50, 0));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
-  ASSERT_EQ(prepare_cb_called, 1);
-  ASSERT_EQ(check_cb_called, 1);
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, prepare_cb_called);
+  ASSERT_EQ(1, check_cb_called);
+  ASSERT_EQ(1, timer_cb_called);
   uv_close((uv_handle_t*) &prepare_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);

--- a/test/test-timer-from-check.c
+++ b/test/test-timer-from-check.c
@@ -32,49 +32,49 @@ static int timer_cb_called;
 
 
 static void prepare_cb(uv_prepare_t* handle) {
-  ASSERT_EQ(0, uv_prepare_stop(&prepare_handle));
-  ASSERT_EQ(prepare_cb_called, 0);
+  ASSERT_OK(uv_prepare_stop(&prepare_handle));
+  ASSERT_OK(prepare_cb_called);
   ASSERT_EQ(check_cb_called, 1);
-  ASSERT_EQ(timer_cb_called, 0);
+  ASSERT_OK(timer_cb_called);
   prepare_cb_called++;
 }
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT_EQ(0, uv_timer_stop(&timer_handle));
+  ASSERT_OK(uv_timer_stop(&timer_handle));
   ASSERT_EQ(prepare_cb_called, 1);
   ASSERT_EQ(check_cb_called, 1);
-  ASSERT_EQ(timer_cb_called, 0);
+  ASSERT_OK(timer_cb_called);
   timer_cb_called++;
 }
 
 
 static void check_cb(uv_check_t* handle) {
-  ASSERT_EQ(0, uv_check_stop(&check_handle));
-  ASSERT_EQ(0, uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT_EQ(0, uv_prepare_start(&prepare_handle, prepare_cb));
-  ASSERT_EQ(prepare_cb_called, 0);
-  ASSERT_EQ(check_cb_called, 0);
-  ASSERT_EQ(timer_cb_called, 0);
+  ASSERT_OK(uv_check_stop(&check_handle));
+  ASSERT_OK(uv_timer_stop(&timer_handle));  /* Runs before timer_cb. */
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_OK(uv_prepare_start(&prepare_handle, prepare_cb));
+  ASSERT_OK(prepare_cb_called);
+  ASSERT_OK(check_cb_called);
+  ASSERT_OK(timer_cb_called);
   check_cb_called++;
 }
 
 
 TEST_IMPL(timer_from_check) {
-  ASSERT_EQ(0, uv_prepare_init(uv_default_loop(), &prepare_handle));
-  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_cb, 50, 0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_prepare_init(uv_default_loop(), &prepare_handle));
+  ASSERT_OK(uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_OK(uv_check_start(&check_handle, check_cb));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_cb, 50, 0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(prepare_cb_called, 1);
   ASSERT_EQ(check_cb_called, 1);
   ASSERT_EQ(timer_cb_called, 1);
   uv_close((uv_handle_t*) &prepare_handle, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -147,11 +147,11 @@ TEST_IMPL(timer) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(once_cb_called, 10);
-  ASSERT_EQ(once_close_cb_called, 10);
+  ASSERT_EQ(10, once_cb_called);
+  ASSERT_EQ(10, once_close_cb_called);
   printf("repeat_cb_called %d\n", repeat_cb_called);
-  ASSERT_EQ(repeat_cb_called, 5);
-  ASSERT_EQ(repeat_close_cb_called, 1);
+  ASSERT_EQ(5, repeat_cb_called);
+  ASSERT_EQ(1, repeat_close_cb_called);
 
   ASSERT_LE(500, uv_now(uv_default_loop()) - start_time);
 
@@ -173,7 +173,7 @@ TEST_IMPL(timer_start_twice) {
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_OK(r);
 
-  ASSERT_EQ(twice_cb_called, 1);
+  ASSERT_EQ(1, twice_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -221,7 +221,7 @@ TEST_IMPL(timer_order) {
   ASSERT_OK(uv_timer_start(&handle_b, order_cb_b, 0, 0));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(order_cb_called, 2);
+  ASSERT_EQ(2, order_cb_called);
 
   ASSERT_OK(uv_timer_stop(&handle_a));
   ASSERT_OK(uv_timer_stop(&handle_b));
@@ -235,7 +235,7 @@ TEST_IMPL(timer_order) {
   ASSERT_OK(uv_timer_start(&handle_a, order_cb_a, 0, 0));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(order_cb_called, 2);
+  ASSERT_EQ(2, order_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -309,11 +309,11 @@ TEST_IMPL(timer_run_once) {
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT_EQ(timer_run_once_timer_cb_called, 1);
+  ASSERT_EQ(1, timer_run_once_timer_cb_called);
 
   ASSERT_OK(uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT_EQ(timer_run_once_timer_cb_called, 2);
+  ASSERT_EQ(2, timer_run_once_timer_cb_called);
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -41,7 +41,7 @@ static void once_close_cb(uv_handle_t* handle) {
   printf("ONCE_CLOSE_CB\n");
 
   ASSERT_NOT_NULL(handle);
-  ASSERT_EQ(0, uv_is_active(handle));
+  ASSERT_OK(uv_is_active(handle));
 
   once_close_cb_called++;
 }
@@ -51,7 +51,7 @@ static void once_cb(uv_timer_t* handle) {
   printf("ONCE_CB %d\n", once_cb_called);
 
   ASSERT_NOT_NULL(handle);
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
+  ASSERT_OK(uv_is_active((uv_handle_t*) handle));
 
   once_cb_called++;
 
@@ -65,7 +65,7 @@ static void twice_close_cb(uv_handle_t* handle) {
   printf("TWICE_CLOSE_CB\n");
 
   ASSERT_NOT_NULL(handle);
-  ASSERT_EQ(0, uv_is_active(handle));
+  ASSERT_OK(uv_is_active(handle));
 
   twice_close_cb_called++;
 }
@@ -74,7 +74,7 @@ static void twice_cb(uv_timer_t* handle) {
   printf("TWICE_CB %d\n", twice_cb_called);
 
   ASSERT_NOT_NULL(handle);
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
+  ASSERT_OK(uv_is_active((uv_handle_t*) handle));
 
   twice_cb_called++;
 
@@ -125,24 +125,24 @@ TEST_IMPL(timer) {
   for (i = 0; i < ARRAY_SIZE(once_timers); i++) {
     once = once_timers + i;
     r = uv_timer_init(uv_default_loop(), once);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     r = uv_timer_start(once, once_cb, i * 50, 0);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   /* The 11th timer is a repeating timer that runs 4 times */
   r = uv_timer_init(uv_default_loop(), &repeat);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&repeat, repeat_cb, 100, 100);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* The 12th timer should not do anything. */
   r = uv_timer_init(uv_default_loop(), &never);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&never, never_cb, 100, 100);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_stop(&never);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_unref((uv_handle_t*)&never);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -165,13 +165,13 @@ TEST_IMPL(timer_start_twice) {
   int r;
 
   r = uv_timer_init(uv_default_loop(), &once);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&once, never_cb, 86400 * 1000, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_timer_start(&once, twice_cb, 10, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   ASSERT_EQ(twice_cb_called, 1);
 
@@ -183,10 +183,10 @@ TEST_IMPL(timer_start_twice) {
 TEST_IMPL(timer_init) {
   uv_timer_t handle;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
-  ASSERT_EQ(0, uv_timer_get_repeat(&handle));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_OK(uv_timer_get_repeat(&handle));
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&handle));
-  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &handle));
+  ASSERT_OK(uv_is_active((uv_handle_t*) &handle));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -211,29 +211,29 @@ TEST_IMPL(timer_order) {
 
   first = 0;
   second = 1;
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle_a));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle_b));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &handle_a));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &handle_b));
 
   /* Test for starting handle_a then handle_b */
   handle_a.data = &first;
-  ASSERT_EQ(0, uv_timer_start(&handle_a, order_cb_a, 0, 0));
+  ASSERT_OK(uv_timer_start(&handle_a, order_cb_a, 0, 0));
   handle_b.data = &second;
-  ASSERT_EQ(0, uv_timer_start(&handle_b, order_cb_b, 0, 0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_start(&handle_b, order_cb_b, 0, 0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(order_cb_called, 2);
 
-  ASSERT_EQ(0, uv_timer_stop(&handle_a));
-  ASSERT_EQ(0, uv_timer_stop(&handle_b));
+  ASSERT_OK(uv_timer_stop(&handle_a));
+  ASSERT_OK(uv_timer_stop(&handle_b));
 
   /* Test for starting handle_b then handle_a */
   order_cb_called = 0;
   handle_b.data = &first;
-  ASSERT_EQ(0, uv_timer_start(&handle_b, order_cb_b, 0, 0));
+  ASSERT_OK(uv_timer_start(&handle_b, order_cb_b, 0, 0));
 
   handle_a.data = &second;
-  ASSERT_EQ(0, uv_timer_start(&handle_a, order_cb_a, 0, 0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_start(&handle_a, order_cb_a, 0, 0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(order_cb_called, 2);
 
@@ -251,19 +251,19 @@ static void tiny_timer_cb(uv_timer_t* handle) {
 
 
 TEST_IMPL(timer_huge_timeout) {
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &tiny_timer));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer1));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer2));
-  ASSERT_EQ(0, uv_timer_start(&tiny_timer, tiny_timer_cb, 1, 0));
-  ASSERT_EQ(0, uv_timer_start(&huge_timer1,
-                              tiny_timer_cb,
-                              0xffffffffffffLL,
-                              0));
-  ASSERT_EQ(0, uv_timer_start(&huge_timer2, tiny_timer_cb, (uint64_t) -1, 0));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &tiny_timer));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &huge_timer1));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &huge_timer2));
+  ASSERT_OK(uv_timer_start(&tiny_timer, tiny_timer_cb, 1, 0));
+  ASSERT_OK(uv_timer_start(&huge_timer1,
+                           tiny_timer_cb,
+                           0xffffffffffffLL,
+                           0));
+  ASSERT_OK(uv_timer_start(&huge_timer2, tiny_timer_cb, (uint64_t) -1, 0));
   ASSERT_UINT64_EQ(1, uv_timer_get_due_in(&tiny_timer));
   ASSERT_UINT64_EQ(281474976710655, uv_timer_get_due_in(&huge_timer1));
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&huge_timer2));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -285,11 +285,11 @@ static void huge_repeat_cb(uv_timer_t* handle) {
 
 
 TEST_IMPL(timer_huge_repeat) {
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &tiny_timer));
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer1));
-  ASSERT_EQ(0, uv_timer_start(&tiny_timer, huge_repeat_cb, 2, 2));
-  ASSERT_EQ(0, uv_timer_start(&huge_timer1, huge_repeat_cb, 1, (uint64_t) -1));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &tiny_timer));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &huge_timer1));
+  ASSERT_OK(uv_timer_start(&tiny_timer, huge_repeat_cb, 2, 2));
+  ASSERT_OK(uv_timer_start(&huge_timer1, huge_repeat_cb, 1, (uint64_t) -1));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -306,17 +306,17 @@ static void timer_run_once_timer_cb(uv_timer_t* handle) {
 TEST_IMPL(timer_run_once) {
   uv_timer_t timer_handle;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(timer_run_once_timer_cb_called, 1);
 
-  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_OK(uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(timer_run_once_timer_cb_called, 2);
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -326,7 +326,7 @@ TEST_IMPL(timer_run_once) {
 TEST_IMPL(timer_is_closing) {
   uv_timer_t handle;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &handle));
   uv_close((uv_handle_t *)&handle, NULL);
 
   ASSERT_EQ(UV_EINVAL, uv_timer_start(&handle, never_cb, 100, 100));
@@ -339,7 +339,7 @@ TEST_IMPL(timer_is_closing) {
 TEST_IMPL(timer_null_callback) {
   uv_timer_t handle;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &handle));
   ASSERT_EQ(UV_EINVAL, uv_timer_start(&handle, NULL, 100, 100));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -362,15 +362,15 @@ TEST_IMPL(timer_early_check) {
 
   timer_early_check_expected_time = uv_now(uv_default_loop()) + timeout_ms;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle,
-                              timer_early_check_cb,
-                              timeout_ms,
-                              0));
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle,
+                           timer_early_check_cb,
+                           timeout_ms,
+                           0));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -384,11 +384,11 @@ TEST_IMPL(timer_no_double_call_once) {
   uv_timer_t timer_handle;
   const uint64_t timeout_ms = 10;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle,
-                              timer_check_double_call,
-                              timeout_ms,
-                              timeout_ms));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle,
+                           timer_check_double_call,
+                           timeout_ms,
+                           timeout_ms));
   uv_sleep(timeout_ms * 2);
   ASSERT_EQ(1, uv_run(uv_default_loop(), UV_RUN_ONCE));
   ASSERT_EQ(1, timer_check_double_call_called);
@@ -401,11 +401,11 @@ TEST_IMPL(timer_no_double_call_nowait) {
   uv_timer_t timer_handle;
   const uint64_t timeout_ms = 10;
 
-  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT_EQ(0, uv_timer_start(&timer_handle,
-                              timer_check_double_call,
-                              timeout_ms,
-                              timeout_ms));
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_OK(uv_timer_start(&timer_handle,
+                           timer_check_double_call,
+                           timeout_ms,
+                           timeout_ms));
   uv_sleep(timeout_ms * 2);
   ASSERT_EQ(1, uv_run(uv_default_loop(), UV_RUN_NOWAIT));
   ASSERT_EQ(1, timer_check_double_call_called);
@@ -420,7 +420,7 @@ TEST_IMPL(timer_no_run_on_unref) {
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer_handle));
   ASSERT_OK(uv_timer_start(&timer_handle, (uv_timer_cb) abort, 0, 0));
   uv_unref((uv_handle_t*) &timer_handle);
-  ASSERT_EQ(uv_run(uv_default_loop(), UV_RUN_DEFAULT), 0);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-timer.c
+++ b/test/test-timer.c
@@ -41,7 +41,7 @@ static void once_close_cb(uv_handle_t* handle) {
   printf("ONCE_CLOSE_CB\n");
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(0 == uv_is_active(handle));
+  ASSERT_EQ(0, uv_is_active(handle));
 
   once_close_cb_called++;
 }
@@ -51,7 +51,7 @@ static void once_cb(uv_timer_t* handle) {
   printf("ONCE_CB %d\n", once_cb_called);
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(0 == uv_is_active((uv_handle_t*) handle));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
 
   once_cb_called++;
 
@@ -65,7 +65,7 @@ static void twice_close_cb(uv_handle_t* handle) {
   printf("TWICE_CLOSE_CB\n");
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(0 == uv_is_active(handle));
+  ASSERT_EQ(0, uv_is_active(handle));
 
   twice_close_cb_called++;
 }
@@ -74,7 +74,7 @@ static void twice_cb(uv_timer_t* handle) {
   printf("TWICE_CB %d\n", twice_cb_called);
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(0 == uv_is_active((uv_handle_t*) handle));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) handle));
 
   twice_cb_called++;
 
@@ -96,7 +96,7 @@ static void repeat_cb(uv_timer_t* handle) {
   printf("REPEAT_CB\n");
 
   ASSERT_NOT_NULL(handle);
-  ASSERT(1 == uv_is_active((uv_handle_t*) handle));
+  ASSERT_EQ(1, uv_is_active((uv_handle_t*) handle));
 
   repeat_cb_called++;
 
@@ -119,41 +119,41 @@ TEST_IMPL(timer) {
   int r;
 
   start_time = uv_now(uv_default_loop());
-  ASSERT(0 < start_time);
+  ASSERT_LT(0, start_time);
 
   /* Let 10 timers time out in 500 ms total. */
   for (i = 0; i < ARRAY_SIZE(once_timers); i++) {
     once = once_timers + i;
     r = uv_timer_init(uv_default_loop(), once);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
     r = uv_timer_start(once, once_cb, i * 50, 0);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* The 11th timer is a repeating timer that runs 4 times */
   r = uv_timer_init(uv_default_loop(), &repeat);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&repeat, repeat_cb, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* The 12th timer should not do anything. */
   r = uv_timer_init(uv_default_loop(), &never);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&never, never_cb, 100, 100);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_stop(&never);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_unref((uv_handle_t*)&never);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(once_cb_called == 10);
-  ASSERT(once_close_cb_called == 10);
+  ASSERT_EQ(once_cb_called, 10);
+  ASSERT_EQ(once_close_cb_called, 10);
   printf("repeat_cb_called %d\n", repeat_cb_called);
-  ASSERT(repeat_cb_called == 5);
-  ASSERT(repeat_close_cb_called == 1);
+  ASSERT_EQ(repeat_cb_called, 5);
+  ASSERT_EQ(repeat_close_cb_called, 1);
 
-  ASSERT(500 <= uv_now(uv_default_loop()) - start_time);
+  ASSERT_LE(500, uv_now(uv_default_loop()) - start_time);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -165,15 +165,15 @@ TEST_IMPL(timer_start_twice) {
   int r;
 
   r = uv_timer_init(uv_default_loop(), &once);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&once, never_cb, 86400 * 1000, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_timer_start(&once, twice_cb, 10, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(twice_cb_called == 1);
+  ASSERT_EQ(twice_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -183,10 +183,10 @@ TEST_IMPL(timer_start_twice) {
 TEST_IMPL(timer_init) {
   uv_timer_t handle;
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &handle));
-  ASSERT(0 == uv_timer_get_repeat(&handle));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_EQ(0, uv_timer_get_repeat(&handle));
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&handle));
-  ASSERT(0 == uv_is_active((uv_handle_t*) &handle));
+  ASSERT_EQ(0, uv_is_active((uv_handle_t*) &handle));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -194,12 +194,12 @@ TEST_IMPL(timer_init) {
 
 
 static void order_cb_a(uv_timer_t *handle) {
-  ASSERT(order_cb_called++ == *(int*)handle->data);
+  ASSERT_EQ(order_cb_called++, *(int*)handle->data);
 }
 
 
 static void order_cb_b(uv_timer_t *handle) {
-  ASSERT(order_cb_called++ == *(int*)handle->data);
+  ASSERT_EQ(order_cb_called++, *(int*)handle->data);
 }
 
 
@@ -211,31 +211,31 @@ TEST_IMPL(timer_order) {
 
   first = 0;
   second = 1;
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &handle_a));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &handle_b));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle_a));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle_b));
 
   /* Test for starting handle_a then handle_b */
   handle_a.data = &first;
-  ASSERT(0 == uv_timer_start(&handle_a, order_cb_a, 0, 0));
+  ASSERT_EQ(0, uv_timer_start(&handle_a, order_cb_a, 0, 0));
   handle_b.data = &second;
-  ASSERT(0 == uv_timer_start(&handle_b, order_cb_b, 0, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_start(&handle_b, order_cb_b, 0, 0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(order_cb_called == 2);
+  ASSERT_EQ(order_cb_called, 2);
 
-  ASSERT(0 == uv_timer_stop(&handle_a));
-  ASSERT(0 == uv_timer_stop(&handle_b));
+  ASSERT_EQ(0, uv_timer_stop(&handle_a));
+  ASSERT_EQ(0, uv_timer_stop(&handle_b));
 
   /* Test for starting handle_b then handle_a */
   order_cb_called = 0;
   handle_b.data = &first;
-  ASSERT(0 == uv_timer_start(&handle_b, order_cb_b, 0, 0));
+  ASSERT_EQ(0, uv_timer_start(&handle_b, order_cb_b, 0, 0));
 
   handle_a.data = &second;
-  ASSERT(0 == uv_timer_start(&handle_a, order_cb_a, 0, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_start(&handle_a, order_cb_a, 0, 0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT(order_cb_called == 2);
+  ASSERT_EQ(order_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -243,7 +243,7 @@ TEST_IMPL(timer_order) {
 
 
 static void tiny_timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &tiny_timer);
+  ASSERT_PTR_EQ(handle, &tiny_timer);
   uv_close((uv_handle_t*) &tiny_timer, NULL);
   uv_close((uv_handle_t*) &huge_timer1, NULL);
   uv_close((uv_handle_t*) &huge_timer2, NULL);
@@ -251,16 +251,19 @@ static void tiny_timer_cb(uv_timer_t* handle) {
 
 
 TEST_IMPL(timer_huge_timeout) {
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &tiny_timer));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &huge_timer1));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &huge_timer2));
-  ASSERT(0 == uv_timer_start(&tiny_timer, tiny_timer_cb, 1, 0));
-  ASSERT(0 == uv_timer_start(&huge_timer1, tiny_timer_cb, 0xffffffffffffLL, 0));
-  ASSERT(0 == uv_timer_start(&huge_timer2, tiny_timer_cb, (uint64_t) -1, 0));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &tiny_timer));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer1));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer2));
+  ASSERT_EQ(0, uv_timer_start(&tiny_timer, tiny_timer_cb, 1, 0));
+  ASSERT_EQ(0, uv_timer_start(&huge_timer1,
+                              tiny_timer_cb,
+                              0xffffffffffffLL,
+                              0));
+  ASSERT_EQ(0, uv_timer_start(&huge_timer2, tiny_timer_cb, (uint64_t) -1, 0));
   ASSERT_UINT64_EQ(1, uv_timer_get_due_in(&tiny_timer));
   ASSERT_UINT64_EQ(281474976710655, uv_timer_get_due_in(&huge_timer1));
   ASSERT_UINT64_LE(0, uv_timer_get_due_in(&huge_timer2));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -270,9 +273,9 @@ static void huge_repeat_cb(uv_timer_t* handle) {
   static int ncalls;
 
   if (ncalls == 0)
-    ASSERT(handle == &huge_timer1);
+    ASSERT_PTR_EQ(handle, &huge_timer1);
   else
-    ASSERT(handle == &tiny_timer);
+    ASSERT_PTR_EQ(handle, &tiny_timer);
 
   if (++ncalls == 10) {
     uv_close((uv_handle_t*) &tiny_timer, NULL);
@@ -282,11 +285,11 @@ static void huge_repeat_cb(uv_timer_t* handle) {
 
 
 TEST_IMPL(timer_huge_repeat) {
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &tiny_timer));
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &huge_timer1));
-  ASSERT(0 == uv_timer_start(&tiny_timer, huge_repeat_cb, 2, 2));
-  ASSERT(0 == uv_timer_start(&huge_timer1, huge_repeat_cb, 1, (uint64_t) -1));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &tiny_timer));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &huge_timer1));
+  ASSERT_EQ(0, uv_timer_start(&tiny_timer, huge_repeat_cb, 2, 2));
+  ASSERT_EQ(0, uv_timer_start(&huge_timer1, huge_repeat_cb, 1, (uint64_t) -1));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -303,17 +306,17 @@ static void timer_run_once_timer_cb(uv_timer_t* handle) {
 TEST_IMPL(timer_run_once) {
   uv_timer_t timer_handle;
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(1 == timer_run_once_timer_cb_called);
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_run_once_timer_cb, 0, 0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(timer_run_once_timer_cb_called, 1);
 
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
-  ASSERT(2 == timer_run_once_timer_cb_called);
+  ASSERT_EQ(0, uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(timer_run_once_timer_cb_called, 2);
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -323,10 +326,10 @@ TEST_IMPL(timer_run_once) {
 TEST_IMPL(timer_is_closing) {
   uv_timer_t handle;
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
   uv_close((uv_handle_t *)&handle, NULL);
 
-  ASSERT(UV_EINVAL == uv_timer_start(&handle, never_cb, 100, 100));
+  ASSERT_EQ(UV_EINVAL, uv_timer_start(&handle, never_cb, 100, 100));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -336,8 +339,8 @@ TEST_IMPL(timer_is_closing) {
 TEST_IMPL(timer_null_callback) {
   uv_timer_t handle;
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &handle));
-  ASSERT(UV_EINVAL == uv_timer_start(&handle, NULL, 100, 100));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &handle));
+  ASSERT_EQ(UV_EINVAL, uv_timer_start(&handle, NULL, 100, 100));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -349,7 +352,7 @@ static uint64_t timer_early_check_expected_time;
 
 static void timer_early_check_cb(uv_timer_t* handle) {
   uint64_t hrtime = uv_hrtime() / 1000000;
-  ASSERT(hrtime >= timer_early_check_expected_time);
+  ASSERT_GE(hrtime, timer_early_check_expected_time);
 }
 
 
@@ -359,12 +362,15 @@ TEST_IMPL(timer_early_check) {
 
   timer_early_check_expected_time = uv_now(uv_default_loop()) + timeout_ms;
 
-  ASSERT(0 == uv_timer_init(uv_default_loop(), &timer_handle));
-  ASSERT(0 == uv_timer_start(&timer_handle, timer_early_check_cb, timeout_ms, 0));
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_timer_init(uv_default_loop(), &timer_handle));
+  ASSERT_EQ(0, uv_timer_start(&timer_handle,
+                              timer_early_check_cb,
+                              timeout_ms,
+                              0));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   uv_close((uv_handle_t*) &timer_handle, NULL);
-  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -36,46 +36,46 @@ TEST_IMPL(tmpdir) {
   len = sizeof tmpdir;
   tmpdir[0] = '\0';
 
-  ASSERT(strlen(tmpdir) == 0);
+  ASSERT_EQ(strlen(tmpdir), 0);
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == 0);
-  ASSERT(strlen(tmpdir) == len);
-  ASSERT(len > 0);
-  ASSERT(tmpdir[len] == '\0');
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(strlen(tmpdir), len);
+  ASSERT_GT(len, 0);
+  ASSERT_EQ(tmpdir[len], '\0');
 
   if (len > 1) {
     last = tmpdir[len - 1];
 #ifdef _WIN32
-    ASSERT(last != '\\');
+    ASSERT_NE(last, '\\');
 #else
-    ASSERT(last != '/');
+    ASSERT_NE(last, '/');
 #endif
   }
 
   /* Test the case where the buffer is too small */
   len = SMALLPATH;
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == UV_ENOBUFS);
-  ASSERT(len > SMALLPATH);
+  ASSERT_EQ(r, UV_ENOBUFS);
+  ASSERT_GT(len, SMALLPATH);
 
   /* Test invalid inputs */
   r = uv_os_tmpdir(NULL, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   r = uv_os_tmpdir(tmpdir, NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   len = 0;
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
 #ifdef _WIN32
   const char *name = "TMP";
   char tmpdir_win[] = "C:\\xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   r = uv_os_setenv(name, tmpdir_win);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   char tmpdirx[PATHMAX];
   size_t lenx = sizeof tmpdirx;
   r = uv_os_tmpdir(tmpdirx, &lenx);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 #endif
 
   return 0;

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -36,9 +36,9 @@ TEST_IMPL(tmpdir) {
   len = sizeof tmpdir;
   tmpdir[0] = '\0';
 
-  ASSERT_EQ(strlen(tmpdir), 0);
+  ASSERT_OK(strlen(tmpdir));
   r = uv_os_tmpdir(tmpdir, &len);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(strlen(tmpdir), len);
   ASSERT_GT(len, 0);
   ASSERT_EQ(tmpdir[len], '\0');
@@ -71,11 +71,11 @@ TEST_IMPL(tmpdir) {
   const char *name = "TMP";
   char tmpdir_win[] = "C:\\xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   r = uv_os_setenv(name, tmpdir_win);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   char tmpdirx[PATHMAX];
   size_t lenx = sizeof tmpdirx;
   r = uv_os_tmpdir(tmpdirx, &lenx);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #endif
 
   return 0;

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -73,7 +73,7 @@ static void tty_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
     }
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   }
 }
 
@@ -150,25 +150,25 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = ESC"[[A";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /*
    * Send F1 keystrokes. Test of issue cause by #2114 that vt100 fn key
@@ -176,7 +176,7 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
    */
   make_key_event_records(VK_F1, 0, TRUE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -204,45 +204,45 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = ESC"a"ESC"a";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate transmission of M-a at normal console */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(handle, &alt_records[0], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == 2);
+  ASSERT_EQ(written, 2);
   WriteConsoleInputW(handle, &alt_records[1], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
 
   /* Emulate transmission of M-a at WSL(#2111) */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(handle, &alt_records[0], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, TRUE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == 2);
+  ASSERT_EQ(written, 2);
   WriteConsoleInputW(handle, &alt_records[1], 1, &written);
-  ASSERT(written == 1);
+  ASSERT_EQ(written, 1);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
@@ -270,25 +270,25 @@ TEST_IMPL(tty_composing_character) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   expect_str = EUR_UTF8;
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Emulate EUR inputs by LEFT ALT+NUMPAD ASCII KeyComos */
   make_key_event_records(VK_MENU, 0, FALSE, alt_records);
@@ -296,16 +296,16 @@ TEST_IMPL(tty_composing_character) {
   WriteConsoleInputW(handle, &alt_records[0], 1, &written);
   make_key_event_records(VK_NUMPAD0, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD1, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD2, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   make_key_event_records(VK_NUMPAD8, LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT(written == ARRAY_SIZE(records));
+  ASSERT_EQ(written, ARRAY_SIZE(records));
   WriteConsoleInputW(handle, &alt_records[1], 1, &written);
 
   uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -227,22 +227,22 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
   /* Emulate transmission of M-a at normal console */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(handle, &alt_records[0], 1, &written);
-  ASSERT_EQ(written, 1);
+  ASSERT_EQ(1, written);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, FALSE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT_EQ(written, 2);
+  ASSERT_EQ(2, written);
   WriteConsoleInputW(handle, &alt_records[1], 1, &written);
-  ASSERT_EQ(written, 1);
+  ASSERT_EQ(1, written);
 
   /* Emulate transmission of M-a at WSL(#2111) */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
   WriteConsoleInputW(handle, &alt_records[0], 1, &written);
-  ASSERT_EQ(written, 1);
+  ASSERT_EQ(1, written);
   make_key_event_records(L'A', LEFT_ALT_PRESSED, TRUE, records);
   WriteConsoleInputW(handle, records, ARRAY_SIZE(records), &written);
-  ASSERT_EQ(written, 2);
+  ASSERT_EQ(2, written);
   WriteConsoleInputW(handle, &alt_records[1], 1, &written);
-  ASSERT_EQ(written, 1);
+  ASSERT_EQ(1, written);
 
   uv_run(loop, UV_RUN_DEFAULT);
 

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -73,7 +73,7 @@ static void tty_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
     }
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
-    ASSERT_EQ(nread, 0);
+    ASSERT_OK(nread);
   }
 }
 
@@ -156,19 +156,19 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   expect_str = ESC"[[A";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /*
    * Send F1 keystrokes. Test of issue cause by #2114 that vt100 fn key
@@ -210,19 +210,19 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   expect_str = ESC"a"ESC"a";
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Emulate transmission of M-a at normal console */
   make_key_event_records(VK_MENU, 0, TRUE, alt_records);
@@ -276,19 +276,19 @@ TEST_IMPL(tty_composing_character) {
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_alloc, tty_read);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   expect_str = EUR_UTF8;
   expect_nread = strlen(expect_str);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Emulate EUR inputs by LEFT ALT+NUMPAD ASCII KeyComos */
   make_key_event_records(VK_MENU, 0, FALSE, alt_records);

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -366,7 +366,7 @@ static void initialize_tty(uv_tty_t* tty_out) {
   ASSERT_GE(ttyout_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyout_fd));
   r = uv_tty_init(uv_default_loop(), tty_out, ttyout_fd, 0); /* Writable. */
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 static void terminate_tty(uv_tty_t* tty_out) {
@@ -1334,7 +1334,7 @@ TEST_IMPL(tty_full_reset) {
   ASSERT(compare_screen(&tty_out, &actual, &expect));
   ASSERT_EQ(get_cursor_size(&tty_out), saved_cursor_size);
   ASSERT_EQ(get_cursor_visibility(&tty_out), saved_cursor_visibility);
-  ASSERT_EQ(actual.si.csbi.srWindow.Top, 0);
+  ASSERT_OK(actual.si.csbi.srWindow.Top);
 
   terminate_tty(&tty_out);
 

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -165,8 +165,8 @@ static void write_console(uv_tty_t* tty_out, char* src) {
   buf.len = strlen(buf.base);
 
   r = uv_try_write((uv_stream_t*) tty_out, &buf, 1);
-  ASSERT(r >= 0);
-  ASSERT((unsigned int) r == buf.len);
+  ASSERT_GE(r, 0);
+  ASSERT_EQ((unsigned int) r, buf.len);
 }
 
 static void setup_screen(uv_tty_t* tty_out) {
@@ -178,8 +178,8 @@ static void setup_screen(uv_tty_t* tty_out) {
   origin.X = 0;
   origin.Y = info.srWindow.Top;
   ASSERT(FillConsoleOutputCharacter(
-      tty_out->handle, '.', length, origin, &number_of_written));
-  ASSERT(length == number_of_written);
+         tty_out->handle, '.', length, origin, &number_of_written));
+  ASSERT_EQ(length, number_of_written);
 }
 
 static void clear_screen(uv_tty_t* tty_out, struct screen_info* si) {
@@ -192,10 +192,10 @@ static void clear_screen(uv_tty_t* tty_out, struct screen_info* si) {
   origin.Y = info.srWindow.Top;
   FillConsoleOutputCharacterA(
       tty_out->handle, ' ', length, origin, &number_of_written);
-  ASSERT(length == number_of_written);
+  ASSERT_EQ(length, number_of_written);
   FillConsoleOutputAttribute(
       tty_out->handle, si->default_attr, length, origin, &number_of_written);
-  ASSERT(length == number_of_written);
+  ASSERT_EQ(length, number_of_written);
 }
 
 static void free_screen(struct captured_screen* cs) {
@@ -216,11 +216,11 @@ static void capture_screen(uv_tty_t* tty_out, struct captured_screen* cs) {
   cs->attributes = (WORD*) malloc(cs->si.length * sizeof(*cs->attributes));
   ASSERT_NOT_NULL(cs->attributes);
   ASSERT(ReadConsoleOutputCharacter(
-      tty_out->handle, cs->text, cs->si.length, origin, &length));
-  ASSERT((unsigned int) cs->si.length == length);
+         tty_out->handle, cs->text, cs->si.length, origin, &length));
+  ASSERT_EQ((unsigned int) cs->si.length, length);
   ASSERT(ReadConsoleOutputAttribute(
-      tty_out->handle, cs->attributes, cs->si.length, origin, &length));
-  ASSERT((unsigned int) cs->si.length == length);
+         tty_out->handle, cs->attributes, cs->si.length, origin, &length));
+  ASSERT_EQ((unsigned int) cs->si.length, length);
 }
 
 static void make_expect_screen_erase(struct captured_screen* cs,
@@ -261,8 +261,8 @@ static void make_expect_screen_erase(struct captured_screen* cs,
   } else {
     ASSERT(FALSE);
   }
-  ASSERT(start < end);
-  ASSERT(end - cs->text <= cs->si.length);
+  ASSERT_LT(start, end);
+  ASSERT_LE(end - cs->text, cs->si.length);
   for (; start < end; start++) {
     *start = ' ';
   }
@@ -360,13 +360,13 @@ static void initialize_tty(uv_tty_t* tty_out) {
                                      NULL,
                                      CONSOLE_TEXTMODE_BUFFER,
                                      NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
 
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyout_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
+  ASSERT_GE(ttyout_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyout_fd));
   r = uv_tty_init(uv_default_loop(), tty_out, ttyout_fd, 0); /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 static void terminate_tty(uv_tty_t* tty_out) {
@@ -394,16 +394,16 @@ TEST_IMPL(tty_cursor_up) {
   snprintf(buffer, sizeof(buffer), "%sA", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y - 1, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dA", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y - si.height / 4, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor up from Window top does nothing */
   cursor_pos_old.X = 1;
@@ -412,8 +412,8 @@ TEST_IMPL(tty_cursor_up) {
   snprintf(buffer, sizeof(buffer), "%sA", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -445,16 +445,16 @@ TEST_IMPL(tty_cursor_down) {
   snprintf(buffer, sizeof(buffer), "%sB", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y + 1, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dB", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y + si.height / 4, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor down from bottom line does nothing */
   cursor_pos_old.X = si.width / 2;
@@ -463,8 +463,8 @@ TEST_IMPL(tty_cursor_down) {
   snprintf(buffer, sizeof(buffer), "%sB", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -496,16 +496,16 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X + 1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X + 1, cursor_pos.X);
 
   /* cursor forward nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dC", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X + si.width / 4 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X + si.width / 4, cursor_pos.X);
 
   /* cursor forward from end of line does nothing*/
   cursor_pos_old.X = si.width;
@@ -514,8 +514,8 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor forward from end of screen does nothing */
   cursor_pos_old.X = si.width;
@@ -524,8 +524,8 @@ TEST_IMPL(tty_cursor_forward) {
   snprintf(buffer, sizeof(buffer), "%sC", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -557,16 +557,16 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X - 1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X - 1, cursor_pos.X);
 
   /* cursor back nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dD", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X - si.width / 4 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X - si.width / 4, cursor_pos.X);
 
   /* cursor back from beginning of line does nothing */
   cursor_pos_old.X = 1;
@@ -575,8 +575,8 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(cursor_pos_old.X == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos_old.X, cursor_pos.X);
 
   /* cursor back from top of screen does nothing */
   cursor_pos_old.X = 1;
@@ -585,8 +585,8 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -618,16 +618,16 @@ TEST_IMPL(tty_cursor_next_line) {
   snprintf(buffer, sizeof(buffer), "%sE", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + 1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y + 1, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dE", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y + si.height / 4 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y + si.height / 4, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor next line from buttom row moves beginning of line */
   cursor_pos_old.X = si.width / 2;
@@ -636,8 +636,8 @@ TEST_IMPL(tty_cursor_next_line) {
   snprintf(buffer, sizeof(buffer), "%sE", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -669,16 +669,16 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%sF", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - 1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y - 1, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line nth times */
   cursor_pos_old = cursor_pos;
   snprintf(buffer, sizeof(buffer), "%s%dF", CSI, si.height / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos_old.Y - si.height / 4 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y - si.height / 4, cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
 
   /* cursor previous line from top of screen does nothing */
   cursor_pos_old.X = 1;
@@ -687,8 +687,8 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.Y);
-  ASSERT(1 == cursor_pos.X);
+  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(cursor_pos.X, 1);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -720,22 +720,22 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sG", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.X);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Move cursor to nth character */
   snprintf(buffer, sizeof(buffer), "%s%dG", CSI, si.width / 4);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 4 == cursor_pos.X);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(si.width / 4, cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Moving out of screen will fit within screen */
   snprintf(buffer, sizeof(buffer), "%s%dG", CSI, si.width + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width == cursor_pos.X);
-  ASSERT(cursor_pos_old.Y == cursor_pos.Y);
+  ASSERT_EQ(si.width, cursor_pos.X);
+  ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   terminate_tty(&tty_out);
 
@@ -766,31 +766,31 @@ TEST_IMPL(tty_cursor_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sH", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(1 == cursor_pos.X);
-  ASSERT(1 == cursor_pos.Y);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Move the cursor to the middle of the screen */
   snprintf(
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height / 2, si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 2 == cursor_pos.X);
-  ASSERT(si.height / 2 == cursor_pos.Y);
+  ASSERT_EQ(si.width / 2, cursor_pos.X);
+  ASSERT_EQ(si.height / 2, cursor_pos.Y);
 
   /* Moving out of screen will fit within screen */
   snprintf(
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height / 2, si.width + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width == cursor_pos.X);
-  ASSERT(si.height / 2 == cursor_pos.Y);
+  ASSERT_EQ(si.width, cursor_pos.X);
+  ASSERT_EQ(si.height / 2, cursor_pos.Y);
 
   snprintf(
       buffer, sizeof(buffer), "%s%d;%df", CSI, si.height + 1, si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(si.width / 2 == cursor_pos.X);
-  ASSERT(si.height == cursor_pos.Y);
+  ASSERT_EQ(si.width / 2, cursor_pos.X);
+  ASSERT_EQ(si.height, cursor_pos.Y);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -1000,38 +1000,38 @@ TEST_IMPL(tty_set_cursor_shape) {
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_LARGE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_LARGE);
 
   /* cursor size large */
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s1 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_LARGE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_LARGE);
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s2 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_LARGE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_LARGE);
 
   /* cursor size small */
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s3 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_SMALL);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_SMALL);
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s6 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_SMALL);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_SMALL);
 
   /* Nothing occurs with arguments outside valid range */
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s7 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_MIDDLE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_MIDDLE);
 
   /* restore cursor size if arguments is zero */
   snprintf(buffer, sizeof(buffer), "%s0 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == saved_cursor_size);
+  ASSERT_EQ(get_cursor_size(&tty_out), saved_cursor_size);
 
   terminate_tty(&tty_out);
 
@@ -1122,7 +1122,7 @@ TEST_IMPL(tty_set_style) {
   }
 
   /* Set foreground and background color */
-  ASSERT(ARRAY_SIZE(fg_attrs) == ARRAY_SIZE(bg_attrs));
+  ASSERT_EQ(ARRAY_SIZE(fg_attrs), ARRAY_SIZE(bg_attrs));
   length = ARRAY_SIZE(bg_attrs);
   for (i = 0; i < length; i++) {
     capture_screen(&tty_out, &expect);
@@ -1271,8 +1271,8 @@ TEST_IMPL(tty_save_restore_cursor_position) {
   snprintf(buffer, sizeof(buffer), "%su", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == cursor_pos_old.X);
-  ASSERT(cursor_pos.Y == cursor_pos_old.Y);
+  ASSERT_EQ(cursor_pos.X, cursor_pos_old.X);
+  ASSERT_EQ(cursor_pos.Y, cursor_pos_old.Y);
 
   cursor_pos_old.X = si.width / 2;
   cursor_pos_old.Y = si.height / 2;
@@ -1290,8 +1290,8 @@ TEST_IMPL(tty_save_restore_cursor_position) {
   snprintf(buffer, sizeof(buffer), "%s8", ESC);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == cursor_pos_old.X);
-  ASSERT(cursor_pos.Y == cursor_pos_old.Y);
+  ASSERT_EQ(cursor_pos.X, cursor_pos_old.X);
+  ASSERT_EQ(cursor_pos.Y, cursor_pos_old.Y);
 
   terminate_tty(&tty_out);
 
@@ -1332,9 +1332,9 @@ TEST_IMPL(tty_full_reset) {
   write_console(&tty_out, buffer);
   capture_screen(&tty_out, &actual);
   ASSERT(compare_screen(&tty_out, &actual, &expect));
-  ASSERT(get_cursor_size(&tty_out) == saved_cursor_size);
-  ASSERT(get_cursor_visibility(&tty_out) == saved_cursor_visibility);
-  ASSERT(actual.si.csbi.srWindow.Top == 0);
+  ASSERT_EQ(get_cursor_size(&tty_out), saved_cursor_size);
+  ASSERT_EQ(get_cursor_visibility(&tty_out), saved_cursor_visibility);
+  ASSERT_EQ(actual.si.csbi.srWindow.Top, 0);
 
   terminate_tty(&tty_out);
 
@@ -1520,8 +1520,8 @@ TEST_IMPL(tty_escape_sequence_processing) {
   snprintf(buffer, sizeof(buffer), "%s1;%dH", CSI, UINT16_MAX + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == 1);
-  ASSERT(cursor_pos.Y == 1);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Too many argument are ignored */
   cursor_pos.X = 1;
@@ -1554,18 +1554,18 @@ TEST_IMPL(tty_escape_sequence_processing) {
            expect.si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT(cursor_pos.X == 1);
-  ASSERT(cursor_pos.Y == 1);
+  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(cursor_pos.Y, 1);
 
   /* Invalid sequence are ignored */
   saved_cursor_size = get_cursor_size(&tty_out);
   set_cursor_size(&tty_out, CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s 1q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_MIDDLE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_MIDDLE);
   snprintf(buffer, sizeof(buffer), "%s 1 q", CSI);
   write_console(&tty_out, buffer);
-  ASSERT(get_cursor_size(&tty_out) == CURSOR_SIZE_MIDDLE);
+  ASSERT_EQ(get_cursor_size(&tty_out), CURSOR_SIZE_MIDDLE);
   set_cursor_size(&tty_out, saved_cursor_size);
 
   /* #1874 2. */

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -585,8 +585,8 @@ TEST_IMPL(tty_cursor_back) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.Y, 1);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.Y);
+  ASSERT_EQ(1, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -619,7 +619,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y + 1, cursor_pos.Y);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
 
   /* cursor next line nth times */
   cursor_pos_old = cursor_pos;
@@ -627,7 +627,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y + si.height / 4, cursor_pos.Y);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
 
   /* cursor next line from buttom row moves beginning of line */
   cursor_pos_old.X = si.width / 2;
@@ -637,7 +637,7 @@ TEST_IMPL(tty_cursor_next_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -670,7 +670,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y - 1, cursor_pos.Y);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
 
   /* cursor previous line nth times */
   cursor_pos_old = cursor_pos;
@@ -678,7 +678,7 @@ TEST_IMPL(tty_cursor_previous_line) {
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
   ASSERT_EQ(cursor_pos_old.Y - si.height / 4, cursor_pos.Y);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
 
   /* cursor previous line from top of screen does nothing */
   cursor_pos_old.X = 1;
@@ -687,8 +687,8 @@ TEST_IMPL(tty_cursor_previous_line) {
   snprintf(buffer, sizeof(buffer), "%sD", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.Y, 1);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.Y);
+  ASSERT_EQ(1, cursor_pos.X);
   ASSERT(!is_scrolling(&tty_out, si));
 
   terminate_tty(&tty_out);
@@ -720,7 +720,7 @@ TEST_IMPL(tty_cursor_horizontal_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sG", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.X, 1);
+  ASSERT_EQ(1, cursor_pos.X);
   ASSERT_EQ(cursor_pos_old.Y, cursor_pos.Y);
 
   /* Move cursor to nth character */
@@ -766,8 +766,8 @@ TEST_IMPL(tty_cursor_move_absolute) {
   snprintf(buffer, sizeof(buffer), "%sH", CSI);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.X, 1);
-  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(1, cursor_pos.X);
+  ASSERT_EQ(1, cursor_pos.Y);
 
   /* Move the cursor to the middle of the screen */
   snprintf(
@@ -1520,8 +1520,8 @@ TEST_IMPL(tty_escape_sequence_processing) {
   snprintf(buffer, sizeof(buffer), "%s1;%dH", CSI, UINT16_MAX + 1);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.X, 1);
-  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(1, cursor_pos.X);
+  ASSERT_EQ(1, cursor_pos.Y);
 
   /* Too many argument are ignored */
   cursor_pos.X = 1;
@@ -1554,8 +1554,8 @@ TEST_IMPL(tty_escape_sequence_processing) {
            expect.si.width / 2);
   write_console(&tty_out, buffer);
   get_cursor_position(&tty_out, &cursor_pos);
-  ASSERT_EQ(cursor_pos.X, 1);
-  ASSERT_EQ(cursor_pos.Y, 1);
+  ASSERT_EQ(1, cursor_pos.X);
+  ASSERT_EQ(1, cursor_pos.Y);
 
   /* Invalid sequence are ignored */
   saved_cursor_size = get_cursor_size(&tty_out);

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -154,7 +154,7 @@ static void tty_raw_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT_EQ(nread , 1);
+    ASSERT_EQ(1, nread );
     ASSERT_EQ(buf->base[0], ' ');
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
@@ -297,7 +297,7 @@ TEST_IMPL(tty_large_write) {
   bufs[0] = uv_buf_init(dummy, sizeof(dummy));
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
-  ASSERT_EQ(r, 10000);
+  ASSERT_EQ(10000, r);
 
   uv_close((uv_handle_t*) &tty_out, NULL);
 

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -57,7 +57,7 @@ TEST_IMPL(tty) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
 
   handle = CreateFileA("conout$",
@@ -67,7 +67,7 @@ TEST_IMPL(tty) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
 #else /* unix */
@@ -86,26 +86,26 @@ TEST_IMPL(tty) {
   }
 #endif
 
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(ttyout_fd >= 0);
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_GE(ttyout_fd, 0);
 
-  ASSERT(UV_UNKNOWN_HANDLE == uv_guess_handle(-1));
+  ASSERT_EQ(UV_UNKNOWN_HANDLE, uv_guess_handle(-1));
 
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
-  ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(loop, &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
 
   r = uv_tty_get_winsize(&tty_out, &width, &height);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   printf("width=%d height=%d\n", width, height);
 
@@ -121,18 +121,18 @@ TEST_IMPL(tty) {
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Turn off raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_NORMAL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Calling uv_tty_reset_mode() repeatedly should not clobber errno. */
   errno = 0;
-  ASSERT(0 == uv_tty_reset_mode());
-  ASSERT(0 == uv_tty_reset_mode());
-  ASSERT(0 == uv_tty_reset_mode());
-  ASSERT(0 == errno);
+  ASSERT_EQ(0, uv_tty_reset_mode());
+  ASSERT_EQ(0, uv_tty_reset_mode());
+  ASSERT_EQ(0, uv_tty_reset_mode());
+  ASSERT_EQ(errno, 0);
 
   /* TODO check the actual mode! */
 
@@ -154,11 +154,11 @@ static void tty_raw_alloc(uv_handle_t* handle, size_t size, uv_buf_t* buf) {
 
 static void tty_raw_read(uv_stream_t* tty_in, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
-    ASSERT(nread  == 1);
-    ASSERT(buf->base[0] == ' ');
+    ASSERT_EQ(nread , 1);
+    ASSERT_EQ(buf->base[0], ' ');
     uv_close((uv_handle_t*) tty_in, NULL);
   } else {
-    ASSERT(nread == 0);
+    ASSERT_EQ(nread, 0);
   }
 }
 
@@ -179,25 +179,25 @@ TEST_IMPL(tty_raw) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(loop, &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(uv_is_readable((uv_stream_t*) &tty_in));
   ASSERT(!uv_is_writable((uv_stream_t*) &tty_in));
 
   r = uv_read_start((uv_stream_t*)&tty_in, tty_raw_alloc, tty_raw_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Give uv_tty_line_read_thread time to block on ReadConsoleW */
   Sleep(100);
 
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Write ' ' that should be read in raw mode */
   record.EventType = KEY_EVENT;
@@ -235,15 +235,15 @@ TEST_IMPL(tty_empty_write) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
-  ASSERT(ttyout_fd >= 0);
+  ASSERT_GE(ttyout_fd, 0);
 
-  ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   ASSERT(!uv_is_readable((uv_stream_t*) &tty_out));
   ASSERT(uv_is_writable((uv_stream_t*) &tty_out));
 
@@ -251,7 +251,7 @@ TEST_IMPL(tty_empty_write) {
   bufs[0].base = &dummy[0];
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &tty_out, NULL);
 
@@ -281,15 +281,15 @@ TEST_IMPL(tty_large_write) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
-  ASSERT(ttyout_fd >= 0);
+  ASSERT_GE(ttyout_fd, 0);
 
-  ASSERT(UV_TTY == uv_guess_handle(ttyout_fd));
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyout_fd));
 
   r = uv_tty_init(loop, &tty_out, ttyout_fd, 0);  /* Writable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   memset(dummy, '.', sizeof(dummy) - 1);
   dummy[sizeof(dummy) - 1] = '\n';
@@ -297,7 +297,7 @@ TEST_IMPL(tty_large_write) {
   bufs[0] = uv_buf_init(dummy, sizeof(dummy));
 
   r = uv_try_write((uv_stream_t*) &tty_out, bufs, 1);
-  ASSERT(r == 10000);
+  ASSERT_EQ(r, 10000);
 
   uv_close((uv_handle_t*) &tty_out, NULL);
 
@@ -321,20 +321,20 @@ TEST_IMPL(tty_raw_cancel) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT(handle != INVALID_HANDLE_VALUE);
+  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
-  ASSERT(ttyin_fd >= 0);
-  ASSERT(UV_TTY == uv_guess_handle(ttyin_fd));
+  ASSERT_GE(ttyin_fd, 0);
+  ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
 
   r = uv_tty_init(uv_default_loop(), &tty_in, ttyin_fd, 1);  /* Readable. */
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_read_start((uv_stream_t*)&tty_in, tty_raw_alloc, tty_raw_read);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_read_stop((uv_stream_t*) &tty_in);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -350,35 +350,35 @@ TEST_IMPL(tty_file) {
   uv_tty_t tty_wo;
   int fd;
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   fd = open("test/fixtures/empty_file", O_RDONLY);
   if (fd != -1) {
-    ASSERT(UV_EINVAL == uv_tty_init(&loop, &tty, fd, 1));
-    ASSERT(0 == close(fd));
+    ASSERT_EQ(UV_EINVAL, uv_tty_init(&loop, &tty, fd, 1));
+    ASSERT_EQ(0, close(fd));
     /* test EBADF handling */
-    ASSERT(UV_EINVAL == uv_tty_init(&loop, &tty, fd, 1));
+    ASSERT_EQ(UV_EINVAL, uv_tty_init(&loop, &tty, fd, 1));
   }
 
 /* Bug on AIX where '/dev/random' returns 1 from isatty() */
 #ifndef _AIX
   fd = open("/dev/random", O_RDONLY);
   if (fd != -1) {
-    ASSERT(UV_EINVAL == uv_tty_init(&loop, &tty, fd, 1));
-    ASSERT(0 == close(fd));
+    ASSERT_EQ(UV_EINVAL, uv_tty_init(&loop, &tty, fd, 1));
+    ASSERT_EQ(0, close(fd));
   }
 #endif /* _AIX */
 
   fd = open("/dev/zero", O_RDONLY);
   if (fd != -1) {
-    ASSERT(UV_EINVAL == uv_tty_init(&loop, &tty, fd, 1));
-    ASSERT(0 == close(fd));
+    ASSERT_EQ(UV_EINVAL, uv_tty_init(&loop, &tty, fd, 1));
+    ASSERT_EQ(0, close(fd));
   }
 
   fd = open("/dev/tty", O_RDWR);
   if (fd != -1) {
-    ASSERT(0 == uv_tty_init(&loop, &tty, fd, 1));
-    ASSERT(0 == close(fd)); /* TODO: it's indeterminate who owns fd now */
+    ASSERT_EQ(0, uv_tty_init(&loop, &tty, fd, 1));
+    ASSERT_EQ(0, close(fd)); /* TODO: it's indeterminate who owns fd now */
     ASSERT(uv_is_readable((uv_stream_t*) &tty));
     ASSERT(uv_is_writable((uv_stream_t*) &tty));
     uv_close((uv_handle_t*) &tty, NULL);
@@ -388,8 +388,8 @@ TEST_IMPL(tty_file) {
 
   fd = open("/dev/tty", O_RDONLY);
   if (fd != -1) {
-    ASSERT(0 == uv_tty_init(&loop, &tty_ro, fd, 1));
-    ASSERT(0 == close(fd)); /* TODO: it's indeterminate who owns fd now */
+    ASSERT_EQ(0, uv_tty_init(&loop, &tty_ro, fd, 1));
+    ASSERT_EQ(0, close(fd)); /* TODO: it's indeterminate who owns fd now */
     ASSERT(uv_is_readable((uv_stream_t*) &tty_ro));
     ASSERT(!uv_is_writable((uv_stream_t*) &tty_ro));
     uv_close((uv_handle_t*) &tty_ro, NULL);
@@ -399,8 +399,8 @@ TEST_IMPL(tty_file) {
 
   fd = open("/dev/tty", O_WRONLY);
   if (fd != -1) {
-    ASSERT(0 == uv_tty_init(&loop, &tty_wo, fd, 0));
-    ASSERT(0 == close(fd)); /* TODO: it's indeterminate who owns fd now */
+    ASSERT_EQ(0, uv_tty_init(&loop, &tty_wo, fd, 0));
+    ASSERT_EQ(0, close(fd)); /* TODO: it's indeterminate who owns fd now */
     ASSERT(!uv_is_readable((uv_stream_t*) &tty_wo));
     ASSERT(uv_is_writable((uv_stream_t*) &tty_wo));
     uv_close((uv_handle_t*) &tty_wo, NULL);
@@ -409,7 +409,7 @@ TEST_IMPL(tty_file) {
   }
 
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(&loop);
 #endif
@@ -436,14 +436,14 @@ TEST_IMPL(tty_pty) {
   uv_loop_t loop;
   uv_tty_t master_tty, slave_tty;
 
-  ASSERT(0 == uv_loop_init(&loop));
+  ASSERT_EQ(0, uv_loop_init(&loop));
 
   r = openpty(&master_fd, &slave_fd, NULL, NULL, &w);
   if (r != 0)
     RETURN_SKIP("No pty available, skipping.");
 
-  ASSERT(0 == uv_tty_init(&loop, &slave_tty, slave_fd, 0));
-  ASSERT(0 == uv_tty_init(&loop, &master_tty, master_fd, 0));
+  ASSERT_EQ(0, uv_tty_init(&loop, &slave_tty, slave_fd, 0));
+  ASSERT_EQ(0, uv_tty_init(&loop, &master_tty, master_fd, 0));
   ASSERT(uv_is_readable((uv_stream_t*) &slave_tty));
   ASSERT(uv_is_writable((uv_stream_t*) &slave_tty));
   ASSERT(uv_is_readable((uv_stream_t*) &master_tty));
@@ -451,16 +451,16 @@ TEST_IMPL(tty_pty) {
   /* Check if the file descriptor was reopened. If it is,
    * UV_HANDLE_BLOCKING_WRITES (value 0x100000) isn't set on flags.
    */
-  ASSERT(0 == (slave_tty.flags & 0x100000));
+  ASSERT_EQ(0, (slave_tty.flags & 0x100000));
   /* The master_fd of a pty should never be reopened.
    */
   ASSERT(master_tty.flags & 0x100000);
-  ASSERT(0 == close(slave_fd));
+  ASSERT_EQ(0, close(slave_fd));
   uv_close((uv_handle_t*) &slave_tty, NULL);
-  ASSERT(0 == close(master_fd));
+  ASSERT_EQ(0, close(master_fd));
   uv_close((uv_handle_t*) &master_tty, NULL);
 
-  ASSERT(0 == uv_run(&loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(&loop, UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(&loop);
 #endif

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -129,7 +129,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   r = uv_udp_recv_stop(handle);
@@ -185,11 +185,11 @@ TEST_IMPL(udp_alloc_cb_fail) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(cl_send_cb_called, 1);
-  ASSERT_EQ(cl_recv_cb_called, 1);
-  ASSERT_EQ(sv_send_cb_called, 1);
-  ASSERT_EQ(sv_recv_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, cl_send_cb_called);
+  ASSERT_EQ(1, cl_recv_cb_called);
+  ASSERT_EQ(1, sv_send_cb_called);
+  ASSERT_EQ(1, sv_recv_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -71,7 +71,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
   ASSERT_EQ(nread, UV_ENOBUFS);
 
   cl_recv_cb_called++;
@@ -84,11 +84,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, cl_alloc_cb, cl_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   cl_send_cb_called++;
 }
@@ -96,7 +96,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -126,21 +126,21 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
   ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   r = uv_udp_recv_stop(handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   req = malloc(sizeof *req);
   ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   sv_recv_cb_called++;
 }
@@ -152,21 +152,21 @@ TEST_IMPL(udp_alloc_cb_fail) {
   uv_buf_t buf;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, sv_alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init("PING", 4);
   r = uv_udp_send(&req,
@@ -175,13 +175,13 @@ TEST_IMPL(udp_alloc_cb_fail) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(cl_send_cb_called, 0);
-  ASSERT_EQ(cl_recv_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
-  ASSERT_EQ(sv_recv_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(cl_send_cb_called);
+  ASSERT_OK(cl_recv_cb_called);
+  ASSERT_OK(sv_send_cb_called);
+  ASSERT_OK(sv_recv_cb_called);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-alloc-cb-fail.c
+++ b/test/test-udp-alloc-cb-fail.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -60,7 +60,7 @@ static void cl_alloc_cb(uv_handle_t* handle,
 
 static void close_cb(uv_handle_t* handle) {
   CHECK_HANDLE(handle);
-  ASSERT(1 == uv_is_closing(handle));
+  ASSERT_EQ(1, uv_is_closing(handle));
   close_cb_called++;
 }
 
@@ -71,8 +71,8 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
-  ASSERT(nread == UV_ENOBUFS);
+  ASSERT_EQ(flags, 0);
+  ASSERT_EQ(nread, UV_ENOBUFS);
 
   cl_recv_cb_called++;
 
@@ -84,11 +84,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, cl_alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   cl_send_cb_called++;
 }
@@ -96,7 +96,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -126,21 +126,21 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   req = malloc(sizeof *req);
   ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sv_recv_cb_called++;
 }
@@ -152,21 +152,21 @@ TEST_IMPL(udp_alloc_cb_fail) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, sv_alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PING", 4);
   r = uv_udp_send(&req,
@@ -175,21 +175,21 @@ TEST_IMPL(udp_alloc_cb_fail) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_send_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
-  ASSERT(sv_recv_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_send_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_EQ(sv_recv_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 1);
-  ASSERT(cl_recv_cb_called == 1);
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(sv_recv_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 1);
+  ASSERT_EQ(cl_recv_cb_called, 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(sv_recv_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-bind.c
+++ b/test/test-udp-bind.c
@@ -33,18 +33,18 @@ TEST_IMPL(udp_bind) {
   uv_udp_t h1, h2;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, 0);
   ASSERT_EQ(r, UV_EADDRINUSE);
@@ -53,7 +53,7 @@ TEST_IMPL(udp_bind) {
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -66,27 +66,27 @@ TEST_IMPL(udp_bind_reuseaddr) {
   uv_udp_t h1, h2;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*) &h1, NULL);
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-udp-bind.c
+++ b/test/test-udp-bind.c
@@ -33,27 +33,27 @@ TEST_IMPL(udp_bind) {
   uv_udp_t h1, h2;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == UV_EADDRINUSE);
+  ASSERT_EQ(r, UV_EADDRINUSE);
 
   uv_close((uv_handle_t*) &h1, NULL);
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -66,27 +66,27 @@ TEST_IMPL(udp_bind_reuseaddr) {
   uv_udp_t h1, h2;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(loop, &h2);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h1, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&h2, (const struct sockaddr*) &addr, UV_UDP_REUSEADDR);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &h1, NULL);
   uv_close((uv_handle_t*) &h2, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -62,7 +62,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
   if (++cl_send_cb_called == 1) {
     uv_udp_connect(&client, NULL);
@@ -74,7 +74,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
                     1,
                     (const struct sockaddr*) &lo_addr,
                     cl_send_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
 }
@@ -88,7 +88,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   if (nread > 0) {
     ASSERT_EQ(nread, 4);
     ASSERT_NOT_NULL(addr);
-    ASSERT_EQ(memcmp("EXIT", rcvbuf->base, nread), 0);
+    ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
     if (++sv_recv_cb_called == 4) {
       uv_close((uv_handle_t*) &server, close_cb);
       uv_close((uv_handle_t*) &client, close_cb);
@@ -107,44 +107,44 @@ TEST_IMPL(udp_connect) {
   int r;
   int addrlen;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &lo_addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &lo_addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &lo_addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init("EXIT", 4);
 
   /* connect() to INADDR_ANY fails on Windows with WSAEADDRNOTAVAIL */
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &tmp_addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &tmp_addr));
   r = uv_udp_connect(&client, (const struct sockaddr*) &tmp_addr);
 #ifdef _WIN32
   ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 #else
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #endif
 
-  ASSERT_EQ(0, uv_ip4_addr("8.8.8.8", TEST_PORT, &ext_addr));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
+  ASSERT_OK(uv_ip4_addr("8.8.8.8", TEST_PORT, &ext_addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
   ASSERT_EQ(r, UV_EISCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* To send messages in connected UDP sockets addr must be NULL */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
@@ -155,7 +155,7 @@ TEST_IMPL(udp_connect) {
   ASSERT_EQ(r, UV_EISCONN);
 
   r = uv_udp_connect(&client, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, NULL);
   ASSERT_EQ(r, UV_ENOTCONN);
 
@@ -171,7 +171,7 @@ TEST_IMPL(udp_connect) {
 
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_send(&req,
                   &client,
                   &buf,
@@ -180,7 +180,7 @@ TEST_IMPL(udp_connect) {
                   cl_send_cb);
   ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -188,8 +188,8 @@ TEST_IMPL(udp_connect) {
   ASSERT_EQ(sv_recv_cb_called, 4);
   ASSERT_EQ(cl_send_cb_called, 2);
 
-  ASSERT_EQ(client.send_queue_size, 0);
-  ASSERT_EQ(server.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
+  ASSERT_OK(server.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -86,7 +86,7 @@ static void sv_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   if (nread > 0) {
-    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(4, nread);
     ASSERT_NOT_NULL(addr);
     ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
     if (++sv_recv_cb_called == 4) {
@@ -150,7 +150,7 @@ TEST_IMPL(udp_connect) {
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
   ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT_EQ(r, 4);
+  ASSERT_EQ(4, r);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
   ASSERT_EQ(r, UV_EISCONN);
 
@@ -165,7 +165,7 @@ TEST_IMPL(udp_connect) {
 
   /* To send messages in disconnected UDP sockets addr must be set */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 4);
+  ASSERT_EQ(4, r);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
   ASSERT_EQ(r, UV_EDESTADDRREQ);
 
@@ -184,9 +184,9 @@ TEST_IMPL(udp_connect) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
-  ASSERT_EQ(sv_recv_cb_called, 4);
-  ASSERT_EQ(cl_send_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(4, sv_recv_cb_called);
+  ASSERT_EQ(2, cl_send_cb_called);
 
   ASSERT_OK(client.send_queue_size);
   ASSERT_OK(server.send_queue_size);

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -45,7 +45,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -62,19 +62,19 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
   if (++cl_send_cb_called == 1) {
     uv_udp_connect(&client, NULL);
     r = uv_udp_send(req, &client, &buf, 1, NULL, cl_send_cb);
-    ASSERT(r == UV_EDESTADDRREQ);
+    ASSERT_EQ(r, UV_EDESTADDRREQ);
     r = uv_udp_send(req,
                     &client,
                     &buf,
                     1,
                     (const struct sockaddr*) &lo_addr,
                     cl_send_cb);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
 }
@@ -86,9 +86,9 @@ static void sv_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   if (nread > 0) {
-    ASSERT(nread == 4);
+    ASSERT_EQ(nread, 4);
     ASSERT_NOT_NULL(addr);
-    ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
+    ASSERT_EQ(memcmp("EXIT", rcvbuf->base, nread), 0);
     if (++sv_recv_cb_called == 4) {
       uv_close((uv_handle_t*) &server, close_cb);
       uv_close((uv_handle_t*) &client, close_cb);
@@ -107,19 +107,19 @@ TEST_IMPL(udp_connect) {
   int r;
   int addrlen;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &lo_addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &lo_addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &lo_addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("EXIT", 4);
 
@@ -134,62 +134,62 @@ TEST_IMPL(udp_connect) {
   ASSERT_EQ(r, 0);
 #endif
 
-  ASSERT(0 == uv_ip4_addr("8.8.8.8", TEST_PORT, &ext_addr));
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
+  ASSERT_EQ(0, uv_ip4_addr("8.8.8.8", TEST_PORT, &ext_addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* To send messages in connected UDP sockets addr must be NULL */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
 
   r = uv_udp_connect(&client, NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_connect(&client, NULL);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT(r == UV_ENOTCONN);
+  ASSERT_EQ(r, UV_ENOTCONN);
 
   /* To send messages in disconnected UDP sockets addr must be set */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT(r == UV_EDESTADDRREQ);
+  ASSERT_EQ(r, UV_EDESTADDRREQ);
 
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_send(&req,
                   &client,
                   &buf,
                   1,
                   (const struct sockaddr*) &lo_addr,
                   cl_send_cb);
-  ASSERT(r == UV_EISCONN);
+  ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 4);
-  ASSERT(cl_send_cb_called == 2);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 4);
+  ASSERT_EQ(cl_send_cb_called, 2);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-connect6.c
+++ b/test/test-udp-connect6.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;

--- a/test/test-udp-connect6.c
+++ b/test/test-udp-connect6.c
@@ -62,7 +62,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
   if (++cl_send_cb_called == 1) {
     uv_udp_connect(&client, NULL);
@@ -74,7 +74,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
                     1,
                     (const struct sockaddr*) &lo_addr,
                     cl_send_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
 }
@@ -88,7 +88,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   if (nread > 0) {
     ASSERT_EQ(nread, 4);
     ASSERT_NOT_NULL(addr);
-    ASSERT_EQ(memcmp("EXIT", rcvbuf->base, nread), 0);
+    ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
     if (++sv_recv_cb_called == 4) {
       uv_close((uv_handle_t*) &server, close_cb);
       uv_close((uv_handle_t*) &client, close_cb);
@@ -110,44 +110,44 @@ TEST_IMPL(udp_connect6) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &lo_addr));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &lo_addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &lo_addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init("EXIT", 4);
 
   /* connect() to INADDR_ANY fails on Windows wih WSAEADDRNOTAVAIL */
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &tmp_addr));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &tmp_addr));
   r = uv_udp_connect(&client, (const struct sockaddr*) &tmp_addr);
 #ifdef _WIN32
   ASSERT_EQ(r, UV_EADDRNOTAVAIL);
 #else
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 #endif
 
-  ASSERT_EQ(0, uv_ip6_addr("2001:4860:4860::8888", TEST_PORT, &ext_addr));
-  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &lo_addr));
+  ASSERT_OK(uv_ip6_addr("2001:4860:4860::8888", TEST_PORT, &ext_addr));
+  ASSERT_OK(uv_ip6_addr("::1", TEST_PORT, &lo_addr));
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
   ASSERT_EQ(r, UV_EISCONN);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* To send messages in connected UDP sockets addr must be NULL */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
@@ -158,7 +158,7 @@ TEST_IMPL(udp_connect6) {
   ASSERT_EQ(r, UV_EISCONN);
 
   r = uv_udp_connect(&client, NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_connect(&client, NULL);
   ASSERT_EQ(r, UV_ENOTCONN);
 
@@ -174,7 +174,7 @@ TEST_IMPL(udp_connect6) {
 
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_send(&req,
                   &client,
                   &buf,
@@ -183,7 +183,7 @@ TEST_IMPL(udp_connect6) {
                   cl_send_cb);
   ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_send(&req, &client, &buf, 1, NULL, cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -191,8 +191,8 @@ TEST_IMPL(udp_connect6) {
   ASSERT_EQ(sv_recv_cb_called, 4);
   ASSERT_EQ(cl_send_cb_called, 2);
 
-  ASSERT_EQ(client.send_queue_size, 0);
-  ASSERT_EQ(server.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
+  ASSERT_OK(server.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-connect6.c
+++ b/test/test-udp-connect6.c
@@ -86,7 +86,7 @@ static void sv_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   if (nread > 0) {
-    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(4, nread);
     ASSERT_NOT_NULL(addr);
     ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
     if (++sv_recv_cb_called == 4) {
@@ -153,7 +153,7 @@ TEST_IMPL(udp_connect6) {
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
   ASSERT_EQ(r, UV_EISCONN);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
-  ASSERT_EQ(r, 4);
+  ASSERT_EQ(4, r);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &ext_addr);
   ASSERT_EQ(r, UV_EISCONN);
 
@@ -168,7 +168,7 @@ TEST_IMPL(udp_connect6) {
 
   /* To send messages in disconnected UDP sockets addr must be set */
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &lo_addr);
-  ASSERT_EQ(r, 4);
+  ASSERT_EQ(4, r);
   r = uv_udp_try_send(&client, &buf, 1, NULL);
   ASSERT_EQ(r, UV_EDESTADDRREQ);
 
@@ -187,9 +187,9 @@ TEST_IMPL(udp_connect6) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
-  ASSERT_EQ(sv_recv_cb_called, 4);
-  ASSERT_EQ(cl_send_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(4, sv_recv_cb_called);
+  ASSERT_EQ(2, cl_send_cb_called);
 
   ASSERT_OK(client.send_queue_size);
   ASSERT_OK(server.send_queue_size);

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -38,32 +38,32 @@ TEST_IMPL(udp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(memcmp(&addr.sin_addr,
+  ASSERT_OK(r);
+  ASSERT_OK(memcmp(&addr.sin_addr,
                    &sockname.sin_addr,
-                   sizeof(addr.sin_addr)), 0);
+                   sizeof(addr.sin_addr)));
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -82,13 +82,13 @@ TEST_IMPL(udp_create_early_bad_bind) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
@@ -98,7 +98,7 @@ TEST_IMPL(udp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
     ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -38,32 +38,32 @@ TEST_IMPL(udp_create_early) {
   uv_os_fd_t fd;
   int r, namelen;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
-  ASSERT(fd != INVALID_FD);
+  ASSERT_EQ(r, 0);
+  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
-  ASSERT(sockname.sin_family == AF_INET);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(sockname.sin_family, AF_INET);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-  ASSERT(r == 0);
-  ASSERT(memcmp(&addr.sin_addr,
-                &sockname.sin_addr,
-                sizeof(addr.sin_addr)) == 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(memcmp(&addr.sin_addr,
+                   &sockname.sin_addr,
+                   sizeof(addr.sin_addr)), 0);
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -82,14 +82,14 @@ TEST_IMPL(udp_create_early_bad_bind) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init_ex(uv_default_loop(), &client, AF_INET6);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
-  ASSERT(r == 0);
-  ASSERT(fd != INVALID_FD);
+  ASSERT_EQ(r, 0);
+  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
@@ -98,16 +98,16 @@ TEST_IMPL(udp_create_early_bad_bind) {
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
     r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
-    ASSERT(r == 0);
-    ASSERT(sockname.sin6_family == AF_INET6);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
 #if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MSYS__)
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 #else
-  ASSERT(r == UV_EFAULT);
+  ASSERT_EQ(r, UV_EFAULT);
 #endif
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -123,10 +123,10 @@ TEST_IMPL(udp_create_early_bad_domain) {
   int r;
 
   r = uv_udp_init_ex(uv_default_loop(), &client, 47);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   r = uv_udp_init_ex(uv_default_loop(), &client, 1024);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -65,10 +65,10 @@ TEST_IMPL(udp_dgram_too_big) {
   memset(dgram, 42, sizeof dgram); /* silence valgrind */
 
   r = uv_udp_init(uv_default_loop(), &handle_);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init(dgram, sizeof dgram);
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_send(&req_,
                   &handle_,
@@ -76,10 +76,10 @@ TEST_IMPL(udp_dgram_too_big) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(send_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(send_cb_called);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -83,8 +83,8 @@ TEST_IMPL(udp_dgram_too_big) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, send_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-dgram-too-big.c
+++ b/test/test-udp-dgram-too-big.c
@@ -27,10 +27,10 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &handle_)
+  ASSERT_PTR_EQ((uv_udp_t*)(handle), &handle_)
 
 #define CHECK_REQ(req) \
-  ASSERT((req) == &req_);
+  ASSERT_PTR_EQ((req), &req_);
 
 static uv_udp_t handle_;
 static uv_udp_send_t req_;
@@ -49,7 +49,7 @@ static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_REQ(req);
   CHECK_HANDLE(req->handle);
 
-  ASSERT(status == UV_EMSGSIZE);
+  ASSERT_EQ(status, UV_EMSGSIZE);
 
   uv_close((uv_handle_t*)req->handle, close_cb);
   send_cb_called++;
@@ -65,10 +65,10 @@ TEST_IMPL(udp_dgram_too_big) {
   memset(dgram, 42, sizeof dgram); /* silence valgrind */
 
   r = uv_udp_init(uv_default_loop(), &handle_);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(dgram, sizeof dgram);
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_send(&req_,
                   &handle_,
@@ -76,15 +76,15 @@ TEST_IMPL(udp_dgram_too_big) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(send_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -81,7 +81,7 @@ static void close_cb(uv_handle_t* handle) {
 static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_REQ(req);
   CHECK_HANDLE(req->handle);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   send_cb_called++;
 }
 
@@ -151,35 +151,32 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
   char dst[256];
   int r;
 
-  ASSERT_EQ(0, uv_ip6_addr("::0", TEST_PORT, &addr6));
+  ASSERT_OK(uv_ip6_addr("::0", TEST_PORT, &addr6));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr6, bind_flags);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   addr6_len = sizeof(addr6);
-  ASSERT_EQ(uv_udp_getsockname(&server,
+  ASSERT_OK(uv_udp_getsockname(&server,
                                (struct sockaddr*) &addr6,
-                               &addr6_len),
-            0);
-  ASSERT_EQ(uv_inet_ntop(addr6.sin6_family,
+                               &addr6_len));
+  ASSERT_OK(uv_inet_ntop(addr6.sin6_family,
                          &addr6.sin6_addr,
                          dst,
-                         sizeof(dst)),
-            0);
+                         sizeof(dst)));
   printf("on [%.*s]:%d\n", (int) sizeof(dst), dst, addr6.sin6_port);
 
   r = uv_udp_recv_start(&server, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(uv_inet_ntop(addr.sin_family, &addr.sin_addr, dst, sizeof(dst)),
-            0);
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_inet_ntop(addr.sin_family, &addr.sin_addr, dst, sizeof(dst)));
   printf("to [%.*s]:%d\n", (int) sizeof(dst), dst, addr.sin_port);
 
   /* Create some unique data to send */
@@ -196,25 +193,23 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   addr_len = sizeof(addr);
-  ASSERT_EQ(uv_udp_getsockname(&client, (struct sockaddr*) &addr, &addr_len),
-            0);
-  ASSERT_EQ(uv_inet_ntop(addr.sin_family, &addr.sin_addr, dst, sizeof(dst)),
-            0);
+  ASSERT_OK(uv_udp_getsockname(&client, (struct sockaddr*) &addr, &addr_len));
+  ASSERT_OK(uv_inet_ntop(addr.sin_family, &addr.sin_addr, dst, sizeof(dst)));
   printf("from [%.*s]:%d\n", (int) sizeof(dst), dst, addr.sin_port);
   client_port = addr.sin_port;
 
   r = uv_timer_init(uv_default_loop(), &timeout);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timeout, timeout_cb, 500, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(send_cb_called, 0);
-  ASSERT_EQ(recv_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(send_cb_called);
+  ASSERT_OK(recv_cb_called);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -257,7 +252,7 @@ TEST_IMPL(udp_ipv6_only) {
 
   do_test(ipv6_recv_fail, UV_UDP_IPV6ONLY);
 
-  ASSERT_EQ(recv_cb_called, 0);
+  ASSERT_OK(recv_cb_called);
   ASSERT_EQ(send_cb_called, 1);
 
   return 0;

--- a/test/test-udp-ipv6.c
+++ b/test/test-udp-ipv6.c
@@ -129,7 +129,7 @@ static void ipv6_recv_ok(uv_udp_t* handle,
   if (!is_from_client(addr) || (nread == 0 && addr == NULL))
     return;
 
-  ASSERT_EQ(nread, 9);
+  ASSERT_EQ(9, nread);
   ASSERT(!memcmp(buf->base, data, 9));
   recv_cb_called++;
 }
@@ -213,7 +213,7 @@ static void do_test(uv_udp_recv_cb recv_cb, int bind_flags) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 3);
+  ASSERT_EQ(3, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
 }
@@ -239,8 +239,8 @@ TEST_IMPL(udp_dual_stack) {
 
   printf("recv_cb_called %d\n", recv_cb_called);
   printf("send_cb_called %d\n", send_cb_called);
-  ASSERT_EQ(recv_cb_called, 1);
-  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(1, recv_cb_called);
+  ASSERT_EQ(1, send_cb_called);
 
   return 0;
 }
@@ -253,7 +253,7 @@ TEST_IMPL(udp_ipv6_only) {
   do_test(ipv6_recv_fail, UV_UDP_IPV6ONLY);
 
   ASSERT_OK(recv_cb_called);
-  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(1, send_cb_called);
 
   return 0;
 }

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -77,7 +77,7 @@ static void recv_cb(uv_udp_t* handle,
 
   /* free and return if this is a mmsg free-only callback invocation */
   if (flags & UV_UDP_MMSG_FREE) {
-    ASSERT_EQ(nread, 0);
+    ASSERT_OK(nread);
     ASSERT_NULL(addr);
     free(rcvbuf->base);
     return;
@@ -110,31 +110,31 @@ TEST_IMPL(udp_mmsg) {
   uv_buf_t buf;
   int i;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_udp_init_ex(uv_default_loop(), &recver,
-                              AF_UNSPEC | UV_UDP_RECVMMSG));
+  ASSERT_OK(uv_udp_init_ex(uv_default_loop(), &recver,
+                           AF_UNSPEC | UV_UDP_RECVMMSG));
 
-  ASSERT_EQ(0, uv_udp_bind(&recver, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_udp_bind(&recver, (const struct sockaddr*) &addr, 0));
 
-  ASSERT_EQ(0, uv_udp_recv_start(&recver, alloc_cb, recv_cb));
+  ASSERT_OK(uv_udp_recv_start(&recver, alloc_cb, recv_cb));
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &sender));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &sender));
 
   buf = uv_buf_init("PING", 4);
   for (i = 0; i < NUM_SENDS; i++) {
     ASSERT_EQ(4, uv_udp_try_send(&sender, &buf, 1, (const struct sockaddr*) &addr));
   }
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT_EQ(close_cb_called, 2);
   ASSERT_EQ(received_datagrams, NUM_SENDS);
 
-  ASSERT_EQ(sender.send_queue_size, 0);
-  ASSERT_EQ(recver.send_queue_size, 0);
+  ASSERT_OK(sender.send_queue_size);
+  ASSERT_OK(recver.send_queue_size);
 
   printf("%d allocs for %d recvs\n", alloc_cb_called, recv_cb_called);
 

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &recver || (uv_udp_t*)(handle) == &sender)
+  ASSERT_NE((uv_udp_t*)(handle) == &recver || (uv_udp_t*)(handle) == &sender, 0)
 
 #define BUFFER_MULTIPLIER 20
 #define MAX_DGRAM_SIZE (64 * 1024)

--- a/test/test-udp-mmsg.c
+++ b/test/test-udp-mmsg.c
@@ -87,7 +87,7 @@ static void recv_cb(uv_udp_t* handle,
     /* There can be no more available data for the time being. */
     ASSERT_NULL(addr);
   } else {
-    ASSERT_EQ(nread, 4);
+    ASSERT_EQ(4, nread);
     ASSERT_NOT_NULL(addr);
     ASSERT_MEM_EQ("PING", rcvbuf->base, nread);
     received_datagrams++;
@@ -130,7 +130,7 @@ TEST_IMPL(udp_mmsg) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, close_cb_called);
   ASSERT_EQ(received_datagrams, NUM_SENDS);
 
   ASSERT_OK(sender.send_queue_size);

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -65,17 +65,17 @@ TEST_IMPL(udp_multicast_interface) {
   struct sockaddr_in addr;
   struct sockaddr_in baddr;
 
-  ASSERT(0 == uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &baddr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_multicast_interface(&server, "0.0.0.0");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -85,19 +85,19 @@ TEST_IMPL(udp_multicast_interface) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -93,8 +93,8 @@ TEST_IMPL(udp_multicast_interface) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(sv_send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, sv_send_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   ASSERT_OK(client.send_queue_size);
   ASSERT_OK(server.send_queue_size);

--- a/test/test-udp-multicast-interface.c
+++ b/test/test-udp-multicast-interface.c
@@ -65,17 +65,17 @@ TEST_IMPL(udp_multicast_interface) {
   struct sockaddr_in addr;
   struct sockaddr_in baddr;
 
-  ASSERT_EQ(0, uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &baddr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_set_multicast_interface(&server, "0.0.0.0");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -85,10 +85,10 @@ TEST_IMPL(udp_multicast_interface) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(sv_send_cb_called);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -96,8 +96,8 @@ TEST_IMPL(udp_multicast_interface) {
   ASSERT_EQ(sv_send_cb_called, 1);
   ASSERT_EQ(close_cb_called, 1);
 
-  ASSERT_EQ(client.send_queue_size, 0);
-  ASSERT_EQ(server.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
+  ASSERT_OK(server.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -100,8 +100,8 @@ TEST_IMPL(udp_multicast_interface6) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(sv_send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, sv_send_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -68,21 +68,21 @@ TEST_IMPL(udp_multicast_interface6) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip6_addr("::", 0, &baddr));
+  ASSERT_OK(uv_ip6_addr("::", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
   r = uv_udp_set_multicast_interface(&server, "::1%lo0");
 #else
   r = uv_udp_set_multicast_interface(&server, NULL);
 #endif
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -92,10 +92,10 @@ TEST_IMPL(udp_multicast_interface6) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(sv_send_cb_called);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-interface6.c
+++ b/test/test-udp-multicast-interface6.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -44,7 +44,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -68,21 +68,21 @@ TEST_IMPL(udp_multicast_interface6) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("::1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("::1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip6_addr("::", 0, &baddr));
+  ASSERT_EQ(0, uv_ip6_addr("::", 0, &baddr));
   r = uv_udp_bind(&server, (const struct sockaddr*)&baddr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
   r = uv_udp_set_multicast_interface(&server, "::1%lo0");
 #else
   r = uv_udp_set_multicast_interface(&server, NULL);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
@@ -92,16 +92,16 @@ TEST_IMPL(udp_multicast_interface6) {
                   1,
                   (const struct sockaddr*)&addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -108,7 +108,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -175,9 +175,9 @@ TEST_IMPL(udp_multicast_join) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(cl_recv_cb_called, 2);
-  ASSERT_EQ(sv_send_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, cl_recv_cb_called);
+  ASSERT_EQ(2, sv_send_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -61,7 +61,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -77,7 +77,7 @@ static int do_send(uv_udp_send_t* send_req) {
   
   buf = uv_buf_init("PING", 4);
 
-  ASSERT_EQ(0, uv_ip4_addr(MULTICAST_ADDR, TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr(MULTICAST_ADDR, TEST_PORT, &addr));
 
   /* client sends "PING" */
   return uv_udp_send(send_req,
@@ -95,7 +95,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -121,18 +121,18 @@ static void cl_recv_cb(uv_udp_t* handle,
     char source_addr[64];
 
     r = uv_ip4_name((const struct sockaddr_in*)addr, source_addr, sizeof(source_addr));
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_LEAVE_GROUP);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
 #if !defined(__OpenBSD__) && !defined(__NetBSD__)
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, NULL, source_addr, UV_JOIN_GROUP);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 #endif
 
     r = do_send(&req_ss);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 }
 
@@ -144,33 +144,33 @@ TEST_IMPL(udp_multicast_join) {
   int r;
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* bind to the desired port */
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* join the multicast channel */
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_JOIN_GROUP);
   if (r == UV_ENODEV)
     RETURN_SKIP("No multicast support.");
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = do_send(&req);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(cl_recv_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(cl_recv_cb_called);
+  ASSERT_OK(sv_send_cb_called);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 #define MULTICAST_ADDR "239.255.0.1"
 
@@ -47,7 +47,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -61,7 +61,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -77,7 +77,7 @@ static int do_send(uv_udp_send_t* send_req) {
   
   buf = uv_buf_init("PING", 4);
 
-  ASSERT(0 == uv_ip4_addr(MULTICAST_ADDR, TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr(MULTICAST_ADDR, TEST_PORT, &addr));
 
   /* client sends "PING" */
   return uv_udp_send(send_req,
@@ -95,7 +95,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -108,7 +108,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -121,18 +121,18 @@ static void cl_recv_cb(uv_udp_t* handle,
     char source_addr[64];
 
     r = uv_ip4_name((const struct sockaddr_in*)addr, source_addr, sizeof(source_addr));
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_LEAVE_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
 #if !defined(__OpenBSD__) && !defined(__NetBSD__)
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, NULL, source_addr, UV_JOIN_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 
     r = do_send(&req_ss);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -144,40 +144,40 @@ TEST_IMPL(udp_multicast_join) {
   int r;
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* bind to the desired port */
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* join the multicast channel */
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_JOIN_GROUP);
   if (r == UV_ENODEV)
     RETURN_SKIP("No multicast support.");
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = do_send(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_recv_cb_called == 2);
-  ASSERT(sv_send_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_recv_cb_called, 2);
+  ASSERT_EQ(sv_send_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -28,7 +28,7 @@
 
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 #if defined(__APPLE__)          || \
     defined(_AIX)               || \
@@ -58,7 +58,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -72,7 +72,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   sv_send_cb_called++;
@@ -88,7 +88,7 @@ static int do_send(uv_udp_send_t* send_req) {
   
   buf = uv_buf_init("PING", 4);
 
-  ASSERT(0 == uv_ip6_addr(MULTICAST_ADDR, TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr(MULTICAST_ADDR, TEST_PORT, &addr));
 
   /* client sends "PING" */
   return uv_udp_send(send_req,
@@ -106,7 +106,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -119,7 +119,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -132,16 +132,16 @@ static void cl_recv_cb(uv_udp_t* handle,
     char source_addr[64];
 
     r = uv_ip6_name((const struct sockaddr_in6*)addr, source_addr, sizeof(source_addr));
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, UV_LEAVE_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, source_addr, UV_JOIN_GROUP);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = do_send(&req_ss);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 }
 
@@ -172,17 +172,17 @@ TEST_IMPL(udp_multicast_join6) {
   if (!can_ipv6_external())
     RETURN_SKIP("No external IPv6 interface available");
 
-  ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* bind to the desired port */
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_membership(&server, MULTICAST_ADDR, INTERFACE_ADDR, UV_JOIN_GROUP);
   if (r == UV_ENODEV) {
@@ -190,28 +190,28 @@ TEST_IMPL(udp_multicast_join6) {
     RETURN_SKIP("No ipv6 multicast route");
   }
 
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 /* TODO(gengjiawen): Fix test on QEMU. */
 #if defined(__QEMU__)
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   
   r = do_send(&req);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_recv_cb_called == 2);
-  ASSERT(sv_send_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_recv_cb_called, 2);
+  ASSERT_EQ(sv_send_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -119,7 +119,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(!memcmp("PING", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -209,9 +209,9 @@ TEST_IMPL(udp_multicast_join6) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(cl_recv_cb_called, 2);
-  ASSERT_EQ(sv_send_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, cl_recv_cb_called);
+  ASSERT_EQ(2, sv_send_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -60,34 +60,34 @@ TEST_IMPL(udp_multicast_ttl) {
   struct sockaddr_in addr;
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &addr));
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_multicast_ttl(&server, 32);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
-  ASSERT(0 == uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
   r = uv_udp_send(&req,
                   &server,
                   &buf,
                   1,
                   (const struct sockaddr*) &addr,
                   sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -60,28 +60,28 @@ TEST_IMPL(udp_multicast_ttl) {
   struct sockaddr_in addr;
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", 0, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &addr));
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_set_multicast_ttl(&server, 32);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* server sends "PING" */
   buf = uv_buf_init("PING", 4);
-  ASSERT_EQ(0, uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("239.255.0.1", TEST_PORT, &addr));
   r = uv_udp_send(&req,
                   &server,
                   &buf,
                   1,
                   (const struct sockaddr*) &addr,
                   sv_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(sv_send_cb_called);
 
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-multicast-ttl.c
+++ b/test/test-udp-multicast-ttl.c
@@ -86,8 +86,8 @@ TEST_IMPL(udp_multicast_ttl) {
   /* run the loop till all events are processed */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(sv_send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, sv_send_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -41,7 +41,7 @@ static void startup(void) {
 #ifdef _WIN32
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 #endif
 }
 
@@ -61,7 +61,7 @@ static uv_os_sock_t create_udp_socket(void) {
     /* Allow reuse of the port. */
     int yes = 1;
     int r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 #endif
 
@@ -76,7 +76,7 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -113,14 +113,14 @@ static void recv_cb(uv_udp_t* handle,
     return;
   }
 
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
   ASSERT_EQ(nread, 4);
-  ASSERT_EQ(memcmp("PING", buf->base, nread), 0);
+  ASSERT_OK(memcmp("PING", buf->base, nread));
 
   r = uv_udp_recv_stop(handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*) handle, close_cb);
 }
@@ -128,7 +128,7 @@ static void recv_cb(uv_udp_t* handle,
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
 
   send_cb_called++;
   uv_close((uv_handle_t*)req->handle, close_cb);
@@ -142,22 +142,22 @@ TEST_IMPL(udp_open) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_open(&client, sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -165,12 +165,12 @@ TEST_IMPL(udp_open) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
 #ifndef _WIN32
   {
     r = uv_udp_init(uv_default_loop(), &client2);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_udp_open(&client2, sock);
     ASSERT_EQ(r, UV_EEXIST);
@@ -186,7 +186,7 @@ TEST_IMPL(udp_open) {
   ASSERT_EQ(send_cb_called, 1);
   ASSERT_EQ(close_cb_called, 1);
 
-  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -203,10 +203,10 @@ TEST_IMPL(udp_open_twice) {
   sock2 = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_open(&client, sock1);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_open(&client, sock2);
   ASSERT_EQ(r, UV_EBUSY);
@@ -225,22 +225,22 @@ TEST_IMPL(udp_open_bound) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = bind(sock, (struct sockaddr*) &addr, sizeof(addr));
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_open(&client, sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -257,28 +257,28 @@ TEST_IMPL(udp_open_connect) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof(addr));
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_open(&client, sock);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -286,14 +286,14 @@ TEST_IMPL(udp_open_connect) {
                   1,
                   NULL,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(send_cb_called, 1);
   ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -322,13 +322,13 @@ TEST_IMPL(udp_send_unix) {
   ASSERT_GE(fd, 0);
 
   unlink(TEST_PIPENAME);
-  ASSERT_EQ(0, bind(fd, (const struct sockaddr*)&addr, sizeof addr));
-  ASSERT_EQ(0, listen(fd, 1));
+  ASSERT_OK(bind(fd, (const struct sockaddr*)&addr, sizeof addr));
+  ASSERT_OK(listen(fd, 1));
 
   r = uv_udp_init(loop, &handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   r = uv_udp_open(&handle, fd);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_udp_send(&req,
@@ -337,7 +337,7 @@ TEST_IMPL(udp_send_unix) {
                   1,
                   (const struct sockaddr*) &addr,
                   NULL);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_close((uv_handle_t*)&handle, NULL);
   uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -116,7 +116,7 @@ static void recv_cb(uv_udp_t* handle,
   ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT_OK(memcmp("PING", buf->base, nread));
 
   r = uv_udp_recv_stop(handle);
@@ -183,8 +183,8 @@ TEST_IMPL(udp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 1);
+  ASSERT_EQ(1, send_cb_called);
+  ASSERT_EQ(1, close_cb_called);
 
   ASSERT_OK(client.send_queue_size);
 
@@ -290,8 +290,8 @@ TEST_IMPL(udp_open_connect) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(send_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, send_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   ASSERT_OK(client.send_queue_size);
 

--- a/test/test-udp-open.c
+++ b/test/test-udp-open.c
@@ -41,7 +41,7 @@ static void startup(void) {
 #ifdef _WIN32
     struct WSAData wsa_data;
     int r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
 }
 
@@ -51,9 +51,9 @@ static uv_os_sock_t create_udp_socket(void) {
 
   sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 #ifdef _WIN32
-  ASSERT(sock != INVALID_SOCKET);
+  ASSERT_NE(sock, INVALID_SOCKET);
 #else
-  ASSERT(sock >= 0);
+  ASSERT_GE(sock, 0);
 #endif
 
 #ifndef _WIN32
@@ -61,7 +61,7 @@ static uv_os_sock_t create_udp_socket(void) {
     /* Allow reuse of the port. */
     int yes = 1;
     int r = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof yes);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 #endif
 
@@ -76,7 +76,7 @@ static void close_socket(uv_os_sock_t sock) {
 #else
   r = close(sock);
 #endif
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -84,7 +84,7 @@ static void alloc_cb(uv_handle_t* handle,
                      size_t suggested_size,
                      uv_buf_t* buf) {
   static char slab[65536];
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -113,14 +113,14 @@ static void recv_cb(uv_udp_t* handle,
     return;
   }
 
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
-  ASSERT(memcmp("PING", buf->base, nread) == 0);
+  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(memcmp("PING", buf->base, nread), 0);
 
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) handle, close_cb);
 }
@@ -128,7 +128,7 @@ static void recv_cb(uv_udp_t* handle,
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
 
   send_cb_called++;
   uv_close((uv_handle_t*)req->handle, close_cb);
@@ -142,22 +142,22 @@ TEST_IMPL(udp_open) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -165,15 +165,15 @@ TEST_IMPL(udp_open) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
   {
     r = uv_udp_init(uv_default_loop(), &client2);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 
     r = uv_udp_open(&client2, sock);
-    ASSERT(r == UV_EEXIST);
+    ASSERT_EQ(r, UV_EEXIST);
 
     uv_close((uv_handle_t*) &client2, NULL);
   }
@@ -183,10 +183,10 @@ TEST_IMPL(udp_open) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 1);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 1);
 
-  ASSERT(client.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -203,13 +203,13 @@ TEST_IMPL(udp_open_twice) {
   sock2 = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock1);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock2);
-  ASSERT(r == UV_EBUSY);
+  ASSERT_EQ(r, UV_EBUSY);
   close_socket(sock2);
 
   uv_close((uv_handle_t*) &client, NULL);
@@ -225,22 +225,22 @@ TEST_IMPL(udp_open_bound) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = bind(sock, (struct sockaddr*) &addr, sizeof(addr));
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*) &client, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
@@ -257,28 +257,28 @@ TEST_IMPL(udp_open_connect) {
   uv_os_sock_t sock;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   startup();
   sock = create_udp_socket();
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = connect(sock, (const struct sockaddr*) &addr, sizeof(addr));
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_open(&client, sock);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_send(&send_req,
                   &client,
@@ -286,14 +286,14 @@ TEST_IMPL(udp_open_connect) {
                   1,
                   NULL,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(send_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(send_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT(client.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -315,20 +315,20 @@ TEST_IMPL(udp_send_unix) {
 
   memset(&addr, 0, sizeof addr);
   addr.sun_family = AF_UNIX;
-  ASSERT(strlen(TEST_PIPENAME) < sizeof(addr.sun_path));
+  ASSERT_LT(strlen(TEST_PIPENAME), sizeof(addr.sun_path));
   memcpy(addr.sun_path, TEST_PIPENAME, strlen(TEST_PIPENAME));
 
   fd = socket(AF_UNIX, SOCK_STREAM, 0);
-  ASSERT(fd >= 0);
+  ASSERT_GE(fd, 0);
 
   unlink(TEST_PIPENAME);
-  ASSERT(0 == bind(fd, (const struct sockaddr*)&addr, sizeof addr));
-  ASSERT(0 == listen(fd, 1));
+  ASSERT_EQ(0, bind(fd, (const struct sockaddr*)&addr, sizeof addr));
+  ASSERT_EQ(0, listen(fd, 1));
 
   r = uv_udp_init(loop, &handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   r = uv_udp_open(&handle, fd);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
   uv_run(loop, UV_RUN_DEFAULT);
 
   r = uv_udp_send(&req,
@@ -337,7 +337,7 @@ TEST_IMPL(udp_send_unix) {
                   1,
                   (const struct sockaddr*) &addr,
                   NULL);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_close((uv_handle_t*)&handle, NULL);
   uv_run(loop, UV_RUN_DEFAULT);

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -36,56 +36,56 @@ static int udp_options_test(const struct sockaddr* addr) {
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_unref((uv_handle_t*)&h); /* don't keep the loop alive */
 
   r = uv_udp_bind(&h, addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 0);
   r |= uv_udp_set_broadcast(&h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* values 1-255 should work */
   for (i = 1; i <= 255; i++) {
     r = uv_udp_set_ttl(&h, i);
 #if defined(__MVS__)
     if (addr->sa_family == AF_INET6)
-      ASSERT(r == 0);
+      ASSERT_EQ(r, 0);
     else
-      ASSERT(r == UV_ENOTSUP);
+      ASSERT_EQ(r, UV_ENOTSUP);
 #else
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
 #endif
   }
 
   for (i = 0; i < (int) ARRAY_SIZE(invalid_ttls); i++) {
     r = uv_udp_set_ttl(&h, invalid_ttls[i]);
-    ASSERT(r == UV_EINVAL);
+    ASSERT_EQ(r, UV_EINVAL);
   }
 
   r = uv_udp_set_multicast_loop(&h, 1);
   r |= uv_udp_set_multicast_loop(&h, 1);
   r |= uv_udp_set_multicast_loop(&h, 0);
   r |= uv_udp_set_multicast_loop(&h, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* values 0-255 should work */
   for (i = 0; i <= 255; i++) {
     r = uv_udp_set_multicast_ttl(&h, i);
-    ASSERT(r == 0);
+    ASSERT_EQ(r, 0);
   }
 
   /* anything >255 should fail */
   r = uv_udp_set_multicast_ttl(&h, 256);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
   /* don't test ttl=-1, it's a valid value on some platforms */
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -95,7 +95,7 @@ static int udp_options_test(const struct sockaddr* addr) {
 TEST_IMPL(udp_options) {
   struct sockaddr_in addr;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   return udp_options_test((const struct sockaddr*) &addr);
 }
 
@@ -106,7 +106,7 @@ TEST_IMPL(udp_options6) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT(0 == uv_ip6_addr("::", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr));
   return udp_options_test((const struct sockaddr*) &addr);
 }
 
@@ -119,41 +119,41 @@ TEST_IMPL(udp_no_autobind) {
   loop = uv_default_loop();
 
   /* Test a lazy initialized socket. */
-  ASSERT(0 == uv_udp_init(loop, &h));
-  ASSERT(UV_EBADF == uv_udp_set_multicast_ttl(&h, 32));
-  ASSERT(UV_EBADF == uv_udp_set_broadcast(&h, 1));
+  ASSERT_EQ(0, uv_udp_init(loop, &h));
+  ASSERT_EQ(UV_EBADF, uv_udp_set_multicast_ttl(&h, 32));
+  ASSERT_EQ(UV_EBADF, uv_udp_set_broadcast(&h, 1));
 #if defined(__MVS__)
-  ASSERT(UV_ENOTSUP == uv_udp_set_ttl(&h, 1));
+  ASSERT_EQ(UV_ENOTSUP, uv_udp_set_ttl(&h, 1));
 #else
-  ASSERT(UV_EBADF == uv_udp_set_ttl(&h, 1));
+  ASSERT_EQ(UV_EBADF, uv_udp_set_ttl(&h, 1));
 #endif
-  ASSERT(UV_EBADF == uv_udp_set_multicast_loop(&h, 1));
+  ASSERT_EQ(UV_EBADF, uv_udp_set_multicast_loop(&h, 1));
 /* TODO(gengjiawen): Fix test on QEMU. */
 #if defined(__QEMU__)
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
-  ASSERT(UV_EBADF == uv_udp_set_multicast_interface(&h, "0.0.0.0"));
+  ASSERT_EQ(UV_EBADF, uv_udp_set_multicast_interface(&h, "0.0.0.0"));
 
   uv_close((uv_handle_t*) &h, NULL);
 
   /* Test a non-lazily initialized socket. */
-  ASSERT(0 == uv_udp_init_ex(loop, &h2, AF_INET | UV_UDP_RECVMMSG));
-  ASSERT(0 == uv_udp_set_multicast_ttl(&h2, 32));
-  ASSERT(0 == uv_udp_set_broadcast(&h2, 1));
+  ASSERT_EQ(0, uv_udp_init_ex(loop, &h2, AF_INET | UV_UDP_RECVMMSG));
+  ASSERT_EQ(0, uv_udp_set_multicast_ttl(&h2, 32));
+  ASSERT_EQ(0, uv_udp_set_broadcast(&h2, 1));
 
 #if defined(__MVS__)
   /* zOS only supports setting ttl for IPv6 sockets. */
-  ASSERT(UV_ENOTSUP == uv_udp_set_ttl(&h2, 1));
+  ASSERT_EQ(UV_ENOTSUP, uv_udp_set_ttl(&h2, 1));
 #else
-  ASSERT(0 == uv_udp_set_ttl(&h2, 1));
+  ASSERT_EQ(0, uv_udp_set_ttl(&h2, 1));
 #endif
 
-  ASSERT(0 == uv_udp_set_multicast_loop(&h2, 1));
-  ASSERT(0 == uv_udp_set_multicast_interface(&h2, "0.0.0.0"));
+  ASSERT_EQ(0, uv_udp_set_multicast_loop(&h2, 1));
+  ASSERT_EQ(0, uv_udp_set_multicast_interface(&h2, "0.0.0.0"));
 
   uv_close((uv_handle_t*) &h2, NULL);
 
-  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-udp-options.c
+++ b/test/test-udp-options.c
@@ -36,29 +36,29 @@ static int udp_options_test(const struct sockaddr* addr) {
   loop = uv_default_loop();
 
   r = uv_udp_init(loop, &h);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_unref((uv_handle_t*)&h); /* don't keep the loop alive */
 
   r = uv_udp_bind(&h, addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 1);
   r |= uv_udp_set_broadcast(&h, 0);
   r |= uv_udp_set_broadcast(&h, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* values 1-255 should work */
   for (i = 1; i <= 255; i++) {
     r = uv_udp_set_ttl(&h, i);
 #if defined(__MVS__)
     if (addr->sa_family == AF_INET6)
-      ASSERT_EQ(r, 0);
+      ASSERT_OK(r);
     else
       ASSERT_EQ(r, UV_ENOTSUP);
 #else
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 #endif
   }
 
@@ -71,12 +71,12 @@ static int udp_options_test(const struct sockaddr* addr) {
   r |= uv_udp_set_multicast_loop(&h, 1);
   r |= uv_udp_set_multicast_loop(&h, 0);
   r |= uv_udp_set_multicast_loop(&h, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* values 0-255 should work */
   for (i = 0; i <= 255; i++) {
     r = uv_udp_set_multicast_ttl(&h, i);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   /* anything >255 should fail */
@@ -85,7 +85,7 @@ static int udp_options_test(const struct sockaddr* addr) {
   /* don't test ttl=-1, it's a valid value on some platforms */
 
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
@@ -95,7 +95,7 @@ static int udp_options_test(const struct sockaddr* addr) {
 TEST_IMPL(udp_options) {
   struct sockaddr_in addr;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
   return udp_options_test((const struct sockaddr*) &addr);
 }
 
@@ -106,7 +106,7 @@ TEST_IMPL(udp_options6) {
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
 
-  ASSERT_EQ(0, uv_ip6_addr("::", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip6_addr("::", TEST_PORT, &addr));
   return udp_options_test((const struct sockaddr*) &addr);
 }
 
@@ -119,7 +119,7 @@ TEST_IMPL(udp_no_autobind) {
   loop = uv_default_loop();
 
   /* Test a lazy initialized socket. */
-  ASSERT_EQ(0, uv_udp_init(loop, &h));
+  ASSERT_OK(uv_udp_init(loop, &h));
   ASSERT_EQ(UV_EBADF, uv_udp_set_multicast_ttl(&h, 32));
   ASSERT_EQ(UV_EBADF, uv_udp_set_broadcast(&h, 1));
 #if defined(__MVS__)
@@ -137,23 +137,23 @@ TEST_IMPL(udp_no_autobind) {
   uv_close((uv_handle_t*) &h, NULL);
 
   /* Test a non-lazily initialized socket. */
-  ASSERT_EQ(0, uv_udp_init_ex(loop, &h2, AF_INET | UV_UDP_RECVMMSG));
-  ASSERT_EQ(0, uv_udp_set_multicast_ttl(&h2, 32));
-  ASSERT_EQ(0, uv_udp_set_broadcast(&h2, 1));
+  ASSERT_OK(uv_udp_init_ex(loop, &h2, AF_INET | UV_UDP_RECVMMSG));
+  ASSERT_OK(uv_udp_set_multicast_ttl(&h2, 32));
+  ASSERT_OK(uv_udp_set_broadcast(&h2, 1));
 
 #if defined(__MVS__)
   /* zOS only supports setting ttl for IPv6 sockets. */
   ASSERT_EQ(UV_ENOTSUP, uv_udp_set_ttl(&h2, 1));
 #else
-  ASSERT_EQ(0, uv_udp_set_ttl(&h2, 1));
+  ASSERT_OK(uv_udp_set_ttl(&h2, 1));
 #endif
 
-  ASSERT_EQ(0, uv_udp_set_multicast_loop(&h2, 1));
-  ASSERT_EQ(0, uv_udp_set_multicast_interface(&h2, "0.0.0.0"));
+  ASSERT_OK(uv_udp_set_multicast_loop(&h2, 1));
+  ASSERT_OK(uv_udp_set_multicast_interface(&h2, "0.0.0.0"));
 
   uv_close((uv_handle_t*) &h2, NULL);
 
-  ASSERT_EQ(0, uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-udp-recv-in-a-row.c
+++ b/test/test-udp-recv-in-a-row.c
@@ -53,7 +53,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   if (++ recv_cnt < N) {
     ASSERT_EQ(sizeof(send_data), nread);
   } else {
-    ASSERT_EQ(0, nread);
+    ASSERT_OK(nread);
   }
 }
 
@@ -69,7 +69,7 @@ static void check_cb(uv_check_t* handle) {
   check_cb_called = 1;
 
   /* we are done */
-  ASSERT_EQ(0, uv_check_stop(handle));
+  ASSERT_OK(uv_check_stop(handle));
   uv_close((uv_handle_t*) &client, NULL);
   uv_close((uv_handle_t*) &check_handle, NULL);
   uv_close((uv_handle_t*) &server, NULL);
@@ -79,16 +79,16 @@ static void check_cb(uv_check_t* handle) {
 TEST_IMPL(udp_recv_in_a_row) {
   int i, r;
   
-  ASSERT_EQ(0, uv_check_init(uv_default_loop(), &check_handle));
-  ASSERT_EQ(0, uv_check_start(&check_handle, check_cb));
+  ASSERT_OK(uv_check_init(uv_default_loop(), &check_handle));
+  ASSERT_OK(uv_check_start(&check_handle, check_cb));
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &server));
-  ASSERT_EQ(0, uv_udp_bind(&server, (const struct sockaddr*) &addr, 0));
-  ASSERT_EQ(0, uv_udp_recv_start(&server, alloc_cb, sv_recv_cb));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &server));
+  ASSERT_OK(uv_udp_bind(&server, (const struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_udp_recv_start(&server, alloc_cb, sv_recv_cb));
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &client));
 
   /* send N-1 udp packets */
   buf = uv_buf_init(send_data, sizeof(send_data));
@@ -106,13 +106,13 @@ TEST_IMPL(udp_recv_in_a_row) {
                       &buf,
                       1,
                       (const struct sockaddr*) &addr);
-  ASSERT_EQ(0, r);
+  ASSERT_OK(r);
 
   /* check_cb() asserts that the N packets can be received
    * before it gets called. 
    */
 
-  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
 
   ASSERT(check_cb_called);
 

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -78,7 +78,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(!memcmp("PONG", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -136,7 +136,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   /* FIXME? `uv_udp_recv_stop` does what it says: recv_cb is not called
@@ -198,11 +198,11 @@ TEST_IMPL(udp_send_and_recv) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(cl_send_cb_called, 1);
-  ASSERT_EQ(cl_recv_cb_called, 1);
-  ASSERT_EQ(sv_send_cb_called, 1);
-  ASSERT_EQ(sv_recv_cb_called, 1);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(1, cl_send_cb_called);
+  ASSERT_EQ(1, cl_recv_cb_called);
+  ASSERT_EQ(1, sv_send_cb_called);
+  ASSERT_EQ(1, sv_recv_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   ASSERT_OK(client.send_queue_size);
   ASSERT_OK(server.send_queue_size);

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -65,7 +65,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -91,11 +91,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, alloc_cb, cl_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   cl_send_cb_called++;
 }
@@ -103,7 +103,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -133,7 +133,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
   ASSERT_EQ(nread, 4);
@@ -144,14 +144,14 @@ static void sv_recv_cb(uv_udp_t* handle,
     * either... Not sure I like that but it's consistent with `uv_read_stop`.
     */
   r = uv_udp_recv_stop(handle);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   req = malloc(sizeof *req);
   ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   sv_recv_cb_called++;
 }
@@ -163,21 +163,21 @@ TEST_IMPL(udp_send_and_recv) {
   uv_buf_t buf;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* client sends "PING", expects "PONG" */
   buf = uv_buf_init("PING", 4);
@@ -188,13 +188,13 @@ TEST_IMPL(udp_send_and_recv) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(close_cb_called, 0);
-  ASSERT_EQ(cl_send_cb_called, 0);
-  ASSERT_EQ(cl_recv_cb_called, 0);
-  ASSERT_EQ(sv_send_cb_called, 0);
-  ASSERT_EQ(sv_recv_cb_called, 0);
+  ASSERT_OK(close_cb_called);
+  ASSERT_OK(cl_send_cb_called);
+  ASSERT_OK(cl_recv_cb_called);
+  ASSERT_OK(sv_send_cb_called);
+  ASSERT_OK(sv_recv_cb_called);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -204,8 +204,8 @@ TEST_IMPL(udp_send_and_recv) {
   ASSERT_EQ(sv_recv_cb_called, 1);
   ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT_EQ(client.send_queue_size, 0);
-  ASSERT_EQ(server.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
+  ASSERT_OK(server.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-send-and-recv.c
+++ b/test/test-udp-send-and-recv.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -46,7 +46,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -54,7 +54,7 @@ static void alloc_cb(uv_handle_t* handle,
 
 static void close_cb(uv_handle_t* handle) {
   CHECK_HANDLE(handle);
-  ASSERT(1 == uv_is_closing(handle));
+  ASSERT_EQ(1, uv_is_closing(handle));
   close_cb_called++;
 }
 
@@ -65,7 +65,7 @@ static void cl_recv_cb(uv_udp_t* handle,
                        const struct sockaddr* addr,
                        unsigned flags) {
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   if (nread < 0) {
     ASSERT(0 && "unexpected error");
@@ -78,7 +78,7 @@ static void cl_recv_cb(uv_udp_t* handle,
   }
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PONG", buf->base, nread));
 
   cl_recv_cb_called++;
@@ -91,11 +91,11 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
   int r;
 
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   r = uv_udp_recv_start(req->handle, alloc_cb, cl_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   cl_send_cb_called++;
 }
@@ -103,7 +103,7 @@ static void cl_send_cb(uv_udp_send_t* req, int status) {
 
 static void sv_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   uv_close((uv_handle_t*) req->handle, close_cb);
@@ -133,10 +133,10 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(!memcmp("PING", rcvbuf->base, nread));
 
   /* FIXME? `uv_udp_recv_stop` does what it says: recv_cb is not called
@@ -144,14 +144,14 @@ static void sv_recv_cb(uv_udp_t* handle,
     * either... Not sure I like that but it's consistent with `uv_read_stop`.
     */
   r = uv_udp_recv_stop(handle);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   req = malloc(sizeof *req);
   ASSERT_NOT_NULL(req);
 
   sndbuf = uv_buf_init("PONG", 4);
   r = uv_udp_send(req, handle, &sndbuf, 1, addr, sv_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   sv_recv_cb_called++;
 }
@@ -163,21 +163,21 @@ TEST_IMPL(udp_send_and_recv) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", expects "PONG" */
   buf = uv_buf_init("PING", 4);
@@ -188,24 +188,24 @@ TEST_IMPL(udp_send_and_recv) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(close_cb_called == 0);
-  ASSERT(cl_send_cb_called == 0);
-  ASSERT(cl_recv_cb_called == 0);
-  ASSERT(sv_send_cb_called == 0);
-  ASSERT(sv_recv_cb_called == 0);
+  ASSERT_EQ(close_cb_called, 0);
+  ASSERT_EQ(cl_send_cb_called, 0);
+  ASSERT_EQ(cl_recv_cb_called, 0);
+  ASSERT_EQ(sv_send_cb_called, 0);
+  ASSERT_EQ(sv_recv_cb_called, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 1);
-  ASSERT(cl_recv_cb_called == 1);
-  ASSERT(sv_send_cb_called == 1);
-  ASSERT(sv_recv_cb_called == 1);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 1);
+  ASSERT_EQ(cl_recv_cb_called, 1);
+  ASSERT_EQ(sv_send_cb_called, 1);
+  ASSERT_EQ(sv_recv_cb_called, 1);
+  ASSERT_EQ(close_cb_called, 2);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_OBJECT(handle, type, parent) \
-  ASSERT((type*)(handle) == &(parent))
+  ASSERT_PTR_EQ((type*)(handle), &(parent))
 
 static uv_udp_t client;
 static uv_idle_t idle_handle;
@@ -46,7 +46,7 @@ static void idle_cb(uv_idle_t* handle) {
 
   ASSERT_NULL(send_req.handle);
   CHECK_OBJECT(handle, uv_idle_t, idle_handle);
-  ASSERT(0 == uv_idle_stop(handle));
+  ASSERT_EQ(0, uv_idle_stop(handle));
 
   /* It probably would have stalled by now if it's going to stall at all. */
   if (++loop_hang_called > 1000) {
@@ -61,7 +61,7 @@ static void idle_cb(uv_idle_t* handle) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 }
 
 
@@ -72,27 +72,27 @@ static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_OBJECT(req, uv_udp_send_t, send_req);
   req->handle = NULL;
 
-  ASSERT(0 == uv_idle_start(&idle_handle, idle_cb));
+  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_cb));
 }
 
 
 TEST_IMPL(udp_send_hang_loop) {
-  ASSERT(0 == uv_idle_init(uv_default_loop(), &idle_handle));
+  ASSERT_EQ(0, uv_idle_init(uv_default_loop(), &idle_handle));
 
   /* 192.0.2.0/8 is "TEST-NET" and reserved for documentation.
    * Good for us, though. Since we want to have something unreachable.
    */
-  ASSERT(0 == uv_ip4_addr("192.0.2.3", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("192.0.2.3", TEST_PORT, &addr));
 
-  ASSERT(0 == uv_udp_init(uv_default_loop(), &client));
+  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &client));
 
   buf = uv_buf_init(send_data, sizeof(send_data));
 
-  ASSERT(0 == uv_idle_start(&idle_handle, idle_cb));
+  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_cb));
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(loop_hang_called > 1000);
+  ASSERT_GT(loop_hang_called, 1000);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-send-hang-loop.c
+++ b/test/test-udp-send-hang-loop.c
@@ -46,7 +46,7 @@ static void idle_cb(uv_idle_t* handle) {
 
   ASSERT_NULL(send_req.handle);
   CHECK_OBJECT(handle, uv_idle_t, idle_handle);
-  ASSERT_EQ(0, uv_idle_stop(handle));
+  ASSERT_OK(uv_idle_stop(handle));
 
   /* It probably would have stalled by now if it's going to stall at all. */
   if (++loop_hang_called > 1000) {
@@ -61,7 +61,7 @@ static void idle_cb(uv_idle_t* handle) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 }
 
 
@@ -72,23 +72,23 @@ static void send_cb(uv_udp_send_t* req, int status) {
   CHECK_OBJECT(req, uv_udp_send_t, send_req);
   req->handle = NULL;
 
-  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_cb));
+  ASSERT_OK(uv_idle_start(&idle_handle, idle_cb));
 }
 
 
 TEST_IMPL(udp_send_hang_loop) {
-  ASSERT_EQ(0, uv_idle_init(uv_default_loop(), &idle_handle));
+  ASSERT_OK(uv_idle_init(uv_default_loop(), &idle_handle));
 
   /* 192.0.2.0/8 is "TEST-NET" and reserved for documentation.
    * Good for us, though. Since we want to have something unreachable.
    */
-  ASSERT_EQ(0, uv_ip4_addr("192.0.2.3", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("192.0.2.3", TEST_PORT, &addr));
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &client));
 
   buf = uv_buf_init(send_data, sizeof(send_data));
 
-  ASSERT_EQ(0, uv_idle_start(&idle_handle, idle_cb));
+  ASSERT_OK(uv_idle_start(&idle_handle, idle_cb));
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -57,7 +57,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
 
   cl_send_cb_called++;
@@ -80,7 +80,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT_EQ(flags, 0);
+  ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
   ASSERT_EQ(nread, 4);
@@ -100,21 +100,21 @@ TEST_IMPL(udp_send_immediate) {
   uv_buf_t buf;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -125,7 +125,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -135,7 +135,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -83,7 +83,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_OK(flags);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT(memcmp("PING", rcvbuf->base, nread) == 0 ||
          memcmp("PANG", rcvbuf->base, nread) == 0);
 
@@ -139,9 +139,9 @@ TEST_IMPL(udp_send_immediate) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(cl_send_cb_called, 2);
-  ASSERT_EQ(sv_recv_cb_called, 2);
-  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(2, cl_send_cb_called);
+  ASSERT_EQ(2, sv_recv_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-send-immediate.c
+++ b/test/test-udp-send-immediate.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -42,7 +42,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -50,14 +50,14 @@ static void alloc_cb(uv_handle_t* handle,
 
 static void close_cb(uv_handle_t* handle) {
   CHECK_HANDLE(handle);
-  ASSERT(1 == uv_is_closing(handle));
+  ASSERT_EQ(1, uv_is_closing(handle));
   close_cb_called++;
 }
 
 
 static void cl_send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
 
   cl_send_cb_called++;
@@ -80,10 +80,10 @@ static void sv_recv_cb(uv_udp_t* handle,
   }
 
   CHECK_HANDLE(handle);
-  ASSERT(flags == 0);
+  ASSERT_EQ(flags, 0);
 
   ASSERT_NOT_NULL(addr);
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT(memcmp("PING", rcvbuf->base, nread) == 0 ||
          memcmp("PANG", rcvbuf->base, nread) == 0);
 
@@ -100,21 +100,21 @@ TEST_IMPL(udp_send_immediate) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -125,7 +125,7 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -135,13 +135,13 @@ TEST_IMPL(udp_send_immediate) {
                   1,
                   (const struct sockaddr*) &addr,
                   cl_send_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(cl_send_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 2);
-  ASSERT(close_cb_called == 2);
+  ASSERT_EQ(cl_send_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 2);
+  ASSERT_EQ(close_cb_called, 2);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &client || (uv_udp_t*)(handle) == &client2)
+  ASSERT_NE((uv_udp_t*)(handle) == &client || (uv_udp_t*)(handle) == &client2, 0)
 
 static uv_udp_t client;
 static uv_udp_t client2;
@@ -61,7 +61,7 @@ static void close_cb(uv_handle_t* handle) {
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT(status == 0);
+  ASSERT_EQ(status, 0);
   ASSERT_EQ(status, 0);
   CHECK_HANDLE(req->handle);
   send_cb_called++;

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -193,7 +193,7 @@ TEST_IMPL(udp_send_unreachable) {
 
   ASSERT_EQ(send_cb_called, (long)(can_recverr ? 4 : 2));
   ASSERT_EQ(recv_cb_called, alloc_cb_called);
-  ASSERT_EQ(timer_cb_called, 1);
+  ASSERT_EQ(1, timer_cb_called);
   ASSERT_EQ(close_cb_called, (long)(can_recverr ? 3 : 2));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -61,8 +61,8 @@ static void close_cb(uv_handle_t* handle) {
 
 static void send_cb(uv_udp_send_t* req, int status) {
   ASSERT_NOT_NULL(req);
-  ASSERT_EQ(status, 0);
-  ASSERT_EQ(status, 0);
+  ASSERT_OK(status);
+  ASSERT_OK(status);
   CHECK_HANDLE(req->handle);
   send_cb_called++;
 }
@@ -115,24 +115,24 @@ TEST_IMPL(udp_send_unreachable) {
   can_recverr = 1;
 #endif
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT_3, &addr3));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT_2, &addr2));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT_3, &addr3));
 
   r = uv_timer_init( uv_default_loop(), &timer );
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start( &timer, timer_cb, 1000, 0 );
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr2, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&client, alloc_cb, recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* client sends "PING", then "PANG" */
   buf = uv_buf_init("PING", 4);
@@ -143,7 +143,7 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init("PANG", 4);
 
@@ -153,19 +153,19 @@ TEST_IMPL(udp_send_unreachable) {
                   1,
                   (const struct sockaddr*) &addr,
                   send_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   if (can_recverr) {
     r = uv_udp_init(uv_default_loop(), &client2);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_udp_bind(&client2,
                     (const struct sockaddr*) &addr3,
                     UV_UDP_LINUX_RECVERR);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     r = uv_udp_recv_start(&client2, alloc_cb, recv_cb);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     /* client sends "PING", then "PANG" */
     buf = uv_buf_init("PING", 4);
@@ -176,7 +176,7 @@ TEST_IMPL(udp_send_unreachable) {
                     1,
                     (const struct sockaddr*) &addr,
                     send_cb_recverr);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
 
     buf = uv_buf_init("PANG", 4);
 
@@ -186,7 +186,7 @@ TEST_IMPL(udp_send_unreachable) {
                     1,
                     (const struct sockaddr*) &addr,
                     send_cb_recverr);
-    ASSERT_EQ(r, 0);
+    ASSERT_OK(r);
   }
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-udp-sendmmsg-error.c
+++ b/test/test-udp-sendmmsg-error.c
@@ -55,20 +55,20 @@ TEST_IMPL(udp_sendmmsg_error) {
   uv_buf_t buf;
   int i;
 
-  ASSERT_EQ(0, uv_udp_init(uv_default_loop(), &client));
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  ASSERT_EQ(0, uv_udp_connect(&client, (const struct sockaddr*)&addr));
+  ASSERT_OK(uv_udp_init(uv_default_loop(), &client));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_udp_connect(&client, (const struct sockaddr*)&addr));
 
   buf = uv_buf_init("TEST", 4);
   for (i = 0; i < DATAGRAMS; ++i)
-    ASSERT_EQ(0, uv_udp_send(&req[i], &client, &buf, 1, NULL, send_cb));
+    ASSERT_OK(uv_udp_send(&req[i], &client, &buf, 1, NULL, send_cb));
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(1, close_cb_called);
   ASSERT_EQ(DATAGRAMS, send_cb_called);
 
-  ASSERT_EQ(0, client.send_queue_size);
+  ASSERT_OK(client.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -67,7 +67,7 @@ static void sv_recv_cb(uv_udp_t* handle,
     return;
   }
 
-  ASSERT_EQ(nread, 4);
+  ASSERT_EQ(4, nread);
   ASSERT_NOT_NULL(addr);
 
   ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
@@ -106,12 +106,12 @@ TEST_IMPL(udp_try_send) {
 
   buf = uv_buf_init("EXIT", 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
-  ASSERT_EQ(r, 4);
+  ASSERT_EQ(4, r);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT_EQ(close_cb_called, 2);
-  ASSERT_EQ(sv_recv_cb_called, 1);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(1, sv_recv_cb_called);
 
   ASSERT_OK(client.send_queue_size);
   ASSERT_OK(server.send_queue_size);

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define CHECK_HANDLE(handle) \
-  ASSERT((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client)
+  ASSERT_NE((uv_udp_t*)(handle) == &server || (uv_udp_t*)(handle) == &client, 0)
 
 static uv_udp_t server;
 static uv_udp_t client;
@@ -42,7 +42,7 @@ static void alloc_cb(uv_handle_t* handle,
                      uv_buf_t* buf) {
   static char slab[65536];
   CHECK_HANDLE(handle);
-  ASSERT(suggested_size <= sizeof(slab));
+  ASSERT_LE(suggested_size, sizeof(slab));
   buf->base = slab;
   buf->len = sizeof(slab);
 }
@@ -60,17 +60,17 @@ static void sv_recv_cb(uv_udp_t* handle,
                        const uv_buf_t* rcvbuf,
                        const struct sockaddr* addr,
                        unsigned flags) {
-  ASSERT(nread > 0);
+  ASSERT_GT(nread, 0);
 
   if (nread == 0) {
     ASSERT_NULL(addr);
     return;
   }
 
-  ASSERT(nread == 4);
+  ASSERT_EQ(nread, 4);
   ASSERT_NOT_NULL(addr);
 
-  ASSERT(memcmp("EXIT", rcvbuf->base, nread) == 0);
+  ASSERT_EQ(memcmp("EXIT", rcvbuf->base, nread), 0);
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &client, close_cb);
 
@@ -84,37 +84,37 @@ TEST_IMPL(udp_try_send) {
   uv_buf_t buf;
   int r;
 
-  ASSERT(0 == uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   buf = uv_buf_init(buffer, sizeof(buffer));
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
-  ASSERT(r == UV_EMSGSIZE);
+  ASSERT_EQ(r, UV_EMSGSIZE);
 
   buf = uv_buf_init("EXIT", 4);
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
-  ASSERT(r == 4);
+  ASSERT_EQ(r, 4);
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  ASSERT(close_cb_called == 2);
-  ASSERT(sv_recv_cb_called == 1);
+  ASSERT_EQ(close_cb_called, 2);
+  ASSERT_EQ(sv_recv_cb_called, 1);
 
-  ASSERT(client.send_queue_size == 0);
-  ASSERT(server.send_queue_size == 0);
+  ASSERT_EQ(client.send_queue_size, 0);
+  ASSERT_EQ(server.send_queue_size, 0);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-try-send.c
+++ b/test/test-udp-try-send.c
@@ -70,7 +70,7 @@ static void sv_recv_cb(uv_udp_t* handle,
   ASSERT_EQ(nread, 4);
   ASSERT_NOT_NULL(addr);
 
-  ASSERT_EQ(memcmp("EXIT", rcvbuf->base, nread), 0);
+  ASSERT_OK(memcmp("EXIT", rcvbuf->base, nread));
   uv_close((uv_handle_t*) handle, close_cb);
   uv_close((uv_handle_t*) &client, close_cb);
 
@@ -84,21 +84,21 @@ TEST_IMPL(udp_try_send) {
   uv_buf_t buf;
   int r;
 
-  ASSERT_EQ(0, uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &server);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_bind(&server, (const struct sockaddr*) &addr, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_udp_recv_start(&server, alloc_cb, sv_recv_cb);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_udp_init(uv_default_loop(), &client);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   buf = uv_buf_init(buffer, sizeof(buffer));
   r = uv_udp_try_send(&client, &buf, 1, (const struct sockaddr*) &addr);
@@ -113,8 +113,8 @@ TEST_IMPL(udp_try_send) {
   ASSERT_EQ(close_cb_called, 2);
   ASSERT_EQ(sv_recv_cb_called, 1);
 
-  ASSERT_EQ(client.send_queue_size, 0);
-  ASSERT_EQ(server.send_queue_size, 0);
+  ASSERT_OK(client.send_queue_size);
+  ASSERT_OK(server.send_queue_size);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-uname.c
+++ b/test/test-uname.c
@@ -43,24 +43,24 @@ TEST_IMPL(uname) {
 
   /* Verify the happy path. */
   r = uv_os_uname(&buffer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
 #ifndef _WIN32
   ASSERT_NE(uname(&buf), -1);
-  ASSERT_EQ(strcmp(buffer.sysname, buf.sysname), 0);
-  ASSERT_EQ(strcmp(buffer.version, buf.version), 0);
+  ASSERT_OK(strcmp(buffer.sysname, buf.sysname));
+  ASSERT_OK(strcmp(buffer.version, buf.version));
 
 # ifdef _AIX
   snprintf(temp, sizeof(temp), "%s.%s", buf.version, buf.release);
-  ASSERT_EQ(strcmp(buffer.release, temp), 0);
+  ASSERT_OK(strcmp(buffer.release, temp));
 # else
-  ASSERT_EQ(strcmp(buffer.release, buf.release), 0);
+  ASSERT_OK(strcmp(buffer.release, buf.release));
 # endif /* _AIX */
 
 # if defined(_AIX) || defined(__PASE__)
-  ASSERT_EQ(strcmp(buffer.machine, "ppc64"), 0);
+  ASSERT_OK(strcmp(buffer.machine, "ppc64"));
 # else
-  ASSERT_EQ(strcmp(buffer.machine, buf.machine), 0);
+  ASSERT_OK(strcmp(buffer.machine, buf.machine));
 # endif /* defined(_AIX) || defined(__PASE__) */
 
 #endif /* _WIN32 */

--- a/test/test-uname.c
+++ b/test/test-uname.c
@@ -39,28 +39,28 @@ TEST_IMPL(uname) {
 
   /* Verify that NULL is handled properly. */
   r = uv_os_uname(NULL);
-  ASSERT(r == UV_EINVAL);
+  ASSERT_EQ(r, UV_EINVAL);
 
   /* Verify the happy path. */
   r = uv_os_uname(&buffer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
 #ifndef _WIN32
-  ASSERT(uname(&buf) != -1);
-  ASSERT(strcmp(buffer.sysname, buf.sysname) == 0);
-  ASSERT(strcmp(buffer.version, buf.version) == 0);
+  ASSERT_NE(uname(&buf), -1);
+  ASSERT_EQ(strcmp(buffer.sysname, buf.sysname), 0);
+  ASSERT_EQ(strcmp(buffer.version, buf.version), 0);
 
 # ifdef _AIX
   snprintf(temp, sizeof(temp), "%s.%s", buf.version, buf.release);
-  ASSERT(strcmp(buffer.release, temp) == 0);
+  ASSERT_EQ(strcmp(buffer.release, temp), 0);
 # else
-  ASSERT(strcmp(buffer.release, buf.release) == 0);
+  ASSERT_EQ(strcmp(buffer.release, buf.release), 0);
 # endif /* _AIX */
 
 # if defined(_AIX) || defined(__PASE__)
-  ASSERT(strcmp(buffer.machine, "ppc64") == 0);
+  ASSERT_EQ(strcmp(buffer.machine, "ppc64"), 0);
 # else
-  ASSERT(strcmp(buffer.machine, buf.machine) == 0);
+  ASSERT_EQ(strcmp(buffer.machine, buf.machine), 0);
 # endif /* defined(_AIX) || defined(__PASE__) */
 
 #endif /* _WIN32 */

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -31,7 +31,7 @@ static uv_timer_t timer;
 
 
 static void walk_cb(uv_handle_t* handle, void* arg) {
-  ASSERT(arg == (void*)magic_cookie);
+  ASSERT_PTR_EQ(arg, (void*)magic_cookie);
 
   if (handle == (uv_handle_t*)&timer) {
     seen_timer_handle++;
@@ -42,7 +42,7 @@ static void walk_cb(uv_handle_t* handle, void* arg) {
 
 
 static void timer_cb(uv_timer_t* handle) {
-  ASSERT(handle == &timer);
+  ASSERT_PTR_EQ(handle, &timer);
 
   uv_walk(handle->loop, walk_cb, magic_cookie);
   uv_close((uv_handle_t*)handle, NULL);
@@ -56,21 +56,21 @@ TEST_IMPL(walk_handles) {
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   r = uv_timer_start(&timer, timer_cb, 1, 0);
-  ASSERT(r == 0);
+  ASSERT_EQ(r, 0);
 
   /* Start event loop, expect to see the timer handle in walk_cb. */
-  ASSERT(seen_timer_handle == 0);
+  ASSERT_EQ(seen_timer_handle, 0);
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT(r == 0);
-  ASSERT(seen_timer_handle == 1);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(seen_timer_handle, 1);
 
   /* Loop is finished, walk_cb should not see our timer handle. */
   seen_timer_handle = 0;
   uv_walk(loop, walk_cb, magic_cookie);
-  ASSERT(seen_timer_handle == 0);
+  ASSERT_EQ(seen_timer_handle, 0);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -65,7 +65,7 @@ TEST_IMPL(walk_handles) {
   ASSERT_OK(seen_timer_handle);
   r = uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_OK(r);
-  ASSERT_EQ(seen_timer_handle, 1);
+  ASSERT_EQ(1, seen_timer_handle);
 
   /* Loop is finished, walk_cb should not see our timer handle. */
   seen_timer_handle = 0;

--- a/test/test-walk-handles.c
+++ b/test/test-walk-handles.c
@@ -56,21 +56,21 @@ TEST_IMPL(walk_handles) {
   loop = uv_default_loop();
 
   r = uv_timer_init(loop, &timer);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   r = uv_timer_start(&timer, timer_cb, 1, 0);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
 
   /* Start event loop, expect to see the timer handle in walk_cb. */
-  ASSERT_EQ(seen_timer_handle, 0);
+  ASSERT_OK(seen_timer_handle);
   r = uv_run(loop, UV_RUN_DEFAULT);
-  ASSERT_EQ(r, 0);
+  ASSERT_OK(r);
   ASSERT_EQ(seen_timer_handle, 1);
 
   /* Loop is finished, walk_cb should not see our timer handle. */
   seen_timer_handle = 0;
   uv_walk(loop, walk_cb, magic_cookie);
-  ASSERT_EQ(seen_timer_handle, 0);
+  ASSERT_OK(seen_timer_handle);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -76,22 +76,22 @@ TEST_IMPL(watcher_cross_stop) {
 
   TEST_FILE_LIMIT(ARRAY_SIZE(sockets) + 32);
 
-  ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   memset(big_string, 'A', sizeof(big_string));
   buf = uv_buf_init(big_string, sizeof(big_string));
 
   for (i = 0; i < ARRAY_SIZE(sockets); i++) {
-    ASSERT(0 == uv_udp_init(loop, &sockets[i]));
-    ASSERT(0 == uv_udp_bind(&sockets[i],
-                            (const struct sockaddr*) &addr,
-                            UV_UDP_REUSEADDR));
-    ASSERT(0 == uv_udp_recv_start(&sockets[i], alloc_cb, recv_cb));
-    ASSERT(0 == uv_udp_send(&reqs[i],
-                            &sockets[i],
-                            &buf,
-                            1,
-                            (const struct sockaddr*) &addr,
-                            send_cb));
+    ASSERT_EQ(0, uv_udp_init(loop, &sockets[i]));
+    ASSERT_EQ(0, uv_udp_bind(&sockets[i],
+                             (const struct sockaddr*) &addr,
+                             UV_UDP_REUSEADDR));
+    ASSERT_EQ(0, uv_udp_recv_start(&sockets[i], alloc_cb, recv_cb));
+    ASSERT_EQ(0, uv_udp_send(&reqs[i],
+                             &sockets[i],
+                             &buf,
+                             1,
+                             (const struct sockaddr*) &addr,
+                             send_cb));
   }
 
   while (recv_cb_called == 0)
@@ -100,12 +100,12 @@ TEST_IMPL(watcher_cross_stop) {
   for (i = 0; i < ARRAY_SIZE(sockets); i++)
     uv_close((uv_handle_t*) &sockets[i], close_cb);
 
-  ASSERT(recv_cb_called > 0);
+  ASSERT_GT(recv_cb_called, 0);
 
   uv_run(loop, UV_RUN_DEFAULT);
 
-  ASSERT(ARRAY_SIZE(sockets) == send_cb_called);
-  ASSERT(ARRAY_SIZE(sockets) == close_cb_called);
+  ASSERT_EQ(ARRAY_SIZE(sockets), send_cb_called);
+  ASSERT_EQ(ARRAY_SIZE(sockets), close_cb_called);
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;

--- a/test/test-watcher-cross-stop.c
+++ b/test/test-watcher-cross-stop.c
@@ -76,22 +76,22 @@ TEST_IMPL(watcher_cross_stop) {
 
   TEST_FILE_LIMIT(ARRAY_SIZE(sockets) + 32);
 
-  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
   memset(big_string, 'A', sizeof(big_string));
   buf = uv_buf_init(big_string, sizeof(big_string));
 
   for (i = 0; i < ARRAY_SIZE(sockets); i++) {
-    ASSERT_EQ(0, uv_udp_init(loop, &sockets[i]));
-    ASSERT_EQ(0, uv_udp_bind(&sockets[i],
-                             (const struct sockaddr*) &addr,
-                             UV_UDP_REUSEADDR));
-    ASSERT_EQ(0, uv_udp_recv_start(&sockets[i], alloc_cb, recv_cb));
-    ASSERT_EQ(0, uv_udp_send(&reqs[i],
-                             &sockets[i],
-                             &buf,
-                             1,
-                             (const struct sockaddr*) &addr,
-                             send_cb));
+    ASSERT_OK(uv_udp_init(loop, &sockets[i]));
+    ASSERT_OK(uv_udp_bind(&sockets[i],
+                          (const struct sockaddr*) &addr,
+                          UV_UDP_REUSEADDR));
+    ASSERT_OK(uv_udp_recv_start(&sockets[i], alloc_cb, recv_cb));
+    ASSERT_OK(uv_udp_send(&reqs[i],
+                          &sockets[i],
+                          &buf,
+                          1,
+                          (const struct sockaddr*) &addr,
+                          send_cb));
   }
 
   while (recv_cb_called == 0)


### PR DESCRIPTION
Using new-style macros makes it easier to debug test failures