### PR TITLE
src: default to stream=stderr in handle printer

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -559,6 +559,9 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
   if (loop == NULL)
     loop = uv_default_loop();
 
+  if (stream == NULL)
+    stream = stderr;
+
   uv__queue_foreach(q, &loop->handle_queue) {
     h = uv__queue_data(q, uv_handle_t, handle_queue);
 


### PR DESCRIPTION
Make printing handles from gdb a little easier because it doesn't always know how to locate the stdout or stderr globals from libc.

With this commit `call uv_print_all_handles(0, 0)` prints the handles from the default loop to stderr.