### PR TITLE
test: switch from ASSERT_* to ASSERT_PTR_* for tests using pointer operands

### DIFF
--- a/test/benchmark-pump.c
+++ b/test/benchmark-pump.c
@@ -278,7 +278,7 @@ static void connection_cb(uv_stream_t* s, int status) {
   uv_stream_t* stream;
   int r;
 
-  ASSERT_EQ(server, s);
+  ASSERT_PTR_EQ(server, s);
   ASSERT_OK(status);
 
   if (type == TCP) {

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -145,7 +145,7 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper3") == 0) {
     char buffer[256];
     notify_parent_process();
-    ASSERT_EQ(buffer, fgets(buffer, sizeof(buffer) - 1, stdin));
+    ASSERT_PTR_EQ(buffer, fgets(buffer, sizeof(buffer) - 1, stdin));
     buffer[sizeof(buffer) - 1] = '\0';
     fputs(buffer, stdout);
     return 1;

--- a/test/task.h
+++ b/test/task.h
@@ -244,6 +244,9 @@ typedef enum {
 #define ASSERT_PTR_NE(a, b) \
   ASSERT_BASE(a, !=, b, void*, "p")
 
+#define ASSERT_PTR_LT(a, b) \
+  ASSERT_BASE(a, <, b, void*, "p")
+
 /* This macro cleans up the event loop. This is used to avoid valgrind
  * warnings about memory being "leaked" by the event loop.
  */

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -295,7 +295,7 @@ static void non_empty_readdir_cb(uv_fs_t* req) {
                    non_empty_closedir_cb);
   } else {
     ASSERT_EQ(1, req->result);
-    ASSERT_EQ(dir->dirents, dirents);
+    ASSERT_PTR_EQ(dir->dirents, dirents);
     ASSERT(strcmp(dirents[0].name, "file1") == 0 ||
            strcmp(dirents[0].name, "file2") == 0 ||
            strcmp(dirents[0].name, "test_subdir") == 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2483,7 +2483,7 @@ TEST_IMPL(fs_non_symlink_reparse_point) {
                            FILE_FLAG_OPEN_REPARSE_POINT |
                              FILE_FLAG_BACKUP_SEMANTICS,
                            NULL);
-  ASSERT_NE(file_handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(file_handle, INVALID_HANDLE_VALUE);
 
   memset(&reparse_buffer, 0, REPARSE_GUID_DATA_BUFFER_HEADER_SIZE);
   reparse_buffer.ReparseTag = REPARSE_TAG;
@@ -3915,7 +3915,7 @@ TEST_IMPL(get_osfhandle_valid_handle) {
 
   fd = uv_get_osfhandle(open_req1.result);
 #ifdef _WIN32
-  ASSERT_NE(fd, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(fd, INVALID_HANDLE_VALUE);
 #else
   ASSERT_GE(fd, 0);
 #endif
@@ -3954,7 +3954,7 @@ TEST_IMPL(open_osfhandle_valid_handle) {
 
   handle = uv_get_osfhandle(open_req1.result);
 #ifdef _WIN32
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
 #else
   ASSERT_GE(handle, 0);
 #endif
@@ -4604,7 +4604,7 @@ TEST_IMPL(fs_wtf) {
                             FILE_FLAG_OPEN_REPARSE_POINT |
                               FILE_FLAG_BACKUP_SEMANTICS,
                             NULL);
-  ASSERT_NE(file_handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(file_handle, INVALID_HANDLE_VALUE);
 
   CloseHandle(file_handle);
 

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -71,7 +71,7 @@ TEST_IMPL(getters_setters) {
   ASSERT_OK(r);
   ASSERT_EQ(uv_handle_get_type((uv_handle_t*)pipe), UV_NAMED_PIPE);
 
-  ASSERT_EQ(uv_handle_get_loop((uv_handle_t*)pipe), loop);
+  ASSERT_PTR_EQ(uv_handle_get_loop((uv_handle_t*)pipe), loop);
   pipe->data = &cookie2;
   ASSERT_PTR_EQ(uv_handle_get_data((uv_handle_t*)pipe), &cookie2);
   uv_handle_set_data((uv_handle_t*)pipe, &cookie1);
@@ -95,7 +95,7 @@ TEST_IMPL(getters_setters) {
 
   ASSERT_EQ(uv_fs_get_type(fs), UV_FS_STAT);
   ASSERT_OK(uv_fs_get_result(fs));
-  ASSERT_EQ(uv_fs_get_ptr(fs), uv_fs_get_statbuf(fs));
+  ASSERT_PTR_EQ(uv_fs_get_ptr(fs), uv_fs_get_statbuf(fs));
   ASSERT(uv_fs_get_statbuf(fs)->st_mode & S_IFDIR);
   ASSERT_OK(strcmp(uv_fs_get_path(fs), "."));
   uv_fs_req_cleanup(fs);

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -32,57 +32,57 @@ TEST_IMPL(utf8_decode1) {
   p = b;
   snprintf(b, sizeof(b), "%c\x7F", 0x00);
   ASSERT_OK(uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 1);
+  ASSERT_PTR_EQ(p, b + 1);
   ASSERT_EQ(127, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 2);
+  ASSERT_PTR_EQ(p, b + 2);
 
   /* Two-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xC2\x80\xDF\xBF");
   ASSERT_EQ(128, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 2);
+  ASSERT_PTR_EQ(p, b + 2);
   ASSERT_EQ(0x7FF, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 4);
+  ASSERT_PTR_EQ(p, b + 4);
 
   /* Three-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xE0\xA0\x80\xEF\xBF\xBF");
   ASSERT_EQ(0x800, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 3);
+  ASSERT_PTR_EQ(p, b + 3);
   ASSERT_EQ(0xFFFF, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 6);
+  ASSERT_PTR_EQ(p, b + 6);
 
   /* Four-byte sequences. */
   p = b;
   snprintf(b, sizeof(b), "\xF0\x90\x80\x80\xF4\x8F\xBF\xBF");
   ASSERT_EQ(0x10000, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 4);
+  ASSERT_PTR_EQ(p, b + 4);
   ASSERT_EQ(0x10FFFF, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 8);
+  ASSERT_PTR_EQ(p, b + 8);
 
   /* Four-byte sequences > U+10FFFF; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xF4\x90\xC0\xC0\xF7\xBF\xBF\xBF");
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 4);
+  ASSERT_PTR_EQ(p, b + 4);
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 8);
+  ASSERT_PTR_EQ(p, b + 8);
 
   /* Overlong; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xC0\x80\xC1\x80");
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 2);
+  ASSERT_PTR_EQ(p, b + 2);
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 4);
+  ASSERT_PTR_EQ(p, b + 4);
 
   /* Surrogate pairs; disallowed. */
   p = b;
   snprintf(b, sizeof(b), "\xED\xA0\x80\xED\xA3\xBF");
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 3);
+  ASSERT_PTR_EQ(p, b + 3);
   ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-  ASSERT_EQ(p, b + 6);
+  ASSERT_PTR_EQ(p, b + 6);
 
   /* Simply illegal. */
   p = b;
@@ -90,7 +90,7 @@ TEST_IMPL(utf8_decode1) {
 
   for (i = 1; i <= 8; i++) {
     ASSERT_EQ((unsigned) -1, uv__utf8_decode1(&p, b + sizeof(b)));
-    ASSERT_EQ(p, b + i);
+    ASSERT_PTR_EQ(p, b + i);
   }
 
   return 0;

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -96,7 +96,7 @@ static void recv_cb(uv_stream_t* handle,
   free(buf->base);
 
   pipe = (uv_pipe_t*) handle;
-  ASSERT_EQ(pipe, &ctx.channel);
+  ASSERT_PTR_EQ(pipe, &ctx.channel);
 
   do {
     if (++recv_cb_count == 1) {
@@ -317,7 +317,7 @@ static void read_cb(uv_stream_t* handle,
   ASSERT_GE(nread, 0);
 
   pipe = (uv_pipe_t*) handle;
-  ASSERT_EQ(pipe, &ctx2.channel);
+  ASSERT_PTR_EQ(pipe, &ctx2.channel);
 
   while (uv_pipe_pending_count(pipe) > 0) {
     if (++read_cb_count == 2) {

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1119,7 +1119,7 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
                                 65536,
                                 0,
                                 NULL);
-  ASSERT_NE(pipe_handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(pipe_handle, INVALID_HANDLE_VALUE);
 
   r = uv_spawn(uv_default_loop(), &process, &options);
   ASSERT_OK(r);
@@ -1994,8 +1994,8 @@ void spawn_stdin_stdout(void) {
   char* pbuf;
   HANDLE h_stdin = GetStdHandle(STD_INPUT_HANDLE);
   HANDLE h_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-  ASSERT_NE(h_stdin, INVALID_HANDLE_VALUE);
-  ASSERT_NE(h_stdout, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(h_stdin, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(h_stdout, INVALID_HANDLE_VALUE);
   for (;;) {
     DWORD n_read;
     DWORD n_written;

--- a/test/test-tcp-close-after-read-timeout.c
+++ b/test/test-tcp-close-after-read-timeout.c
@@ -72,7 +72,7 @@ static void on_client_read(uv_stream_t* stream, ssize_t nread,
 
 
 static void on_client_timeout(uv_timer_t* handle) {
-  ASSERT_EQ(handle, &timer);
+  ASSERT_PTR_EQ(handle, &timer);
   ASSERT_OK(read_cb_called);
   uv_read_stop((uv_stream_t*) &client);
   uv_close((uv_handle_t*) &client, on_close);

--- a/test/test-tcp-close-reset.c
+++ b/test/test-tcp-close-reset.c
@@ -79,10 +79,11 @@ static void do_close(uv_tcp_t* handle) {
   } else if (shutdown_before_close == 2) {
     r = uv_fileno((const uv_handle_t*) handle, &fd);
     ASSERT_OK(r);
-    ASSERT_NE(fd, INVALID_FD);
 #ifdef _WIN32
+    ASSERT_PTR_NE(fd, INVALID_FD);
     ASSERT_OK(shutdown(fd, SD_BOTH));
 #else
+    ASSERT_NE(fd, INVALID_FD);
     ASSERT_OK(shutdown(fd, SHUT_RDWR));
 #endif
     ASSERT_OK(uv_tcp_close_reset(handle, close_cb));

--- a/test/test-tcp-create-socket-early.c
+++ b/test/test-tcp-create-socket-early.c
@@ -105,14 +105,16 @@ TEST_IMPL(tcp_create_early) {
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
   ASSERT_OK(r);
-  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
+  ASSERT_NE(fd, INVALID_FD);
   namelen = sizeof sockname;
   r = uv_tcp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
   ASSERT_OK(r);
   ASSERT_EQ(sockname.sin_family, AF_INET);
+#else
+  ASSERT_PTR_NE(fd, INVALID_FD);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);
@@ -149,10 +151,10 @@ TEST_IMPL(tcp_create_early_bad_bind) {
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
   ASSERT_OK(r);
-  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
+  ASSERT_NE(fd, INVALID_FD);
   {
     int namelen;
     struct sockaddr_in6 sockname;
@@ -161,6 +163,8 @@ TEST_IMPL(tcp_create_early_bad_bind) {
     ASSERT_OK(r);
     ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
+#else 
+  ASSERT_PTR_NE(fd, INVALID_FD);
 #endif
 
   r = uv_tcp_bind(&client, (const struct sockaddr*) &addr, 0);

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -192,7 +192,7 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 static void tls_thread(void* arg) {
   ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, arg);
-  ASSERT_EQ(arg, uv_key_get(&tls_key));
+  ASSERT_PTR_EQ(arg, uv_key_get(&tls_key));
   uv_key_set(&tls_key, NULL);
   ASSERT_NULL(uv_key_get(&tls_key));
 }
@@ -204,7 +204,7 @@ TEST_IMPL(thread_local_storage) {
   ASSERT_OK(uv_key_create(&tls_key));
   ASSERT_NULL(uv_key_get(&tls_key));
   uv_key_set(&tls_key, name);
-  ASSERT_EQ(name, uv_key_get(&tls_key));
+  ASSERT_PTR_EQ(name, uv_key_get(&tls_key));
   ASSERT_OK(uv_thread_create(threads + 0, tls_thread, threads + 0));
   ASSERT_OK(uv_thread_create(threads + 1, tls_thread, threads + 1));
   ASSERT_OK(uv_thread_join(threads + 0));

--- a/test/test-tty-duplicate-key.c
+++ b/test/test-tty-duplicate-key.c
@@ -150,7 +150,7 @@ TEST_IMPL(tty_duplicate_vt100_fn_key) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyin_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
@@ -204,7 +204,7 @@ TEST_IMPL(tty_duplicate_alt_modifier_key) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyin_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
@@ -270,7 +270,7 @@ TEST_IMPL(tty_composing_character) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyin_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));

--- a/test/test-tty-escape-sequence-processing.c
+++ b/test/test-tty-escape-sequence-processing.c
@@ -261,7 +261,7 @@ static void make_expect_screen_erase(struct captured_screen* cs,
   } else {
     ASSERT(FALSE);
   }
-  ASSERT_LT(start, end);
+  ASSERT_PTR_LT(start, end);
   ASSERT_LE(end - cs->text, cs->si.length);
   for (; start < end; start++) {
     *start = ' ';
@@ -360,7 +360,7 @@ static void initialize_tty(uv_tty_t* tty_out) {
                                      NULL,
                                      CONSOLE_TEXTMODE_BUFFER,
                                      NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
 
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyout_fd, 0);

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -57,7 +57,7 @@ TEST_IMPL(tty) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
 
   handle = CreateFileA("conout$",
@@ -67,7 +67,7 @@ TEST_IMPL(tty) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
 #else /* unix */
@@ -179,7 +179,7 @@ TEST_IMPL(tty_raw) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyin_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));
@@ -235,7 +235,7 @@ TEST_IMPL(tty_empty_write) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
   ASSERT_GE(ttyout_fd, 0);
@@ -281,7 +281,7 @@ TEST_IMPL(tty_large_write) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyout_fd = _open_osfhandle((intptr_t) handle, 0);
 
   ASSERT_GE(ttyout_fd, 0);
@@ -321,7 +321,7 @@ TEST_IMPL(tty_raw_cancel) {
                        OPEN_EXISTING,
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
-  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(handle, INVALID_HANDLE_VALUE);
   ttyin_fd = _open_osfhandle((intptr_t) handle, 0);
   ASSERT_GE(ttyin_fd, 0);
   ASSERT_EQ(UV_TTY, uv_guess_handle(ttyin_fd));

--- a/test/test-udp-create-socket-early.c
+++ b/test/test-udp-create-socket-early.c
@@ -45,14 +45,16 @@ TEST_IMPL(udp_create_early) {
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
   ASSERT_OK(r);
-  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
 #ifndef _WIN32
+  ASSERT_NE(fd, INVALID_FD);
   namelen = sizeof sockname;
   r = uv_udp_getsockname(&client, (struct sockaddr*) &sockname, &namelen);
   ASSERT_OK(r);
   ASSERT_EQ(sockname.sin_family, AF_INET);
+#else
+  ASSERT_PTR_NE(fd, INVALID_FD);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);
@@ -89,11 +91,11 @@ TEST_IMPL(udp_create_early_bad_bind) {
 
   r = uv_fileno((const uv_handle_t*) &client, &fd);
   ASSERT_OK(r);
-  ASSERT_NE(fd, INVALID_FD);
 
   /* Windows returns WSAEINVAL if the socket is not bound */
-#ifndef _WIN32
-  {
+#ifndef _WIN32 
+  ASSERT_NE(fd, INVALID_FD);
+  { 
     int namelen;
     struct sockaddr_in6 sockname;
     namelen = sizeof sockname;
@@ -101,6 +103,8 @@ TEST_IMPL(udp_create_early_bad_bind) {
     ASSERT_OK(r);
     ASSERT_EQ(sockname.sin6_family, AF_INET6);
   }
+#else 
+  ASSERT_PTR_NE(fd, INVALID_FD);
 #endif
 
   r = uv_udp_bind(&client, (const struct sockaddr*) &addr, 0);


### PR DESCRIPTION
Following the switch to new-style ASSERT macros some warnings appeared for tests on pointers

Using ASSERT_PTR_* for those tests