### PR TITLE
darwin: workaround apple pthread_cond_wait bug

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -789,11 +789,32 @@ void uv_cond_broadcast(uv_cond_t* cond) {
     abort();
 }
 
+#if defined(__APPLE__) && defined(__MACH__)
+
+void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex) {
+  errno = 0;
+
+  int r = pthread_cond_wait(cond, mutex);
+
+  /* Workaround for a bug in OS X at least up to 13.6
+   * See https://github.com/libuv/libuv/issues/4165
+   */
+  if (r == EINVAL)
+    if (errno == EBUSY)
+      return;
+
+  if (r)
+    abort();
+}
+
+#else /* !(defined(__APPLE__) && defined(__MACH__)) */
+
 void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex) {
   if (pthread_cond_wait(cond, mutex))
     abort();
 }
 
+#endif
 
 int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
   int r;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -792,9 +792,10 @@ void uv_cond_broadcast(uv_cond_t* cond) {
 #if defined(__APPLE__) && defined(__MACH__)
 
 void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex) {
-  errno = 0;
+  int r;
 
-  int r = pthread_cond_wait(cond, mutex);
+  errno = 0;
+  r = pthread_cond_wait(cond, mutex);
 
   /* Workaround for a bug in OS X at least up to 13.6
    * See https://github.com/libuv/libuv/issues/4165


### PR DESCRIPTION
Under heavy workloads `pthread_cond_wait` on macOS can return `EINVAL` while all the input parameters are correct.

As it happens due to a syscall having an `errno` of `EBUSY` we can detect it and workaround it.

Fixes #4165