### PR TITLE
unix: add back preadv/pwritev fallback

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -402,12 +402,18 @@ static ssize_t uv__fs_open(uv_fs_t* req) {
 }
 
 
-static ssize_t uv__fs_read_do(int fd,
-                              const struct iovec* bufs,
-                              unsigned int nbufs,
-                              int64_t off) {
+static ssize_t uv__fs_read(uv_fs_t* req) {
+  const struct iovec* bufs;
   unsigned int iovmax;
+  size_t nbufs;
   ssize_t r;
+  off_t off;
+  int fd;
+
+  fd = req->file;
+  off = req->off;
+  bufs = (const struct iovec*) req->bufs;
+  nbufs = req->nbufs;
 
   iovmax = uv__getiovmax();
   if (nbufs > iovmax)
@@ -438,17 +444,6 @@ static ssize_t uv__fs_read_do(int fd,
   }
 #endif
 
-  return r;
-}
-
-
-static ssize_t uv__fs_read(uv_fs_t* req) {
-  const struct iovec* iov;
-  ssize_t result;
-
-  iov = (const struct iovec*) req->bufs;
-  result = uv__fs_read_do(req->file, iov, req->nbufs, req->off);
-
   /* We don't own the buffer list in the synchronous case. */
   if (req->cb != NULL)
     if (req->bufs != req->bufsml)
@@ -457,7 +452,7 @@ static ssize_t uv__fs_read(uv_fs_t* req) {
   req->bufs = NULL;
   req->nbufs = 0;
 
-  return result;
+  return r;
 }
 
 
@@ -1091,11 +1086,17 @@ static ssize_t uv__fs_lutime(uv_fs_t* req) {
 }
 
 
-static ssize_t uv__fs_write_do(int fd,
-                               const struct iovec* bufs,
-                               unsigned int nbufs,
-                               int64_t off) {
+static ssize_t uv__fs_write(uv_fs_t* req) {
+  const struct iovec* bufs;
+  size_t nbufs;
   ssize_t r;
+  off_t off;
+  int fd;
+
+  fd = req->file;
+  off = req->off;
+  bufs = (const struct iovec*) req->bufs;
+  nbufs = req->nbufs;
 
   r = 0;
   if (off < 0) {
@@ -1111,14 +1112,6 @@ static ssize_t uv__fs_write_do(int fd,
   }
 
   return r;
-}
-
-
-static ssize_t uv__fs_write(uv_fs_t* req) {
-  const struct iovec* iov;
-
-  iov = (const struct iovec*) req->bufs;
-  return uv__fs_write_do(req->file, iov, req->nbufs, req->off);
 }
 
 

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -407,28 +407,28 @@ static ssize_t uv__fs_read_do(int fd,
                               unsigned int nbufs,
                               int64_t off) {
   unsigned int iovmax;
-  ssize_t result;
+  ssize_t r;
 
   iovmax = uv__getiovmax();
   if (nbufs > iovmax)
     nbufs = iovmax;
 
-  result = 0;
+  r = 0;
   if (off < 0) {
     if (nbufs == 1)
-      result = read(fd, bufs->iov_base, bufs->iov_len);
+      r = read(fd, bufs->iov_base, bufs->iov_len);
     else if (nbufs > 1)
-      result = readv(fd, bufs, nbufs);
+      r = readv(fd, bufs, nbufs);
   } else {
     if (nbufs == 1)
-      result = pread(fd, bufs->iov_base, bufs->iov_len, off);
+      r = pread(fd, bufs->iov_base, bufs->iov_len, off);
     else if (nbufs > 1)
-      result = preadv(fd, bufs, nbufs, off);
+      r = preadv(fd, bufs, nbufs, off);
   }
 
 #ifdef __PASE__
   /* PASE returns EOPNOTSUPP when reading a directory, convert to EISDIR */
-  if (result == -1 && errno == EOPNOTSUPP) {
+  if (r == -1 && errno == EOPNOTSUPP) {
     struct stat buf;
     ssize_t rc;
     rc = uv__fstat(fd, &buf);
@@ -438,7 +438,7 @@ static ssize_t uv__fs_read_do(int fd,
   }
 #endif
 
-  return result;
+  return r;
 }
 
 


### PR DESCRIPTION
Implement in terms of pread/pwrite and only try to read/write the first
buffer. Callers are supposed to handle partial reads and writes.

(Our own fs_read_bufs test doesn't but that's fine because this commit
is a fix-up for unsupported platforms that aren't in our CI matrix.)

Fixes: https://github.com/libuv/libuv/issues/4176

<hr>

The second and third commit are cleanup.