### PR TITLE
unix: No preadv/pwritev workaround if not needed.

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -82,7 +82,9 @@
 # include <sys/statfs.h>
 #endif
 
-#if defined(__CYGWIN__) || defined(__HAIKU__) || defined(__sun)
+#if defined(__CYGWIN__) ||                                                    \
+    (defined(__HAIKU__) && B_HAIKU_VERSION < B_HAIKU_VERSION_1_PRE_BETA_5) || \
+    (defined(__sun) && !defined(__illumos__))
 #define preadv(fd, bufs, nbufs, off)                                          \
   pread(fd, (bufs)->iov_base, (bufs)->iov_len, off)
 #define pwritev(fd, bufs, nbufs, off)                                         \


### PR DESCRIPTION
This PR tweaks the logic introduced in commit 8d69f256d18d4a2fc8295399224d433748b8a466 addressing https://github.com/libuv/libuv/issues/4176.

* The workaround for preadv/pwritev is needed only for Solaris, not illumos, so avoid it on illumos; these systems define `__illumos__` which can be used to differentiate them from Sun Solaris systems.

* Also, while the currently released [Haiku](https://www.haiku-os.org/get-haiku/) version requires the workaround, the upcoming Release 1 Beta 5 will provide preadv and pwritev functions; only use the workaround on lower versions.