### PR TITLE
build,win: we need to link against shell32.lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,8 @@ if(WIN32)
        ws2_32
        dbghelp
        ole32
-       uuid)
+       uuid
+       shell32)
   list(APPEND uv_sources
        src/win/async.c
        src/win/core.c

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AM_CONDITIONAL([OS400],    [AS_CASE([$host_os],[os400],         [true], [false])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [
-    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32 -ldbghelp -lole32 -luuid"
+    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv -luser32 -ldbghelp -lole32 -luuid -lshell32"
 ])
 AS_CASE([$host_os], [solaris2.10], [
     CFLAGS="$CFLAGS -DSUNOS_NO_IFADDRS"


### PR DESCRIPTION
The recently added support for minidumps use SHGetKnownFolderPath which requires shell32.lib - for some reason the builds work without that on x64, while failing on arm64.