### PR TITLE
build: fix libuv.a file name for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS390")
 endif()
 target_link_libraries(uv_a ${uv_libraries})
 set_target_properties(uv_a PROPERTIES OUTPUT_NAME "uv")
-if(MSVC)
+if(WIN32)
   set_target_properties(uv_a PROPERTIES PREFIX "lib")
 endif()
 


### PR DESCRIPTION
This makes cmake more consistent about how to name this file, otherwise sometimes it names it uv.lib and sometimes libuv.a depending on which compiler is selected or if ./configure is used.

Refs: https://github.com/libuv/libuv/pull/2085#issuecomment-1735276640