### PR TITLE
build: run sanitizers on macos ci

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  sanitizers:
+  sanitizers-linux:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
@@ -56,6 +56,41 @@ jobs:
         run: |
           mkdir build-ubsan
           (cd build-ubsan && cmake .. -G Ninja -DBUILD_TESTING=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang)
+          cmake --build build-ubsan
+      - name: UBSAN Test
+        run: |
+          ./build-ubsan/uv_run_tests_a
+
+  sanitizers-macos:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Envinfo
+        run: npx envinfo
+
+      - name: ASAN Build
+        run: |
+          mkdir build-asan
+          (cd build-asan && cmake .. -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug)
+          cmake --build build-asan
+      - name: ASAN Test
+        run: |
+          ./build-asan/uv_run_tests_a
+
+      - name: TSAN Build
+        run: |
+          mkdir build-tsan
+          (cd build-tsan && cmake .. -DBUILD_TESTING=ON -DTSAN=ON -DCMAKE_BUILD_TYPE=Release)
+          cmake --build build-tsan
+      - name: TSAN Test
+        run: |
+          ./build-tsan/uv_run_tests_a
+
+      - name: UBSAN Build
+        run: |
+          mkdir build-ubsan
+          (cd build-ubsan && cmake .. -DBUILD_TESTING=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug)
           cmake --build build-ubsan
       - name: UBSAN Test
         run: |

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -405,6 +405,8 @@ TEST_IMPL(fs_event_watch_dir) {
   RETURN_SKIP(NO_FS_EVENTS);
 #elif defined(__MVS__)
   RETURN_SKIP("Directory watching not supported on this platform.");
+#elif defined(__APPLE__) && defined(__TSAN__)
+  RETURN_SKIP("Times out under TSAN.");
 #endif
 
   uv_loop_t* loop = uv_default_loop();
@@ -443,7 +445,9 @@ TEST_IMPL(fs_event_watch_dir) {
 
 
 TEST_IMPL(fs_event_watch_dir_recursive) {
-#if defined(__APPLE__) || defined(_WIN32)
+#if defined(__APPLE__) && defined(__TSAN__)
+  RETURN_SKIP("Times out under TSAN.");
+#elif defined(__APPLE__) || defined(_WIN32)
   uv_loop_t* loop;
   int r;
   uv_fs_event_t fs_event_root;
@@ -946,6 +950,8 @@ TEST_IMPL(fs_event_close_in_callback) {
   RETURN_SKIP(NO_FS_EVENTS);
 #elif defined(__MVS__)
   RETURN_SKIP("Directory watching not supported on this platform.");
+#elif defined(__APPLE__) && defined(__TSAN__)
+  RETURN_SKIP("Times out under TSAN.");
 #endif
   uv_loop_t* loop;
   int r;


### PR DESCRIPTION
Opening as draft because there are some known tsan issues, particularly around our fsevents integration.