### PR TITLE
win: improve accuracy of ProductName between arch

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1506,7 +1506,7 @@ int uv_os_uname(uv_utsname_t* buffer) {
   r = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
                     L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
                     0,
-                    KEY_QUERY_VALUE,
+                    KEY_QUERY_VALUE | KEY_WOW64_64KEY,
                     &registry_key);
 
   if (r == ERROR_SUCCESS) {


### PR DESCRIPTION
> uv_os_uname() on Windows queries the registry value "HKEY_LOCAL_MACHINE\ SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProductName" to fill uv_utsname_t. If calling application was compiled for x86 and run on a x86_64 host, that query is redirected to "Computer\HKEY_LOCAL_MACHINE\ SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\ProductName" instead.
>
> For whatever reason, the value of 'ProductName' in the 32-bit registry section on 64-bit Windows sometimes differs from the 64-bit equivalent value and is inaccurate (e.g. containing the data
"Windows 10 Enterprise" while the 64-bit value accurately contains "Windows 10 Pro").
>
> Adds the 'KEY_WOW64_64KEY' security descriptor when opening the appropriate registry key so that the value of ProductName is always taken from the primary registry on 64-bit systems, regardless of compiled architecture. The descriptor is safely ignored on 32-bit hosts.

On my personal system, Windows 10 Pro, the WOW6432Node value shows "Windows 10 Enterprise" instead. It seems this isn't the first time someone has noticed the WOW64 emulation value being inaccurate:

- https://stackoverflow.com/questions/66981014/why-is-the-windows-productname-different-for-32-bit-applications
- https://answers.microsoft.com/en-us/windows/forum/all/windows-10-1803-wrong-productname/5ef6d385-1615-47e4-bf63-e570ac8b9a00

Similar values (e.g. EditionId), [also seem to be affected](https://stackoverflow.com/questions/54174567/registry-key-editionid-has-wrong-value-under-wow6432node-by-intention-or-bug). 
