### PR TITLE
test: skip tcp-write-in-a-row on IBM i

### DIFF
--- a/test/test-tcp-write-in-a-row.c
+++ b/test/test-tcp-write-in-a-row.c
@@ -114,8 +114,9 @@ static void start_server(void) {
 TEST_IMPL(tcp_write_in_a_row) {
 #if defined(_WIN32)
   RETURN_SKIP("tcp_write_in_a_row does not work on Windows");
+#elif defined(__PASE__)
+  RETURN_SKIP("tcp_write_in_a_row does not work on IBM i PASE");
 #else
-
   uv_connect_t connect_req;
   struct sockaddr_in addr;
 


### PR DESCRIPTION
On IBM i this test fails asserting the write queue size. The test expects the queue size to be greater than 0 but the queue size is 0 on IBM i.

https://github.com/libuv/libuv/blob/66160d6973b41040f6b2066a84359147258f60c3/test/test-tcp-write-in-a-row.c#L75

The test expects the write to get queued because the size of the data is larger than the send and receive buffers.

https://github.com/libuv/libuv/blob/66160d6973b41040f6b2066a84359147258f60c3/test/test-tcp-write-in-a-row.c#L39-L40

For some reason the request does not seem to get queued on IBM i. The root cause of the issue will need further investigation.

Part of #4143 


CC

@libuv/ibmi 
@richardlau 