### PR TITLE
build: disable windows asan buildbot

### DIFF
--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -25,7 +25,8 @@ jobs:
           - {toolchain: Visual Studio 16 2019, arch: x64, server: 2019}
           - {toolchain: Visual Studio 17 2022, arch: Win32, server: 2022}
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: ASAN}
+          # Currently broken, see https://github.com/libuv/libuv/issues/4210
+          #- {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: ASAN}
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: UBSAN}
           - {toolchain: Visual Studio 17 2022, arch: arm64, server: 2022}
     steps:


### PR DESCRIPTION
uv_run_tests.exe fails to start up with exit code 0xC0000135 a.k.a. STATUS_DLL_NOT_FOUND, suggesting it cannot find the ASAN runtime libraries. Disable the buildbot until we figure out how to fix that.

Refs: https://github.com/libuv/libuv/issues/4210