### PR TITLE
darwin: move hardcoded cpu value to header

### DIFF
--- a/include/uv/darwin.h
+++ b/include/uv/darwin.h
@@ -57,5 +57,5 @@
   void* select;                                                               \
 
 #define UV_HAVE_KQUEUE 1
-
+#define DARWIN_CPU_VALUE 2400000000U
 #endif /* UV_DARWIN_H */

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -209,7 +209,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   if (cpuspeed == 0)
     /* If sysctl hw.cputype == CPU_TYPE_ARM64, the correct value is unavailable
      * from Apple, but we can hard-code it here to a plausible value. */
-    cpuspeed = 2400000000U;
+    cpuspeed = DARWIN_CPU_VALUE;
 
   if (host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numcpus,
                           (processor_info_array_t*)&info,


### PR DESCRIPTION
I would like to suggest moving the hardcoded Darwin CPU value to the header. Currently, it appears to be used solely by one file. if we need the value again in the future, we could simply pass the header name into a variable, making it more accessible. 

any suggestions for other naming are welcome :)