### PR TITLE
ipv6_link_local: Ignore ifaddrs with NULL ifa_addr

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -233,8 +233,9 @@ static int uv__ipv6_link_local_scope_id(void) {
     return 0;
 
   for (p = ifa; p != NULL; p = p->ifa_next)
-    if (uv__is_ipv6_link_local(p->ifa_addr))
-      break;
+    if (p->ifa_addr != NULL)
+      if (uv__is_ipv6_link_local(p->ifa_addr))
+        break;
 
   rv = 0;
   if (p != NULL) {


### PR DESCRIPTION
Passing this to uv__is_ipv6_link_local() is causing a segmentation fault. Note that the documentation for getifaddrs() explicitly states that this value may be NULL.