### PR TITLE
test_fs.c: Fix issue on 32-bit systems using btrfs

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -343,7 +343,7 @@ static void statfs_cb(uv_fs_t* req) {
   defined(__OpenBSD__) || defined(__NetBSD__)
   ASSERT_OK(stats->f_type);
 #else
-  ASSERT_GT(stats->f_type, 0);
+  ASSERT_UINT64_GT(stats->f_type, 0);
 #endif
 
   ASSERT_GT(stats->f_bsize, 0);


### PR DESCRIPTION
On Fedora's build system, the build environment runs on btrfs. This revealed a bug in the test on i686 systems, where this comparison was being performed as a comparison of two signed integers, but the filesystem type of btrfs happens to use the higher-order bits, resulting in it appearing as a negative value.

BTRFS_SUPER_MAGIC     0x9123683e
