### PR TITLE
aix: disable ipv6 link local

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-// ifaddrs is not implemented on AIX
+/* ifaddrs is not implemented on AIX and IBM i PASE */
 #if !defined(_AIX)
 #include <ifaddrs.h>
 #endif
@@ -206,10 +206,6 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 
 
 static int uv__is_ipv6_link_local(const struct sockaddr* addr) {
-// disable link local on AIX & PASE for now
-#if defined(_AIX)
-  return 0;
-#else
   const struct sockaddr_in6* a6;
   uint8_t b[2];
 
@@ -220,12 +216,11 @@ static int uv__is_ipv6_link_local(const struct sockaddr* addr) {
   memcpy(b, &a6->sin6_addr, sizeof(b));
 
   return b[0] == 0xFE && b[1] == 0x80;
-#endif
 }
 
 
 static int uv__ipv6_link_local_scope_id(void) {
-// disable link local on AIX & PASE for now
+/* disable link local on AIX & PASE for now */
 #if defined(_AIX)
   return 0;
 #else

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -30,12 +30,8 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#if defined(__PASE__)
-#include <as400_protos.h>
-#define ifaddrs ifaddrs_pase
-#define getifaddrs Qp2getifaddrs
-#define freeifaddrs Qp2freeifaddrs
-#else
+// ifaddrs is not implemented on AIX
+#if !defined(_AIX)
 #include <ifaddrs.h>
 #endif
 
@@ -210,6 +206,10 @@ int uv__tcp_bind(uv_tcp_t* tcp,
 
 
 static int uv__is_ipv6_link_local(const struct sockaddr* addr) {
+// disable link local on AIX & PASE for now
+#if defined(_AIX)
+  return 0;
+#else
   const struct sockaddr_in6* a6;
   uint8_t b[2];
 
@@ -220,10 +220,15 @@ static int uv__is_ipv6_link_local(const struct sockaddr* addr) {
   memcpy(b, &a6->sin6_addr, sizeof(b));
 
   return b[0] == 0xFE && b[1] == 0x80;
+#endif
 }
 
 
 static int uv__ipv6_link_local_scope_id(void) {
+// disable link local on AIX & PASE for now
+#if defined(_AIX)
+  return 0;
+#else
   struct sockaddr_in6* a6;
   struct ifaddrs* ifa;
   struct ifaddrs* p;
@@ -245,6 +250,7 @@ static int uv__ipv6_link_local_scope_id(void) {
 
   freeifaddrs(ifa);
   return rv;
+#endif
 }
 
 


### PR DESCRIPTION
aix does not implement ifaddrs and when retrieving the network interfaces with uv_interface_addresses there was a test failure in tcp_connect6_link_local.

Ref: https://github.com/libuv/libuv/pull/4222#issuecomment-1812962233

For now disable ipv6 link local on aix to:

1) fix broken aix build
2) stop blocking libuv upgrade in node
   Ref: https://github.com/nodejs/node/pull/50650
   
   
I've got a PR open to use `uv_interface_addresses` on AIX. 
Ref: https://github.com/libuv/libuv/pull/4222
This is still a work in progress and will need more review and testing before merging. 
In the meantime, we can skip ipv6 link local on AIX and IBM i to prevent blocking libuv upgrade in node.

CC

@richardlau 
@mhdawson 
@libuv/ibmi
@libuv/aix 

