### PR TITLE
unix: correct pwritev conditional

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -85,7 +85,8 @@
 #if defined(__CYGWIN__) ||                                                    \
     (defined(__HAIKU__) && B_HAIKU_VERSION < B_HAIKU_VERSION_1_PRE_BETA_5) || \
     (defined(__sun) && !defined(__illumos__)) ||                              \
-    (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED <= 101300)
+    (defined(__APPLE__) && !TARGET_OS_IPHONE &&                               \
+     MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 #define preadv(fd, bufs, nbufs, off)                                          \
   pread(fd, (bufs)->iov_base, (bufs)->iov_len, off)
 #define pwritev(fd, bufs, nbufs, off)                                         \


### PR DESCRIPTION
Amendment to #4230.

Correct version bounds based on the function annotations:

```
ssize_t pwritev(int, const struct iovec *, int, off_t) __DARWIN_NOCANCEL(pwritev) __API_AVAILABLE(macos(11.0), ios(14.0), watchos(7.0), tvos(14.0));
```

Also don't apply the logic to iOS, where `MAC_OS_X_VERSION_MIN_REQUIRED` may not be defined:

https://github.com/libuv/libuv/blob/4785ad6337aac8b78224291f0848f25fc8cb41c9/src/unix/internal.h#L74-L76

or otherwise default to something prehistoric like 10.4.

---

I agree though with the comment that perhaps in the future it may be worth switching to runtime checking (or configure/cmake checking), as it could be written OS agnostically. I wouldn't be suprised if there's other fringe platforms.