### PR TITLE
win: provide NoDefaultCurrentDirectoryInExePath env var on Windows

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -377,11 +377,13 @@ static WCHAR* search_path(const WCHAR *file,
   } else {
     dir_end = path;
 
-    /* The file is really only a name; look in cwd first, then scan path */
-    result = path_search_walk_ext(L"", 0,
-                                  file, file_len,
-                                  cwd, cwd_len,
-                                  name_has_ext);
+    if (NeedCurrentDirectoryForExePathW(L"")) {
+      /* The file is really only a name; look in cwd first, then scan path */
+      result = path_search_walk_ext(L"", 0,
+                                    file, file_len,
+                                    cwd, cwd_len,
+                                    name_has_ext);
+    }
 
     while (result == NULL) {
       if (dir_end == NULL || *dir_end == L'\0') {


### PR DESCRIPTION
Refer to this https://github.com/nodejs/node/issues/46264 , Windows always execute executable on current directory without path prefix. This behavior is dangerous.  this change is validate environment variable `NoDefaultCurrentDirectoryInExePath` is set or not.

Before changes:
If you have notepad.exe in current directory, and then execute it. it will return executable path on current directory.

After changes:
This change return original path to notepad.exe if `NoDefaultCurrentDirectoryInExePath` is set.