### PR TITLE
misc: ignore some unnecessary files after build on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 .vscode/
 *.VC.db
 *.VC.opendb
+*.cmake
+*.pc
+*.ninja 
+*.ninja_log
+*.ninja_deps
+*.DS_Store
 core
 vgcore.*
 .buildstamp
@@ -37,6 +43,8 @@ vgcore.*
 /test-driver
 Makefile
 Makefile.in
+CMakeCache.txt
+
 
 /build/
 
@@ -57,6 +65,7 @@ test_file_*
 *.vcxproj
 *.vcxproj.filters
 *.vcxproj.user
+DartConfiguration.tcl
 _UpgradeReport_Files/
 UpgradeLog*.XML
 Debug


### PR DESCRIPTION
When compiling and debugging in Windows environment, sometimes unnecessary files are often committed. I think we can just ignore them. 
