### PR TITLE
win: stop using deprecated names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,11 @@ list(APPEND uv_cflags ${lint-utf8-msvc} )
 check_c_compiler_flag(-fno-strict-aliasing UV_F_STRICT_ALIASING)
 list(APPEND uv_cflags $<$<BOOL:${UV_F_STRICT_ALIASING}>:-fno-strict-aliasing>)
 
+if (MSVC)
+  # Error on calling undeclared functions.
+  list(APPEND uv_cflags "/we4013")
+endif()
+
 set(uv_sources
     src/fs-poll.c
     src/idna.c
@@ -176,7 +181,7 @@ set(uv_sources
     src/version.c)
 
 if(WIN32)
-  list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0602)
+  list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0602 _CRT_DECLARE_NONSTDC_NAMES=0)
   list(APPEND uv_libraries
        psapi
        user32

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -114,7 +114,7 @@ static int uv__split_path(const WCHAR* filename, WCHAR** dir,
       }
     }
 
-    *file = wcsdup(filename);
+    *file = _wcsdup(filename);
   } else {
     if (dir) {
       *dir = (WCHAR*)uv__malloc((i + 2) * sizeof(WCHAR));

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -407,8 +407,8 @@ void fs__open(uv_fs_t* req) {
 
   /* Obtain the active umask. umask() never fails and returns the previous
    * umask. */
-  current_umask = umask(0);
-  umask(current_umask);
+  current_umask = _umask(0);
+  _umask(current_umask);
 
   /* convert flags and mode to CreateFile parameters */
   switch (flags & (UV_FS_O_RDONLY | UV_FS_O_WRONLY | UV_FS_O_RDWR)) {

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -199,7 +199,7 @@ static void close_pipe(uv_pipe_t* pipe) {
   if (pipe->u.fd == -1)
     CloseHandle(pipe->handle);
   else
-    close(pipe->u.fd);
+    _close(pipe->u.fd);
 
   pipe->u.fd = -1;
   pipe->handle = INVALID_HANDLE_VALUE;

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -26,7 +26,7 @@
 #include <signal.h>
 #include <limits.h>
 #include <wchar.h>
-#include <malloc.h>    /* alloca */
+#include <malloc.h>    /* _alloca */
 
 #include "uv.h"
 #include "internal.h"
@@ -511,7 +511,7 @@ WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target) {
     }
   }
   target[0] = L'\0';
-  wcsrev(start);
+  _wcsrev(start);
   *(target++) = L'"';
   return target;
 }
@@ -615,8 +615,8 @@ int env_strncmp(const wchar_t* a, int na, const wchar_t* b) {
   assert(b_eq);
   nb = b_eq - b;
 
-  A = alloca((na+1) * sizeof(wchar_t));
-  B = alloca((nb+1) * sizeof(wchar_t));
+  A = _alloca((na+1) * sizeof(wchar_t));
+  B = _alloca((nb+1) * sizeof(wchar_t));
 
   r = LCMapStringW(LOCALE_INVARIANT, LCMAP_UPPERCASE, a, na, A, na);
   assert(r==na);
@@ -693,7 +693,7 @@ int make_program_env(char* env_block[], WCHAR** dst_ptr) {
   if (dst_copy == NULL && env_len > 0) {
     return UV_ENOMEM;
   }
-  env_copy = alloca(env_block_count * sizeof(WCHAR*));
+  env_copy = _alloca(env_block_count * sizeof(WCHAR*));
 
   ptr = dst_copy;
   ptr_copy = env_copy;

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -695,7 +695,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 
   DWORD records_left, records_read;
   uv_buf_t buf;
-  off_t buf_used;
+  _off_t buf_used;
 
   assert(handle->type == UV_TTY);
   assert(handle->flags & UV_HANDLE_TTY_READABLE);
@@ -2246,7 +2246,7 @@ void uv__tty_close(uv_tty_t* handle) {
   if (handle->u.fd == -1)
     CloseHandle(handle->handle);
   else
-    close(handle->u.fd);
+    _close(handle->u.fd);
 
   handle->u.fd = -1;
   handle->handle = INVALID_HANDLE_VALUE;

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -25,6 +25,7 @@
 
 #ifdef _WIN32
 # include <io.h>
+# define read _read
 #else
 # include <unistd.h>
 #endif

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -310,7 +310,7 @@ static int clear_line(void) {
   COORD coord;
   DWORD written;
 
-  handle = (HANDLE)_get_osfhandle(fileno(stderr));
+  handle = (HANDLE)_get_osfhandle(_fileno(stderr));
   if (handle == INVALID_HANDLE_VALUE)
     return -1;
 

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -74,7 +74,8 @@ static void touch_file(const char* name, unsigned int size) {
   int r;
   unsigned int i;
 
-  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT | O_TRUNC,
+  r = uv_fs_open(NULL, &req, name,
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | UV_FS_O_TRUNC,
                  S_IWUSR | S_IRUSR, NULL);
   uv_fs_req_cleanup(&req);
   ASSERT_GE(r, 0);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -80,7 +80,9 @@ static void create_file(const char* name) {
   uv_file file;
   uv_fs_t req;
 
-  r = uv_fs_open(NULL, &req, name, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, name, UV_FS_O_WRONLY | UV_FS_O_CREAT,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   file = r;
   uv_fs_req_cleanup(&req);
@@ -95,7 +97,7 @@ static void touch_file(const char* name) {
   uv_fs_t req;
   uv_buf_t buf;
 
-  r = uv_fs_open(NULL, &req, name, O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, name, UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   file = r;
   uv_fs_req_cleanup(&req);

--- a/test/test-fs-readdir.c
+++ b/test/test-fs-readdir.c
@@ -359,7 +359,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   r = uv_fs_open(uv_default_loop(),
                  &create_req,
                  "test_dir/file1",
-                 O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&create_req);
@@ -373,7 +373,7 @@ TEST_IMPL(fs_readdir_non_empty_dir) {
   r = uv_fs_open(uv_default_loop(),
                  &create_req,
                  "test_dir/file2",
-                 O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR,
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT, S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&create_req);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -51,6 +51,9 @@
 # ifndef lseek
 #   define lseek _lseek
 # endif
+# define S_IFDIR _S_IFDIR
+# define S_IFCHR _S_IFCHR
+# define S_IFREG _S_IFREG
 #endif
 
 #define TOO_LONG_NAME_LENGTH 65536
@@ -227,7 +230,7 @@ static void realpath_cb(uv_fs_t* req) {
   uv_cwd(test_file_abs_buf, &test_file_abs_size);
 #ifdef _WIN32
   strcat(test_file_abs_buf, "\\test_file");
-  ASSERT_OK(stricmp(req->ptr, test_file_abs_buf));
+  ASSERT_OK(_stricmp(req->ptr, test_file_abs_buf));
 #else
   strcat(test_file_abs_buf, "/test_file");
   ASSERT_OK(strcmp(req->ptr, test_file_abs_buf));
@@ -718,12 +721,13 @@ TEST_IMPL(fs_file_noent) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "does_not_exist", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, "does_not_exist", UV_FS_O_RDONLY, 0, NULL);
   ASSERT_EQ(r, UV_ENOENT);
   ASSERT_EQ(req.result, UV_ENOENT);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, "does_not_exist", O_RDONLY, 0, open_noent_cb);
+  r = uv_fs_open(loop, &req, "does_not_exist", UV_FS_O_RDONLY, 0,
+                 open_noent_cb);
   ASSERT_OK(r);
 
   ASSERT_OK(open_cb_count);
@@ -746,12 +750,12 @@ TEST_IMPL(fs_file_nametoolong) {
   memset(name, 'a', TOO_LONG_NAME_LENGTH);
   name[TOO_LONG_NAME_LENGTH] = 0;
 
-  r = uv_fs_open(NULL, &req, name, O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, name, UV_FS_O_RDONLY, 0, NULL);
   ASSERT_EQ(r, UV_ENAMETOOLONG);
   ASSERT_EQ(req.result, UV_ENAMETOOLONG);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, name, O_RDONLY, 0, open_nametoolong_cb);
+  r = uv_fs_open(loop, &req, name, UV_FS_O_RDONLY, 0, open_nametoolong_cb);
   ASSERT_OK(r);
 
   ASSERT_OK(open_cb_count);
@@ -786,12 +790,12 @@ TEST_IMPL(fs_file_loop) {
   ASSERT_OK(r);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(NULL, &req, "test_symlink", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_symlink", UV_FS_O_RDONLY, 0, NULL);
   ASSERT_EQ(r, UV_ELOOP);
   ASSERT_EQ(req.result, UV_ELOOP);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(loop, &req, "test_symlink", O_RDONLY, 0, open_loop_cb);
+  r = uv_fs_open(loop, &req, "test_symlink", UV_FS_O_RDONLY, 0, open_loop_cb);
   ASSERT_OK(r);
 
   ASSERT_OK(open_cb_count);
@@ -918,7 +922,7 @@ TEST_IMPL(fs_file_async) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(loop, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(loop, &open_req1, "test_file", UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IRUSR | S_IWUSR, create_cb);
   ASSERT_OK(r);
   uv_run(loop, UV_RUN_DEFAULT);
@@ -938,7 +942,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(1, close_cb_count);
   ASSERT_EQ(1, rename_cb_count);
 
-  r = uv_fs_open(loop, &open_req1, "test_file2", O_RDWR, 0, open_cb);
+  r = uv_fs_open(loop, &open_req1, "test_file2", UV_FS_O_RDWR, 0, open_cb);
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
@@ -950,7 +954,7 @@ TEST_IMPL(fs_file_async) {
   ASSERT_EQ(1, write_cb_count);
   ASSERT_EQ(1, ftruncate_cb_count);
 
-  r = uv_fs_open(loop, &open_req1, "test_file2", O_RDONLY, 0, open_cb);
+  r = uv_fs_open(loop, &open_req1, "test_file2", UV_FS_O_RDONLY, 0, open_cb);
   ASSERT_OK(r);
 
   uv_run(loop, UV_RUN_DEFAULT);
@@ -982,7 +986,8 @@ static void fs_file_sync(int add_flags) {
   loop = uv_default_loop();
 
   r = uv_fs_open(loop, &open_req1, "test_file",
-      O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | add_flags, S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -998,7 +1003,8 @@ static void fs_file_sync(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR | add_flags, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDWR | add_flags, 0,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -1025,7 +1031,7 @@ static void fs_file_sync(int add_flags) {
   ASSERT_OK(rename_req.result);
   uv_fs_req_cleanup(&rename_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY | add_flags, 0,
+  r = uv_fs_open(NULL, &open_req1, "test_file2", UV_FS_O_RDONLY | add_flags, 0,
       NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -1071,7 +1077,8 @@ static void fs_file_write_null_buffer(int add_flags) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
-      O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | add_flags, S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -1116,7 +1123,8 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_EQ(1, mkdir_cb_count);
 
   /* Create 2 files synchronously. */
-  r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file1",
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -1124,7 +1132,8 @@ TEST_IMPL(fs_async_dir) {
   ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file2",
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -1193,7 +1202,7 @@ TEST_IMPL(fs_async_dir) {
 }
 
 
-static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
+static int test_sendfile(void (*setup)(int), uv_fs_cb cb, size_t expected_size) {
   int f, r;
   struct stat s1, s2;
   uv_fs_t req;
@@ -1205,7 +1214,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   unlink("test_file");
   unlink("test_file2");
 
-  f = open("test_file", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+  f = open("test_file", UV_FS_O_WRONLY | UV_FS_O_CREAT, S_IWUSR | S_IRUSR);
   ASSERT_NE(f, -1);
 
   if (setup != NULL)
@@ -1215,12 +1224,12 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
   ASSERT_OK(r);
 
   /* Test starts here. */
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
-  r = uv_fs_open(NULL, &open_req2, "test_file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req2, "test_file2", UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req2.result, 0);
@@ -1248,7 +1257,7 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, off_t expected_size) {
 
   if (expected_size > 0) {
     ASSERT_UINT64_EQ(s1.st_size, s2.st_size + 1);
-    r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDWR, 0, NULL);
+    r = uv_fs_open(NULL, &open_req1, "test_file2", UV_FS_O_RDWR, 0, NULL);
     ASSERT_GE(r, 0);
     ASSERT_GE(open_req1.result, 0);
     uv_fs_req_cleanup(&open_req1);
@@ -1364,7 +1373,7 @@ TEST_IMPL(fs_mkstemp) {
   uv_fs_close(NULL, &req, mkstemp_req2.result, NULL);
   uv_fs_req_cleanup(&req);
 
-  fd = uv_fs_open(NULL, &req, mkstemp_req1.path , O_RDONLY, 0, NULL);
+  fd = uv_fs_open(NULL, &req, mkstemp_req1.path, UV_FS_O_RDONLY, 0, NULL);
   ASSERT_GE(fd, 0);
   uv_fs_req_cleanup(&req);
 
@@ -1410,7 +1419,7 @@ TEST_IMPL(fs_fstat) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -1617,7 +1626,7 @@ TEST_IMPL(fs_access) {
   access_cb_count = 0; /* reset for the next test */
 
   /* Create file */
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -1678,7 +1687,7 @@ TEST_IMPL(fs_chmod) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -1777,9 +1786,7 @@ TEST_IMPL(fs_unlink_readonly) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL,
-                 &req,
-                 "test_file",
-                 O_RDWR | O_CREAT,
+                 &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -1836,9 +1843,7 @@ TEST_IMPL(fs_unlink_archive_readonly) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL,
-                 &req,
-                 "test_file",
-                 O_RDWR | O_CREAT,
+                 &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -1894,7 +1899,7 @@ TEST_IMPL(fs_chown) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -1989,7 +1994,7 @@ TEST_IMPL(fs_link) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -2010,7 +2015,7 @@ TEST_IMPL(fs_link) {
   ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(NULL, &req, "test_file_link", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_link", UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   link = req.result;
@@ -2031,7 +2036,7 @@ TEST_IMPL(fs_link) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(1, link_cb_count);
 
-  r = uv_fs_open(NULL, &req, "test_file_link2", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_link2", UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   link = req.result;
@@ -2090,7 +2095,7 @@ TEST_IMPL(fs_readlink) {
     /* Setup */
 
     /* Create a non-symlink file */
-    r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+    r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                    S_IWUSR | S_IRUSR, NULL);
     ASSERT_GE(r, 0);
     ASSERT_GE(req.result, 0);
@@ -2162,7 +2167,7 @@ TEST_IMPL(fs_symlink) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, "test_file", O_RDWR | O_CREAT,
+  r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
@@ -2200,7 +2205,7 @@ TEST_IMPL(fs_symlink) {
   ASSERT_OK(req.result);
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(NULL, &req, "test_file_symlink", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_symlink", UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   link = req.result;
@@ -2236,7 +2241,7 @@ TEST_IMPL(fs_symlink) {
   r = uv_fs_realpath(NULL, &req, "test_file_symlink_symlink", NULL);
   ASSERT_OK(r);
 #ifdef _WIN32
-  ASSERT_OK(stricmp(req.ptr, test_file_abs_buf));
+  ASSERT_OK(_stricmp(req.ptr, test_file_abs_buf));
 #else
   ASSERT_OK(strcmp(req.ptr, test_file_abs_buf));
 #endif
@@ -2253,7 +2258,7 @@ TEST_IMPL(fs_symlink) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT_EQ(1, symlink_cb_count);
 
-  r = uv_fs_open(NULL, &req, "test_file_symlink2", O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, "test_file_symlink2", UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   link = req.result;
@@ -2386,13 +2391,14 @@ int test_symlink_dir_impl(int type) {
   ASSERT_OK(r);
 #ifdef _WIN32
   ASSERT_EQ(strlen(req.ptr), test_dir_abs_size - 5);
-  ASSERT_OK(strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5));
+  ASSERT_OK(_strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5));
 #else
   ASSERT_OK(strcmp(req.ptr, test_dir_abs_buf));
 #endif
   uv_fs_req_cleanup(&req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_dir/file1", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file1",
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -2400,7 +2406,8 @@ int test_symlink_dir_impl(int type) {
   ASSERT_OK(r);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_dir/file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_dir/file2",
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -2622,7 +2629,9 @@ TEST_IMPL(fs_utime) {
   /* Setup. */
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDWR | UV_FS_O_CREAT,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
@@ -2666,7 +2675,9 @@ TEST_IMPL(fs_utime_round) {
 
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDWR | UV_FS_O_CREAT,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
@@ -2743,7 +2754,9 @@ TEST_IMPL(fs_futime) {
   /* Setup. */
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDWR | UV_FS_O_CREAT,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
@@ -2751,7 +2764,7 @@ TEST_IMPL(fs_futime) {
 
   atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
 
-  r = uv_fs_open(NULL, &req, path, O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDWR, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   file = req.result; /* FIXME probably not how it's supposed to be used */
@@ -2803,7 +2816,9 @@ TEST_IMPL(fs_lutime) {
   /* Setup */
   loop = uv_default_loop();
   unlink(path);
-  r = uv_fs_open(NULL, &req, path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDWR | UV_FS_O_CREAT,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   uv_fs_req_cleanup(&req);
@@ -2999,7 +3014,7 @@ TEST_IMPL(fs_open_dir) {
   path = ".";
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &req, path, O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &req, path, UV_FS_O_RDONLY, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
   ASSERT_NULL(req.ptr);
@@ -3009,7 +3024,7 @@ TEST_IMPL(fs_open_dir) {
   r = uv_fs_close(NULL, &req, file, NULL);
   ASSERT_OK(r);
 
-  r = uv_fs_open(loop, &req, path, O_RDONLY, 0, open_cb_simple);
+  r = uv_fs_open(loop, &req, path, UV_FS_O_RDONLY, 0, open_cb_simple);
   ASSERT_OK(r);
 
   ASSERT_OK(open_cb_count);
@@ -3030,7 +3045,8 @@ static void fs_file_open_append(int add_flags) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
-      O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | add_flags, S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -3047,7 +3063,7 @@ static void fs_file_open_append(int add_flags) {
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
-      O_RDWR | O_APPEND | add_flags, 0, NULL);
+                 UV_FS_O_RDWR | UV_FS_O_APPEND | add_flags, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -3063,7 +3079,7 @@ static void fs_file_open_append(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags,
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDONLY | add_flags,
       S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3105,7 +3121,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
 
   loop = uv_default_loop();
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3122,7 +3138,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file2", O_WRONLY | O_CREAT,
+  r = uv_fs_open(NULL, &open_req1, "test_file2", UV_FS_O_WRONLY | UV_FS_O_CREAT,
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3138,7 +3154,7 @@ TEST_IMPL(fs_rename_to_existing_file) {
   ASSERT_OK(rename_req.result);
   uv_fs_req_cleanup(&rename_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file2", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file2", UV_FS_O_RDONLY, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -3171,7 +3187,7 @@ static void fs_read_bufs(int add_flags) {
 
   ASSERT_LE(0, uv_fs_open(NULL, &open_req1,
                           "test/fixtures/lorem_ipsum.txt",
-                          O_RDONLY | add_flags, 0, NULL));
+                          UV_FS_O_RDONLY | add_flags, 0, NULL));
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
 
@@ -3235,7 +3251,8 @@ static void fs_read_file_eof(int add_flags) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
-      O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | add_flags, S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -3251,7 +3268,7 @@ static void fs_read_file_eof(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDONLY | add_flags, 0,
       NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3299,7 +3316,8 @@ static void fs_write_multiple_bufs(int add_flags) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL, &open_req1, "test_file",
-      O_WRONLY | O_CREAT | add_flags, S_IWUSR | S_IRUSR, NULL);
+                 UV_FS_O_WRONLY | UV_FS_O_CREAT | add_flags, S_IWUSR | S_IRUSR,
+                 NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -3316,7 +3334,7 @@ static void fs_write_multiple_bufs(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDONLY | add_flags, 0,
       NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3405,7 +3423,7 @@ static void fs_write_alotof_bufs(int add_flags) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_RDWR | O_CREAT | add_flags,
+                 UV_FS_O_RDWR | UV_FS_O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -3439,7 +3457,7 @@ static void fs_write_alotof_bufs(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY | add_flags, 0,
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDONLY | add_flags, 0,
     NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
@@ -3518,7 +3536,7 @@ static void fs_write_alotof_bufs_with_offset(int add_flags) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_RDWR | O_CREAT | add_flags,
+                 UV_FS_O_RDWR | UV_FS_O_CREAT | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -3904,9 +3922,7 @@ TEST_IMPL(get_osfhandle_valid_handle) {
   loop = uv_default_loop();
 
   r = uv_fs_open(NULL,
-                 &open_req1,
-                 "test_file",
-                 O_RDWR | O_CREAT,
+                 &open_req1, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -3945,7 +3961,7 @@ TEST_IMPL(open_osfhandle_valid_handle) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_RDWR | O_CREAT,
+                 UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -3986,9 +4002,7 @@ TEST_IMPL(fs_file_pos_after_op_with_offset) {
   loop = uv_default_loop();
 
   r = uv_fs_open(loop,
-                 &open_req1,
-                 "test_file",
-                 O_RDWR | O_CREAT,
+                 &open_req1, "test_file", UV_FS_O_RDWR | UV_FS_O_CREAT,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GT(r, 0);
@@ -4060,7 +4074,7 @@ static void fs_file_pos_close_check(const char *contents, int size) {
   uv_fs_req_cleanup(&close_req);
 
   /* Confirm file contents */
-  r = uv_fs_open(NULL, &open_req1, "test_file", O_RDONLY, 0, NULL);
+  r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDONLY, 0, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(open_req1.result, 0);
   uv_fs_req_cleanup(&open_req1);
@@ -4088,7 +4102,7 @@ static void fs_file_pos_write(int add_flags) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_TRUNC | O_CREAT | O_RDWR | add_flags,
+                 UV_FS_O_TRUNC | UV_FS_O_CREAT | UV_FS_O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GT(r, 0);
@@ -4126,7 +4140,7 @@ static void fs_file_pos_append(int add_flags) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_APPEND | O_CREAT | O_RDWR | add_flags,
+                 UV_FS_O_APPEND | UV_FS_O_CREAT | UV_FS_O_RDWR | add_flags,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GT(r, 0);
@@ -4273,7 +4287,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
   r = uv_fs_open(NULL,
                  &open_req1,
                  "test_file",
-                 O_RDWR | O_CREAT | UV_FS_O_EXLOCK,
+                 UV_FS_O_RDWR | UV_FS_O_CREAT | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -4282,8 +4296,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
 
   r = uv_fs_open(NULL,
                  &open_req2,
-                 "test_file",
-                 O_RDONLY | UV_FS_O_EXLOCK,
+                 "test_file", UV_FS_O_RDONLY | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_LT(r, 0);
@@ -4297,8 +4310,7 @@ TEST_IMPL(fs_exclusive_sharing_mode) {
 
   r = uv_fs_open(NULL,
                  &open_req2,
-                 "test_file",
-                 O_RDONLY | UV_FS_O_EXLOCK,
+                 "test_file", UV_FS_O_RDONLY | UV_FS_O_EXLOCK,
                  S_IWUSR | S_IRUSR,
                  NULL);
   ASSERT_GE(r, 0);
@@ -4405,7 +4417,7 @@ TEST_IMPL(fs_open_readonly_acl) {
     r = uv_fs_open(loop,
                    &open_req1,
                    "test_file_icacls",
-                   O_RDONLY | O_CREAT,
+                   UV_FS_O_RDONLY | UV_FS_O_CREAT,
                    S_IRUSR,
                    NULL);
     ASSERT_GE(r, 0);
@@ -4428,7 +4440,8 @@ TEST_IMPL(fs_open_readonly_acl) {
     }
 
     /* Try opening the file */
-    r = uv_fs_open(NULL, &open_req1, "test_file_icacls", O_RDONLY, 0, NULL);
+    r = uv_fs_open(NULL, &open_req1, "test_file_icacls", UV_FS_O_RDONLY, 0,
+                   NULL);
     if (r < 0) {
         goto acl_cleanup;
     }
@@ -4461,9 +4474,7 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     /* Setup*/
     unlink("test_file");
     r = uv_fs_open(NULL,
-                   &req,
-                   "test_file",
-                   O_WRONLY | O_CREAT,
+                   &req, "test_file", UV_FS_O_WRONLY | UV_FS_O_CREAT,
                    S_IWUSR | S_IRUSR,
                    NULL);
     ASSERT_GE(r, 0);
@@ -4478,7 +4489,7 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
     ASSERT(r);
     check_permission("test_file", 0400);
     /* Try fchmod */
-    r = uv_fs_open(NULL, &req, "test_file", O_RDONLY, 0, NULL);
+    r = uv_fs_open(NULL, &req, "test_file", UV_FS_O_RDONLY, 0, NULL);
     ASSERT_GE(r, 0);
     ASSERT_GE(req.result, 0);
     file = req.result;

--- a/test/test-getters-setters.c
+++ b/test/test-getters-setters.c
@@ -24,6 +24,10 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+# define S_IFDIR _S_IFDIR
+#endif
+
 int cookie1;
 int cookie2;
 int cookie3;

--- a/test/test-metrics.c
+++ b/test/test-metrics.c
@@ -217,7 +217,7 @@ static void prepare_cb(uv_prepare_t* handle) {
   ASSERT_OK(uv_fs_open(uv_default_loop(),
                        &fs_reqs.open_req,
                        "test_file",
-                       O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR,
+                       UV_FS_O_WRONLY | UV_FS_O_CREAT, S_IRUSR | S_IWUSR,
                        create_cb));
 }
 
@@ -329,9 +329,7 @@ TEST_IMPL(metrics_pool_events) {
 
   pool_events_counter = 0;
   fd = uv_fs_open(NULL,
-                  &open_req,
-                  "test_file",
-                  O_WRONLY | O_CREAT,
+                  &open_req, "test_file", UV_FS_O_WRONLY | UV_FS_O_CREAT,
                   S_IRUSR | S_IWUSR,
                   NULL);
   ASSERT_GT(fd, 0);

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -23,6 +23,7 @@
 
 #ifdef _WIN32
 # include <fcntl.h>
+# define close _close
 #else
 # include <sys/socket.h>
 # include <unistd.h>
@@ -638,9 +639,9 @@ TEST_IMPL(poll_bad_fdtype) {
   int fd;
 
 #if defined(_WIN32)
-  fd = open("test/fixtures/empty_file", O_RDONLY);
+  fd = _open("test/fixtures/empty_file", UV_FS_O_RDONLY);
 #else
-  fd = open(".", O_RDONLY);
+  fd = open(".", UV_FS_O_RDONLY);
 #endif
   ASSERT_NE(fd, -1);
   ASSERT_NE(0, uv_poll_init(uv_default_loop(), &poll_handle, fd));

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -32,6 +32,9 @@
 # include <shellapi.h>
 # include <wchar.h>
   typedef BOOL (WINAPI *sCompareObjectHandles)(_In_ HANDLE, _In_ HANDLE);
+# define unlink _unlink
+# define putenv _putenv
+# define close _close
 #else
 # include <unistd.h>
 # include <sys/wait.h>
@@ -322,7 +325,7 @@ TEST_IMPL(spawn_stdout_to_file) {
 
   init_process_options("spawn_helper2", exit_cb);
 
-  r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
+  r = uv_fs_open(NULL, &fs_req, "stdout_file", UV_FS_O_CREAT | UV_FS_O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
   ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
@@ -376,7 +379,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
 
   init_process_options("spawn_helper6", exit_cb);
 
-  r = uv_fs_open(NULL, &fs_req, "stdout_file", O_CREAT | O_RDWR,
+  r = uv_fs_open(NULL, &fs_req, "stdout_file", UV_FS_O_CREAT | UV_FS_O_RDWR,
       S_IRUSR | S_IWUSR, NULL);
   ASSERT_NE(r, -1);
   uv_fs_req_cleanup(&fs_req);
@@ -1621,7 +1624,7 @@ TEST_IMPL(spawn_fs_open) {
   const char dev_null[] = "/dev/null";
 #endif
 
-  r = uv_fs_open(NULL, &fs_req, dev_null, O_RDWR, 0, NULL);
+  r = uv_fs_open(NULL, &fs_req, dev_null, UV_FS_O_RDWR, 0, NULL);
   ASSERT_NE(r, -1);
   fd = uv_get_osfhandle((uv_file) fs_req.result);
   uv_fs_req_cleanup(&fs_req);

--- a/test/test-threadpool-cancel.c
+++ b/test/test-threadpool-cancel.c
@@ -22,6 +22,10 @@
 #include "uv.h"
 #include "task.h"
 
+#ifdef _WIN32
+# define putenv _putenv
+#endif
+
 #define INIT_CANCEL_INFO(ci, what)                                            \
   do {                                                                        \
     (ci)->reqs = (what);                                                      \


### PR DESCRIPTION
On Windows, the non-leading-underscore names of the Unix functions are deprecated and become unavailable by default starting from C11.

Also, this changes the build configuration so we diagnose usage of these names.