### PR TITLE
uv__fs_event freebsd fix proposal.

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -488,11 +488,15 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
    * the struct's kf_structsize must be initialised beforehand
    * whether with the KINFO_FILE_SIZE constant or this way.
    */
+  struct stat statbuf;
   struct kinfo_file kf;
-  kf.kf_structsize = sizeof(kf);
 
-  if (fcntl(handle->event_watcher.fd, F_KINFO, &kf) == 0)
-    path = uv__basename_r(kf.kf_path);
+  if (handle->event_watcher.fd != -1 &&
+     (!uv__fstat(handle->event_watcher.fd, &statbuf) && !(statbuf.st_mode & S_IFDIR))) {
+     kf.kf_structsize = KINFO_FILE_SIZE;
+     if (fcntl(handle->event_watcher.fd, F_KINFO, &kf) == 0)
+       path = uv__basename_r(kf.kf_path);
+  }
 #endif
   handle->cb(handle, path, events, 0);
 


### PR DESCRIPTION
the new F_KINFO flag does not seem to work with directories nor with deleted entries.