### PR TITLE
build: add `.cache` clangd folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.VC.db
 *.VC.opendb
 core
+.cache
 vgcore.*
 .buildstamp
 .dirstamp


### PR DESCRIPTION
The clangd index, before creating the `compile_commands.json` file will create the indexes under a `.cache` folder. This does not need to be tracked by the repo.

I know this may be very trivial, but I find it very annoying always double-check that I don't add that freaking folder to the stage.