### PR TITLE
build,win: work around missing uuid.dll on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,6 @@ if(WIN32)
        ws2_32
        dbghelp
        ole32
-       uuid
        shell32)
   list(APPEND uv_sources
        src/win/async.c

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AM_CONDITIONAL([OS400],    [AS_CASE([$host_os],[os400],         [true], [false])
 AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
 AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
 AS_CASE([$host_os],[mingw*], [
-    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -luserenv -luser32 -ldbghelp -lole32 -luuid -lshell32"
+    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -luserenv -luser32 -ldbghelp -lole32 -lshell32"
 ])
 AS_CASE([$host_os], [solaris2.10], [
     CFLAGS="$CFLAGS -DSUNOS_NO_IFADDRS"

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1212,9 +1212,18 @@ static int uv__kill(HANDLE process_handle, int signum) {
                          (PVOID) dump_folder,
                          &dump_folder_len);
       if (ret != ERROR_SUCCESS) {
+        /* Workaround for missing uuid.dll on MinGW. */
+        static const GUID FOLDERID_LocalAppData_libuv = {
+          0xf1b32785, 0x6fba, 0x4fcf,
+              {0x9d, 0x55, 0x7b, 0x8e, 0x7f, 0x15, 0x70, 0x91}
+        };
+
         /* Default value for `dump_folder` is `%LOCALAPPDATA%\CrashDumps`. */
         WCHAR* localappdata;
-        SHGetKnownFolderPath(&FOLDERID_LocalAppData, 0, NULL, &localappdata);
+        SHGetKnownFolderPath(&FOLDERID_LocalAppData_libuv,
+                             0,
+                             NULL,
+                             &localappdata);
         _snwprintf_s(dump_folder,
                      sizeof(dump_folder),
                      _TRUNCATE,


### PR DESCRIPTION
Fixes #4259. See the report and discussion in that issue. This patch is as suggested by @bnoordhuis in https://github.com/libuv/libuv/issues/4259#issuecomment-1862617768.

This patch fixes the build for us on MinGW.

I took the GUID value from MinGW's `shlobj.h`. I based the indentation on

https://github.com/libuv/libuv/blob/1479b76310a38d98eda94db2b7f8a40e04b3ff32/src/win/poll.c#L31-L40