### PR TITLE
linux: retry fs op if unsupported by io_uring

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1630,6 +1630,16 @@ static void uv__fs_done(struct uv__work* w, int status) {
 }
 
 
+void uv__fs_post(uv_loop_t* loop, uv_fs_t* req) {
+  uv__req_register(loop, req);
+  uv__work_submit(loop,
+                  &req->work_req,
+                  UV__WORK_FAST_IO,
+                  uv__fs_work,
+                  uv__fs_done);
+}
+
+
 int uv_fs_access(uv_loop_t* loop,
                  uv_fs_t* req,
                  const char* path,

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -425,6 +425,7 @@ UV_UNUSED(static int uv__stat(const char* path, struct stat* s)) {
 }
 
 #if defined(__linux__)
+void uv__fs_post(uv_loop_t* loop, uv_fs_t* req);
 ssize_t
 uv__fs_copy_file_range(int fd_in,
                        off_t* off_in,

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1155,6 +1155,12 @@ static void uv__poll_io_uring(uv_loop_t* loop, struct uv__iou* iou) {
     uv__req_unregister(loop, req);
     iou->in_flight--;
 
+    /* If the op is not supported by the kernel retry using the thread pool */
+    if (e->res == -EOPNOTSUPP) {
+      uv__fs_post(loop, req);
+      continue;
+    }
+
     /* io_uring stores error codes as negative numbers, same as libuv. */
     req->result = e->res;
 


### PR DESCRIPTION
Fallback to the threadpool if it returns `EOPNOTSUPP`.

Fixes: https://github.com/nodejs/node/issues/50876

Observed when performing a write in a `vboxsf` filesystem as reported in the nodejs issue.