### PR TITLE
Update win.h to fix comments

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -45,7 +45,7 @@ typedef struct pollfd {
 #endif
 
 #include <mswsock.h>
-// Disable the typedef in mstcpip.h of MinGW.
+/* Disable the typedef in mstcpip.h of MinGW. */
 #define _TCP_INITIAL_RTO_PARAMETERS _TCP_INITIAL_RTO_PARAMETERS__AVOID
 #define TCP_INITIAL_RTO_PARAMETERS TCP_INITIAL_RTO_PARAMETERS__AVOID
 #define PTCP_INITIAL_RTO_PARAMETERS PTCP_INITIAL_RTO_PARAMETERS__AVOID
@@ -70,7 +70,7 @@ typedef struct pollfd {
 # define S_IFLNK 0xA000
 #endif
 
-// Define missing in Windows Kit Include\{VERSION}\ucrt\sys\stat.h
+/* Define missing in Windows Kit Include\{VERSION}\ucrt\sys\stat.h */
 #if defined(_CRT_INTERNAL_NONSTDC_NAMES) && _CRT_INTERNAL_NONSTDC_NAMES && !defined(S_IFIFO)
 # define S_IFIFO _S_IFIFO
 #endif


### PR DESCRIPTION
Make comments compliant with ANSI C89/90.
Fixes #4269.
