### PR TITLE
fix kqueue build on freebsd/non intel archs.

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -493,7 +493,13 @@ static void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
 
   if (handle->event_watcher.fd != -1 &&
      (!uv__fstat(handle->event_watcher.fd, &statbuf) && !(statbuf.st_mode & S_IFDIR))) {
-     kf.kf_structsize = KINFO_FILE_SIZE;
+     /* we are purposely not using KINFO_FILE_SIZE here
+      * as it is not available on non intl archs
+      * and here it gives 1392 too on intel.
+      * anyway, the man page also mentions we can proceed
+      * this way.
+      */
+     kf.kf_structsize = sizeof(kf);
      if (fcntl(handle->event_watcher.fd, F_KINFO, &kf) == 0)
        path = uv__basename_r(kf.kf_path);
   }


### PR DESCRIPTION
KINFO_FILE_SIZE is only defined on intel archs.

close #4274.