### PR TITLE
unix: fix signal handling data race

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -231,8 +232,10 @@ static void uv__signal_handler(int signum) {
     assert(r == sizeof msg ||
            (r == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)));
 
-    if (r != -1)
-      handle->caught_signals++;
+    if (r != -1) {
+      atomic_fetch_add_explicit((atomic_uint*) &handle->caught_signals, 1,
+                                memory_order_seq_cst);
+    }
   }
 
   uv__signal_unlock();


### PR DESCRIPTION
Changes to the `caught_signals` field should be immediately visible to other threads, otherwise "we get signal" events can get lost.

Tentative fix for the linked issue. I say "tentative" because the cause is not fully understood but all signs point to libuv's handling of SIGCHLD signals, and they only manifest on architectures with weaker memory models than x86.

Fixes: https://github.com/libuv/libuv/issues/4279