### PR TITLE
test: fix -Wpointer-to-int-cast on 32 bits systems

### DIFF
--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1054,7 +1054,7 @@ TEST_IMPL(kill) {
     sigaddset(&set, SIGTERM);
     ASSERT_OK(pthread_sigmask(SIG_BLOCK, &set, NULL));
   }
-  ASSERT_NE(SIG_ERR, signal(SIGTERM, SIG_IGN));
+  ASSERT_PTR_NE(SIG_ERR, signal(SIGTERM, SIG_IGN));
 #endif
 
   r = uv_spawn(uv_default_loop(), &process, &options);
@@ -1067,7 +1067,7 @@ TEST_IMPL(kill) {
     sigaddset(&set, SIGTERM);
     ASSERT_OK(pthread_sigmask(SIG_UNBLOCK, &set, NULL));
   }
-  ASSERT_NE(SIG_ERR, signal(SIGTERM, SIG_DFL));
+  ASSERT_PTR_NE(SIG_ERR, signal(SIGTERM, SIG_DFL));
 #endif
 
   /* Sending signum == 0 should check if the


### PR DESCRIPTION
The return value from signal(2) is a pointer. Use the right macro.