### PR TITLE
test uv_barrier_t size in right block

### DIFF
--- a/src/thread-common.c
+++ b/src/thread-common.c
@@ -27,10 +27,6 @@
 #include <pthread.h>
 #endif
 
-#if defined(PTHREAD_BARRIER_SERIAL_THREAD)
-STATIC_ASSERT(sizeof(uv_barrier_t) == sizeof(pthread_barrier_t));
-#endif
-
 /* Note: guard clauses should match uv_barrier_t's in include/uv/unix.h. */
 #if defined(_AIX) || \
     defined(__OpenBSD__) || \
@@ -112,6 +108,8 @@ void uv_barrier_destroy(uv_barrier_t* barrier) {
 }
 
 #else
+
+STATIC_ASSERT(sizeof(uv_barrier_t) == sizeof(pthread_barrier_t));
 
 int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
   return UV__ERR(pthread_barrier_init(barrier, NULL, count));


### PR DESCRIPTION
the local uv_barrier_t implementation is used: for AIX, OpenBSD and any system not defining PTHREAD_BARRIER_SERIAL_THREAD.

as the uv_barrier_t struct was modified and it isn't a pointer anymore, the check for uv_barrier_t size isn't right anymore for systems not using local uv_barrier_t implementation. so move the check inside the block implementing uv_barrier_t using pthread_barrier_t.

tested on OpenBSD, where the build failed due to the STATIC_ASSERT().