### PR TITLE
darwin: reduce memory overhead deleting static member in `uv_uptime`

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -174,7 +174,7 @@ int uv_uptime(double* uptime) {
   time_t now;
   struct timeval info;
   size_t size = sizeof(info);
-  static int which[] = {CTL_KERN, KERN_BOOTTIME};
+  int which[] = {CTL_KERN, KERN_BOOTTIME};
 
   if (sysctl(which, ARRAY_SIZE(which), &info, &size, NULL, 0))
     return UV__ERR(errno);


### PR DESCRIPTION
The `uv_uptime` function is not the most used function in libuv, storing the uptime selection the whole execution does not make any sense. This patch will make libuv occupy a bit less memory in runtime.