### PR TITLE
DON'T sendmsg with udp closed

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -141,7 +141,7 @@ static void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int revents) {
   if (revents & POLLIN)
     uv__udp_recvmsg(handle);
 
-  if (revents & POLLOUT) {
+  if (revents & POLLOUT && !uv__is_closing(handle)) {
     uv__udp_sendmsg(handle);
     uv__udp_run_completed(handle);
   }


### PR DESCRIPTION
Issue:
1. uv__io_poll calls uv__udp_io with revents == POLLIN + POLLOUT
2. uv__udp_io calls your recv_cb
3. you close the handle in callback
4. uv__udp_io calls uv__udp_sendmsg
5. uv__udp_sendmsg calls uv__io_feed
6. kaboom!