### PR TITLE
linux: don't delay EPOLL_CTL_DEL operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-hrtime.c
        test/test-idle.c
        test/test-idna.c
+       test/test-iouring-pollhup.c
        test/test-ip4-addr.c
        test/test-ip6-addr.c
        test/test-ip-name.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,6 +198,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-hrtime.c \
                          test/test-idle.c \
                          test/test-idna.c \
+                         test/test-iouring-pollhup.c \
                          test/test-ip4-addr.c \
                          test/test-ip6-addr.c \
                          test/test-ip-name.c \

--- a/test/test-iouring-pollhup.c
+++ b/test/test-iouring-pollhup.c
@@ -1,0 +1,99 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+static uv_pipe_t p1;
+static uv_pipe_t p2;
+static uv_idle_t idle_handle;
+static int iters;
+static int duped_fd;
+static int newpipefds[2];
+
+static void alloc_buffer(uv_handle_t* handle,
+                         size_t suggested_size,
+                         uv_buf_t* buf) {
+  static char slab[32];
+  *buf = uv_buf_init(slab, sizeof(slab));
+}
+
+static void read_data2(uv_stream_t* stream,
+                       ssize_t nread,
+                       const uv_buf_t* buf) {
+  if (nread < 0) {
+    ASSERT_EQ(nread, UV_EOF);
+    ASSERT_OK(close(duped_fd));
+    duped_fd = -1;
+    uv_close((uv_handle_t*) &p2, NULL);
+    uv_close((uv_handle_t*) &idle_handle, NULL);
+  } else {
+    /* If nread == 0 is because of POLLHUP received still from pipefds[0] file
+     * description which is still referenced in duped_fd. It should not happen
+     * if close(p1) was called after EPOLL_CTL_DEL.
+     */
+    ASSERT_GT(nread, 0);
+  }
+}
+
+static void idle_cb(uv_idle_t* handle) {
+  if (++iters == 1) {
+    ASSERT_OK(uv_pipe_open(&p2, newpipefds[0]));
+    ASSERT_OK(uv_read_start((uv_stream_t*) &p2, alloc_buffer, read_data2));
+  } else {
+    ASSERT_OK(uv_idle_stop(handle));
+    ASSERT_OK(close(newpipefds[1]));
+    newpipefds[1] = -1;
+  }
+}
+
+static void read_data(uv_stream_t* stream,
+                      ssize_t nread,
+                      const uv_buf_t* buf) {
+  ASSERT_EQ(nread, UV_EOF);
+  uv_close((uv_handle_t*) stream, NULL);
+  ASSERT_OK(uv_idle_start(&idle_handle, idle_cb));
+}
+
+TEST_IMPL(iouring_pollhup) {
+  uv_loop_t* loop;
+  int pipefds[2];
+
+  loop = uv_default_loop();
+  ASSERT_OK(uv_pipe_init(loop, &p1, 0));
+  ASSERT_OK(uv_pipe_init(loop, &p2, 0));
+  ASSERT_OK(uv_idle_init(loop, &idle_handle));
+  ASSERT_OK(pipe(pipefds));
+  ASSERT_OK(pipe(newpipefds));
+
+  ASSERT_OK(uv_pipe_open(&p1, pipefds[0]));
+  duped_fd = dup(pipefds[0]);
+  ASSERT_NE(duped_fd, -1);
+
+  ASSERT_OK(uv_read_start((uv_stream_t*) &p1, alloc_buffer, read_data));
+  ASSERT_OK(close(pipefds[1]));  /* Close write end, generate POLLHUP. */
+  pipefds[1] = -1;
+
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}

--- a/test/test-iouring-pollhup.c
+++ b/test/test-iouring-pollhup.c
@@ -30,6 +30,8 @@ TEST_IMPL(iouring_pollhup) {
 
 #else  /* !_WIN32 */
 
+#include <unistd.h>  /* close() */
+
 static uv_pipe_t p1;
 static uv_pipe_t p2;
 static uv_idle_t idle_handle;

--- a/test/test-iouring-pollhup.c
+++ b/test/test-iouring-pollhup.c
@@ -74,6 +74,9 @@ static void read_data(uv_stream_t* stream,
 }
 
 TEST_IMPL(iouring_pollhup) {
+#ifdef _WIN32
+  RETURN_SKIP("Not on Windows.");
+#else
   uv_loop_t* loop;
   int pipefds[2];
 
@@ -96,4 +99,5 @@ TEST_IMPL(iouring_pollhup) {
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
+#endif
 }

--- a/test/test-iouring-pollhup.c
+++ b/test/test-iouring-pollhup.c
@@ -22,6 +22,14 @@
 #include "uv.h"
 #include "task.h"
 
+#ifdef _WIN32
+
+TEST_IMPL(iouring_pollhup) {
+  RETURN_SKIP("Not on Windows.");
+}
+
+#else  /* !_WIN32 */
+
 static uv_pipe_t p1;
 static uv_pipe_t p2;
 static uv_idle_t idle_handle;
@@ -74,9 +82,6 @@ static void read_data(uv_stream_t* stream,
 }
 
 TEST_IMPL(iouring_pollhup) {
-#ifdef _WIN32
-  RETURN_SKIP("Not on Windows.");
-#else
   uv_loop_t* loop;
   int pipefds[2];
 
@@ -99,5 +104,6 @@ TEST_IMPL(iouring_pollhup) {
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
-#endif
 }
+
+#endif  /* !_WIN32 */

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -563,6 +563,8 @@ TEST_DECLARE  (fork_threadpool_queue_work_simple)
 #endif
 #endif
 
+TEST_DECLARE  (iouring_pollhup)
+
 TEST_DECLARE  (idna_toascii)
 TEST_DECLARE  (utf8_decode1)
 TEST_DECLARE  (utf8_decode1_overrun)
@@ -1203,6 +1205,8 @@ TASK_LIST_START
   TEST_ENTRY  (fork_threadpool_queue_work_simple)
 #endif
 #endif
+
+  TEST_ENTRY  (iouring_pollhup)
 
   TEST_ENTRY  (utf8_decode1)
   TEST_ENTRY  (utf8_decode1_overrun)


### PR DESCRIPTION
Perform EPOLL_CTL_DEL immediately instead of going through io_uring's submit queue, otherwise the file descriptor may be closed by the time the kernel starts the operation.

<hr>

I still need to ~~steal~~ adopt Santi's test case but I ran out of time for the day.