### PR TITLE
unix: implementation of uv_resident_set_memory for cygwin

### DIFF
--- a/src/unix/cygwin.c
+++ b/src/unix/cygwin.c
@@ -38,19 +38,23 @@ int uv_uptime(double* uptime) {
 int uv_resident_set_memory(size_t* rss) {
   char buf[1024];
   const char* s;
-  ssize_t n;
   long val;
   int rc;
   int i;
   struct sysinfo si;
 
+  /* rss: 24th element */
   rc = uv__slurp("/proc/self/stat", buf, sizeof(buf));
   if (rc < 0)
     return rc;
 
-  /* rss: 24th element */
-  for (s = buf, i = 1; i <= 23; i++, s++) {
-    s = strchr(s, ' ');
+  /* find the last ')' */
+  s = strrchr(buf, ')');
+  if (s == NULL)
+    goto err;
+
+  for (i = 1; i <= 22; i++) {
+    s = strchr(s + 1, ' ');
     if (s == NULL)
       goto err;
   }


### PR DESCRIPTION
According to the documentation for Cygwin, the penultimate field of [/proc/pid/stat](http://www.cygwin.com/cygwin-ug-net/proc.html) corresponds to the RSS, so the method is basically the same as in the Linux version. The only difference is that [`getpagesize()`](https://cygwin.com/cgit/newlib-cygwin/tree/winsup/cygwin/syscalls.cc#n2836) will return `wincap.allocation_granularity()`, but in this mapping, RSS is calculated using [`wincap.page_size()`](https://cygwin.com/cgit/newlib-cygwin/tree/winsup/cygwin/fhandler/process.cc#n1185), which can be accessed by [`sysinfo.mem_unit`](https://cygwin.com/cgit/newlib-cygwin/tree/winsup/cygwin/sysconf.cc#n815).