### PR TITLE
win: robustify uv_os_getenv() error checking

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1259,6 +1259,9 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
     SetLastError(ERROR_SUCCESS);
     len = GetEnvironmentVariableW(name_w, var, varlen);
 
+    if (len == 0)
+      r = uv_translate_sys_error(GetLastError());
+
     if (len < varlen)
       break;
 
@@ -1280,15 +1283,8 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
   uv__free(name_w);
   name_w = NULL;
 
-  if (len == 0) {
-    r = GetLastError();
-    if (r != ERROR_SUCCESS) {
-      r = uv_translate_sys_error(r);
-      goto fail;
-    }
-  }
-
-  r = uv__copy_utf16_to_utf8(var, len, buffer, size);
+  if (r == 0)
+    r = uv__copy_utf16_to_utf8(var, len, buffer, size);
 
 fail:
 


### PR DESCRIPTION
Observed on the Windows 2022 ASAN buildbot but does not reproduce elsewhere.

My hypothesis is that something clobbers the thread-local error variable so restructure the loop to capture it as soon as possible.

Fixes: https://github.com/libuv/libuv/issues/4338