### PR TITLE
test: use newer ASSERT_MEM_EQ macro

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -197,12 +197,13 @@ static void fs_event_cb_dir_multi_file(uv_fs_event_t* handle,
   ASSERT_PTR_EQ(handle, &fs_event);
   ASSERT_OK(status);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
-  #if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
-  ASSERT_OK(strncmp(filename, file_prefix, sizeof(file_prefix) - 1));
-  #else
-  ASSERT_NE(filename == NULL ||
-            strncmp(filename, file_prefix, sizeof(file_prefix) - 1) == 0, 0);
-  #endif
+#if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
+  ASSERT_NOT_NULL(filename);
+  ASSERT_MEM_EQ(filename, file_prefix, sizeof(file_prefix) - 1);
+#else
+  if (filename != NULL)
+    ASSERT_MEM_EQ(filename, file_prefix, sizeof(file_prefix) - 1);
+#endif
 
   if (fs_event_created + fs_event_removed == fs_event_file_count) {
     /* Once we've processed all create events, delete all files */


### PR DESCRIPTION
Should hopefully make it easier to debug CI flakiness because currently the test sometimes fails without a clear indication why.