### PR TITLE
unix,tcp: allow 0 delay in uv_tcp_keepalive

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -467,9 +467,6 @@ int uv__tcp_keepalive(int fd, int on, unsigned int delay) {
   if (!on)
     return 0;
 
-  if (delay == 0)
-    return -1;
-
 #ifdef __sun
   /* The implementation of TCP keep-alive on Solaris/SmartOS is a bit unusual
    * compared to other Unix-like systems.

--- a/test/test-tcp-flags.c
+++ b/test/test-tcp-flags.c
@@ -33,13 +33,19 @@ TEST_IMPL(tcp_flags) {
 
   loop = uv_default_loop();
 
-  r = uv_tcp_init(loop, &handle);
+  r = uv_tcp_init_ex(loop, &handle, AF_INET);
   ASSERT_OK(r);
 
   r = uv_tcp_nodelay(&handle, 1);
   ASSERT_OK(r);
 
   r = uv_tcp_keepalive(&handle, 1, 60);
+  ASSERT_OK(r);
+
+  r = uv_tcp_keepalive(&handle, 0, 0);
+  ASSERT_OK(r);
+
+  r = uv_tcp_keepalive(&handle, 1, 0);
   ASSERT_OK(r);
 
   uv_close((uv_handle_t*)&handle, NULL);


### PR DESCRIPTION
The removed check was introduced in
https://github.com/libuv/libuv/pull/4272 but it breaks previously working (and documented) behavior: https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay