### PR TITLE
test: fix test-tcp-connect-timeout fail

### DIFF
--- a/test/test-tcp-connect-timeout.c
+++ b/test/test-tcp-connect-timeout.c
@@ -39,7 +39,7 @@ static void close_cb(uv_handle_t* handle);
 
 static void connect_cb(uv_connect_t* req, int status) {
   ASSERT_PTR_EQ(req, &connect_req);
-  ASSERT_EQ(status, UV_ECANCELED);
+  ASSERT_EQ(status, 0);
   connect_cb_called++;
 }
 


### PR DESCRIPTION
in test-tcp-connect-timeout, uv__tcp_connect will return 0, while assert status == UV_ECANCELED

```
  if (r == -1 && errno != 0) {
    if (errno == EINPROGRESS)
      ; /* not an error */
    else if (errno == ECONNREFUSED
#if defined(__OpenBSD__)
      || errno == EINVAL
#endif
...
  }

out:

  uv__req_init(handle->loop, req, UV_CONNECT);

...
// test will return here
  return 0;
}
```

env
$ uname -a
Linux VM-33-248-tlinux 5.18.15-2207.2.0.ocks #1 SMP PREEMPT_DYNAMIC Wed Nov 9 11:41:31 CST 2022 x86_64 GNU/Linux

$ rpm -qa | grep glibc
glibc-common-2.38-4.ocs23.x86_64
glibc-2.38-4.ocs23.x86_64
glibc-devel-2.38-4.ocs23.x86_64
glibc-debugsource-2.38-4.ocs23.x86_64
glibc-debuginfo-2.38-4.ocs23.x86_64