### PR TITLE
test,ci: fix [AM]San, disable ASLR

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Envinfo
         run: npx envinfo
 
+      # [AM]SAN fail on newer kernels due to a bigger PIE slide
+      - name: Disable ASLR
+        run: |
+          sudo sysctl -w kernel.randomize_va_space=0
+
       - name: ASAN Build
         run: |
           mkdir build-asan

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -110,7 +110,7 @@ TEST_IMPL(platform_output) {
   if (cgroup_version == 0) {
     file = fopen("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "r");
     if (file) {
-      if (fscanf(file, "%lu", &quota) == 1 && quota > 0) {
+      if (fscanf(file, "%lu", &quota) == 1 && quota > 0 && quota < ~0ULL) {
         fclose(file);
         file = fopen("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "r");
         if (file && fscanf(file, "%lu", &period) == 1) {


### PR DESCRIPTION
The new Ubuntu 22.04 image seem to ship a buggy version of ASAN that spams thousands of "AddressSanitizer:DEADLYSIGNAL" warnings to the console for no apparent reason when the barrier_3 test runs.

Pin the sanitizers to the old Ubuntu LTS for now.

This commit also fixes a small bug in the platform_output test where the cgroups v1 logic did not handle the "unlimited quota" special case properly. Ubuntu 20.04 still uses cgroups v1.