### PR TITLE
doc: correct udp socket options documentation

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -285,7 +285,9 @@ API
     local sockets.
 
     :param handle: UDP handle. Should have been initialized with
-        :c:func:`uv_udp_init`.
+        :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
+        been bound to an address explicitly with :c:func:`uv_udp_bind`, or
+        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
 
     :param on: 1 for on, 0 for off.
 
@@ -296,7 +298,9 @@ API
     Set the multicast ttl.
 
     :param handle: UDP handle. Should have been initialized with
-        :c:func:`uv_udp_init`.
+        :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
+        been bound to an address explicitly with :c:func:`uv_udp_bind`, or
+        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
 
     :param ttl: 1 through 255.
 
@@ -307,7 +311,9 @@ API
     Set the multicast interface to send or receive data on.
 
     :param handle: UDP handle. Should have been initialized with
-        :c:func:`uv_udp_init`.
+        :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
+        been bound to an address explicitly with :c:func:`uv_udp_bind`, or
+        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
 
     :param interface_addr: interface address.
 
@@ -318,7 +324,9 @@ API
     Set broadcast on or off.
 
     :param handle: UDP handle. Should have been initialized with
-        :c:func:`uv_udp_init`.
+        :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
+        been bound to an address explicitly with :c:func:`uv_udp_bind`, or
+        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
 
     :param on: 1 for on, 0 for off.
 
@@ -329,7 +337,9 @@ API
     Set the time to live.
 
     :param handle: UDP handle. Should have been initialized with
-        :c:func:`uv_udp_init`.
+        :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
+        been bound to an address explicitly with :c:func:`uv_udp_bind`, or
+        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
 
     :param ttl: 1 through 255.
 


### PR DESCRIPTION
uv_udp_init() creates the UDP socket lazily but to set socket options there must be, well, a socket to set the options on. Document how and when that requirement is met.

Fixes: https://github.com/libuv/libuv/issues/4370