### PR TITLE
process: de-duplicate conditions for using kqueue

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -63,11 +63,7 @@ extern char **environ;
 # include "zos-base.h"
 #endif
 
-#if defined(__APPLE__) || \
-    defined(__DragonFly__) || \
-    defined(__FreeBSD__) || \
-    defined(__NetBSD__) || \
-    defined(__OpenBSD__)
+#ifdef UV_HAVE_KQUEUE
 #include <sys/event.h>
 #else
 #define UV_USE_SIGCHLD


### PR DESCRIPTION
Our platform-specific headers provide a dedicated indicator.