### PR TITLE
win: change process startup style

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1036,7 +1036,7 @@ int uv_spawn(uv_loop_t* loop,
     /* Use SW_HIDE to avoid any potential process window. */
     startup.wShowWindow = SW_HIDE;
   } else {
-    startup.wShowWindow = SW_SHOWDEFAULT;
+    startup.wShowWindow = SW_SHOWNORMAL;
   }
 
   if (options->flags & UV_PROCESS_DETACHED) {


### PR DESCRIPTION
According to the Windows documentation, `SW_SHOWNORMAL` should be used for newly spawned processes instead of `SW_SHOWDEFAULT`.

[Here](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow) it says about `STARTUPINFOW` that `wShowWindow` "can be any of the values that can be specified in the nCmdShow parameter for the ShowWindow function, except for SW_SHOWDEFAULT".

[Here](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow), referring to `SW_SHOWNORMAL`, it says that applications "should specify this flag when displaying the window for the first time".