### PR TITLE
win: added support NUMA configuration with multiple count CPU sockets (fix #3458)

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1302,7 +1302,7 @@ enum {
 UV_EXTERN int uv_thread_getpriority(uv_thread_t tid, int* priority);
 UV_EXTERN int uv_thread_setpriority(uv_thread_t tid, int priority);
 
-UV_EXTERN unsigned int uv_available_parallelism(void);
+UV_EXTERN unsigned int uv_available_cores(void);
 UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);
 UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);
 UV_EXTERN int uv_cpumask_size(void);

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -86,9 +86,9 @@ TEST_IMPL(platform_output) {
   printf("  maximum resident set size: %llu\n",
          (unsigned long long) rusage.ru_maxrss);
 
-  par = uv_available_parallelism();
+  par = uv_available_cores();
   ASSERT_GE(par, 1);
-  printf("uv_available_parallelism: %u\n", par);
+  printf("uv_available_cores: %u\n", par);
 
 #ifdef __linux__
   FILE* file;


### PR DESCRIPTION
I have a board with NUMA and I noticed it myself that only 50% cpu util, although all two should be fully loaded at 100%.