### PR TITLE
darwin: simplify uv_hrtime

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -47,8 +47,8 @@ Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
 Sam Roberts <vieuxtech@gmail.com> <sam@strongloop.com>
 San-Tai Hsu <vanilla@fatpipi.com>
 Santiago Gimeno <santiago.gimeno@quantion.es> <santiago.gimeno@gmail.com>
-Saúl Ibarra Corretgé <saghul@gmail.com>
-Saúl Ibarra Corretgé <saghul@gmail.com> <s@saghul.net>
+Saúl Ibarra Corretgé <s@saghul.net>
+Saúl Ibarra Corretgé <s@saghul.net> <saghul@gmail.com>
 Shigeki Ohtsu <ohtsu@iij.ad.jp> <ohtsu@ohtsu.org>
 Shuowang (Wayne) Zhang <shuowang.zhang@ibm.com>
 TK-one <tk5641@naver.com>


### PR DESCRIPTION
mach_continuous_time is available since macOS 10.12, but our minimum version is 11, so no need for a workaround.

Also, prefer that to `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)` which the documentation suggests
(https://developer.apple.com/documentation/driverkit/3438077-mach_continuous_time) since the latter calls mach_timebase_info every time, unnecessarify: https://github.com/apple-open-source/macos/blob/49dcc07a40d19fa97384033a8398dae5d00d11a1/Libc/gen/clock_gettime.c#L107