### PR TITLE
win: remove no longer needed define

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1557,11 +1557,6 @@ int uv__tcp_connect(uv_connect_t* req,
   return 0;
 }
 
-#ifndef WSA_FLAG_NO_HANDLE_INHERIT
-/* Added in Windows 7 SP1. Specify this to avoid race conditions, */
-/* but also manually clear the inherit flag in case this failed. */
-#define WSA_FLAG_NO_HANDLE_INHERIT 0x80
-#endif
 
 int uv_socketpair(int type, int protocol, uv_os_sock_t fds[2], int flags0, int flags1) {
   SOCKET server = INVALID_SOCKET;


### PR DESCRIPTION
Windows 7 is no longer supported.