### PR TITLE
linux,darwin: make `uv_fs_copyfile` behaves like `cp -r`

### DIFF
--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -46,6 +46,8 @@ static void handle_result(uv_fs_t* req) {
   uv_fs_t stat_req;
   uint64_t size;
   uint64_t mode;
+  uint64_t uid;
+  uint64_t gid;
   int r;
 
   ASSERT_EQ(req->fs_type, UV_FS_COPYFILE);
@@ -56,11 +58,15 @@ static void handle_result(uv_fs_t* req) {
   ASSERT_OK(r);
   size = stat_req.statbuf.st_size;
   mode = stat_req.statbuf.st_mode;
+  uid = stat_req.statbuf.st_uid;
+  gid = stat_req.statbuf.st_gid;
   uv_fs_req_cleanup(&stat_req);
   r = uv_fs_stat(NULL, &stat_req, dst, NULL);
   ASSERT_OK(r);
   ASSERT_EQ(stat_req.statbuf.st_size, size);
   ASSERT_EQ(stat_req.statbuf.st_mode, mode);
+  ASSERT_EQ(stat_req.statbuf.st_uid, uid);
+  ASSERT_EQ(stat_req.statbuf.st_gid, gid);
   uv_fs_req_cleanup(&stat_req);
   uv_fs_req_cleanup(req);
   result_check_count++;


### PR DESCRIPTION
This commit changes the timestamps in the file, the ownership and the group.

Fixes: https://github.com/libuv/libuv/issues/3125

Am I missing any metadata here?

```sh
juan@ubuntu:/tmp$ ls -l | grep cop
-rwxrwxrwx 1 juan testing  811 Apr 26 22:12 copied
-rwxrwxrwx 1 juan testing  811 Apr 26 22:12 copied2
-rwxrwxrwx 1 juan testing  811 Apr 26 21:47 copyFile.c
```