### PR TITLE
dragonfly: disable SO_REUSEPORT for UDP socket bindings

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -438,7 +438,7 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
  *
  * Linux as of 3.9 and DragonflyBSD 3.6 have the SO_REUSEPORT socket option but
  * with semantics that are different from the BSDs: it _shares_ the port rather
- * than steal it from the current listener. While useful, it's not something we
+ * than steals it from the current listener. While useful, it's not something we
  * can emulate on other platforms so we don't enable it.
  *
  * zOS does not support getsockname with SO_REUSEPORT option when using

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -461,7 +461,7 @@ static int uv__set_reuse(int fd) {
        return UV__ERR(errno);
   }
 #elif defined(SO_REUSEPORT) && !defined(__linux__) && !defined(__GNU__) && \
-	!defined(__sun__)
+	!defined(__sun__) && !defined(__DragonFly__)
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
     return UV__ERR(errno);
 #else

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -436,10 +436,10 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
 /* On the BSDs, SO_REUSEPORT implies SO_REUSEADDR but with some additional
  * refinements for programs that use multicast.
  *
- * Linux as of 3.9 has a SO_REUSEPORT socket option but with semantics that
- * are different from the BSDs: it _shares_ the port rather than steal it
- * from the current listener.  While useful, it's not something we can emulate
- * on other platforms so we don't enable it.
+ * Linux as of 3.9 and DragonflyBSD 3.6 have the SO_REUSEPORT socket option but
+ * with semantics that are different from the BSDs: it _shares_ the port rather
+ * than steal it from the current listener. While useful, it's not something we
+ * can emulate on other platforms so we don't enable it.
  *
  * zOS does not support getsockname with SO_REUSEPORT option when using
  * AF_UNIX.


### PR DESCRIPTION
We shouldn't enable SO_REUSEPORT on `DragonflyBSD` because that socket option has different semantics from other *BSD: [it shares the port rather than steals it.](https://gitweb.dragonflybsd.org/dragonfly.git/commit/740d1d9f7b7bf9c9c021abb8197718d7a2d441c9)