### PR TITLE
test: remove the obsolete HAVE_KQUEUE macro

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -29,16 +29,6 @@
 # include <AvailabilityMacros.h>
 #endif
 
-#ifndef HAVE_KQUEUE
-# if defined(__APPLE__) ||                                                    \
-     defined(__DragonFly__) ||                                                \
-     defined(__FreeBSD__) ||                                                  \
-     defined(__OpenBSD__) ||                                                  \
-     defined(__NetBSD__)
-#  define HAVE_KQUEUE 1
-# endif
-#endif
-
 static uv_fs_event_t fs_event;
 static const char file_prefix[] = "fsevent-";
 static const int fs_event_file_count = 16;


### PR DESCRIPTION
This macro was first introduced by 4741a112ad7116486977361691738d6bb3f0c729 and should've been removed in ad20b96a8f258db79f67d7465a7373737e253802, but somehow it got left out.