### PR TITLE
bsd: support pipe2() on *BSD

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -487,7 +487,11 @@ int uv_pipe_chmod(uv_pipe_t* handle, int mode) {
 int uv_pipe(uv_os_fd_t fds[2], int read_flags, int write_flags) {
   uv_os_fd_t temp[2];
   int err;
-#if defined(__FreeBSD__) || defined(__linux__)
+#if defined(__linux__) || \
+    defined(__FreeBSD__) || \
+    defined(__OpenBSD__) || \
+    defined(__DragonFly__) || \
+    defined(__NetBSD__)
   int flags = O_CLOEXEC;
 
   if ((read_flags & UV_NONBLOCK_PIPE) && (write_flags & UV_NONBLOCK_PIPE))


### PR DESCRIPTION
Before this PR, `pipe2()` is only enabled on Linux and FreeBSD while `pipe2()` is available on *BSD.

This PR enables `pipe2()` for the rest of *BSD: DragonFlyBSD, NetBSD and OpenBSD.

## References

- [pipe2 on DraonFlyBSD](https://man.dragonflybsd.org/?command=pipe&section=2)
- [pipe2 on  NetBSD](https://man.netbsd.org/pipe.2)
- [pipe2 on OpenBSD](https://man.openbsd.org/pipe.2)

---------

Signed-off-by: Andy Pan <i@andypan.me>