### PR TITLE
unix: use the presence of SOCK_* instead of OS macros for socketpair

### DIFF
--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -610,7 +610,7 @@ void uv__tcp_close(uv_tcp_t* handle) {
 int uv_socketpair(int type, int protocol, uv_os_sock_t fds[2], int flags0, int flags1) {
   uv_os_sock_t temp[2];
   int err;
-#if defined(__FreeBSD__) || defined(__linux__)
+#if defined(SOCK_NONBLOCK) && defined(SOCK_CLOEXEC)
   int flags;
 
   flags = type | SOCK_CLOEXEC;


### PR DESCRIPTION
Stuffing `SOCK_NONBLOCK` and `SOCK_CLOEXEC` into the `type` argument when calling `socketpair()` is widely supported across UNIX-like OS: Linux, *BSD, Solaris, etc., as is the `socket()`. [`socket()`](https://pubs.opengroup.org/onlinepubs/009604499/functions/socket.html) and [`socketpair()`](https://pubs.opengroup.org/onlinepubs/009604499/functions/socketpair.html) share the SOCK_* flags under the hood.

Currently, we detect the presence of `SOCK_NONBLOCK` and `SOCK_CLOEXEC` for `socket()`:
https://github.com/libuv/libuv/blob/bf61390769068de603e6deec8e16623efcbe761a/src/unix/core.c#L494-L499
while checking the specific OS macros for `socketpair()`. We keep them in sync to expand the scope of SOCK_* flags for `socketpair()`.

### References

- [socketpair(2) on Linux](https://man7.org/linux/man-pages/man2/socketpair.2.html#HISTORY)
- [socketpair(2) on FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=socketpair&sektion=2#DESCRIPTION)
- [socketpair(2) on DragonFly](https://man.dragonflybsd.org/?command=socketpair&section=2)
- [socketpair(2) on NetBSD](https://man.netbsd.org/socketpair.2#DESCRIPTION)
- [socketpair(2) on OpenBSD](https://man.openbsd.org/socketpair.2)
- [socketpair(3C) on Solaris](https://docs.oracle.com/cd/E88353_01/html/E37843/socketpair-3c.html)