### PR TITLE
win: Do not call GetSystemTimePreciseAsFileTime on Windows 7

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -435,6 +435,7 @@ typedef void(_stdcall* GetSystemTimePreciseAsFileTimeType)(_Out_ LPFILETIME);
 int uv_clock_gettime(uv_clock_id clock_id, uv_timespec64_t* ts) {
   FILETIME ft;
   int64_t t;
+  HMODULE hModule;
 
   if (ts == NULL)
     return UV_EFAULT;
@@ -447,7 +448,7 @@ int uv_clock_gettime(uv_clock_id clock_id, uv_timespec64_t* ts) {
       ts->tv_nsec = t % 1000000000;
       return 0;
     case UV_CLOCK_REALTIME:
-      HMODULE hModule = GetModuleHandleW(L"kernel32.dll");
+      hModule = GetModuleHandleW(L"kernel32.dll");
       GetSystemTimePreciseAsFileTimeType pGetSystemTimePreciseAsFileTime = (GetSystemTimePreciseAsFileTimeType)GetProcAddress(hModule, "GetSystemTimePreciseAsFileTime");
       if (pGetSystemTimePreciseAsFileTime)
       {


### PR DESCRIPTION
Modify uv_clock_gettime so that GetSystemTimePreciseAsFileTime is only used if OS supports it, otherwise GetSystemTimeAsFileTime is used. GetSystemTimePreciseAsFileTime is supported on Windows 8 or newer.

Without this change, any program using libuv that runs on Windows 7 will not start but get a dialog 'Entry Point Not Found' with text 'The procedure entry point GetSystemTimePreciseAsFileTime could not be located in the dynamic link library KERNEL32.dll.'

For reference, see https://stackoverflow.com/questions/54933940/what-clock-does-the-visual-studio-2017-crt-implementation-of-stdchronosystem.