### PR TITLE
src: add uv_credentials_changed() function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-condvar.c
        test/test-connect-unspecified.c
        test/test-connection-fail.c
+       test/test-credentials-changed.c
        test/test-cwd-and-chdir.c
        test/test-default-loop-close.c
        test/test-delayed-accept.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -165,6 +165,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-condvar.c \
                          test/test-connect-unspecified.c \
                          test/test-connection-fail.c \
+                         test/test-credentials-changed.c \
                          test/test-cwd-and-chdir.c \
                          test/test-default-loop-close.c \
                          test/test-delayed-accept.c \

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -913,6 +913,18 @@ API
         return 0;
     }
 
+.. c:function:: void uv_credentials_changed()
+
+    To be called by embedders to notify `libuv` that credentials of the
+    running process have changed. Only functional if iouring sqpoll-ring is
+    enabled: it synchronizes the ring credentials with the process'. In any
+    other scenario is a no-op.
+
+    Without calling this function after dropping privileges, a process could
+    still perform privileged filesystem operations through io_uring.
+
+    .. versionadded:: 1.53.0
+
 String manipulation functions
 -----------------------------
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -1181,6 +1181,7 @@ UV_EXTERN int uv_process_kill(uv_process_t*, int signum);
 UV_EXTERN int uv_kill(int pid, int signum);
 UV_EXTERN uv_pid_t uv_process_get_pid(const uv_process_t*);
 
+UV_EXTERN void uv_credentials_changed(void);
 
 /*
  * uv_work_t is a subclass of uv_req_t.

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -170,6 +170,10 @@ enum {
   UV__IORING_SQ_CQ_OVERFLOW = 2u,
 };
 
+enum {
+  UV__IORING_REGISTER_PERSONALITY = 9u,
+};
+
 struct uv__io_cqring_offsets {
   uint32_t head;
   uint32_t tail;
@@ -227,8 +231,11 @@ struct uv__io_uring_sqe {
   uint64_t user_data;
   union {
     uint16_t buf_index;
-    uint64_t pad[3];
+    uint16_t buf_group;
   };
+  uint16_t personality;
+  uint32_t pad1;
+  uint64_t pad2[2];
 };
 
 STATIC_ASSERT(64 == sizeof(struct uv__io_uring_sqe));
@@ -294,6 +301,10 @@ static void uv__epoll_ctl_prep(int epollfd,
 
 RB_GENERATE_STATIC(watcher_root, watcher_list, entry, compare_watchers)
 
+/* personality_index will be increased every time
+ * uv_credentials_changed() is called, allowing us to know whether to
+ * register the current credentials in the ring. */
+static _Atomic unsigned personality_index = 0;
 
 static struct watcher_root* uv__inotify_watchers(uv_loop_t* loop) {
   /* This cast works because watcher_root is a struct with a pointer as its
@@ -612,6 +623,9 @@ static void uv__iou_init(int epollfd,
   iou->sqelen = sqelen;
   iou->ringfd = ringfd;
   iou->in_flight = 0;
+  iou->personality = 0;
+  iou->personality_index = atomic_load_explicit(&personality_index,
+                                                memory_order_relaxed);
 
   if (no_sqarray)
     return;
@@ -768,6 +782,8 @@ static struct uv__io_uring_sqe* uv__iou_get_sqe(struct uv__iou* iou,
   uint32_t tail;
   uint32_t mask;
   uint32_t slot;
+  unsigned cur;
+  int r;
 
   /* Lazily create the ring. State machine: -2 means uninitialized, -1 means
    * initialization failed. Anything else is a valid ring file descriptor.
@@ -788,6 +804,22 @@ static struct uv__io_uring_sqe* uv__iou_get_sqe(struct uv__iou* iou,
   if (iou->ringfd == -1)
     return NULL;
 
+  cur = atomic_load_explicit(&personality_index, memory_order_relaxed);
+  if (cur != iou->personality_index) {
+    r = uv__io_uring_register(iou->ringfd,
+                              UV__IORING_REGISTER_PERSONALITY,
+                              NULL,
+                              0);
+    /* Potentially this could fail if no personality slots are available, as
+     * we're not unregistering personalities. I think it's a fine compromise to
+     * avoid the complexity of ref counting personality slots.
+     */
+    if (r == -1)
+      return NULL;
+    iou->personality_index = cur;
+    iou->personality = r;
+  }
+
   head = atomic_load_explicit((_Atomic uint32_t*) iou->sqhead,
                               memory_order_acquire);
   tail = *iou->sqtail;
@@ -801,6 +833,7 @@ static struct uv__io_uring_sqe* uv__iou_get_sqe(struct uv__iou* iou,
   sqe = &sqe[slot];
   memset(sqe, 0, sizeof(*sqe));
   sqe->user_data = (uintptr_t) req;
+  sqe->personality = iou->personality;
 
   /* Pacify uv_cancel(). */
   req->work_req.loop = loop;
@@ -2747,4 +2780,9 @@ int uv_fs_event_stop(uv_fs_event_t* handle) {
 
 void uv__fs_event_close(uv_fs_event_t* handle) {
   uv_fs_event_stop(handle);
+}
+
+
+void uv__credentials_changed() {
+  atomic_fetch_add_explicit(&personality_index, 1, memory_order_relaxed);
 }

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -1092,3 +1092,9 @@ void uv_free_interface_addresses(uv_interface_address_t* addresses,
   uv__free(addresses);
 }
 #endif  /* !__MVS__ */
+
+void uv_credentials_changed(void) {
+#ifdef __linux__
+  uv__credentials_changed();
+#endif
+}

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -431,7 +431,11 @@ struct uv__iou {
   size_t sqelen;
   int ringfd;
   uint32_t in_flight;
+  uint16_t personality;
+  unsigned personality_index;
 };
+
+void uv__credentials_changed(void);
 #endif  /* __linux__ */
 
 struct uv__loop_internal_fields_s {

--- a/test/test-credentials-changed.c
+++ b/test/test-credentials-changed.c
@@ -1,0 +1,76 @@
+/* Copyright the libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/types.h>
+
+struct passwd* pw;
+
+void open_cb(uv_fs_t* req) {
+  ASSERT_EQ(UV_EACCES, req->result);
+  uv_fs_req_cleanup(req);
+}
+
+void stat_cb(uv_fs_t* req) {
+  /* become the "nobody" user. */
+  ASSERT_OK(setuid(pw->pw_uid));
+
+  uv_credentials_changed();
+
+  uv_fs_req_cleanup(req);
+
+  uv_fs_open(req->loop,
+             req, "/etc/shadow",
+             UV_FS_O_CREAT | UV_FS_O_RDWR,
+             0666,
+             open_cb);
+}
+
+TEST_FS_IMPL(credentials_changed) {
+  uv_loop_t* loop;
+  uv_fs_t req;
+
+  uv_uid_t uid;
+  /* if not root, then this will fail. */
+  uid = getuid();
+  if (uid != 0)
+    RETURN_SKIP("It should be run as root user");
+
+  pw = getpwnam("nobody");
+  if (pw == NULL)
+    RETURN_SKIP("'nobody' user not available");
+
+  loop = uv_default_loop();
+
+  /* This first request is only to make sure the io_uring instance is
+   * initialized. */
+  uv_fs_stat(loop, &req, ".", stat_cb);
+
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
+
+  MAKE_VALGRIND_HAPPY(loop);
+  return 0;
+}
+#endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -606,6 +606,10 @@ TEST_DECLARE  (metrics_idle_time)
 TEST_DECLARE  (metrics_idle_time_thread)
 TEST_DECLARE  (metrics_idle_time_zero)
 
+#ifndef _WIN32
+TEST_FS_DECLARE  (credentials_changed)
+#endif
+
 TASK_LIST_START
   TEST_ENTRY_CUSTOM (platform_output, 0, 1, 5000)
 
@@ -1290,6 +1294,10 @@ TASK_LIST_START
   TEST_ENTRY  (metrics_idle_time)
   TEST_ENTRY  (metrics_idle_time_thread)
   TEST_ENTRY  (metrics_idle_time_zero)
+
+#ifndef _WIN32
+  TEST_FS_ENTRY  (credentials_changed)
+#endif
 
 #if 0
   /* These are for testing the test runner. */


### PR DESCRIPTION
To be called by embedders to notify `libuv` that credentials of the
running process have changed. Only functional if iouring sqpoll-ring is
enabled: it synchronizes the ring credentials with the process'. In any
other scenario is a no-op.

Without this change, a privileged-dropped process could end up
performing privileged fs operations via the iouring.

Refs: https://github.com/advisories/GHSA-vr4q-vx84-9g5x