### PR TITLE
Add new UV_RUN_FORCE type to uv_run_mode to ensure loop runs even after uv_stop is called

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -266,7 +266,8 @@ typedef enum {
 typedef enum {
   UV_RUN_DEFAULT = 0,
   UV_RUN_ONCE,
-  UV_RUN_NOWAIT
+  UV_RUN_NOWAIT,
+  UV_RUN_FORCE = 1024
 } uv_run_mode;
 
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -620,7 +620,13 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
   DWORD timeout;
   int r;
   int can_sleep;
-
+  
+  if (mode & UV_RUN_FORCE) {
+    if (loop->stop_flag != 0)
+     loop->stop_flag = 0;
+    mode &= ~UV_RUN_FORCE;
+  }
+ 
   r = uv__loop_alive(loop);
   if (!r)
     uv_update_time(loop);


### PR DESCRIPTION
# Add new `UV_RUN_FORCE` type to `uv_run_mode` to ensure loop runs even after `uv_stop` is called

## Description

This PR introduces a new type `UV_RUN_FORCE` to the `uv_run_mode` enum in libuv. This addition aims to address an issue where the loop, after having `uv_stop` called before invoking `uv_run`, fails to run as expected due to the `stop_flag` not being reset appropriately.

### Problem

When `uv_stop` is called before `uv_run`, the loop's `stop_flag` is set. If `uv_run` is called subsequently, it exits immediately without running the loop, and without any error indication, because the `stop_flag` is not cleared.

### Solution

A new `UV_RUN_FORCE` type has been added to the `uv_run_mode` enum. When `UV_RUN_FORCE` is used, the `stop_flag` will be forcibly cleared, ensuring that the loop runs as expected.

Initially, the approach considered was to reset the `stop_flag` unconditionally within `uv_run`. However, this could potentially interfere with existing functionality and logic. To avoid such issues, the new type `UV_RUN_FORCE` was introduced to provide this functionality explicitly.

## Code Changes

The following code changes were made:

```c
// In uv.h or the relevant header file
typedef enum {
  UV_RUN_DEFAULT = 0,
  UV_RUN_ONCE,
  UV_RUN_NOWAIT,
  UV_RUN_FORCE = 1024
} uv_run_mode;

// In core.c or the relevant source file
int uv_run(uv_loop_t *loop, uv_run_mode mode) {
  DWORD timeout;
  int r;
  int can_sleep;
  
  // Add code
  if (mode & UV_RUN_FORCE) {
    if (loop->stop_flag != 0)
      loop->stop_flag = 0;
    mode &= ~UV_RUN_FORCE;
  }
  // Add code end

  r = uv__loop_alive(loop);
  if (!r)
    uv_update_time(loop);

  // Existing code...
}
