### PR TITLE
[docs] Add instruction how to install libuv using Conan

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ $ ./bootstrap-vcpkg.sh # for bash
 $ ./vcpkg install libuv
 ```
 
+### Install with Conan
+
+You can install pre-built binaries for libuv or build it from source using [Conan](https://conan.io/). Use the following command:
+
+```bash
+conan install --requires="libuv/[*]" --build=missing
+```
+
+The libuv Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.
+
+
 ### Running tests
 
 Some tests are timing sensitive. Relaxing test timeouts may be necessary


### PR DESCRIPTION
Greetings, fellow community!

We have just added the latest version of libuv to [Conan Center](https://conan.io/center/recipes/libuv?version=1.48.0) and thought it would be a nice addition to include instructions on how to install libuv via Conan in the README file.

Please let me know if this is okay, or if you would prefer it placed elsewhere.

Regards! 