### PR TITLE
Remove unused parameter from uv__req_register and uv__req_unregister macros

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -82,7 +82,7 @@ static void uv__random_done(struct uv__work* w, int status) {
   uv_random_t* req;
 
   req = container_of(w, uv_random_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   if (status == 0)
     status = req->status;

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -356,7 +356,7 @@ static void uv__queue_done(struct uv__work* w, int err) {
   uv_work_t* req;
 
   req = container_of(w, uv_work_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   if (req->after_work_cb == NULL)
     return;

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -139,7 +139,7 @@ extern char *mkdtemp(char *template); /* See issue #740 on AIX < 7 */
 #define POST                                                                  \
   do {                                                                        \
     if (cb != NULL) {                                                         \
-      uv__req_register(loop);                                            \
+      uv__req_register(loop);                                                 \
       uv__work_submit(loop,                                                   \
                       &req->work_req,                                         \
                       UV__WORK_FAST_IO,                                       \

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -139,7 +139,7 @@ extern char *mkdtemp(char *template); /* See issue #740 on AIX < 7 */
 #define POST                                                                  \
   do {                                                                        \
     if (cb != NULL) {                                                         \
-      uv__req_register(loop, req);                                            \
+      uv__req_register(loop);                                            \
       uv__work_submit(loop,                                                   \
                       &req->work_req,                                         \
                       UV__WORK_FAST_IO,                                       \
@@ -1756,7 +1756,7 @@ static void uv__fs_done(struct uv__work* w, int status) {
   uv_fs_t* req;
 
   req = container_of(w, uv_fs_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   if (status == UV_ECANCELED) {
     assert(req->result == 0);
@@ -1768,7 +1768,7 @@ static void uv__fs_done(struct uv__work* w, int status) {
 
 
 void uv__fs_post(uv_loop_t* loop, uv_fs_t* req) {
-  uv__req_register(loop, req);
+  uv__req_register(loop);
   uv__work_submit(loop,
                   &req->work_req,
                   UV__WORK_FAST_IO,

--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -109,7 +109,7 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   uv_getaddrinfo_t* req;
 
   req = container_of(w, uv_getaddrinfo_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   /* See initialization in uv_getaddrinfo(). */
   if (req->hints)

--- a/src/unix/getnameinfo.c
+++ b/src/unix/getnameinfo.c
@@ -58,7 +58,7 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
   char* service;
 
   req = container_of(w, uv_getnameinfo_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
   host = service = NULL;
 
   if (status == UV_ECANCELED) {

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -789,7 +789,7 @@ static struct uv__io_uring_sqe* uv__iou_get_sqe(struct uv__iou* iou,
   req->work_req.done = NULL;
   uv__queue_init(&req->work_req.wq);
 
-  uv__req_register(loop, req);
+  uv__req_register(loop);
   iou->in_flight++;
 
   return sqe;
@@ -1157,7 +1157,7 @@ static void uv__poll_io_uring(uv_loop_t* loop, struct uv__iou* iou) {
     req = (uv_fs_t*) (uintptr_t) e->user_data;
     assert(req->type == UV_FS);
 
-    uv__req_unregister(loop, req);
+    uv__req_unregister(loop);
     iou->in_flight--;
 
     /* If the op is not supported by the kernel retry using the thread pool */

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -457,7 +457,7 @@ void uv__stream_destroy(uv_stream_t* stream) {
   assert(stream->flags & UV_HANDLE_CLOSED);
 
   if (stream->connect_req) {
-    uv__req_unregister(stream->loop, stream->connect_req);
+    uv__req_unregister(stream->loop);
     stream->connect_req->cb(stream->connect_req, UV_ECANCELED);
     stream->connect_req = NULL;
   }
@@ -642,7 +642,7 @@ static void uv__drain(uv_stream_t* stream) {
   if ((stream->flags & UV_HANDLE_CLOSING) ||
       !(stream->flags & UV_HANDLE_SHUT)) {
     stream->shutdown_req = NULL;
-    uv__req_unregister(stream->loop, req);
+    uv__req_unregister(stream->loop);
 
     err = 0;
     if (stream->flags & UV_HANDLE_CLOSING)
@@ -912,7 +912,7 @@ static void uv__write_callbacks(uv_stream_t* stream) {
     q = uv__queue_head(&pq);
     req = uv__queue_data(q, uv_write_t, queue);
     uv__queue_remove(q);
-    uv__req_unregister(stream->loop, req);
+    uv__req_unregister(stream->loop);
 
     if (req->bufs != NULL) {
       stream->write_queue_size -= uv__write_req_size(req);
@@ -1272,7 +1272,7 @@ static void uv__stream_connect(uv_stream_t* stream) {
     return;
 
   stream->connect_req = NULL;
-  uv__req_unregister(stream->loop, req);
+  uv__req_unregister(stream->loop);
 
   if (error < 0 || uv__queue_empty(&stream->write_queue)) {
     uv__io_stop(stream->loop, &stream->io_watcher, POLLOUT);

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -100,7 +100,7 @@ static void uv__udp_run_completed(uv_udp_t* handle) {
     uv__queue_remove(q);
 
     req = uv__queue_data(q, uv_udp_send_t, queue);
-    uv__req_unregister(handle->loop, req);
+    uv__req_unregister(handle->loop);
 
     handle->send_queue_size -= uv__count_bufs(req->bufs, req->nbufs);
     handle->send_queue_count--;
@@ -734,7 +734,7 @@ int uv__udp_send(uv_udp_send_t* req,
     req->bufs = uv__malloc(nbufs * sizeof(bufs[0]));
 
   if (req->bufs == NULL) {
-    uv__req_unregister(handle->loop, req);
+    uv__req_unregister(handle->loop);
     return UV_ENOMEM;
   }
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -233,13 +233,13 @@ void uv__threadpool_cleanup(void);
 #define uv__has_active_reqs(loop)                                             \
   ((loop)->active_reqs.count > 0)
 
-#define uv__req_register(loop)                                           \
+#define uv__req_register(loop)                                                \
   do {                                                                        \
     (loop)->active_reqs.count++;                                              \
   }                                                                           \
   while (0)
 
-#define uv__req_unregister(loop)                                         \
+#define uv__req_unregister(loop)                                              \
   do {                                                                        \
     assert(uv__has_active_reqs(loop));                                        \
     (loop)->active_reqs.count--;                                              \
@@ -349,7 +349,7 @@ void uv__threadpool_cleanup(void);
 #define uv__req_init(loop, req, typ)                                          \
   do {                                                                        \
     UV_REQ_INIT(req, typ);                                                    \
-    uv__req_register(loop);                                              \
+    uv__req_register(loop);                                                   \
   }                                                                           \
   while (0)
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -233,13 +233,13 @@ void uv__threadpool_cleanup(void);
 #define uv__has_active_reqs(loop)                                             \
   ((loop)->active_reqs.count > 0)
 
-#define uv__req_register(loop, req)                                           \
+#define uv__req_register(loop)                                           \
   do {                                                                        \
     (loop)->active_reqs.count++;                                              \
   }                                                                           \
   while (0)
 
-#define uv__req_unregister(loop, req)                                         \
+#define uv__req_unregister(loop)                                         \
   do {                                                                        \
     assert(uv__has_active_reqs(loop));                                        \
     (loop)->active_reqs.count--;                                              \
@@ -349,7 +349,7 @@ void uv__threadpool_cleanup(void);
 #define uv__req_init(loop, req, typ)                                          \
   do {                                                                        \
     UV_REQ_INIT(req, typ);                                                    \
-    uv__req_register(loop, req);                                              \
+    uv__req_register(loop);                                              \
   }                                                                           \
   while (0)
 

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -58,7 +58,7 @@
 #define POST                                                                  \
   do {                                                                        \
     if (cb != NULL) {                                                         \
-      uv__req_register(loop);                                            \
+      uv__req_register(loop);                                                 \
       uv__work_submit(loop,                                                   \
                       &req->work_req,                                         \
                       UV__WORK_FAST_IO,                                       \

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -58,7 +58,7 @@
 #define POST                                                                  \
   do {                                                                        \
     if (cb != NULL) {                                                         \
-      uv__req_register(loop, req);                                            \
+      uv__req_register(loop);                                            \
       uv__work_submit(loop,                                                   \
                       &req->work_req,                                         \
                       UV__WORK_FAST_IO,                                       \
@@ -2830,7 +2830,7 @@ static void uv__fs_done(struct uv__work* w, int status) {
   uv_fs_t* req;
 
   req = container_of(w, uv_fs_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   if (status == UV_ECANCELED) {
     assert(req->result == 0);

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -206,7 +206,7 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   }
 
 complete:
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
 
   /* finally do callback with converted result */
   if (req->getaddrinfo_cb)
@@ -325,7 +325,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
     req->addrinfow = NULL;
   }
 
-  uv__req_register(loop, req);
+  uv__req_register(loop);
 
   if (getaddrinfo_cb) {
     uv__work_submit(loop,

--- a/src/win/getnameinfo.c
+++ b/src/win/getnameinfo.c
@@ -82,7 +82,7 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
   char* service;
 
   req = container_of(w, uv_getnameinfo_t, work_req);
-  uv__req_unregister(req->loop, req);
+  uv__req_unregister(req->loop);
   host = service = NULL;
 
   if (status == UV_ECANCELED) {
@@ -124,7 +124,7 @@ int uv_getnameinfo(uv_loop_t* loop,
   }
 
   UV_REQ_INIT(req, UV_GETNAMEINFO);
-  uv__req_register(loop, req);
+  uv__req_register(loop);
 
   req->getnameinfo_cb = getnameinfo_cb;
   req->flags = flags;

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -868,7 +868,7 @@ void uv_pipe_connect(uv_connect_t* req,
     SET_REQ_ERROR(req, err);
     uv__insert_pending_req(loop, (uv_req_t*) req);
     handle->reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
   }
 }
 
@@ -959,7 +959,7 @@ int uv_pipe_connect2(uv_connect_t* req,
         goto error;
       }
 
-      REGISTER_HANDLE_REQ(loop, handle, req);
+      REGISTER_HANDLE_REQ(loop, handle);
       handle->reqs_pending++;
 
       return 0;
@@ -974,7 +974,7 @@ int uv_pipe_connect2(uv_connect_t* req,
   SET_REQ_SUCCESS(req);
   uv__insert_pending_req(loop, (uv_req_t*) req);
   handle->reqs_pending++;
-  REGISTER_HANDLE_REQ(loop, handle, req);
+  REGISTER_HANDLE_REQ(loop, handle);
   return 0;
 
 error:
@@ -992,7 +992,7 @@ error:
   SET_REQ_ERROR(req, err);
   uv__insert_pending_req(loop, (uv_req_t*) req);
   handle->reqs_pending++;
-  REGISTER_HANDLE_REQ(loop, handle, req);
+  REGISTER_HANDLE_REQ(loop, handle);
   return 0;
 }
 
@@ -1638,7 +1638,7 @@ static int uv__pipe_write_data(uv_loop_t* loop,
       req->u.io.queued_bytes = 0;
     }
 
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     handle->reqs_pending++;
     handle->stream.conn.write_reqs_pending++;
     POST_COMPLETION_FOR_REQ(loop, req);
@@ -1686,7 +1686,7 @@ static int uv__pipe_write_data(uv_loop_t* loop,
     CloseHandle(req->event_handle);
     req->event_handle = NULL;
 
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     handle->reqs_pending++;
     handle->stream.conn.write_reqs_pending++;
     return 0;
@@ -1719,7 +1719,7 @@ static int uv__pipe_write_data(uv_loop_t* loop,
     }
   }
 
-  REGISTER_HANDLE_REQ(loop, handle, req);
+  REGISTER_HANDLE_REQ(loop, handle);
   handle->reqs_pending++;
   handle->stream.conn.write_reqs_pending++;
 
@@ -2132,7 +2132,7 @@ void uv__process_pipe_write_req(uv_loop_t* loop, uv_pipe_t* handle,
   assert(handle->write_queue_size >= req->u.io.queued_bytes);
   handle->write_queue_size -= req->u.io.queued_bytes;
 
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
     if (req->wait_handle != INVALID_HANDLE_VALUE) {
@@ -2219,7 +2219,7 @@ void uv__process_pipe_connect_req(uv_loop_t* loop, uv_pipe_t* handle,
 
   assert(handle->type == UV_NAMED_PIPE);
 
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   err = 0;
   if (REQ_SUCCESS(req)) {
@@ -2251,7 +2251,7 @@ void uv__process_pipe_shutdown_req(uv_loop_t* loop, uv_pipe_t* handle,
 
   /* Clear the shutdown_req field so we don't go here again. */
   handle->stream.conn.shutdown_req = NULL;
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   if (handle->flags & UV_HANDLE_CLOSING) {
     /* Already closing. Cancel the shutdown. */

--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -53,16 +53,16 @@
   (uv__ntstatus_to_winsock_error(GET_REQ_STATUS((req))))
 
 
-#define REGISTER_HANDLE_REQ(loop, handle, req)                          \
+#define REGISTER_HANDLE_REQ(loop, handle)                               \
   do {                                                                  \
     INCREASE_ACTIVE_COUNT((loop), (handle));                            \
-    uv__req_register((loop), (req));                                    \
+    uv__req_register((loop));                                           \
   } while (0)
 
-#define UNREGISTER_HANDLE_REQ(loop, handle, req)                        \
+#define UNREGISTER_HANDLE_REQ(loop, handle)                             \
   do {                                                                  \
     DECREASE_ACTIVE_COUNT((loop), (handle));                            \
-    uv__req_unregister((loop), (req));                                  \
+    uv__req_unregister((loop));                                         \
   } while (0)
 
 

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -216,7 +216,7 @@ int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb) {
   handle->flags &= ~UV_HANDLE_WRITABLE;
   handle->stream.conn.shutdown_req = req;
   handle->reqs_pending++;
-  REGISTER_HANDLE_REQ(loop, handle, req);
+  REGISTER_HANDLE_REQ(loop, handle);
 
   if (handle->stream.conn.write_reqs_pending == 0) {
     if (handle->type == UV_NAMED_PIPE)

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -212,7 +212,7 @@ void uv__process_tcp_shutdown_req(uv_loop_t* loop, uv_tcp_t* stream, uv_shutdown
   assert(stream->flags & UV_HANDLE_CONNECTION);
 
   stream->stream.conn.shutdown_req = NULL;
-  UNREGISTER_HANDLE_REQ(loop, stream, req);
+  UNREGISTER_HANDLE_REQ(loop, stream);
 
   err = 0;
   if (stream->flags & UV_HANDLE_CLOSING)
@@ -834,7 +834,7 @@ out:
   if (handle->delayed_error != 0) {
     /* Process the req without IOCP. */
     handle->reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     uv__insert_pending_req(loop, (uv_req_t*)req);
     return 0;
   }
@@ -850,12 +850,12 @@ out:
   if (UV_SUCCEEDED_WITHOUT_IOCP(success)) {
     /* Process the req without IOCP. */
     handle->reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     uv__insert_pending_req(loop, (uv_req_t*)req);
   } else if (UV_SUCCEEDED_WITH_IOCP(success)) {
     /* The req will be processed with IOCP. */
     handle->reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
   } else {
     return WSAGetLastError();
   }
@@ -925,14 +925,14 @@ int uv__tcp_write(uv_loop_t* loop,
     req->u.io.queued_bytes = 0;
     handle->reqs_pending++;
     handle->stream.conn.write_reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     uv__insert_pending_req(loop, (uv_req_t*) req);
   } else if (UV_SUCCEEDED_WITH_IOCP(result == 0)) {
     /* Request queued by the kernel. */
     req->u.io.queued_bytes = uv__count_bufs(bufs, nbufs);
     handle->reqs_pending++;
     handle->stream.conn.write_reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     handle->write_queue_size += req->u.io.queued_bytes;
     if (handle->flags & UV_HANDLE_EMULATE_IOCP &&
         !RegisterWaitForSingleObject(&req->wait_handle,
@@ -946,7 +946,7 @@ int uv__tcp_write(uv_loop_t* loop,
     req->u.io.queued_bytes = 0;
     handle->reqs_pending++;
     handle->stream.conn.write_reqs_pending++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     SET_REQ_ERROR(req, WSAGetLastError());
     uv__insert_pending_req(loop, (uv_req_t*) req);
   }
@@ -1117,7 +1117,7 @@ void uv__process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
   assert(handle->write_queue_size >= req->u.io.queued_bytes);
   handle->write_queue_size -= req->u.io.queued_bytes;
 
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   if (handle->flags & UV_HANDLE_EMULATE_IOCP) {
     if (req->wait_handle != INVALID_HANDLE_VALUE) {
@@ -1209,7 +1209,7 @@ void uv__process_tcp_connect_req(uv_loop_t* loop, uv_tcp_t* handle,
 
   assert(handle->type == UV_TCP);
 
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   err = 0;
   if (handle->delayed_error) {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2183,7 +2183,7 @@ int uv__tty_write(uv_loop_t* loop,
 
   handle->reqs_pending++;
   handle->stream.conn.write_reqs_pending++;
-  REGISTER_HANDLE_REQ(loop, handle, req);
+  REGISTER_HANDLE_REQ(loop, handle);
 
   req->u.io.queued_bytes = 0;
 
@@ -2219,7 +2219,7 @@ void uv__process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
   int err;
 
   handle->write_queue_size -= req->u.io.queued_bytes;
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   if (req->cb) {
     err = GET_REQ_ERROR(req);
@@ -2263,7 +2263,7 @@ void uv__process_tty_shutdown_req(uv_loop_t* loop, uv_tty_t* stream, uv_shutdown
   assert(req);
 
   stream->stream.conn.shutdown_req = NULL;
-  UNREGISTER_HANDLE_REQ(loop, stream, req);
+  UNREGISTER_HANDLE_REQ(loop, stream);
 
   /* TTY shutdown is really just a no-op */
   if (req->cb) {

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -376,7 +376,7 @@ static int uv__send(uv_udp_send_t* req,
     handle->reqs_pending++;
     handle->send_queue_size += req->u.io.queued_bytes;
     handle->send_queue_count++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
     uv__insert_pending_req(loop, (uv_req_t*)req);
   } else if (UV_SUCCEEDED_WITH_IOCP(result == 0)) {
     /* Request queued by the kernel. */
@@ -384,7 +384,7 @@ static int uv__send(uv_udp_send_t* req,
     handle->reqs_pending++;
     handle->send_queue_size += req->u.io.queued_bytes;
     handle->send_queue_count++;
-    REGISTER_HANDLE_REQ(loop, handle, req);
+    REGISTER_HANDLE_REQ(loop, handle);
   } else {
     /* Send failed due to an error. */
     return WSAGetLastError();
@@ -527,7 +527,7 @@ void uv__process_udp_send_req(uv_loop_t* loop, uv_udp_t* handle,
   handle->send_queue_size -= req->u.io.queued_bytes;
   handle->send_queue_count--;
 
-  UNREGISTER_HANDLE_REQ(loop, handle, req);
+  UNREGISTER_HANDLE_REQ(loop, handle);
 
   if (req->cb) {
     err = 0;


### PR DESCRIPTION
`req` parameter is unused in uv__req_register and uv__req_unregister macros. So, I suggest to remove it.