### PR TITLE
unix,win: export wtf8 functions properly

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1929,17 +1929,17 @@ struct uv_loop_s {
 UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
 UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
 
-/* String utilities needed internally for dealing with Windows. */
-size_t uv_utf16_length_as_wtf8(const uint16_t* utf16,
-                               ssize_t utf16_len);
-int uv_utf16_to_wtf8(const uint16_t* utf16,
-                     ssize_t utf16_len,
-                     char** wtf8_ptr,
-                     size_t* wtf8_len_ptr);
-ssize_t uv_wtf8_length_as_utf16(const char* wtf8);
-void uv_wtf8_to_utf16(const char* wtf8,
-                      uint16_t* utf16,
-                      size_t utf16_len);
+/* Unicode utilities needed for dealing with Windows. */
+UV_EXTERN size_t uv_utf16_length_as_wtf8(const uint16_t* utf16,
+                                         ssize_t utf16_len);
+UV_EXTERN int uv_utf16_to_wtf8(const uint16_t* utf16,
+                               ssize_t utf16_len,
+                               char** wtf8_ptr,
+                               size_t* wtf8_len_ptr);
+UV_EXTERN ssize_t uv_wtf8_length_as_utf16(const char* wtf8);
+UV_EXTERN void uv_wtf8_to_utf16(const char* wtf8,
+                                uint16_t* utf16,
+                                size_t utf16_len);
 
 /* Don't export the private CPP symbols. */
 #undef UV_HANDLE_TYPE_PRIVATE


### PR DESCRIPTION
Mark them UV_EXTERN so they are visible on Windows.

Fixes: https://github.com/libuv/libuv/issues/4436