### PR TITLE
test: pipe_overlong_path handle ENAMETOOLONG

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -85,13 +85,6 @@ int uv_pipe_bind2(uv_pipe_t* handle,
   if (flags & UV_PIPE_NO_TRUNCATE)
     if (namelen > sizeof(saddr.sun_path))
       return UV_EINVAL;
-  /*
-   * _PC_NAME_MAX returns the maximum length of a filename in the directory
-   * path that the process is allowed to create
-   * https://linux.die.net/man/3/pathconf
-   */
-  if (namelen > (size_t) pathconf(".", _PC_NAME_MAX))
-    return UV_EINVAL;
 
   /* Truncate long paths. Documented behavior. */
   if (namelen > sizeof(saddr.sun_path))
@@ -279,13 +272,6 @@ int uv_pipe_connect2(uv_connect_t* req,
   if (flags & UV_PIPE_NO_TRUNCATE)
     if (namelen > sizeof(saddr.sun_path))
       return UV_EINVAL;
-  /*
-   * _PC_NAME_MAX returns the maximum length of a filename in the directory
-   * path that the process is allowed to create
-   * https://linux.die.net/man/3/pathconf
-   */
-  if (namelen > (size_t) pathconf(".", _PC_NAME_MAX))
-    return UV_EINVAL;
 
   /* Truncate long paths. Documented behavior. */
   if (namelen > sizeof(saddr.sun_path))

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -85,6 +85,13 @@ int uv_pipe_bind2(uv_pipe_t* handle,
   if (flags & UV_PIPE_NO_TRUNCATE)
     if (namelen > sizeof(saddr.sun_path))
       return UV_EINVAL;
+  /*
+   * _PC_NAME_MAX returns the maximum length of a filename in the directory
+   * path that the process is allowed to create
+   * https://linux.die.net/man/3/pathconf
+   */
+  if (namelen > (size_t) pathconf(".", _PC_NAME_MAX))
+    return UV_EINVAL;
 
   /* Truncate long paths. Documented behavior. */
   if (namelen > sizeof(saddr.sun_path))
@@ -272,6 +279,13 @@ int uv_pipe_connect2(uv_connect_t* req,
   if (flags & UV_PIPE_NO_TRUNCATE)
     if (namelen > sizeof(saddr.sun_path))
       return UV_EINVAL;
+  /*
+   * _PC_NAME_MAX returns the maximum length of a filename in the directory
+   * path that the process is allowed to create
+   * https://linux.die.net/man/3/pathconf
+   */
+  if (namelen > (size_t) pathconf(".", _PC_NAME_MAX))
+    return UV_EINVAL;
 
   /* Truncate long paths. Documented behavior. */
   if (namelen > sizeof(saddr.sun_path))

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -23,8 +23,9 @@
 #include "task.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <sys/un.h>
-
+#endif
 
 #ifdef _WIN32
 # define BAD_PIPENAME "bad-pipe"

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+
 #ifdef _WIN32
 # define BAD_PIPENAME "bad-pipe"
 #else

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -23,9 +23,6 @@
 #include "task.h"
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef _WIN32
-#include <sys/un.h>
-#endif
 
 #ifdef _WIN32
 # define BAD_PIPENAME "bad-pipe"
@@ -174,7 +171,6 @@ TEST_IMPL(pipe_overlong_path) {
 #ifndef _WIN32
   char path[512];
   memset(path, '@', sizeof(path));
-  struct sockaddr_un addr;
 
   /* On most platforms sun_path is smaller than the NAME_MAX
    * Though there is nothing in the POSIX spec that says it needs to be.

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -186,9 +186,9 @@ TEST_IMPL(pipe_overlong_path) {
   if (sizeof(addr.sun_path) > (size_t) pathconf(".", _PC_NAME_MAX)) {
     ASSERT_EQ(UV_ENAMETOOLONG,
             uv_pipe_bind2(&pipe, path, sizeof(path), UV_PIPE_NO_TRUNCATE));
-    /* UV_ENAMETOOLONG is delayed in uv_pipe_connect2 won't propgate until
-     * uv_run is called and causes timeouts
-     ^ therefore in this case we skipp calling uv_pipe_connect2
+    /* UV_ENAMETOOLONG is delayed in uv_pipe_connect2 and won't propagate until
+     * uv_run is called and causes timeouts, therefore in this case we skip calling
+     * uv_pipe_connect2
      */
   } else {
     ASSERT_EQ(UV_EINVAL,


### PR DESCRIPTION
~~I've added a check to ensure long file names
are not larger than NAME_MAX.~~

This issue was discovered when debugging
a failing test case on AIX.

ref: https://github.com/libuv/libuv/issues/4231

On AIX saddr.sun_path is set to a large buffer size but file names cannot be greater than NAME_MAX.

NAME_MAX is a standard posix constant that we can get the value of using pathconf.

https://linux.die.net/man/3/pathconf

~~The code now returns EINVAL when the name length
is greater than the NAME_MAX.~~

~~Test Build on AIX now passes: https://ci.nodejs.org/job/libuv-test-commit-aix/nodes=aix72-ppc64/lastBuild/console~~

This PR was orginally a code change but now its been adjusted to be a test case change see: https://github.com/libuv/libuv/pull/4442#issuecomment-2240492087 

fixes https://github.com/libuv/libuv/issues/4231

CC 
@richardlau
@bnoordhuis 
@mhdawson

For comments / review