### PR TITLE
udp: call udp recv_cb with 0 and NULL when nread is 0

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -253,8 +253,8 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
     }
     while (nread == -1 && errno == EINTR);
 
-    if (nread == -1) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
+    if (nread < 1) {
+      if (nread == 0 || errno == EAGAIN || errno == EWOULDBLOCK)
         handle->recv_cb(handle, 0, &buf, NULL, 0);
       else
         handle->recv_cb(handle, UV__ERR(errno), &buf, NULL, 0);


### PR DESCRIPTION
Be consistent with `uv__udp_recvmmsg`.