### PR TITLE
build: fix android ci build

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -30,8 +30,13 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     container: reactnativecommunity/react-native-android:2020-5-20
+    # Work around an issue where the node from actions/checkout is too new
+    # to run inside the long-in-the-tooth react-nactive-android container
+    # image.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Envinfo
         run: npx envinfo
       - name: Configure android arm64

--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     container: reactnativecommunity/react-native-android:2020-5-20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Envinfo
         run: npx envinfo
       - name: Configure android arm64


### PR DESCRIPTION
It's complaining in the post-run step about a missing symbol:

    /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version
    `GLIBC_2.28' not found (required by /__e/node20/bin/node)

Which is likely coming from the obsolete actions/checkout@v2 because the runner itself is using ubuntu-latest and that comes with a new enough glibc.