### PR TITLE
[hurd] includes and macro prerequisites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ if(APPLE)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "GNU")
+  list(APPEND uv_defines _GNU_SOURCE _POSIX_C_SOURCE=200112 _XOPEN_SOURCE=500)
   list(APPEND uv_libraries dl)
   list(APPEND uv_sources
        src/unix/bsd-ifaddrs.c

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -55,7 +55,8 @@
 extern char **environ;
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || \
+    defined(__GNU__)
 # include <grp.h>
 #endif
 


### PR DESCRIPTION
This PR defines some macro prerequisites and a header include to get libuv compile again on gnu-hurd.

- ptsname() needs _XOPEN_SOURCE >= 500
- setenv() needs _POSIX_C_SOURCE >= 200112
- setgroups() needs grp.h