### PR TITLE
[hurd] Replace uv_thread_setpriority() by a stub

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1616,6 +1616,7 @@ static int set_nice_for_calling_thread(int priority) {
  * If the function fails, the return value is non-zero.
 */
 int uv_thread_setpriority(uv_thread_t tid, int priority) {
+#if !defined(__GNU__)
   int r;
   int min;
   int max;
@@ -1681,6 +1682,14 @@ int uv_thread_setpriority(uv_thread_t tid, int priority) {
   }
 
   return 0;
+
+#else /* !defined(__GNU__) */
+/*
+ * Simulate a success on systems where thread priority is not implemented.
+ */
+  return 0;
+
+#endif /* !defined(__GNU__) */
 }
 
 int uv_os_uname(uv_utsname_t* buffer) {

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1682,14 +1682,10 @@ int uv_thread_setpriority(uv_thread_t tid, int priority) {
   }
 
   return 0;
-
-#else /* !defined(__GNU__) */
-/*
- * Simulate a success on systems where thread priority is not implemented.
- */
+#else  /* !defined(__GNU__) */
+  /* Simulate success on systems where thread priority is not implemented. */
   return 0;
-
-#endif /* !defined(__GNU__) */
+#endif  /* !defined(__GNU__) */
 }
 
 int uv_os_uname(uv_utsname_t* buffer) {


### PR DESCRIPTION
On GNU/Hurd, the scheduling priorities on pthreads are not implemented. As we don't want all applications to have to handle this particular case, libuv falls back on simulating a success and no-op.