### PR TITLE
ci: use macOS 12 for macOS and iOS builds

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -51,9 +51,9 @@ jobs:
           ls -lh build
 
   build-macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Envinfo
         run: npx envinfo
       - name: Setup
@@ -86,9 +86,9 @@ jobs:
           make -C build-auto -j4
 
   build-ios:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Configure
         run: |
           mkdir build-ios

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -67,9 +67,9 @@ jobs:
           ./build-ubsan/uv_run_tests_a
 
   sanitizers-macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Envinfo
         run: npx envinfo


### PR DESCRIPTION
macOS 11 is gone: https://github.com/actions/runner-images/pull/10198