### PR TITLE
Change heap function signatures

### DIFF
--- a/src/heap-inl.h
+++ b/src/heap-inl.h
@@ -30,7 +30,7 @@ struct heap_node {
   struct heap_node* parent;
 };
 
-/* The heap is used as binary min heap.  The usual properties hold: the root is the lowest
+/* The heap is used as a binary min heap.  The usual properties hold: the root is the lowest
  * element in the set, the height of the tree is at most log2(nodes) and
  * it's always a complete binary tree.
  *

--- a/src/timer.c
+++ b/src/timer.c
@@ -146,7 +146,7 @@ int uv__next_timeout(const uv_loop_t* loop) {
   const uv_timer_t* handle;
   uint64_t diff;
 
-  heap_node = heap_min(timer_heap(loop));
+  heap_node = heap_root(timer_heap(loop));
   if (heap_node == NULL)
     return -1; /* block indefinitely */
 
@@ -171,7 +171,7 @@ void uv__run_timers(uv_loop_t* loop) {
   uv__queue_init(&ready_queue);
 
   for (;;) {
-    heap_node = heap_min(timer_heap(loop));
+    heap_node = heap_root(timer_heap(loop));
     if (heap_node == NULL)
       break;
 


### PR DESCRIPTION
The current heap implementation does not assume whether it is minimum or maximum. Only the comparison function determines whether it will be a min or max heap, and this function is passed externally. So I suggest avoiding any words in a heap implementation that somehow say what kind of heap it is.
Also, I suggest to remove unused function ```heap_dequeue```.