### PR TITLE
test,openbsd: remove superfluous ifdef guard

### DIFF
--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -126,7 +126,7 @@ static void cl_recv_cb(uv_udp_t* handle,
     r = uv_udp_set_membership(&server, MULTICAST_ADDR, NULL, UV_LEAVE_GROUP);
     ASSERT_OK(r);
 
-#if !defined(__OpenBSD__) && !defined(__NetBSD__)
+#if !defined(__NetBSD__)
     r = uv_udp_set_source_membership(&server, MULTICAST_ADDR, NULL, source_addr, UV_JOIN_GROUP);
     ASSERT_OK(r);
 #endif


### PR DESCRIPTION
The test is skipped in its entirety on OpenBSD so there is no point in compiling out code on said platform later on, it's not run anyway.