### PR TITLE
win: fix env var in uv_os_homedir and uv_os_tmpdir

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -988,7 +988,7 @@ int uv_os_tmpdir(char* buffer, size_t* size) {
 
   /* tmp path is empty or invalid */
   if (len < 3) {
-      return UV_ENOENT;
+    return UV_ENOENT;
   }
 
   /* Include space for terminating null char. */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -942,8 +942,13 @@ int uv_os_homedir(char* buffer, size_t* size) {
   r = uv_os_getenv("USERPROFILE", buffer, size);
 
   /* Don't return an error if USERPROFILE was not found. */
-  if (r != UV_ENOENT)
+  if (r != UV_ENOENT) {
+    /* USERPROFILE is empty or invalid */
+    if (r == 0 && *size < 3) {
+      return UV_ENOENT;
+    }
     return r;
+  }
 
   /* USERPROFILE is not set, so call uv_os_get_passwd() */
   r = uv_os_get_passwd(&pwd);
@@ -980,6 +985,12 @@ int uv_os_tmpdir(char* buffer, size_t* size) {
   if (len == 0) {
     return uv_translate_sys_error(GetLastError());
   }
+
+  /* tmp path is empty or invalid */
+  if (len < 3) {
+      return UV_ENOENT;
+  }
+
   /* Include space for terminating null char. */
   len += 1;
   path = uv__malloc(len * sizeof(wchar_t));

--- a/test/test-homedir.c
+++ b/test/test-homedir.c
@@ -68,5 +68,14 @@ TEST_IMPL(homedir) {
   r = uv_os_homedir(homedir, &len);
   ASSERT_EQ(r, UV_EINVAL);
 
+#ifdef _WIN32
+  /* Test empty environment variable */
+  r = uv_os_setenv("USERPROFILE", "");
+  ASSERT_EQ(r, 0);
+  len = sizeof homedir;
+  r = uv_os_homedir(homedir, &len);
+  ASSERT_EQ(r, UV_ENOENT);
+#endif
+
   return 0;
 }

--- a/test/test-tmpdir.c
+++ b/test/test-tmpdir.c
@@ -76,6 +76,13 @@ TEST_IMPL(tmpdir) {
   size_t lenx = sizeof tmpdirx;
   r = uv_os_tmpdir(tmpdirx, &lenx);
   ASSERT_OK(r);
+
+  /* Test empty environment variable */
+  r = uv_os_setenv("TMP", "");
+  ASSERT_EQ(r, 0);
+  len = sizeof tmpdir;
+  r = uv_os_tmpdir(tmpdir, &len);
+  ASSERT_EQ(r, UV_ENOENT);
 #endif
 
   return 0;


### PR DESCRIPTION
If the corresponding environment variables are empty, the `uv_us_homedir()` and `uv_os_tmpdir()` return garbage values. The reason for this situation is the Windows API which doesn't return an error even if the path is empty.

This PR fixes this problem by checking the return value of the API call. If it is not an error and the length of the value is less than  3, `uv_us_homedir()` and `uv_os_tmpdir()` will return `UV_ENOENT`.

Fixes: https://github.com/libuv/libuv/issues/2328