### PR TITLE
win,error: remap ERROR_NO_DATA to EAGAIN

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -78,6 +78,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAEADDRNOTAVAIL:                  return UV_EADDRNOTAVAIL;
     case WSAEAFNOSUPPORT:                   return UV_EAFNOSUPPORT;
     case WSAEWOULDBLOCK:                    return UV_EAGAIN;
+    case ERROR_NO_DATA:                     return UV_EAGAIN;
     case WSAEALREADY:                       return UV_EALREADY;
     case ERROR_INVALID_FLAGS:               return UV_EBADF;
     case ERROR_INVALID_HANDLE:              return UV_EBADF;
@@ -157,7 +158,6 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_ACCESS_DENIED:               return UV_EPERM;
     case ERROR_PRIVILEGE_NOT_HELD:          return UV_EPERM;
     case ERROR_BAD_PIPE:                    return UV_EPIPE;
-    case ERROR_NO_DATA:                     return UV_EPIPE;
     case ERROR_PIPE_NOT_CONNECTED:          return UV_EPIPE;
     case WSAESHUTDOWN:                      return UV_EPIPE;
     case WSAEPROTONOSUPPORT:                return UV_EPROTONOSUPPORT;


### PR DESCRIPTION
This was incorrectly mapped originally, which makes for confusing error messages about an EPIPE if a program happens to (unwisely) set PIPE_NOWAIT on the handle. It is unclear to me if libuv should try to handle this in some meaningful way (as would normally be done on unix platforms) since the OS documents that it is not possible to handle correctly (the OS just documents that this flag should never be set because it cannot be handled correctly), and so it is very unclear what that way would look like. But this goal is to at least expose this errno to the caller with the correct translation.

This error shouldn't be possible to trigger currently, so I don't think this is breaking, but it is intended to be clearer for anyone else who happens to run into #4467 being caused by running a cygwin program that connects to the same stdio object after libuv.