### PR TITLE
Calculate can_sleep outside of loop within uv_run

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -429,13 +429,9 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  timeout = 0;
+  timeout = mode == UV_RUN_ONCE ? uv__backend_timeout(loop) : 0;
 
   while (r != 0 && loop->stop_flag == 0) {
-    if (mode == UV_RUN_ONCE) {
-      timeout = uv__backend_timeout(loop);
-    }
-    
     uv__run_pending(loop);
     uv__run_idle(loop);
     uv__run_prepare(loop);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -431,18 +431,18 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   }
 
   can_sleep =
-    mode == UV_RUN_ONCE &&
-    uv__queue_empty(&loop->pending_queue) &&
-    uv__queue_empty(&loop->idle_handles);
+    mode == UV_RUN_DEFAULT || (
+      mode == UV_RUN_ONCE &&
+      uv__queue_empty(&loop->pending_queue) &&
+      uv__queue_empty(&loop->idle_handles)
+    );
 
   while (r != 0 && loop->stop_flag == 0) {
     uv__run_pending(loop);
     uv__run_idle(loop);
     uv__run_prepare(loop);
 
-    timeout = 0;
-    if (can_sleep || mode == UV_RUN_DEFAULT)
-      timeout = uv__backend_timeout(loop);
+    timeout = can_sleep ? uv__backend_timeout(loop) : 0;
 
     uv__metrics_inc_loop_count(loop);
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -399,11 +399,6 @@ static int uv__backend_timeout(const uv_loop_t* loop) {
 }
 
 
-static int uv__backend_timeout_zero(const uv_loop_t* loop) {
-  return 0;
-}
-
-
 int uv_backend_timeout(const uv_loop_t* loop) {
   if (uv__queue_empty(&loop->watcher_queue))
     return uv__backend_timeout(loop);
@@ -420,7 +415,7 @@ int uv_loop_alive(const uv_loop_t* loop) {
 int uv_run(uv_loop_t* loop, uv_run_mode mode) {
   int timeout;
   int r;
-  int (*backend_timeout_fn)(const uv_loop_t* loop);
+  int can_sleep;
 
   r = uv__loop_alive(loop);
   if (!r)
@@ -435,24 +430,19 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  backend_timeout_fn = uv__backend_timeout_zero;
-
-  if (
-    mode == UV_RUN_DEFAULT || (
-      mode == UV_RUN_ONCE && 
+  can_sleep = 
       uv__queue_empty(&loop->pending_queue) && 
-      uv__queue_empty(&loop->idle_handles)
-  )) {
-    backend_timeout_fn = uv__backend_timeout;
-  }
+      uv__queue_empty(&loop->idle_handles);
+  timeout = 0;
 
   while (r != 0 && loop->stop_flag == 0) {
     uv__run_pending(loop);
     uv__run_idle(loop);
     uv__run_prepare(loop);
 
-    timeout = backend_timeout_fn(loop);
-
+    if (mode == UV_RUN_DEFAULT || (mode == UV_RUN_ONCE && can_sleep))
+      timeout = uv__backend_timeout(loop);
+    
     uv__metrics_inc_loop_count(loop);
 
     uv__io_poll(loop, timeout);

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -430,17 +430,18 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  while (r != 0 && loop->stop_flag == 0) {
-    can_sleep =
-        uv__queue_empty(&loop->pending_queue) &&
-        uv__queue_empty(&loop->idle_handles);
+  can_sleep =
+    mode == UV_RUN_ONCE &&
+    uv__queue_empty(&loop->pending_queue) &&
+    uv__queue_empty(&loop->idle_handles);
 
+  while (r != 0 && loop->stop_flag == 0) {
     uv__run_pending(loop);
     uv__run_idle(loop);
     uv__run_prepare(loop);
 
     timeout = 0;
-    if ((mode == UV_RUN_ONCE && can_sleep) || mode == UV_RUN_DEFAULT)
+    if (can_sleep || mode == UV_RUN_DEFAULT)
       timeout = uv__backend_timeout(loop);
 
     uv__metrics_inc_loop_count(loop);

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -634,15 +634,18 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  while (r != 0 && loop->stop_flag == 0) {
-    can_sleep = loop->pending_reqs_tail == NULL && loop->idle_handles == NULL;
+  can_sleep = 
+    mode == UV_RUN_ONCE && 
+    loop->pending_reqs_tail == NULL && 
+    loop->idle_handles == NULL;
 
+  while (r != 0 && loop->stop_flag == 0) {
     uv__process_reqs(loop);
     uv__idle_invoke(loop);
     uv__prepare_invoke(loop);
 
     timeout = 0;
-    if ((mode == UV_RUN_ONCE && can_sleep) || mode == UV_RUN_DEFAULT)
+    if (can_sleep || mode == UV_RUN_DEFAULT)
       timeout = uv_backend_timeout(loop);
 
     uv__metrics_inc_loop_count(loop);

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -422,6 +422,9 @@ int uv_backend_timeout(const uv_loop_t* loop) {
   return 0;
 }
 
+static int uv__backend_timeout_zero(const uv_loop_t* loop) {
+  return 0;
+}
 
 static void uv__poll_wine(uv_loop_t* loop, DWORD timeout) {
   uv__loop_internal_fields_t* lfields;
@@ -619,6 +622,7 @@ static void uv__poll(uv_loop_t* loop, DWORD timeout) {
 int uv_run(uv_loop_t *loop, uv_run_mode mode) {
   DWORD timeout;
   int r;
+  int (*backend_timeout_fn)(const uv_loop_t* loop);
 
   r = uv__loop_alive(loop);
   if (!r)
@@ -633,16 +637,23 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  timeout = mode == UV_RUN_ONCE ? uv_backend_timeout(loop) : 0;
+  backend_timeout_fn = uv__backend_timeout_zero;
+
+  if (
+    mode == UV_RUN_DEFAULT || (
+      mode == UV_RUN_ONCE && 
+      loop->pending_reqs_tail == NULL && 
+      loop->idle_handles == NULL
+  )) {
+    backend_timeout_fn = uv_backend_timeout;
+  }
 
   while (r != 0 && loop->stop_flag == 0) {
     uv__process_reqs(loop);
     uv__idle_invoke(loop);
     uv__prepare_invoke(loop);
 
-    if (mode == UV_RUN_DEFAULT) {
-      timeout = uv_backend_timeout(loop);
-    }
+    timeout = backend_timeout_fn(loop);
 
     uv__metrics_inc_loop_count(loop);
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -633,13 +633,9 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
     uv__run_timers(loop);
   }
 
-  timeout = 0;
+  timeout = mode == UV_RUN_ONCE ? uv_backend_timeout(loop) : 0;
 
   while (r != 0 && loop->stop_flag == 0) {
-    if (mode == UV_RUN_ONCE) {
-      timeout = uv_backend_timeout(loop);
-    }
-
     uv__process_reqs(loop);
     uv__idle_invoke(loop);
     uv__prepare_invoke(loop);

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -635,18 +635,18 @@ int uv_run(uv_loop_t *loop, uv_run_mode mode) {
   }
 
   can_sleep = 
-    mode == UV_RUN_ONCE && 
-    loop->pending_reqs_tail == NULL && 
-    loop->idle_handles == NULL;
+    mode == UV_RUN_DEFAULT || (
+      mode == UV_RUN_ONCE && 
+      loop->pending_reqs_tail == NULL && 
+      loop->idle_handles == NULL
+    );
 
   while (r != 0 && loop->stop_flag == 0) {
     uv__process_reqs(loop);
     uv__idle_invoke(loop);
     uv__prepare_invoke(loop);
 
-    timeout = 0;
-    if (can_sleep || mode == UV_RUN_DEFAULT)
-      timeout = uv_backend_timeout(loop);
+    timeout = can_sleep ? uv_backend_timeout(loop) : 0;
 
     uv__metrics_inc_loop_count(loop);
 


### PR DESCRIPTION
`can_sleep` can be calculated once outside the loop.
For `mode` equals to UV_RUN_DEFAULT `can_sleep` is always equals to `true`;
For `mode` equals to UV_RUN_ONCE `can_sleep` value depends on pending callbacks and the loop breaks after one iteration;
For `mode` equals to UV_RUN_NOWAIT `can_sleep` is always equals to `false` and the loop breaks after one iteration;