### PR TITLE
fix: suppress clang -Wdeprecated-declarations in libuv

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1535,20 +1535,7 @@ int uv_os_uname(uv_utsname_t* buffer) {
   os_info.dwOSVersionInfoSize = sizeof(os_info);
   os_info.szCSDVersion[0] = L'\0';
 
-  /* Try calling RtlGetVersion(), and fall back to the deprecated GetVersionEx()
-     if RtlGetVersion() is not available. */
-  if (pRtlGetVersion) {
-    pRtlGetVersion(&os_info);
-  } else {
-    /* Silence GetVersionEx() deprecation warning. */
-    #ifdef _MSC_VER
-    #pragma warning(suppress : 4996)
-    #endif
-    if (GetVersionExW(&os_info) == 0) {
-      r = uv_translate_sys_error(GetLastError());
-      goto error;
-    }
-  }
+  pRtlGetVersion(&os_info);
 
   /* Populate the version field. */
   version_size = 0;


### PR DESCRIPTION
Electron builds on Windows with clang, not msvc, and likewise hits this issue without this extra handling. This would allow us to remove a [patch](https://github.com/electron/electron/blob/9c94fd7afb4706c2d2228a455f0874a0370cfe1d/patches/node/fix_suppress_clang_-wdeprecated-declarations_in_libuv.patch#L6)