### PR TITLE
win,signal: fix data race dispatching SIGWINCH

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -2380,8 +2380,8 @@ static DWORD WINAPI uv__tty_console_resize_watcher_thread(void* param) {
     /* Make sure to not overwhelm the system with resize events */
     Sleep(33);
     WaitForSingleObject(uv__tty_console_resized, INFINITE);
-    uv__tty_console_signal_resize();
     ResetEvent(uv__tty_console_resized);
+    uv__tty_console_signal_resize();
   }
   return 0;
 }


### PR DESCRIPTION
The Event should be reset before reading the value, or libuv might miss an update that occurred too rapidly after the previously one.

This thread and the delay here seems to have been added in https://github.com/libuv/libuv/pull/2381 by @bzoz, but I don't see a justification there for why 30 fps is correct, or why libuv shouldn't just assume the system will limit to the USB polling and thread-switching frequencies anyways. In libuv, it seems to be causing strictly more work for the system by limiting it to 30 fps, since it has to jump through an extra thread, when SIGWINCH should be coalescing these events anyways. I am somewhat inclined thus to say we should just delete the extra thread and the delay (alternatively, libuv could also use MsgWaitForMultipleEvents with a 33 ms timeout to avoid the thread in the implementation). Additionally, since this hook has been known to cause some performance problems for the rest of the OS, we may want to consider deactivating the hook whenever SIGWINCH is not active, and reactivating it only when SIGWINCH is active.

Refs: https://github.com/libuv/libuv/discussions/4485