### PR TITLE
Check if we already define ssize_t

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -24,7 +24,9 @@
 #endif
 
 #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+# ifndef ssize_t
 typedef intptr_t ssize_t;
+# endif
 # define SSIZE_MAX INTPTR_MAX
 # define _SSIZE_T_
 # define _SSIZE_T_DEFINED


### PR DESCRIPTION
When compile curl with libuv (for their tests) in vcpkg, I get this error:
```
C:\vcpkg\installed\x64-windows\include\uv\win.h(27,18): error C2628: 'intptr_t' followed by '__int64' is illegal (did you forget a ';'?) [D:\a\curl\curl\bld\src\curl.vcxproj]
Error: Process completed with exit code 1.
```

curl project already define the `ssize_t`.
So I added a `#if defined` that check that.

