### PR TITLE
fs test fixes

### DIFF
--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -152,7 +152,7 @@ static void fs_event_cb_del_dir(uv_fs_event_t* handle,
   ++fs_event_cb_called;
   ASSERT_PTR_EQ(handle, &fs_event);
   ASSERT_OK(status);
-  ASSERT_EQ(events, UV_RENAME);
+  ASSERT(events == UV_CHANGE || events == UV_RENAME);
   ASSERT_OK(strcmp(filename, "watch_del_dir"));
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1084,7 +1084,7 @@ TEST_IMPL(fs_posix_delete) {
 
   /* should not be possible to delete the non-empty dir */
   r = uv_fs_rmdir(NULL, &rmdir_req, "test_dir", NULL);
-  ASSERT_EQ(r, UV_ENOTEMPTY);
+  ASSERT((r == UV_ENOTEMPTY) || (r == UV_EEXIST));
   ASSERT_EQ(r, rmdir_req.result);
   uv_fs_req_cleanup(&rmdir_req);
 


### PR DESCRIPTION
- [test: rmdir can return EEXIST or ENOTEMPTY](https://github.com/libuv/libuv/commit/8bbd7dae57c80368b46f77973a7a29b8ee61632f) 
POSIX allows `rmdir` to return `EEXIST` or `ENOTEMPTY` for a non-empty
directory, so the test needs to allow both.

- [test: check for UV_CHANGE or UV_RENAME event](https://github.com/libuv/libuv/commit/a0c6eb19328da10da1f3e9ad7cee864dec80d27a) 
All other checks for `UV_RENAME` in `test-fs-event` also allow
`UV_CHANGE`.

Fixes: https://github.com/libuv/libuv/issues/4483
Fixes: https://github.com/libuv/libuv/issues/4484