### PR TITLE
[pipe] use cached name for unix sockets

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -385,6 +385,22 @@ static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
 
 
 int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size) {
+  if (handle->pipe_fname) {
+    size_t result_size = strlen(handle->pipe_fname) + 1;
+    size_t buffer_size = *size;
+
+    *size = result_size;
+
+    if (buffer == NULL)
+      return UV_ENOBUFS;
+
+    if (result_size > buffer_size)
+      result_size = buffer_size;
+
+    memcpy(buffer, handle->pipe_fname, result_size);
+
+    return 0;
+  }
   return uv__pipe_getsockpeername(handle, getsockname, buffer, size);
 }
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -389,7 +389,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size) {
     size_t result_size = strlen(handle->pipe_fname) + 1;
     size_t buffer_size = *size;
 
-    *size = result_size;
+    *size = result_size - 1;
 
     if (buffer == NULL)
       return UV_ENOBUFS;


### PR DESCRIPTION
## Description
 
In order to unlink unix sockets, we already need to keep a copy of the path in their handle struct. When getting the name of a pipe, we currently default to calling getsockname() on the underlying socket, which is notoriously broken on some systems, notably FreeBSD and GNU/Hurd.

This change proposes to make use of the cached path whenever available.