### PR TITLE
Adjust paragraph format and document enum type uv_loop_option

### DIFF
--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -16,6 +16,19 @@ Data types
 
     Loop data type.
 
+.. c:enum:: uv_loop_option
+
+    Additional loop options.
+    See :c:func:`uv_loop_configure`.
+
+    ::
+
+        typedef enum {
+            UV_LOOP_BLOCK_SIGNAL = 0,
+            UV_METRICS_IDLE_TIME,
+            UV_LOOP_USE_IO_URING_SQPOLL
+        } uv_loop_option;
+
 .. c:enum:: uv_run_mode
 
     Mode used to run the loop with :c:func:`uv_run`.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -199,7 +199,7 @@ Data types
             char* homedir;
         } uv_passwd_t;
 
-.. c:type:: uv_group_s
+.. c:type:: uv_group_t
 
     Data type for group file information.
 
@@ -209,7 +209,7 @@ Data types
           char* groupname;
           unsigned long gid;
           char** members;
-        };
+        } uv_group_t;
 
 .. c:type:: uv_utsname_t
 
@@ -590,7 +590,7 @@ API
 
     .. versionadded:: 1.45.0
 
-.. c:function:: int uv_os_get_group(uv_group_s* group, uv_uid_t gid)
+.. c:function:: int uv_os_get_group(uv_group_t* group, uv_uid_t gid)
 
     Gets a subset of the group file entry for the provided uid.
     The populated data includes the group name, gid, and members. On non-Windows

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -21,17 +21,9 @@ Data types
 
     Union of all request types.
 
+.. c:enum:: uv_req_type
 
-Public members
-^^^^^^^^^^^^^^
-
-.. c:member:: void* uv_req_t.data
-
-    Space for user-defined arbitrary data. libuv does not use this field.
-
-.. c:member:: uv_req_type uv_req_t.type
-
-    Indicated the type of request. Readonly.
+    The kind of the libuv request.
 
     ::
 
@@ -48,6 +40,18 @@ Public members
             UV_GETNAMEINFO,
             UV_REQ_TYPE_MAX,
         } uv_req_type;
+
+
+Public members
+^^^^^^^^^^^^^^
+
+.. c:member:: void* uv_req_t.data
+
+    Space for user-defined arbitrary data. libuv does not use this field.
+
+.. c:member:: uv_req_type uv_req_t.type
+
+    The :c:type:`uv_req_type`, indicating the type of the request. Readonly.
 
 
 API


### PR DESCRIPTION
I use python to scan rst files for generating nim binding.
Some data types are not described in the rst file so the generated code needs to be maintained manually.

I added the `uv_loop_option` in the `Data types` section.
I modified the `uv_group_s` in the document to `uv_group_t`.
I moved the description of `uv_req_type` to the `Data types` section for easier parsing.
