### PR TITLE
Fix docs: Some `c:enum` types are incorrectly annotated as `c:type`.

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -132,10 +132,9 @@ Data types
             uint64_t f_spare[4];
         } uv_statfs_t;
 
-.. c:enum:: uv_dirent_t
+.. c:enum:: uv_dirent_type_t
 
-    Cross platform (reduced) equivalent of ``struct dirent``.
-    Used in :c:func:`uv_fs_scandir_next`.
+    Type of dirent.
 
     ::
 
@@ -149,6 +148,14 @@ Data types
             UV_DIRENT_CHAR,
             UV_DIRENT_BLOCK
         } uv_dirent_type_t;
+
+
+.. c:type:: uv_dirent_t
+
+    Cross platform (reduced) equivalent of ``struct dirent``.
+    Used in :c:func:`uv_fs_scandir_next`.
+
+    ::
 
         typedef struct uv_dirent_s {
             const char* name;

--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -45,9 +45,9 @@ Data types
     be a relative path to a file contained in the directory, or `NULL` if the
     file name cannot be determined.
 
-    The `events` parameter is an ORed mask of :c:type:`uv_fs_event` elements.
+    The `events` parameter is an ORed mask of :c:enum:`uv_fs_event` elements.
 
-.. c:type:: uv_fs_event
+.. c:enum:: uv_fs_event
 
     Event types that :c:type:`uv_fs_event_t` handles monitor.
 
@@ -58,7 +58,7 @@ Data types
             UV_CHANGE = 2
         };
 
-.. c:type:: uv_fs_event_flags
+.. c:enum:: uv_fs_event_flags
 
     Flags that can be passed to :c:func:`uv_fs_event_start` to control its
     behavior.
@@ -109,7 +109,7 @@ API
 .. c:function:: int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb, const char* path, unsigned int flags)
 
     Start the handle with the given callback, which will watch the specified
-    `path` for changes. `flags` can be an ORed mask of :c:type:`uv_fs_event_flags`.
+    `path` for changes. `flags` can be an ORed mask of :c:enum:`uv_fs_event_flags`.
 
     .. note:: Currently the only supported flag is ``UV_FS_EVENT_RECURSIVE`` and
               only on OSX and Windows.

--- a/docs/src/handle.rst
+++ b/docs/src/handle.rst
@@ -94,7 +94,7 @@ Public members
 
 .. c:member:: uv_handle_type uv_handle_t.type
 
-    The :c:type:`uv_handle_type`, indicating the type of the underlying handle. Readonly.
+    The :c:enum:`uv_handle_type`, indicating the type of the underlying handle. Readonly.
 
 .. c:member:: void* uv_handle_t.data
 

--- a/docs/src/poll.rst
+++ b/docs/src/poll.rst
@@ -45,7 +45,7 @@ Data types
 
     Type definition for callback passed to :c:func:`uv_poll_start`.
 
-.. c:type:: uv_poll_event
+.. c:enum:: uv_poll_event
 
     Poll event types
 

--- a/docs/src/process.rst
+++ b/docs/src/process.rst
@@ -40,7 +40,7 @@ Data types
     will indicate the exit status and the signal that caused the process to
     terminate, if any.
 
-.. c:type:: uv_process_flags
+.. c:enum:: uv_process_flags
 
     Flags to be set on the flags field of :c:type:`uv_process_options_t`.
 
@@ -190,7 +190,7 @@ Public members
     Command line arguments. args[0] should be the path to the program. On
     Windows this uses `CreateProcess` which concatenates the arguments into a
     string this can cause some strange errors. See the
-    ``UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS`` flag on :c:type:`uv_process_flags`.
+    ``UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS`` flag on :c:enum:`uv_process_flags`.
 
 .. c:member:: char** uv_process_options_t.env
 
@@ -203,7 +203,7 @@ Public members
 .. c:member:: unsigned int uv_process_options_t.flags
 
     Various flags that control how :c:func:`uv_spawn` behaves. See
-    :c:type:`uv_process_flags`.
+    :c:enum:`uv_process_flags`.
 
 .. c:member:: int uv_process_options_t.stdio_count
 .. c:member:: uv_stdio_container_t* uv_process_options_t.stdio

--- a/docs/src/request.rst
+++ b/docs/src/request.rst
@@ -51,7 +51,7 @@ Public members
 
 .. c:member:: uv_req_type uv_req_t.type
 
-    The :c:type:`uv_req_type`, indicating the type of the request. Readonly.
+    The :c:enum:`uv_req_type`, indicating the type of the request. Readonly.
 
 
 API

--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -16,7 +16,7 @@ Data types
 
     TCP handle type.
 
-.. c:type:: uv_tcp_flags
+.. c:enum:: uv_tcp_flags
 
     Flags used in :c:func:`uv_tcp_bind`.
 

--- a/docs/src/tty.rst
+++ b/docs/src/tty.rst
@@ -98,7 +98,7 @@ API
 .. c:function:: int uv_tty_set_mode(uv_tty_t* handle, uv_tty_mode_t mode)
 
     .. versionchanged:: 1.2.0: the mode is specified as a
-                        :c:type:`uv_tty_mode_t` value.
+                        :c:enum:`uv_tty_mode_t` value.
 
     Set the TTY using the specified terminal mode.
 

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -18,7 +18,7 @@ Data types
 
     UDP send request type.
 
-.. c:type:: uv_udp_flags
+.. c:enum:: uv_udp_flags
 
     Flags used in :c:func:`uv_udp_bind` and :c:type:`uv_udp_recv_cb`..
 


### PR DESCRIPTION
I'm sorry, I've been filing various documentation issues lately, and these trivial issues caused my script to generate incorrect code.

![image](https://github.com/user-attachments/assets/c614216d-72ce-4f62-b7c9-04ac4b3d1e5b)

Correct version:
![image](https://github.com/user-attachments/assets/41586da6-40d8-445d-936b-ec408fcd6eed)
