### PR TITLE
win, util: optimize the performance of uv_os_getppid

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -75,6 +75,10 @@ static CRITICAL_SECTION process_title_lock;
 /* Frequency of the high-resolution clock. */
 static uint64_t hrtime_frequency_ = 0;
 
+/* Cache parent pid to optimize performance */
+static uv_once_t parent_pid_init_guard = UV_ONCE_INIT;
+static int parent_pid = -1;
+
 
 /*
  * One-time initialization code for functionality defined in util.c.
@@ -317,8 +321,7 @@ uv_pid_t uv_os_getpid(void) {
 }
 
 
-uv_pid_t uv_os_getppid(void) {
-  int parent_pid = -1;
+static void uv__init_ppid(void) {
   HANDLE handle;
   PROCESSENTRY32 pe;
   DWORD current_pid = GetCurrentProcessId();
@@ -336,6 +339,11 @@ uv_pid_t uv_os_getppid(void) {
   }
 
   CloseHandle(handle);
+}
+
+
+uv_pid_t uv_os_getppid(void) {
+  uv_once(&parent_pid_init_guard, uv__init_ppid);
   return parent_pid;
 }
 


### PR DESCRIPTION
uv_os_getppid uses CreateToolhelp32Snapshot to enumerate processes and find the parent process PID. However, CreateToolhelp32Snapshot has poor performance. To optimize the performance of subsequent calls, a static variable is used to cache the result.

While analyzing the performance of an Electron application, I discovered that calling Node.js process.ppid invokes uv_os_getppid, which in turn calls CreateToolhelp32Snapshot, a function known for its relatively poor performance.