### PR TITLE
win, util: uv_os_getppid use NtQueryInformationProcess

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -316,25 +316,19 @@ uv_pid_t uv_os_getpid(void) {
 
 
 uv_pid_t uv_os_getppid(void) {
-  int parent_pid = -1;
-  HANDLE handle;
-  PROCESSENTRY32 pe;
-  DWORD current_pid = GetCurrentProcessId();
+  NTSTATUS nt_status;
+  PROCESS_BASIC_INFORMATION basic_info;
 
-  pe.dwSize = sizeof(PROCESSENTRY32);
-  handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-
-  if (Process32First(handle, &pe)) {
-    do {
-      if (pe.th32ProcessID == current_pid) {
-        parent_pid = pe.th32ParentProcessID;
-        break;
-      }
-    } while( Process32Next(handle, &pe));
+  nt_status = pNtQueryInformationProcess(GetCurrentProcess(),
+    ProcessBasicInformation,
+    &basic_info,
+    sizeof(basic_info),
+    NULL);
+  if (NT_SUCCESS(nt_status)) {
+    return basic_info.InheritedFromUniqueProcessId;
+  } else {
+    return -1;
   }
-
-  CloseHandle(handle);
-  return parent_pid;
 }
 
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4458,6 +4458,14 @@ typedef struct _FILE_FS_SECTOR_SIZE_INFORMATION {
   ULONG ByteOffsetForPartitionAlignment;
 } FILE_FS_SECTOR_SIZE_INFORMATION, *PFILE_FS_SECTOR_SIZE_INFORMATION;
 
+typedef struct _PROCESS_BASIC_INFORMATION {
+  PVOID Reserved1;
+  PVOID PebBaseAddress;
+  PVOID Reserved2[2];
+  ULONG_PTR UniqueProcessId;
+  ULONG_PTR InheritedFromUniqueProcessId;
+} PROCESS_BASIC_INFORMATION, *PPROCESS_BASIC_INFORMATION;
+
 typedef struct _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
     LARGE_INTEGER IdleTime;
     LARGE_INTEGER KernelTime;
@@ -4469,6 +4477,10 @@ typedef struct _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
 
 #ifndef SystemProcessorPerformanceInformation
 # define SystemProcessorPerformanceInformation 8
+#endif
+
+#ifndef ProcessBasicInformation
+# define ProcessBasicInformation 0
 #endif
 
 #ifndef ProcessConsoleHostProcess


### PR DESCRIPTION
Get parent process ID using NtQueryInformationProcess is faster than using CreateToolhelp32Snapshot.

My colleague suggested using NtQueryInformationProcess to implement uv_os_getppid, claiming it would be much faster. I ran some tests and found that NtQueryInformationProcess took only 0.00027 ms, while CreateToolhelp32Snapshot took 3.6 ms.