### PR TITLE
win,pipe: fix missing assignment to success

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2004,7 +2004,9 @@ static int uv__pipe_read_data(uv_loop_t* loop,
       if (r == ERROR_IO_PENDING) {
         r = CancelIoEx(handle->handle, &req->u.io.overlapped);
         assert(r || GetLastError() == ERROR_NOT_FOUND);
-        if (!GetOverlappedResult(handle->handle, &req->u.io.overlapped, bytes_read, TRUE)) {
+        if (GetOverlappedResult(handle->handle, &req->u.io.overlapped, bytes_read, TRUE)) {
+          r = ERROR_SUCCESS;
+        } else {
           r = GetLastError();
           *bytes_read = 0;
         }


### PR DESCRIPTION
Otherwise this accidentally results in `r == 1` (aka UV_EISDIR) on this code path, which can be quite confusing for the caller indeed. I now ran all of the neovim tests locally this time, and none hang (some fail, but seems like that is because it expects some test dependencies to be installed, and I don't know what they are)