### PR TITLE
Remove unused parameters from RB-trees macros

### DIFF
--- a/include/uv/tree.h
+++ b/include/uv/tree.h
@@ -483,8 +483,8 @@ name##_RB_MINMAX(struct name *head, int val)                                  \
 #define RB_REMOVE(name, x, y)   name##_RB_REMOVE(x, y)
 #define RB_FIND(name, x, y)     name##_RB_FIND(x, y)
 #define RB_NFIND(name, x, y)    name##_RB_NFIND(x, y)
-#define RB_NEXT(name, x, y)     name##_RB_NEXT(y)
-#define RB_PREV(name, x, y)     name##_RB_PREV(y)
+#define RB_NEXT(name, x)        name##_RB_NEXT(x)
+#define RB_PREV(name, x)        name##_RB_PREV(x)
 #define RB_MIN(name, x)         name##_RB_MINMAX(x, RB_NEGINF)
 #define RB_MAX(name, x)         name##_RB_MINMAX(x, RB_INF)
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -195,7 +195,7 @@ static void uv__signal_handler(int signum) {
 
   for (handle = uv__signal_first_handle(signum);
        handle != NULL && handle->signum == signum;
-       handle = RB_NEXT(uv__signal_tree_s, &uv__signal_tree, handle)) {
+       handle = RB_NEXT(uv__signal_tree_s, handle)) {
     int r;
 
     msg.signum = signum;

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -91,7 +91,7 @@ int uv__signal_dispatch(int signum) {
 
   for (handle = RB_NFIND(uv_signal_tree_s, &uv__signal_tree, &lookup);
        handle != NULL && handle->signum == signum;
-       handle = RB_NEXT(uv_signal_tree_s, &uv__signal_tree, handle)) {
+       handle = RB_NEXT(uv_signal_tree_s, handle)) {
     unsigned long previous = InterlockedExchange(
             (volatile LONG*) &handle->pending_signum, signum);
 


### PR DESCRIPTION
The PR removes unused parameters from RB-trees macros: RB_NEXT and RB_PREV.