### PR TITLE
win,pipe: fix another missing assignment to success

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1983,6 +1983,7 @@ static int uv__pipe_read_data(uv_loop_t* loop,
     } else {
       if (max_bytes > bytes_available)
         max_bytes = bytes_available;
+      *bytes_read = 0;
       if (max_bytes == 0 || ReadFile(handle->handle, buf.base, max_bytes, bytes_read, NULL))
         r = ERROR_SUCCESS;
       else


### PR DESCRIPTION
Yet another followup to #4511. `functional/legacy/increment_spec.lua` failed most of the time without this. You would think I had never written software before or something. Hopefully this is the last fix to this PR🤞