### PR TITLE
win: fix uv_available_parallelism on win32

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -516,7 +516,7 @@ unsigned int uv_available_parallelism(void) {
    */
   count = 0;
   if (GetProcessAffinityMask(GetCurrentProcess(), &procmask, &sysmask))
-    for (i = 0; i < 64; i++)  /* a.k.a. count = popcount(procmask); */
+    for (i = 0; i < 8 * sizeof(procmask); i++)
       count += 1 & (procmask >> i);
 
   if (count > 0)


### PR DESCRIPTION
Fixes commit 58dfb6c89b from a few days ago. DWORD_PTR is 32 bits on x86 Windows. Use the right bit count when checking the population count.

Interestingly enough, it manifested itself as double counting available processors, presumably because the compiler emits a ROR instead of SHR.

Fixes: https://github.com/libuv/libuv/issues/4524