### PR TITLE
unix: work around arm-linux-gnueabihf-gcc bug

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -482,7 +482,10 @@ static ssize_t uv__preadv_or_pwritev(int fd,
     atomic_store_explicit(cache, (uintptr_t) p, memory_order_relaxed);
   }
 
-  f = p;
+  /* Use memcpy instead of `f = p` to work around a compiler bug,
+   * see https://github.com/libuv/libuv/issues/4532
+   */
+  memcpy(&f, &p, sizeof(p));
   return f(fd, bufs, nbufs, off);
 }
 


### PR DESCRIPTION
Both gcc 11 and 12 emit wrong code for a function call pointer in one very specific context.

Fixes: https://github.com/libuv/libuv/issues/4532