### PR TITLE
linux: use IORING_SETUP_NO_SQARRAY when available

### DIFF
--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -400,7 +400,6 @@ void uv__metrics_set_provider_entry_time(uv_loop_t* loop);
 struct uv__iou {
   uint32_t* sqhead;
   uint32_t* sqtail;
-  uint32_t* sqarray;
   uint32_t sqmask;
   uint32_t* sqflags;
   uint32_t* cqhead;


### PR DESCRIPTION
Introduced in Linux 6.6, it tells the kernel to omit the sqarray from the ring buffer.

Libuv initalizes the array once to an identity mapping and then forgets about it, so not only does it save a little memory (ca. 1 KiB per ring) but it also makes things more efficient kernel-side because it removes a level of indirection.