### PR TITLE
linux: use IORING_OP_FTRUNCATE when available

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1910,6 +1910,9 @@ int uv_fs_ftruncate(uv_loop_t* loop,
   INIT(FTRUNCATE);
   req->file = file;
   req->off = off;
+  if (cb != NULL)
+    if (uv__iou_fs_ftruncate(loop, req))
+      return 0;
   POST;
 }
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -344,6 +344,7 @@ int uv__random_sysctl(void* buf, size_t buflen);
 /* io_uring */
 #ifdef __linux__
 int uv__iou_fs_close(uv_loop_t* loop, uv_fs_t* req);
+int uv__iou_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req);
 int uv__iou_fs_fsync_or_fdatasync(uv_loop_t* loop,
                                   uv_fs_t* req,
                                   uint32_t fsync_flags);
@@ -362,6 +363,7 @@ int uv__iou_fs_symlink(uv_loop_t* loop, uv_fs_t* req);
 int uv__iou_fs_unlink(uv_loop_t* loop, uv_fs_t* req);
 #else
 #define uv__iou_fs_close(loop, req) 0
+#define uv__iou_fs_ftruncate(loop, req) 0
 #define uv__iou_fs_fsync_or_fdatasync(loop, req, fsync_flags) 0
 #define uv__iou_fs_link(loop, req) 0
 #define uv__iou_fs_mkdir(loop, req) 0

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -414,7 +414,6 @@ struct uv__iou {
   size_t sqelen;
   int ringfd;
   uint32_t in_flight;
-  uint32_t flags;
 };
 #endif  /* __linux__ */
 


### PR DESCRIPTION
Route ftruncate() system calls through io_uring instead of the thread pool when the kernel is new enough to support it (linux >= 6.9).

This commit harmonizes how libuv checks if the kernel is new enough. Some ops were checking against `uv__kernel_version()` directly while others stored the result of the version check as a feature flag.

Because the kernel version is cached, and because it is more direct than a feature flag, I opted for the former approach.