### PR TITLE
win: fix pNtQueryDirectoryFile check

### DIFF
--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -103,7 +103,7 @@ void uv__winapi_init(void) {
 
   pNtQueryDirectoryFile = (sNtQueryDirectoryFile)
       GetProcAddress(ntdll_module, "NtQueryDirectoryFile");
-  if (pNtQueryVolumeInformationFile == NULL) {
+  if (pNtQueryDirectoryFile == NULL) {
     uv_fatal_error(GetLastError(), "GetProcAddress");
   }
 


### PR DESCRIPTION
Fixed incorrect verification of the pNtQueryDirectoryFile pointer.