### PR TITLE
win,fs: fix bug in fs__readdir

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1650,12 +1650,12 @@ void fs__readdir(uv_fs_t* req) {
       goto error;
 
     /* Copy file type. */
-    if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
-      dent.d_type = UV__DT_DIR;
+    if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_DEVICE) != 0)
+      dent.d_type = UV__DT_CHAR;
     else if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
       dent.d_type = UV__DT_LINK;
-    else if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_DEVICE) != 0)
-      dent.d_type = UV__DT_CHAR;
+    else if ((find_data->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
+      dent.d_type = UV__DT_DIR;
     else
       dent.d_type = UV__DT_FILE;
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -428,6 +428,9 @@ TEST_DECLARE   (fs_readdir_empty_dir)
 TEST_DECLARE   (fs_readdir_file)
 TEST_DECLARE   (fs_readdir_non_empty_dir)
 TEST_DECLARE   (fs_readdir_non_existing_dir)
+#ifdef _WIN32
+TEST_DECLARE   (fs_readdir_symlink)
+#endif
 TEST_DECLARE   (fs_rename_to_existing_file)
 TEST_DECLARE   (fs_write_multiple_bufs)
 TEST_DECLARE   (fs_read_write_null_arguments)
@@ -1138,6 +1141,9 @@ TASK_LIST_START
   TEST_ENTRY  (fs_readdir_file)
   TEST_ENTRY  (fs_readdir_non_empty_dir)
   TEST_ENTRY  (fs_readdir_non_existing_dir)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_readdir_symlink)
+#endif
   TEST_ENTRY  (fs_rename_to_existing_file)
   TEST_ENTRY  (fs_write_multiple_bufs)
   TEST_ENTRY  (fs_write_alotof_bufs)


### PR DESCRIPTION
`isSymbolicLink()` was returning wrong values for the symlink folders. I've updated the order of the conditions to be consistent with `fs__scandir` in order to fix this issue.

Refs: https://github.com/nodejs/node/issues/48799