### PR TITLE
win: fix WriteFile() error translation

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -172,3 +172,12 @@ int uv_translate_sys_error(int sys_errno) {
     default:                                return UV_UNKNOWN;
   }
 }
+
+int uv_translate_write_sys_error(int sys_errno) {
+  switch (sys_errno) {
+    case ERROR_BROKEN_PIPE:                 return UV_EPIPE;
+    case ERROR_NO_DATA:                     return UV_EPIPE;
+    default:
+      return uv_translate_sys_error(sys_errno);
+  }
+}

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1078,7 +1078,7 @@ void fs__write(uv_fs_t* req) {
       error = ERROR_INVALID_FLAGS;
     }
 
-    SET_REQ_WIN32_ERROR(req, error);
+    SET_REQ_UV_ERROR(req, uv_translate_write_sys_error(error), error);
   }
 }
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -330,4 +330,6 @@ void uv__wake_all_loops(void);
  */
 void uv__init_detect_system_wakeup(void);
 
+int uv_translate_write_sys_error(int sys_errno);
+
 #endif /* UV_WIN_INTERNAL_H_ */

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -131,7 +131,7 @@ int uv_write(uv_write_t* req,
     case UV_NAMED_PIPE:
       err = uv__pipe_write(
           loop, req, (uv_pipe_t*) handle, bufs, nbufs, NULL, cb);
-      break;
+      return uv_translate_write_sys_error(err);
     case UV_TTY:
       err = uv__tty_write(loop, req, (uv_tty_t*) handle, bufs, nbufs, cb);
       break;
@@ -164,7 +164,7 @@ int uv_write2(uv_write_t* req,
 
   err = uv__pipe_write(
       loop, req, (uv_pipe_t*) handle, bufs, nbufs, send_handle, cb);
-  return uv_translate_sys_error(err);
+  return uv_translate_write_sys_error(err);
 }
 
 


### PR DESCRIPTION
Translate `ERROR_BROKEN_PIPE` and `ERROR_NO_DATA` to `UV_EPIPE` instead of their default translation, which will be used for the rest of cases.

Refs: https://github.com/libuv/libuv/issues/4548#issuecomment-2383998849