### PR TITLE
win,fs: uv_fs_rmdir() to return ENOENT on file

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1113,8 +1113,9 @@ static void fs__unlink_rmdir(uv_fs_t* req, BOOL isrmdir) {
   }
 
   if (isrmdir && !(info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-    /* Error if we're in rmdir mode but it is not a dir */
-    SET_REQ_UV_ERROR(req, UV_ENOTDIR, ERROR_DIRECTORY);
+    /* Error if we're in rmdir mode but it is not a dir.
+     * TODO: change it to UV_NOTDIR in v2. */
+    SET_REQ_UV_ERROR(req, UV_ENOENT, ERROR_DIRECTORY);
     CloseHandle(handle);
     return;
   }

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1088,6 +1088,11 @@ TEST_IMPL(fs_posix_delete) {
   ASSERT_EQ(r, rmdir_req.result);
   uv_fs_req_cleanup(&rmdir_req);
 
+  r = uv_fs_rmdir(NULL, &rmdir_req, "test_dir/file", NULL);
+  ASSERT((r == UV_ENOTDIR) || (r == UV_ENOENT));
+  ASSERT_EQ(r, rmdir_req.result);
+  uv_fs_req_cleanup(&rmdir_req);
+
   r = uv_fs_unlink(NULL, &unlink_req, "test_dir/file", NULL);
   ASSERT_OK(r);
   ASSERT_OK(unlink_req.result);


### PR DESCRIPTION
After commit 18266a6969, it changed to return `ENOTDIR`, which makes it consistent with other platforms but it also can be considered a breaking change.