### PR TITLE
unix: workaround gcc bug on armv7 (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,6 @@ after the process terminates unless the event loop is closed.
 
 Use the `ipcrm` command to manually clear up System V resources.
 
-## Known Issues
-
-- A possible arm-linux-gnueabihf-gcc bug causing, sometimes, incorrect generated code on `armv7` when calling `preadv()`: https://github.com/libuv/libuv/issues/4532.
-
 ## Patches
 
 See the [guidelines for contributing][].


### PR DESCRIPTION
Disable optimization on `uv__preadv_or_pwritev`.

Fixes: https://github.com/libuv/libuv/issues/4532
Fixes: https://github.com/libuv/libuv/issues/4550