### PR TITLE
win: remap ERROR_NOACCESS and ERROR_BUFFER_OVERFLOW

### DIFF
--- a/src/win/error.c
+++ b/src/win/error.c
@@ -69,7 +69,6 @@ int uv_translate_sys_error(int sys_errno) {
   }
 
   switch (sys_errno) {
-    case ERROR_NOACCESS:                    return UV_EACCES;
     case WSAEACCES:                         return UV_EACCES;
     case ERROR_ELEVATION_REQUIRED:          return UV_EACCES;
     case ERROR_CANT_ACCESS_FILE:            return UV_EACCES;
@@ -96,7 +95,7 @@ int uv_translate_sys_error(int sys_errno) {
     case WSAECONNRESET:                     return UV_ECONNRESET;
     case ERROR_ALREADY_EXISTS:              return UV_EEXIST;
     case ERROR_FILE_EXISTS:                 return UV_EEXIST;
-    case ERROR_BUFFER_OVERFLOW:             return UV_EFAULT;
+    case ERROR_NOACCESS:                    return UV_EFAULT;
     case WSAEFAULT:                         return UV_EFAULT;
     case ERROR_HOST_UNREACHABLE:            return UV_EHOSTUNREACH;
     case WSAEHOSTUNREACH:                   return UV_EHOSTUNREACH;
@@ -127,6 +126,7 @@ int uv_translate_sys_error(int sys_errno) {
     case ERROR_TOO_MANY_OPEN_FILES:         return UV_EMFILE;
     case WSAEMFILE:                         return UV_EMFILE;
     case WSAEMSGSIZE:                       return UV_EMSGSIZE;
+    case ERROR_BUFFER_OVERFLOW:             return UV_ENAMETOOLONG;
     case ERROR_FILENAME_EXCED_RANGE:        return UV_ENAMETOOLONG;
     case ERROR_NETWORK_UNREACHABLE:         return UV_ENETUNREACH;
     case WSAENETUNREACH:                    return UV_ENETUNREACH;

--- a/test/test-error.c
+++ b/test/test-error.c
@@ -64,7 +64,7 @@ TEST_IMPL(error_message) {
 
 TEST_IMPL(sys_error) {
 #if defined(_WIN32)
-  ASSERT_EQ(uv_translate_sys_error(ERROR_NOACCESS), UV_EACCES);
+  ASSERT_EQ(uv_translate_sys_error(ERROR_NOACCESS), UV_EFAULT);
   ASSERT_EQ(uv_translate_sys_error(ERROR_ELEVATION_REQUIRED), UV_EACCES);
   ASSERT_EQ(uv_translate_sys_error(WSAEADDRINUSE), UV_EADDRINUSE);
   ASSERT_EQ(uv_translate_sys_error(ERROR_BAD_PIPE), UV_EPIPE);


### PR DESCRIPTION
It seemed incorrect to map a segfault to EACCES, since posix would typically map this to EFAULT. The ERROR_BUFFER_OVERFLOW is literally "the filename is too long", and is not typically an invalid parameter in posix.

Test originally added in #1060 to test the API, not the value.

Refs: https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--500-999-