### PR TITLE
Windows: Allow users to configure crash handling

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1170,7 +1170,14 @@ enum uv_process_flags {
    * search for the exact file name before trying variants with
    * extensions like '.exe' or '.cmd'.
    */
-  UV_PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = (1 << 7)
+  UV_PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = (1 << 7),
+  /*
+   * Suppress Windows Error Reporting. Windows Error Reporting may display
+   * interactive popups when a fatal error occurs. Setting this flag disables
+   * that popup. This option is only meaningful on Windows systems. On Unix
+   * it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_CATCH_EXCEPTIONS = (1 << 8)
 };
 
 /*

--- a/include/uv.h
+++ b/include/uv.h
@@ -1172,12 +1172,11 @@ enum uv_process_flags {
    */
   UV_PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = (1 << 7),
   /*
-   * Suppress Windows Error Reporting. Windows Error Reporting may display
-   * interactive popups when a fatal error occurs. Setting this flag disables
-   * that popup. This option is only meaningful on Windows systems. On Unix
+   * Spawn the child process with the error mode of its parent.
+   * This option is only meaningful on Windows systems. On Unix
    * it is silently ignored.
    */
-  UV_PROCESS_WINDOWS_CATCH_EXCEPTIONS = (1 << 8)
+  UV_PROCESS_WINDOWS_USE_PARENT_ERROR_MODE = (1 << 8)
 };
 
 /*

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -1029,7 +1029,8 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_WINDOWS_HIDE |
                               UV_PROCESS_WINDOWS_HIDE_CONSOLE |
                               UV_PROCESS_WINDOWS_HIDE_GUI |
-                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
+                              UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
+                              UV_PROCESS_WINDOWS_CATCH_EXCEPTIONS)));
 
   uv__handle_init(loop, (uv_handle_t*)process, UV_PROCESS);
   uv__queue_init(&process->queue);

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -1030,7 +1030,7 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_WINDOWS_HIDE_CONSOLE |
                               UV_PROCESS_WINDOWS_HIDE_GUI |
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
-                              UV_PROCESS_WINDOWS_CATCH_EXCEPTIONS)));
+                              UV_PROCESS_WINDOWS_USE_PARENT_ERROR_MODE)));
 
   uv__handle_init(loop, (uv_handle_t*)process, UV_PROCESS);
   uv__queue_init(&process->queue);


### PR DESCRIPTION
Add UV_PROCESS_WINDOWS_CATCH_EXCEPTIONS to allow the user to suppress Windows Error Reporting. Windows Error Reporting may display interactive popups when a fatal error occurs.

Related to https://github.com/libuv/libuv/pull/3838 (This MR makes these changes configurable, instead of being applied unconditionally)

Also related to https://github.com/libuv/libuv/issues/1327 and https://github.com/libuv/libuv/issues/2829

Default behavior is unchanged.