### PR TITLE
unix: fix uv_tcp_keepalive in smartOS

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -496,7 +496,7 @@ typedef struct {
 int uv__get_constrained_cpu(uv__cpu_constraint* constraint);
 #endif
 
-#ifdef __sun
+#if defined(__sun) && !defined(__illumos__)
 #ifdef SO_FLOW_NAME
 /* Since it's impossible to detect the Solaris 11.4 version via OS macros,
  * so we check the presence of the socket option SO_FLOW_NAME that was first


### PR DESCRIPTION
Make sure `UV__SOLARIS_11_4` is not set for `smartOS`/`illumOS`. In our codebase is used only twice:
- Detect correct implementation of `SO_REUSEPORT`, which is not even implemented on `illumOS`.
- Detect the time unit used for the TCP keepalive options. If set to `0`, which was the case for `illumOS`, it chose milliseconds, which is not correct for `illumOS` either as it uses seconds.

/cc @panjf2000 