### PR TITLE
Fix uv_getrusage's ru_maxrss calculation on Solaris

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1034,7 +1034,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
 #if defined(__APPLE__)
   rusage->ru_maxrss /= 1024;                  /* macOS and iOS report bytes. */
 #elif defined(__sun)
-  rusage->ru_maxrss /= getpagesize() / 1024;  /* Solaris reports pages. */
+  rusage->ru_maxrss *= getpagesize() / 1024;  /* Solaris reports pages. */
 #endif
 
   return 0;


### PR DESCRIPTION
This appears to be a simple math error that bugged me! I tested on omnios but `rusage->ru_maxrss` there was always 0 so the change didn't make any difference! Still might be good to fix. 