### PR TITLE
Fix compilation against Windows 24H2 SDK

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4125,6 +4125,12 @@ typedef const UNICODE_STRING *PCUNICODE_STRING;
 # define DEVICE_TYPE DWORD
 #endif
 
+#ifndef NTDDI_WIN11_ZN
+# define NTDDI_WIN11_ZN  0x0A00000E
+#endif
+
+/* API is defined in newer SDKS */
+#if (NTDDI_VERSION < NTDDI_WIN11_ZN)
 typedef struct _FILE_STAT_BASIC_INFORMATION {
   LARGE_INTEGER FileId;
   LARGE_INTEGER CreationTime;
@@ -4142,6 +4148,7 @@ typedef struct _FILE_STAT_BASIC_INFORMATION {
   FILE_ID_128 FileId128;
   LARGE_INTEGER VolumeSerialNumber;
 } FILE_STAT_BASIC_INFORMATION;
+#endif
 
 /* MinGW already has a definition for REPARSE_DATA_BUFFER, but mingw-w64 does
  * not.
@@ -4783,6 +4790,8 @@ typedef struct _TCP_INITIAL_RTO_PARAMETERS {
 #endif
 
 /* from winnt.h */
+/* API is defined in newer SDKS */
+#if (NTDDI_VERSION < NTDDI_WIN11_ZN)
 typedef enum _FILE_INFO_BY_NAME_CLASS {
   FileStatByNameInfo,
   FileStatLxByNameInfo,
@@ -4790,6 +4799,7 @@ typedef enum _FILE_INFO_BY_NAME_CLASS {
   FileStatBasicByNameInfo,
   MaximumFileInfoByNameClass
 } FILE_INFO_BY_NAME_CLASS;
+#endif
 
 typedef BOOL(WINAPI* sGetFileInformationByName)(
     PCWSTR FileName,


### PR DESCRIPTION
Compilation against the 24H2 SDK is broken by #4327

Fix that issue by only conditionally defining the new values.

Closes #4575 