### PR TITLE
unix: switch from execvp() to execvpe()

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -386,19 +386,12 @@ static void uv__process_child_init(const uv_process_options_t* options,
   if ((options->flags & UV_PROCESS_SETUID) && setuid(options->uid))
     uv__write_errno(error_fd);
 
-  if (options->env != NULL)
-    environ = options->env;
-
   /* Reset signal mask just before exec. */
   sigemptyset(&signewset);
   if (sigprocmask(SIG_SETMASK, &signewset, NULL) != 0)
     abort();
 
-#ifdef __MVS__
-  execvpe(options->file, options->args, environ);
-#else
-  execvp(options->file, options->args);
-#endif
+  execvpe(options->file, options->args, options->env ? options->env : environ);
 
   uv__write_errno(error_fd);
 }


### PR DESCRIPTION
The use case is passing an environ with PATH="" but still wanting the path search to use the PATH variable from the current environ.

execvpe() is non-standard. Let's see how well supported it is. Known to support it: Linux (glibc and musl), recent FreeBSD, OpenBSD.

Refs: https://github.com/nodejs/node/issues/55374