### PR TITLE
win,fs: remove trailing slash in junctions

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -2566,7 +2566,6 @@ static void fs__create_junction(uv_fs_t* req, const WCHAR* path,
 
     path_buf[path_buf_len++] = path[i];
   }
-  path_buf[path_buf_len++] = L'\\';
   len = path_buf_len - start;
 
   /* Set the info about the substitute name */

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -2379,8 +2379,8 @@ int test_symlink_dir_impl(int type) {
   strcpy(test_dir_abs_buf, "\\\\?\\");
   uv_cwd(test_dir_abs_buf + 4, &test_dir_abs_size);
   test_dir_abs_size += 4;
-  strcat(test_dir_abs_buf, "\\test_dir\\");
-  test_dir_abs_size += strlen("\\test_dir\\");
+  strcat(test_dir_abs_buf, "\\test_dir");
+  test_dir_abs_size += strlen("\\test_dir");
   test_dir = test_dir_abs_buf;
 #else
   uv_cwd(test_dir_abs_buf, &test_dir_abs_size);
@@ -2435,8 +2435,8 @@ int test_symlink_dir_impl(int type) {
   r = uv_fs_realpath(NULL, &req, "test_dir_symlink", NULL);
   ASSERT_OK(r);
 #ifdef _WIN32
-  ASSERT_EQ(strlen(req.ptr), test_dir_abs_size - 5);
-  ASSERT_OK(_strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 5));
+  ASSERT_EQ(strlen(req.ptr), test_dir_abs_size - 4);
+  ASSERT_OK(_strnicmp(req.ptr, test_dir + 4, test_dir_abs_size - 4));
 #else
   ASSERT_OK(strcmp(req.ptr, test_dir_abs_buf));
 #endif


### PR DESCRIPTION
I've investigated why this trailing slash was added originally, but I couldn't find any reason.

Fixes: https://github.com/libuv/libuv/issues/3329