### PR TITLE
Revert "linux: eliminate a read on eventfd per wakeup (#4400)"

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -35,10 +35,6 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#if defined(__APPLE__) || defined(__DragonFly__) || \
-    defined(__FreeBSD__) || defined(__NetBSD__)
-#include <sys/event.h>
-#endif
 
 #define uv__msan_unpoison(p, n)                                               \
   do {                                                                        \
@@ -506,24 +502,6 @@ int uv__get_constrained_cpu(uv__cpu_constraint* constraint);
 #else
 #define UV__SOLARIS_11_4 (0)
 #endif
-#endif
-
-#if defined(EVFILT_USER) && defined(NOTE_TRIGGER)
-/* EVFILT_USER is available since OS X 10.6, DragonFlyBSD 4.0,
- * FreeBSD 8.1, and NetBSD 10.0.
- * 
- * Note that even though EVFILT_USER is defined on the current system,
- * it may still fail to work at runtime somehow. In that case, we fall
- * back to pipe-based signaling.
- */
-#define UV__KQUEUE_EVFILT_USER 1
-/* Magic number of identifier used for EVFILT_USER during runtime detection.
- * There are no Google hits for this number when I create it. That way,
- * people will be directed here if this number gets printed due to some
- * kqueue error and they google for help. */
-#define UV__KQUEUE_EVFILT_USER_IDENT 0x1e7e7711
-#else
-#define UV__KQUEUE_EVFILT_USER 0
 #endif
 
 #endif /* UV_UNIX_INTERNAL_H_ */

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -367,17 +367,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         continue;
       }
 
-#if UV__KQUEUE_EVFILT_USER
-      if (ev->filter == EVFILT_USER) {
-        w = &loop->async_io_watcher;
-        assert(fd == w->fd);
-        uv__metrics_update_idle_time(loop);
-        w->cb(loop, w, w->events);
-        nevents++;
-        continue;
-      }
-#endif
-
       if (ev->filter == EVFILT_VNODE) {
         assert(w->events == POLLIN);
         assert(w->pevents == POLLIN);

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1414,12 +1414,6 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
     w->events = w->pevents;
     e.events = w->pevents;
-    if (w == &loop->async_io_watcher)
-      /* Enable edge-triggered mode on async_io_watcher(eventfd),
-       * so that we're able to eliminate the overhead of reading
-       * the eventfd via system call on each event loop wakeup.
-       */
-      e.events |= EPOLLET;
     e.data.fd = w->fd;
     fd = w->fd;
 


### PR DESCRIPTION
This reverts commit e5cb1d3d3d4ab3178ac567fb6a7f0f4b5eef3083.

Reason: bisecting says it breaks dnstap.

Also revert commit 27134547ff ("kqueue: use EVFILT_USER for async if available") because otherwise the first commit doesn't revert cleanly, with enough conflicts in src/unix/async.c that I'm not comfortable fixing those up manually.

Fixes: https://github.com/libuv/libuv/issues/4584

cc @panjf2000