### PR TITLE
win: fix some compiler warnings

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -287,7 +287,7 @@ typedef struct {
   DWORD tls_index;
 } uv_key_t;
 
-#define UV_ONCE_INIT { 0, NULL }
+#define UV_ONCE_INIT { 0, INIT_ONCE_STATIC_INIT }
 
 typedef struct uv_once_s {
   unsigned char unused;

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -223,7 +223,7 @@ int uv__stdio_create(uv_loop_t* loop,
           if (err)
             goto error;
 
-		  memcpy(CHILD_STDIO_HANDLE(buffer, i), &nul, sizeof(HANDLE));
+          memcpy(CHILD_STDIO_HANDLE(buffer, i), &nul, sizeof(HANDLE));
           CHILD_STDIO_CRT_FLAGS(buffer, i) = FOPEN | FDEV;
         }
         break;
@@ -248,7 +248,7 @@ int uv__stdio_create(uv_loop_t* loop,
         if (err)
           goto error;
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_pipe, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_pipe, sizeof(HANDLE));
         CHILD_STDIO_CRT_FLAGS(buffer, i) = FOPEN | FPIPE;
         break;
       }
@@ -299,7 +299,7 @@ int uv__stdio_create(uv_loop_t* loop,
             return -1;
         }
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
         break;
       }
 
@@ -335,7 +335,7 @@ int uv__stdio_create(uv_loop_t* loop,
         if (err)
           goto error;
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
         CHILD_STDIO_CRT_FLAGS(buffer, i) = crt_flags;
         break;
       }

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -215,7 +215,8 @@ int uv__stdio_create(uv_loop_t* loop,
          * handles in the stdio buffer are initialized with.
          * INVALID_HANDLE_VALUE, which should be okay. */
         if (i <= 2) {
-          HANDLE nul;
+          /* Redundantly initialize to make the compiler happy. */
+          HANDLE nul = INVALID_HANDLE_VALUE;
           DWORD access = (i == 0) ? FILE_GENERIC_READ :
                                     FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES;
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -509,7 +509,7 @@ unsigned int uv_available_parallelism(void) {
   DWORD_PTR procmask;
   DWORD_PTR sysmask;
   int count;
-  int i;
+  unsigned int i;
 
   /* TODO(bnoordhuis) Use GetLogicalProcessorInformationEx() to support systems
    * with > 64 CPUs? See https://github.com/libuv/libuv/pull/3458

--- a/test/test-tcp-connect-error-after-write.c
+++ b/test/test-tcp-connect-error-after-write.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _WIN32
 static int connect_cb_called;
 static int write_cb_called;
 static int close_cb_called;
@@ -47,6 +48,7 @@ static void write_cb(uv_write_t* req, int status) {
   ASSERT_LT(status, 0);
   write_cb_called++;
 }
+#endif
 
 
 /*

--- a/test/test-tcp-rst.c
+++ b/test/test-tcp-rst.c
@@ -22,6 +22,7 @@
 #include "uv.h"
 #include "task.h"
 
+#if !defined(__OpenBSD__) && !defined(_WIN32)
 static uv_tcp_t tcp;
 static uv_connect_t connect_req;
 static uv_buf_t qbuf;
@@ -69,6 +70,7 @@ static void connect_cb(uv_connect_t *req, int status) {
 
   called_connect_cb++;
 }
+#endif
 
 
 /*

--- a/test/test-tcp-write-in-a-row.c
+++ b/test/test-tcp-write-in-a-row.c
@@ -26,6 +26,7 @@
 #include "task.h"
 #include "uv.h"
 
+#if !defined(_WIN32) && !defined(__PASE__)
 static uv_tcp_t server;
 static uv_tcp_t client;
 static uv_tcp_t incoming;
@@ -110,6 +111,7 @@ static void start_server(void) {
   ASSERT_OK(uv_tcp_bind(&server, (struct sockaddr*) &addr, 0));
   ASSERT_OK(uv_listen((uv_stream_t*) &server, 128, connection_cb));
 }
+#endif
 
 TEST_IMPL(tcp_write_in_a_row) {
 #if defined(_WIN32)


### PR DESCRIPTION
These changes aren't sufficient to get a warning-free build with MinGW, but they clean things up a bit.