### PR TITLE
win,unix: handle `EINPROGRESS|WSAEWOULDBLOCK` for UDP connected mode

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -636,7 +636,7 @@ int uv__udp_connect(uv_udp_t* handle,
     err = connect(handle->io_watcher.fd, addr, addrlen);
   } while (err == -1 && errno == EINTR);
 
-  if (err)
+  if (err && errno != EINPROGRESS)
     return UV__ERR(errno);
 
   handle->flags |= UV_HANDLE_UDP_CONNECTED;

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -1033,7 +1033,7 @@ int uv__udp_connect(uv_udp_t* handle,
   }
 
   err = connect(handle->socket, addr, addrlen);
-  if (err)
+  if (err && WSAGetLastError() != WSAEWOULDBLOCK)
     return uv_translate_sys_error(WSAGetLastError());
 
   handle->flags |= UV_HANDLE_UDP_CONNECTED;


### PR DESCRIPTION
In case of `EINPROGRESS|WSAEWOULDBLOCK` add the flag UV_HANDLE_UDP_CONNECTED to the udp handle.

Fixes: https://github.com/libuv/libuv/issues/3209