### PR TITLE
unix: fix return type for uv__udp_recvmmsg()

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -147,7 +147,7 @@ static void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int revents) {
   }
 }
 
-static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
+static ssize_t uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
   struct sockaddr_in6 peers[20];
   struct iovec iov[ARRAY_SIZE(peers)];


### PR DESCRIPTION
On FreeBSD (and other BSDs), recvmmsg() returns a ssize_t instead of an int.  recvmsg_x() returns a ssize_t as well.  Avoid casting the return value through an int as this might corrupt the value on big-endian systems.

On Linux the return value will be sign-extended, and the sole caller already saves it to a variable of type ssize_t, so this should have no functional impact there.