### PR TITLE
linux: cap number of in-flight io_uring SQEs

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -158,7 +158,6 @@ enum {
 
 enum {
   UV__IORING_SQ_NEED_WAKEUP = 1u,
-  UV__IORING_SQ_CQ_OVERFLOW = 2u,
 };
 
 struct uv__io_cqring_offsets {
@@ -604,6 +603,7 @@ static void uv__iou_init(int epollfd,
   iou->sqelen = sqelen;
   iou->ringfd = ringfd;
   iou->in_flight = 0;
+  iou->max_in_flight = params.cq_entries;
 
   if (no_sqarray)
     return;
@@ -779,6 +779,9 @@ static struct uv__io_uring_sqe* uv__iou_get_sqe(struct uv__iou* iou,
   }
 
   if (iou->ringfd == -1)
+    return NULL;
+
+  if (iou->in_flight >= iou->max_in_flight)
     return NULL;
 
   head = atomic_load_explicit((_Atomic uint32_t*) iou->sqhead,
@@ -1169,9 +1172,7 @@ static void uv__poll_io_uring(uv_loop_t* loop, struct uv__iou* iou) {
   uint32_t tail;
   uint32_t mask;
   uint32_t i;
-  uint32_t flags;
   int nevents;
-  int rc;
 
   head = *iou->cqhead;
   tail = atomic_load_explicit((_Atomic uint32_t*) iou->cqtail,
@@ -1216,21 +1217,6 @@ static void uv__poll_io_uring(uv_loop_t* loop, struct uv__iou* iou) {
   atomic_store_explicit((_Atomic uint32_t*) iou->cqhead,
                         tail,
                         memory_order_release);
-
-  /* Check whether CQE's overflowed, if so enter the kernel to make them
-   * available. Don't grab them immediately but in the next loop iteration to
-   * avoid loop starvation. */
-  flags = atomic_load_explicit((_Atomic uint32_t*) iou->sqflags,
-                               memory_order_acquire);
-
-  if (flags & UV__IORING_SQ_CQ_OVERFLOW) {
-    do
-      rc = uv__io_uring_enter(iou->ringfd, 0, 0, UV__IORING_ENTER_GETEVENTS);
-    while (rc == -1 && errno == EINTR);
-
-    if (rc < 0)
-      perror("libuv: io_uring_enter(getevents)");  /* Can't happen. */
-  }
 
   uv__metrics_inc_events(loop, nevents);
   if (uv__get_internal_fields(loop)->current_timeout == 0)

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -414,6 +414,7 @@ struct uv__iou {
   size_t sqelen;
   int ringfd;
   uint32_t in_flight;
+  uint32_t max_in_flight;
 };
 #endif  /* __linux__ */
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -4621,6 +4621,7 @@ TEST_IMPL(fs_stat_batch_multiple) {
   ASSERT_OK(r);
 
   loop = uv_default_loop();
+  uv_loop_configure(loop, UV_LOOP_USE_IO_URING_SQPOLL);
 
   for (i = 0; i < (int) ARRAY_SIZE(req); ++i) {
     r = uv_fs_stat(loop, &req[i], "test_dir", stat_batch_cb);


### PR DESCRIPTION
Limit the number of in-flight submission entries to the size of the completion queue. The kernel's sqpoll thread hoovers them up really fast and we may end up posting way more submissions than fit in the completion queue.

That's not fatal as such, the kernel stores them in an overflow queue that we flush eventually, but that queue can grow pretty big if the program submits lots of file operations.

Salient questions are:

1. Is this change a bug fix? If yes, why? If not, why not?

2. Is this change a (de)optimization? Is the kernel's overflow queue more or less efficient than libuv's thread pool?

This commit removes the IORING_SQ_CQ_OVERFLOW handling that was added in commit 30fc896c ("unix: handle CQ overflow in iou ring") from May 2023 because it is no longer needed.

Fixes: https://github.com/libuv/libuv/issues/4598