### PR TITLE
build: update minimum cmake to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW) # Enable MSVC_RUNTIME_LIBRARY setting


### PR DESCRIPTION
Fixes a deprecation warning with new cmake versions.

Changing the minimum from 3.9 to 3.10 should be safe because there isn't even a non-EoL'd distro left that ships 3.10, let alone 3.9.

Fixes: https://github.com/libuv/libuv/issues/4603