### PR TITLE
unix,pipe: fix handling null buffer in uv_pipe_get{sock,peer}name

### DIFF
--- a/test/test-pipe-getsockname.c
+++ b/test/test-pipe-getsockname.c
@@ -154,6 +154,15 @@ TEST_IMPL(pipe_getsockname) {
   ASSERT_STR_EQ(pipe_server.pipe_fname, TEST_PIPENAME);
 #endif
 
+  r = uv_pipe_getsockname(&pipe_server, NULL, &len);
+  ASSERT_EQ(r, UV_EINVAL);
+
+  r = uv_pipe_getsockname(&pipe_server, buf, NULL);
+  ASSERT_EQ(r, UV_EINVAL);
+
+  r = uv_pipe_getsockname(&pipe_server, NULL, NULL);
+  ASSERT_EQ(r, UV_EINVAL);
+
   len = sizeof(TEST_PIPENAME) - 1;
   ASSERT_EQ(UV_ENOBUFS, uv_pipe_getsockname(&pipe_server, buf, &len));
 


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/4610