### PR TITLE
unix: fix build breakage on haiku, openbsd, etc

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -508,7 +508,6 @@ int uv__get_constrained_cpu(uv__cpu_constraint* constraint);
 #endif
 #endif
 
-#if defined(EVFILT_USER) && defined(NOTE_TRIGGER)
 /* EVFILT_USER is available since OS X 10.6, DragonFlyBSD 4.0,
  * FreeBSD 8.1, and NetBSD 10.0.
  *
@@ -516,12 +515,11 @@ int uv__get_constrained_cpu(uv__cpu_constraint* constraint);
  * it may still fail to work at runtime somehow. In that case, we fall
  * back to pipe-based signaling.
  */
+#if defined(__APPLE__) || \
+    defined(__DragonFly__) || \
+    defined(__FreeBSD__) || \
+    defined(__NetBSD__)
 #define UV__KQUEUE_EVFILT_USER 1
-/* Magic number of identifier used for EVFILT_USER during runtime detection.
- * There are no Google hits for this number when I create it. That way,
- * people will be directed here if this number gets printed due to some
- * kqueue error and they google for help. */
-#define UV__KQUEUE_EVFILT_USER_IDENT 0x1e7e7711
 #else
 #define UV__KQUEUE_EVFILT_USER 0
 #endif


### PR DESCRIPTION
The compile-time detection check from commit 7b75935b ("kqueue: use EVFILT_USER for async if available") reportedly breaks the build on numerous operating systems. This commit hopefully unbreaks them.

Fixes: https://github.com/libuv/libuv/issues/4608