### PR TITLE
unix: fix build breakage on haiku, openbsd, etc

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -227,7 +227,7 @@ static void uv__async_send(uv_loop_t* loop) {
     len = sizeof(val);
     fd = loop->async_io_watcher.fd;  /* eventfd */
   }
-#elif defined(UV__KQUEUE_EVFILT_USER)
+#elif UV__KQUEUE_EVFILT_USER
   struct kevent ev;
 
   if (kqueue_evfilt_user_support) {


### PR DESCRIPTION
The compile-time detection check from commit 7b75935 ("kqueue: use EVFILT_USER for async if available") was not actually used, breaking numerous operating systems.