### PR TITLE
build: downgrade QEMU version to 6.2 for GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -168,7 +168,7 @@ jobs:
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:
           QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_7\\.2+dfsg-.*_amd64.deb$"
+          QEMU_VER: "qemu-user-static_6\\.2+dfsg-.*_amd64.deb"
         run: |
           DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
           wget $QEMU_SRC/$DEB


### PR DESCRIPTION
For unknown reasons 7.2 was removed from de registry.

Fixes: https://github.com/libuv/libuv/issues/4625