### PR TITLE
win: use GetHostNameW unconditionally

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1368,10 +1368,7 @@ int uv_os_gethostname(char* buffer, size_t* size) {
 
   uv__once_init(); /* Initialize winsock */
 
-  if (pGetHostNameW == NULL)
-    return UV_ENOSYS;
-
-  if (pGetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
+  if (GetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
     return uv_translate_sys_error(WSAGetLastError());
 
   return uv__copy_utf16_to_utf8(buf, -1, buffer, size);

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -45,9 +45,6 @@ sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
 /* User32.dll function pointer */
 sSetWinEventHook pSetWinEventHook;
 
-/* ws2_32.dll function pointer */
-uv_sGetHostNameW pGetHostNameW;
-
 /* api-ms-win-core-file-l2-1-4.dll function pointer */
 sGetFileInformationByName pGetFileInformationByName;
 
@@ -56,7 +53,6 @@ void uv__winapi_init(void) {
   HMODULE powrprof_module;
   HMODULE user32_module;
   HMODULE kernel32_module;
-  HMODULE ws2_32_module;
   HMODULE api_win_core_file_module;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
@@ -140,13 +136,6 @@ void uv__winapi_init(void) {
   if (user32_module != NULL) {
     pSetWinEventHook = (sSetWinEventHook)
       GetProcAddress(user32_module, "SetWinEventHook");
-  }
-
-  ws2_32_module = GetModuleHandleA("ws2_32.dll");
-  if (ws2_32_module != NULL) {
-    pGetHostNameW = (uv_sGetHostNameW) GetProcAddress(
-        ws2_32_module,
-        "GetHostNameW");
   }
 
   api_win_core_file_module = GetModuleHandleA("api-ms-win-core-file-l2-1-4.dll");

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4830,11 +4830,4 @@ extern sSetWinEventHook pSetWinEventHook;
 /* api-ms-win-core-file-l2-1-4.dll function pointers */
 extern sGetFileInformationByName pGetFileInformationByName;
 
-/* ws2_32.dll function pointer */
-/* mingw doesn't have this definition, so let's declare it here locally */
-typedef int (WINAPI *uv_sGetHostNameW)
-            (PWSTR,
-             int);
-extern uv_sGetHostNameW pGetHostNameW;
-
 #endif /* UV_WIN_WINAPI_H_ */


### PR DESCRIPTION
The dynamic lookup was added three years ago to work around broken mingw builds but that particular bug has long been fixed upstream.