### PR TITLE
win: enable uv_thread_{get,set}name on MinGW

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -279,9 +279,6 @@ int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
 
 
 int uv_thread_setname(const char* name) {
-#ifdef __MINGW32__
-  return UV_ENOSYS;
-#else
   HRESULT hr;
   WCHAR* namew;
   int err;
@@ -304,14 +301,10 @@ int uv_thread_setname(const char* name) {
     return uv_translate_sys_error(HRESULT_CODE(hr));
 
   return 0;
-#endif /* __MINGW32__ */
 }
 
 
 int uv_thread_getname(uv_thread_t* tid, char* name, size_t size) {
-#ifdef __MINGW32__
-  return UV_ENOSYS;
-#else
   HRESULT hr;
   WCHAR* namew;
   char* thread_name;
@@ -347,7 +340,6 @@ int uv_thread_getname(uv_thread_t* tid, char* name, size_t size) {
 
   LocalFree(namew);
   return r;
-#endif /* __MINGW32__ */
 }
 
 

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4826,4 +4826,13 @@ typedef int (WINAPI *uv_sGetHostNameW)
              int);
 extern uv_sGetHostNameW pGetHostNameW;
 
+/* processthreadsapi.h */
+#if defined(__MINGW32__)
+WINBASEAPI
+HRESULT WINAPI GetThreadDescription(HANDLE hThread,
+                                    PWSTR *ppszThreadDescription);
+WINBASEAPI
+HRESULT WINAPI SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
+#endif
+
 #endif /* UV_WIN_WINAPI_H_ */

--- a/test/test-thread-name.c
+++ b/test/test-thread-name.c
@@ -66,8 +66,7 @@ TEST_IMPL(thread_name) {
   char long_thread_name[UV_PTHREAD_MAX_NAMELEN_NP + 1];
   struct semaphores sem;
 
-#if defined(__MINGW32__) || \
-    defined(__ANDROID_API__) && __ANDROID_API__ < 26 || \
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 26 || \
     defined(_AIX) || \
     defined(__MVS__) || \
     defined(__PASE__)
@@ -140,4 +139,3 @@ TEST_IMPL(thread_name) {
 
   return 0;
 }
-


### PR DESCRIPTION
It supports the API: https://github.com/mirror/mingw-w64/blob/93f3505a758fe70e56678f00e753af3bc4f640bb/mingw-w64-headers/include/processthreadsapi.h#L358