### PR TITLE
Freeing short_path to fix win watch leak

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -253,6 +253,8 @@ short_path_done:
     }
 
     dir_to_watch = dir;
+    uv__free(short_path);
+    short_path = NULL;
     uv__free(pathw);
     pathw = NULL;
   }


### PR DESCRIPTION
This PR is in response to a node bug I found:
https://github.com/nodejs/node/issues/52769

The leak appears to be coming from libuv leaking short_path.  This PR fixes it by freeing it.