### PR TITLE
test: address FreeBSD kernel bug causing NULL path in fsevents

### DIFF
--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -47,6 +47,11 @@ Data types
 
     The `events` parameter is an ORed mask of :c:enum:`uv_fs_event` elements.
 
+.. note::
+   For FreeBSD path could sometimes be `NULL` due to a kernel bug.
+
+    .. _Reference: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=197695
+
 .. c:enum:: uv_fs_event
 
     Event types that :c:type:`uv_fs_event_t` handles monitor.

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -153,7 +153,14 @@ static void fs_event_cb_del_dir(uv_fs_event_t* handle,
   ASSERT_PTR_EQ(handle, &fs_event);
   ASSERT_OK(status);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
+  /* There is a bug in the FreeBSD kernel where the filename is sometimes NULL.
+   * Refs: https://github.com/libuv/libuv/issues/4606
+   */
+  #if defined(__FreeBSD__)
+  ASSERT(filename == NULL || strcmp(filename, "watch_del_dir") == 0);
+  #else
   ASSERT_OK(strcmp(filename, "watch_del_dir"));
+  #endif
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }


### PR DESCRIPTION
This commit documents a FreeBSD kernel issue where uv_fs_event can receive a NULL filename and updates test-fs-event.c to skip filename assertions on FreeBSD.

* Bugzilla: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=197695

Refs: https://github.com/libuv/libuv/issues/4606

-----
This is not precisely a fix, but I'm open to pivot this PR into something else.