### PR TITLE
zos: remove deadcode in library shutdown

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -170,11 +170,6 @@ void uv__threadpool_cleanup(void) {
   if (nthreads == 0)
     return;
 
-#ifndef __MVS__
-  /* TODO(gabylb) - zos: revisit when Woz compiler is available. */
-  post(&exit_message, UV__WORK_CPU);
-#endif
-
   for (i = 0; i < nthreads; i++)
     if (uv_thread_join(threads + i))
       abort();


### PR DESCRIPTION
This removed coded won't be called as the teardown for z/OS is `uv__os390_cleanup`[1] instead of `uv__threadpool_cleanup`


[1]: https://github.com/libuv/libuv/blob/ec5a4b54f7da7eeb01679005c615fee9633cdb3b/src/uv-common.c#L979