### PR TITLE
threadpool: remove non required prepocessor conditionals

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -160,20 +160,13 @@ static void post(struct uv__queue* q, enum uv__work_kind kind) {
 }
 
 
-#ifdef __MVS__
-/* TODO(itodorov) - zos: revisit when Woz compiler is available. */
-__attribute__((destructor))
-#endif
 void uv__threadpool_cleanup(void) {
   unsigned int i;
 
   if (nthreads == 0)
     return;
 
-#ifndef __MVS__
-  /* TODO(gabylb) - zos: revisit when Woz compiler is available. */
   post(&exit_message, UV__WORK_CPU);
-#endif
 
   for (i = 0; i < nthreads; i++)
     if (uv_thread_join(threads + i))


### PR DESCRIPTION
---
My GH actions seems happy w/ this patch, If I'm not mistaken, those conditionals are not required at all.

Refs: https://github.com/libuv/libuv/pull/4657