### PR TITLE
win,fs: get fstat of AppExecLink reparse points

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1953,7 +1953,7 @@ INLINE static void fs__stat_prepare_path(WCHAR* pathw) {
   }
 }
 
-INLINE static DWORD fs__stat_get_handle(HANDLE handle, WCHAR* path, int do_lstat) {
+INLINE static DWORD fs__stat_get_handle(HANDLE* handle, WCHAR* path, int do_lstat) {
   WCHAR* tmp_path = NULL;
   char *target = NULL;
   size_t len = 0;


### PR DESCRIPTION
This fixes the problem of getting the fstat of AppExecLink reparse points (e.g. Windows Apps). 

Refs: https://github.com/nodejs/node/issues/36790