### PR TITLE
[RFC] unix: Update signal handling to use `sa_sigaction`

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -412,7 +412,17 @@ typedef void (*uv_fs_poll_cb)(uv_fs_poll_t* handle,
                               const uv_stat_t* prev,
                               const uv_stat_t* curr);
 
-typedef void (*uv_signal_cb)(uv_signal_t* handle, int signum);
+#ifdef _WIN32
+typedef void (*uv_signal_cb)(uv_signal_t* handle,
+                            int signum);
+#else
+typedef void (*uv_signal_cb)(uv_signal_t* handle,
+                            int signum,
+                            int sigcode,
+                            int sigpid,
+                            int siguid,
+                            int sigval);
+#endif
 
 
 typedef enum {
@@ -1705,6 +1715,12 @@ struct uv_signal_s {
   UV_HANDLE_FIELDS
   uv_signal_cb signal_cb;
   int signum;
+#ifndef _WIN32
+  int sigcode;
+  int sigpid;
+  int siguid;
+  int sigval;
+#endif
   UV_SIGNAL_PRIVATE_FIELDS
 };
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -35,6 +35,10 @@
 typedef struct {
   uv_signal_t* handle;
   int signum;
+  int sigcode;
+  int sigpid;
+  int siguid;
+  int sigval;
 } uv__signal_msg_t;
 
 RB_HEAD(uv__signal_tree_s, uv_signal_s);
@@ -180,7 +184,7 @@ static uv_signal_t* uv__signal_first_handle(int signum) {
 }
 
 
-static void uv__signal_handler(int signum) {
+static void uv__signal_handler(int signum, siginfo_t *siginfo, void *ptr) {
   uv__signal_msg_t msg;
   uv_signal_t* handle;
   int saved_errno;
@@ -199,6 +203,12 @@ static void uv__signal_handler(int signum) {
     int r;
 
     msg.signum = signum;
+    if (siginfo) {
+      msg.sigcode = siginfo->si_code;
+      msg.sigpid = siginfo->si_pid;
+      msg.siguid = siginfo->si_uid;
+      msg.sigval = siginfo->si_value.sival_int;
+    }
     msg.handle = handle;
 
     /* write() should be atomic for small data chunks, so the entire message
@@ -229,8 +239,8 @@ static int uv__signal_register_handler(int signum, int oneshot) {
   memset(&sa, 0, sizeof(sa));
   if (sigfillset(&sa.sa_mask))
     abort();
-  sa.sa_handler = uv__signal_handler;
-  sa.sa_flags = SA_RESTART;
+  sa.sa_sigaction = uv__signal_handler;
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
   if (oneshot)
     sa.sa_flags |= SA_RESETHAND;
 
@@ -475,7 +485,7 @@ static void uv__signal_event(uv_loop_t* loop,
 
       if (msg->signum == handle->signum) {
         assert(!(handle->flags & UV_HANDLE_CLOSING));
-        handle->signal_cb(handle, handle->signum);
+        handle->signal_cb(handle, handle->signum, handle->sigcode, handle->sigpid, handle->siguid, handle->sigval);
       }
 
       handle->dispatched_signals++;

--- a/test/test-eintr-handling.c
+++ b/test/test-eintr-handling.c
@@ -57,7 +57,7 @@ static void thread_main(void* arg) {
   ASSERT_EQ(nwritten, sizeof(test_buf));
 }
 
-static void sig_func(uv_signal_t* handle, int signum) {
+static void sig_func(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   uv_signal_stop(handle);
 }
 

--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -236,7 +236,7 @@ TEST_IMPL(fork_socketpair_started) {
 
 static int fork_signal_cb_called;
 
-void fork_signal_to_child_cb(uv_signal_t* handle, int signum)
+void fork_signal_to_child_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval)
 {
   fork_signal_cb_called = signum;
   uv_close((uv_handle_t*)handle, NULL);
@@ -375,8 +375,8 @@ TEST_IMPL(fork_signal_to_child_closed) {
   return 0;
 }
 
-static void fork_signal_cb(uv_signal_t* h, int s) {
-  fork_signal_cb_called = s;
+static void fork_signal_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
+  fork_signal_cb_called = signum;
 }
 static void empty_close_cb(uv_handle_t* h){}
 

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -3776,7 +3776,7 @@ static void thread_main(void* arg) {
   }
 }
 
-static void sig_func(uv_signal_t* handle, int signum) {
+static void sig_func(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   uv_signal_stop(handle);
 }
 

--- a/test/test-signal-multiple-loops.c
+++ b/test/test-signal-multiple-loops.c
@@ -65,14 +65,14 @@ static void increment_counter(int* counter) {
 }
 
 
-static void signal1_cb(uv_signal_t* handle, int signum) {
+static void signal1_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   ASSERT_EQ(signum, SIGUSR1);
   increment_counter(&signal1_cb_counter);
   uv_signal_stop(handle);
 }
 
 
-static void signal2_cb(uv_signal_t* handle, int signum) {
+static void signal2_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   ASSERT_EQ(signum, SIGUSR2);
   increment_counter(&signal2_cb_counter);
   uv_signal_stop(handle);
@@ -156,7 +156,7 @@ static void signal_handling_worker(void* context) {
 }
 
 
-static void signal_unexpected_cb(uv_signal_t* handle, int signum) {
+static void signal_unexpected_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   ASSERT(0 && "signal_unexpected_cb should never be called");
 }
 

--- a/test/test-signal-pending-on-close.c
+++ b/test/test-signal-pending-on-close.c
@@ -34,12 +34,12 @@ static char* buf;
 static int close_cb_called;
 
 
-static void stop_loop_cb(uv_signal_t* signal, int signum) {
+static void stop_loop_cb(uv_signal_t* signal, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   ASSERT_EQ(signum, SIGPIPE);
   uv_stop(signal->loop);
 }
 
-static void signal_cb(uv_signal_t* signal, int signum) {
+static void signal_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   ASSERT(0);
 }
 

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -98,7 +98,7 @@ struct signal_ctx {
 };
 
 
-static void signal_cb(uv_signal_t* handle, int signum) {
+static void signal_cb(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
   ASSERT_EQ(signum, ctx->signum);
   if (++ctx->ncalls == NSIGNALS) {
@@ -111,7 +111,7 @@ static void signal_cb(uv_signal_t* handle, int signum) {
   }
 }
 
-static void signal_cb_one_shot(uv_signal_t* handle, int signum) {
+static void signal_cb_one_shot(uv_signal_t* handle, int signum, int sigcode, int sigpid, int siguid, int sigval) {
   struct signal_ctx* ctx = container_of(handle, struct signal_ctx, handle);
   ASSERT_EQ(signum, ctx->signum);
   ASSERT_EQ(1, ++ctx->ncalls);


### PR DESCRIPTION
- Switched to `sa_sigaction` for extended signal info (`SA_SIGINFO`)
- Extend the uv_signal_cb with signal code, PID, UID and signal value