### PR TITLE
win: lazy-load [GS]etThreadDescription symbols

### DIFF
--- a/docs/src/threading.rst
+++ b/docs/src/threading.rst
@@ -146,6 +146,8 @@ Threads
     a thread name can be: Linux, IBM i (16), macOS (64), Windows (32767), and NetBSD (32), etc. `uv_thread_setname()`
     will truncate it in case `name` is larger than the limit of the platform.
 
+    Not supported on Windows Server 2016, returns `UV_ENOSYS`.
+
     .. versionadded:: 1.50.0
 
 .. c:function:: int uv_thread_getname(uv_thread_t* tid, char* name, size_t* size)
@@ -154,6 +156,8 @@ Threads
     pointed to by `name`. The `size` parameter specifies the size of the buffer pointed to by `name`.
     The buffer should be large enough to hold the name of the thread plus the trailing NUL, or it will be truncated to fit
     with the trailing NUL.
+
+    Not supported on Windows Server 2016, returns `UV_ENOSYS`.
 
     .. versionadded:: 1.50.0
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -57,6 +57,9 @@ STATIC_ASSERT(sizeof(uv_thread_t) <= sizeof(void*));
 
 static uv_key_t uv__current_thread_key;
 static uv_once_t uv__current_thread_init_guard = UV_ONCE_INIT;
+static uv_once_t uv__thread_name_once = UV_ONCE_INIT;
+HRESULT WINAPI (*pGetThreadDescription)(HANDLE, PWSTR*);
+HRESULT WINAPI (*pSetThreadDescription)(HANDLE, PCWSTR);
 
 
 static void uv__init_current_thread_key(void) {
@@ -278,11 +281,24 @@ int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
 }
 
 
+static void uv__thread_name_init_once(void) {
+  HMODULE m;
+
+  m = GetModuleHandleA("api-ms-win-core-processthreads-l1-1-3.dll");
+  if (m != NULL) {
+    pGetThreadDescription = (void*) GetProcAddress(m, "GetThreadDescription");
+    pSetThreadDescription = (void*) GetProcAddress(m, "SetThreadDescription");
+  }
+}
+
+
 int uv_thread_setname(const char* name) {
   HRESULT hr;
   WCHAR* namew;
   int err;
   char namebuf[UV_PTHREAD_MAX_NAMELEN_NP];
+
+  uv_once(&uv__thread_name_once, uv__thread_name_init_once);
 
   if (pSetThreadDescription == NULL)
     return UV_ENOSYS;
@@ -314,6 +330,8 @@ int uv_thread_getname(uv_thread_t* tid, char* name, size_t size) {
   size_t buf_size;
   int r;
   DWORD exit_code;
+
+  uv_once(&uv__thread_name_once, uv__thread_name_init_once);
 
   if (pGetThreadDescription == NULL)
     return UV_ENOSYS;

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -284,6 +284,9 @@ int uv_thread_setname(const char* name) {
   int err;
   char namebuf[UV_PTHREAD_MAX_NAMELEN_NP];
 
+  if (pSetThreadDescription == NULL)
+    return UV_ENOSYS;
+
   if (name == NULL)
     return UV_EINVAL;
 
@@ -295,7 +298,7 @@ int uv_thread_setname(const char* name) {
   if (err)
     return err;
 
-  hr = SetThreadDescription(GetCurrentThread(), namew);
+  hr = pSetThreadDescription(GetCurrentThread(), namew);
   uv__free(namew);
   if (FAILED(hr))
     return uv_translate_sys_error(HRESULT_CODE(hr));
@@ -312,6 +315,9 @@ int uv_thread_getname(uv_thread_t* tid, char* name, size_t size) {
   int r;
   DWORD exit_code;
 
+  if (pGetThreadDescription == NULL)
+    return UV_ENOSYS;
+
   if (name == NULL || size == 0)
     return UV_EINVAL;
 
@@ -324,7 +330,7 @@ int uv_thread_getname(uv_thread_t* tid, char* name, size_t size) {
 
   namew = NULL;
   thread_name = NULL;
-  hr = GetThreadDescription(*tid, &namew);
+  hr = pGetThreadDescription(*tid, &namew);
   if (FAILED(hr))
     return uv_translate_sys_error(HRESULT_CODE(hr));
 

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -58,8 +58,8 @@ STATIC_ASSERT(sizeof(uv_thread_t) <= sizeof(void*));
 static uv_key_t uv__current_thread_key;
 static uv_once_t uv__current_thread_init_guard = UV_ONCE_INIT;
 static uv_once_t uv__thread_name_once = UV_ONCE_INIT;
-HRESULT WINAPI (*pGetThreadDescription)(HANDLE, PWSTR*);
-HRESULT WINAPI (*pSetThreadDescription)(HANDLE, PCWSTR);
+HRESULT (WINAPI *pGetThreadDescription)(HANDLE, PWSTR*);
+HRESULT (WINAPI *pSetThreadDescription)(HANDLE, PCWSTR);
 
 
 static void uv__init_current_thread_key(void) {

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -35,6 +35,8 @@ sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 sNtQueryDirectoryFile pNtQueryDirectoryFile;
 sNtQuerySystemInformation pNtQuerySystemInformation;
 sNtQueryInformationProcess pNtQueryInformationProcess;
+sGetThreadDescription pGetThreadDescription;
+sSetThreadDescription pSetThreadDescription;
 
 /* Powrprof.dll function pointer */
 sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
@@ -51,6 +53,7 @@ sGetFileInformationByName pGetFileInformationByName;
 void uv__winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE powrprof_module;
+  HMODULE kernel32_module;
   HMODULE user32_module;
   HMODULE ws2_32_module;
   HMODULE api_win_core_file_module;
@@ -121,6 +124,14 @@ void uv__winapi_init(void) {
   if (powrprof_module != NULL) {
     pPowerRegisterSuspendResumeNotification = (sPowerRegisterSuspendResumeNotification)
       GetProcAddress(powrprof_module, "PowerRegisterSuspendResumeNotification");
+  }
+
+  kernel32_module = GetModuleHandleA("kernel32.dll");
+  if (kernel32_module != NULL) {
+    pGetThreadDescription = (sGetThreadDescription)
+      GetProcAddress(kernel32_module, "GetThreadDescription");
+    pSetThreadDescription = (sSetThreadDescription)
+      GetProcAddress(kernel32_module, "SetThreadDescription");
   }
 
   user32_module = GetModuleHandleA("user32.dll");

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -35,8 +35,6 @@ sNtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
 sNtQueryDirectoryFile pNtQueryDirectoryFile;
 sNtQuerySystemInformation pNtQuerySystemInformation;
 sNtQueryInformationProcess pNtQueryInformationProcess;
-sGetThreadDescription pGetThreadDescription;
-sSetThreadDescription pSetThreadDescription;
 
 /* Powrprof.dll function pointer */
 sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
@@ -53,7 +51,6 @@ sGetFileInformationByName pGetFileInformationByName;
 void uv__winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE powrprof_module;
-  HMODULE kernelbase_module;
   HMODULE user32_module;
   HMODULE ws2_32_module;
   HMODULE api_win_core_file_module;
@@ -124,14 +121,6 @@ void uv__winapi_init(void) {
   if (powrprof_module != NULL) {
     pPowerRegisterSuspendResumeNotification = (sPowerRegisterSuspendResumeNotification)
       GetProcAddress(powrprof_module, "PowerRegisterSuspendResumeNotification");
-  }
-
-  kernelbase_module = GetModuleHandleA("kernelbase.dll");
-  if (kernelbase_module != NULL) {
-    pGetThreadDescription = (sGetThreadDescription)
-      GetProcAddress(kernelbase_module, "GetThreadDescription");
-    pSetThreadDescription = (sSetThreadDescription)
-      GetProcAddress(kernelbase_module, "SetThreadDescription");
   }
 
   user32_module = GetModuleHandleA("user32.dll");

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -53,7 +53,7 @@ sGetFileInformationByName pGetFileInformationByName;
 void uv__winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE powrprof_module;
-  HMODULE kernel32_module;
+  HMODULE kernelbase_module;
   HMODULE user32_module;
   HMODULE ws2_32_module;
   HMODULE api_win_core_file_module;
@@ -126,12 +126,12 @@ void uv__winapi_init(void) {
       GetProcAddress(powrprof_module, "PowerRegisterSuspendResumeNotification");
   }
 
-  kernel32_module = GetModuleHandleA("kernel32.dll");
-  if (kernel32_module != NULL) {
+  kernelbase_module = GetModuleHandleA("kernelbase.dll");
+  if (kernelbase_module != NULL) {
     pGetThreadDescription = (sGetThreadDescription)
-      GetProcAddress(kernel32_module, "GetThreadDescription");
+      GetProcAddress(kernelbase_module, "GetThreadDescription");
     pSetThreadDescription = (sSetThreadDescription)
-      GetProcAddress(kernel32_module, "SetThreadDescription");
+      GetProcAddress(kernelbase_module, "SetThreadDescription");
   }
 
   user32_module = GetModuleHandleA("user32.dll");

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4829,12 +4829,12 @@ typedef int (WINAPI *uv_sGetHostNameW)
 extern uv_sGetHostNameW pGetHostNameW;
 
 /* processthreadsapi.h */
-#if defined(__MINGW32__)
-WINBASEAPI
-HRESULT WINAPI GetThreadDescription(HANDLE hThread,
-                                    PWSTR *ppszThreadDescription);
-WINBASEAPI
-HRESULT WINAPI SetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription);
-#endif
+typedef HRESULT (WINAPI *sGetThreadDescription)(HANDLE hThread,
+                                                PWSTR *ppszThreadDescription);
+typedef HRESULT (WINAPI *sSetThreadDescription)(HANDLE hThread,
+                                                PCWSTR lpThreadDescription);
+
+extern sGetThreadDescription pGetThreadDescription;
+extern sSetThreadDescription pSetThreadDescription;
 
 #endif /* UV_WIN_WINAPI_H_ */

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4828,13 +4828,4 @@ typedef int (WINAPI *uv_sGetHostNameW)
              int);
 extern uv_sGetHostNameW pGetHostNameW;
 
-/* processthreadsapi.h */
-typedef HRESULT (WINAPI *sGetThreadDescription)(HANDLE hThread,
-                                                PWSTR *ppszThreadDescription);
-typedef HRESULT (WINAPI *sSetThreadDescription)(HANDLE hThread,
-                                                PCWSTR lpThreadDescription);
-
-extern sGetThreadDescription pGetThreadDescription;
-extern sSetThreadDescription pSetThreadDescription;
-
 #endif /* UV_WIN_WINAPI_H_ */


### PR DESCRIPTION
As said symbols are unavailable on Windows Server 2016.

Fixes: https://github.com/libuv/libuv/issues/4677