### PR TITLE
docs: fix RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 
 sphinx:
   builder: html
-  configuration: null
+  configuration: docs/src/conf.py
   fail_on_warning: false
 
 build:


### PR DESCRIPTION
Setting the configuration key is now mandatory: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/