### PR TITLE
fix for missing /dev/null in chrooted enviroment

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -282,6 +282,11 @@ static int uv__async_start(uv_loop_t* loop) {
      * during the cleanup, as other FDs. */
     err = uv__open_cloexec("/dev/null", O_RDONLY);
     if (err < 0)
+        /* In the rare case that "/dev/null" isn't mounted open "/"
+         * instead.
+         */
+        err = uv__open_cloexec("/", O_RDONLY);
+    if (err < 0)
       return err;
 
     pipefd[0] = err;

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -280,12 +280,7 @@ static int uv__async_start(uv_loop_t* loop) {
      * thus we create one for that, but this fd will not be actually used,
      * it's just a placeholder and magic number which is going to be closed
      * during the cleanup, as other FDs. */
-    err = uv__open_cloexec("/dev/null", O_RDONLY);
-    if (err < 0)
-        /* In the rare case that "/dev/null" isn't mounted open "/"
-         * instead.
-         */
-        err = uv__open_cloexec("/", O_RDONLY);
+    err = uv__open_cloexec("/", O_RDONLY);
     if (err < 0)
       return err;
 


### PR DESCRIPTION
In chrooted env without /dev/null uv_loop_init() fails. Use "/" instead. 
The same fix is already present in src/unix/stream.c