### PR TITLE
win: fix order of FILE_STAT_BASIC_INFORMATION struct fields

### DIFF
--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4145,8 +4145,8 @@ typedef struct _FILE_STAT_BASIC_INFORMATION {
   ULONG DeviceType;
   ULONG DeviceCharacteristics;
   ULONG Reserved;
-  FILE_ID_128 FileId128;
   LARGE_INTEGER VolumeSerialNumber;
+  FILE_ID_128 FileId128;
 } FILE_STAT_BASIC_INFORMATION;
 #endif
 


### PR DESCRIPTION
This fixes the order of the last two fields in the `FILE_STAT_BASIC_INFORMATION` struct.
Documentation: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-file_stat_basic_information