### PR TITLE
unix: Add support for affinity on openharmony

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -214,7 +214,7 @@ int uv_thread_setaffinity(uv_thread_t* tid,
     if (cpumask[i])
       CPU_SET(i, &cpuset);
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(__OHOS__)
   if (sched_setaffinity(pthread_gettid_np(*tid), sizeof(cpuset), &cpuset))
     r = errno;
   else
@@ -242,7 +242,7 @@ int uv_thread_getaffinity(uv_thread_t* tid,
     return UV_EINVAL;
 
   CPU_ZERO(&cpuset);
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(__OHOS__)
   if (sched_getaffinity(pthread_gettid_np(*tid), sizeof(cpuset), &cpuset))
     r = errno;
   else


### PR DESCRIPTION
The pthread_getaffinity_np function is not supported on OpenHarmony systems. Add **\_\_OHOS\_\_** Macro to support affinity.