### PR TITLE
unix,sunos: enable use of sendmmsg on Solaris and Illumos

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -1298,7 +1298,8 @@ static int uv__udp_sendmsgv(int fd,
   r = 0;
   nsent = 0;
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || \
+  (defined(__sun__) && defined(MSG_WAITFORONE))
   if (count > 1) {
     for (i = 0; i < count; /*empty*/) {
       struct mmsghdr m[20];
@@ -1325,7 +1326,9 @@ static int uv__udp_sendmsgv(int fd,
 
     goto exit;
   }
-#endif  /* defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) */
+#endif  /* defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) ||
+	 * (defined(__sun__) && defined(MSG_WAITFORONE))
+	 */
 
   for (i = 0; i < count; i++, nsent++)
     if ((r = uv__udp_sendmsg1(fd, bufs[i], nbufs[i], addrs[i])))


### PR DESCRIPTION
Solaris provides sendmmsg() as of 11.3.32.
It was added at the same time as MSG_WAITFORONE.

The same is seen in Illumos guarded by __BSD_VISIBLE

Fixes: https://github.com/libuv/libuv/issues/4715