### PR TITLE
Free pointer `lib` before function returns.

### DIFF
--- a/docs/code/plugin/main.c
+++ b/docs/code/plugin/main.c
@@ -34,6 +34,6 @@ int main(int argc, char **argv) {
 
         init_plugin();
     }
-
+    free(lib);
     return 0;
 }

--- a/docs/code/plugin/main.c
+++ b/docs/code/plugin/main.c
@@ -34,6 +34,5 @@ int main(int argc, char **argv) {
 
         init_plugin();
     }
-    
     return 0;
 }

--- a/docs/code/plugin/main.c
+++ b/docs/code/plugin/main.c
@@ -18,22 +18,22 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    uv_lib_t *lib = (uv_lib_t*) malloc(sizeof(uv_lib_t));
+    uv_lib_t lib;
     while (--argc) {
         fprintf(stderr, "Loading %s\n", argv[argc]);
-        if (uv_dlopen(argv[argc], lib)) {
-            fprintf(stderr, "Error: %s\n", uv_dlerror(lib));
+        if (uv_dlopen(argv[argc], &lib)) {
+            fprintf(stderr, "Error: %s\n", uv_dlerror(&lib));
             continue;
         }
 
         init_plugin_function init_plugin;
-        if (uv_dlsym(lib, "initialize", (void **) &init_plugin)) {
-            fprintf(stderr, "dlsym error: %s\n", uv_dlerror(lib));
+        if (uv_dlsym(&lib, "initialize", (void **) &init_plugin)) {
+            fprintf(stderr, "dlsym error: %s\n", uv_dlerror(&lib));
             continue;
         }
 
         init_plugin();
     }
-    free(lib);
+    
     return 0;
 }


### PR DESCRIPTION
In function main, the pointer lib allocated at line 7 is passed as an argument to functions uv_dlopen at line 10, uv_dlerror at lines 11 and 17, and uv_dlsym at line 16, but it is never freed before the function returns at line 24. This results in a memory leak bug.

Thus we add a free operation before the function returns.