### PR TITLE
Free `loop` objects in function `thread2_worker`

### DIFF
--- a/docs/code/signal/main.c
+++ b/docs/code/signal/main.c
@@ -49,6 +49,8 @@ void thread2_worker(void *userp)
 
     while (uv_run(loop2, UV_RUN_NOWAIT) || uv_run(loop3, UV_RUN_NOWAIT)) {
     }
+    free(loop2);
+    free(loop3);
 }
 
 int main()


### PR DESCRIPTION
The function `create_loop()` returns a loop object. 
```c
uv_loop_t* create_loop()
{
    uv_loop_t *loop = malloc(sizeof(uv_loop_t));    // memory allocated here
    if (loop) {
      uv_loop_init(loop);
    }
    return loop;
}
``` 
In function `thread2_worker`, the pointers `loop2` and `loop3` are not freed, causing a memory leak bug.