### PR TITLE
unix: handle out of memory in iface name copy

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1120,6 +1120,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   struct ifreq *ifr, *p, flg;
   struct in6_ifreq if6;
   struct sockaddr_dl* sa_addr;
+  size_t namelen;
+  char* name;
 
   ifc.ifc_req = NULL;
   sock6fd = -1;
@@ -1156,6 +1158,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 #define ADDR_SIZE(p) MAX((p).sa_len, sizeof(p))
 
   /* Count all up and running ipv4/ipv6 addresses */
+  namelen = 0;
   ifr = ifc.ifc_req;
   while ((char*)ifr < (char*)ifc.ifc_req + ifc.ifc_len) {
     p = ifr;
@@ -1175,6 +1178,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (!(flg.ifr_flags & IFF_UP && flg.ifr_flags & IFF_RUNNING))
       continue;
 
+    namelen += strlen(ent->ifa_name) + 1;
     (*count)++;
   }
 
@@ -1182,8 +1186,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     goto cleanup;
 
   /* Alloc the return interface structs */
-  *addresses = uv__calloc(*count, sizeof(**addresses));
-  if (!(*addresses)) {
+  *addresses = uv__calloc(1, *count * sizeof(**addresses) + namelen);
+  if (*addresses == NULL) {
     r = UV_ENOMEM;
     goto cleanup;
   }
@@ -1210,7 +1214,9 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
     /* All conditions above must match count loop */
 
-    address->name = uv__strdup(p->ifr_name);
+    namelen = strlen(p->ifr_name) + 1;
+    address->name = memcpy(name, p->ifr_name, namelen);
+    name += namelen;
 
     if (inet6)
       address->address.address6 = *((struct sockaddr_in6*) &p->ifr_addr);
@@ -1282,13 +1288,7 @@ cleanup:
 
 
 void uv_free_interface_addresses(uv_interface_address_t* addresses,
-  int count) {
-  int i;
-
-  for (i = 0; i < count; ++i) {
-    uv__free(addresses[i].name);
-  }
-
+                                 int count) {
   uv__free(addresses);
 }
 

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -403,6 +403,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     return UV_ENOSYS;
 
   /* The first loop to get the size of the array to be allocated */
+  namelen = 0;
   for (cur = ifap; cur; cur = cur->ifa_next) {
     if (!(cur->ifa_addr->sa_family == AF_INET6 ||
           cur->ifa_addr->sa_family == AF_INET))
@@ -411,6 +412,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (!(cur->ifa_flags & IFF_UP && cur->ifa_flags & IFF_RUNNING))
       continue;
 
+    namelen += strlen(cur->ifa_name) + 1;
     (*count)++;
   }
 
@@ -420,11 +422,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   }
 
   /* Alloc the return interface structs */
-  *addresses = uv__calloc(*count, sizeof(**addresses));
+  *addresses = uv__calloc(1, *count * sizeof(**addresses) + namelen);
   if (*addresses == NULL) {
     Qp2freeifaddrs(ifap);
     return UV_ENOMEM;
   }
+
+  name = (char*) &(*addresses)[*count];
   address = *addresses;
 
   /* The second loop to fill in the array */
@@ -436,7 +440,9 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     if (!(cur->ifa_flags & IFF_UP && cur->ifa_flags & IFF_RUNNING))
       continue;
 
-    address->name = uv__strdup(cur->ifa_name);
+    namelen = strlen(cur->ifa_name) + 1;
+    address->name = memcpy(name, cur->ifa_name, namelen);
+    name += namelen;
 
     inet6 = (cur->ifa_addr->sa_family == AF_INET6);
 
@@ -497,13 +503,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses, int count) {
-  int i;
-
-  for (i = 0; i < count; ++i) {
-    uv__free(addresses[i].name);
-  }
-
+void uv_free_interface_addresses(uv_interface_address_t* addresses,
+                                 int count) {
   uv__free(addresses);
 }
 


### PR DESCRIPTION
Allocate storage upfront, that way we can never run out of memory halfway through processing the interface list.

Fixes: https://github.com/libuv/libuv/issues/4723