### PR TITLE
openbsd: do not error out if cpuspeed is not available

### DIFF
--- a/src/unix/openbsd.c
+++ b/src/unix/openbsd.c
@@ -211,8 +211,16 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   which[1] = HW_CPUSPEED;
   size = sizeof(cpuspeed);
-  if (sysctl(which, ARRAY_SIZE(which), &cpuspeed, &size, NULL, 0))
+  cpuspeed = 0;
+  /*
+   * HW_CPUSPEED can return EOPNOTSUPP if cpuspeed is 0,
+   * so ignore that and continue the flow, because we
+   * still care about the rest of the CPU info.
+   */
+  if (sysctl(which, ARRAY_SIZE(which), &cpuspeed, &size, NULL, 0) &&
+      (errno != EOPNOTSUPP)) {
     goto error;
+  }
 
   size = sizeof(info);
   for (i = 0; i < numcpus; i++) {


### PR DESCRIPTION
On OpenBSD we do not know the cpuspeed in same cases (mostly arm64) and the HW_CPUSPEED sysctl will return EOPNOTSUPP in that case, which can be ignored because we still need the rest of the CPU information.