### PR TITLE
test: aix/ibmi skip thread_name_threadpool

### DIFF
--- a/test/test-thread-name.c
+++ b/test/test-thread-name.c
@@ -178,6 +178,10 @@ static void after_work_cb(uv_work_t* req, int status) {
 }
 
 TEST_IMPL(thread_name_threadpool) {
+
+#if defined(_AIX) || defined(__PASE__)
+  RETURN_SKIP("API not available on this platform");
+#endif
   uv_work_t req;
   loop = uv_default_loop();
   // Just to make sure all workers will be executed


### PR DESCRIPTION
`uv_thread_getname` is not available on aix and ibm i

Same issue as thread_name test case
see: https://github.com/libuv/libuv/pull/4599#issuecomment-2498376606

CC
@libuv/ibmi 
@libuv/aix 