### PR TITLE
unix,sunos: prefer SO_REUSEPORT for Load-balancing

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -300,6 +300,9 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
  *
  * zOS does not support getsockname with SO_REUSEPORT option when using
  * AF_UNIX.
+ *
+ * Solaris 11.4: SO_REUSEPORT will not load balance when SO_REUSEADDR
+ * is also set, but it's not valid for every socket type.
  */
 static int uv__sock_reuseaddr(int fd) {
   int yes;
@@ -317,8 +320,20 @@ static int uv__sock_reuseaddr(int fd) {
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
        return UV__ERR(errno);
   }
-#elif defined(SO_REUSEPORT) && !defined(__linux__) && !defined(__GNU__) && \
-	!defined(__sun__) && !defined(__DragonFly__) && !defined(_AIX73)
+#elif defined(SO_REUSEPORT) && (defined(UV__SOLARIS_11_4) && UV__SOLARIS_11_4)
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes))) {
+    if (errno != ENOPROTOOPT) {
+      return UV__ERR(errno);
+    }
+    /* Not all socket types accept SO_REUSEPORT. */
+    errno = 0;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes))) {
+      return UV__ERR(errno);
+    }
+  }
+#elif defined(SO_REUSEPORT) && \
+  !defined(__linux__) && !defined(__GNU__) && \
+  !defined(__illumos__) && !defined(__DragonFly__) && !defined(_AIX73)
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
     return UV__ERR(errno);
 #else


### PR DESCRIPTION
Solaris 11.4 has Load Balancing for SO_REUSEPORT, but setting SO_REUSEADDR disables load balancing.  As per comments in test/test-udp-reuseport.c prefer SO_REUSEPORT when available.

With these changes in place udp-reuseport testing passes.  BIND (named), which uses routing sockets which cause ENOPROTOOPT to be returned when SO_REUSEPORT is requested, also continues to work with the change.

Notes:
- The use of getsockopt() to query if SO_REUSEPORT was available was erroneous.
- Selectively limiting SO_REUSEPORT setting to specific types of socket was considered but not entertained.
- Oracle will investigate if the setting of SO_REUSEADDR was intentionally ment to prevent load balancing.
- Adding a test for routing sockets is left for future work.

Fixes: https://github.com/libuv/libuv/issues/4732