### PR TITLE
style: rename parameter to match definition

### DIFF
--- a/src/fs-poll.c
+++ b/src/fs-poll.c
@@ -51,7 +51,7 @@ struct poll_ctx {
 static int statbuf_eq(const uv_stat_t* a, const uv_stat_t* b);
 static void poll_cb(uv_fs_t* req);
 static void timer_cb(uv_timer_t* timer);
-static void timer_close_cb(uv_handle_t* handle);
+static void timer_close_cb(uv_handle_t* timer);
 
 static uv_stat_t zero_statbuf;
 


### PR DESCRIPTION
Rename the `handle` parameter of `timer_close_cb`'s declaration to `timer` to match the definition.