### PR TITLE
test: support partial output lines in test runner

### DIFF
--- a/test/runner-unix.c
+++ b/test/runner-unix.c
@@ -367,6 +367,7 @@ long int process_output_size(process_info_t *p) {
 /* Copy the contents of the stdio output buffer to `fd`. */
 int process_copy_output(process_info_t* p, FILE* stream) {
   char buf[1024];
+  int partial;
   int r;
 
   r = fseek(p->stdout_file, 0, SEEK_SET);
@@ -375,9 +376,9 @@ int process_copy_output(process_info_t* p, FILE* stream) {
     return -1;
   }
 
-  /* TODO: what if the line is longer than buf */
+  partial = 0;
   while ((r = fread(buf, 1, sizeof(buf), p->stdout_file)) != 0)
-    print_lines(buf, r, stream);
+    partial = print_lines(buf, r, stream, partial);
 
   if (ferror(p->stdout_file)) {
     perror("read");

--- a/test/runner-win.c
+++ b/test/runner-win.c
@@ -219,6 +219,7 @@ long int process_output_size(process_info_t *p) {
 
 int process_copy_output(process_info_t* p, FILE* stream) {
   char buf[1024];
+  int partial;
   int fd, r;
 
   fd = _open_osfhandle((intptr_t)p->stdio_out, _O_RDONLY | _O_TEXT);
@@ -229,8 +230,9 @@ int process_copy_output(process_info_t* p, FILE* stream) {
   if (r < 0)
     return -1;
 
+  partial = 0;
   while ((r = _read(fd, buf, sizeof(buf))) != 0)
-    print_lines(buf, r, stream);
+    partial = print_lines(buf, r, stream, partial);
 
   _close(fd);
   return 0;

--- a/test/runner.c
+++ b/test/runner.c
@@ -426,13 +426,17 @@ void print_tests(FILE* stream) {
 }
 
 
-void print_lines(const char* buffer, size_t size, FILE* stream) {
+int print_lines(const char* buffer, size_t size, FILE* stream, int partial) {
   const char* start;
   const char* end;
 
   start = buffer;
   while ((end = memchr(start, '\n', &buffer[size] - start))) {
-    fputs("# ", stream);
+    if (partial == 0)
+      fputs("# ", stream);
+    else
+      partial = 0;
+
     fwrite(start, 1, (int)(end - start), stream);
     fputs("\n", stream);
     fflush(stream);
@@ -441,9 +445,13 @@ void print_lines(const char* buffer, size_t size, FILE* stream) {
 
   end = &buffer[size];
   if (start < end) {
-    fputs("# ", stream);
+    if (partial == 0)
+      fputs("# ", stream);
+
     fwrite(start, 1, (int)(end - start), stream);
-    fputs("\n", stream);
     fflush(stream);
+    return 1;
   }
+
+  return 0;
 }

--- a/test/runner.h
+++ b/test/runner.h
@@ -123,7 +123,7 @@ int run_test_part(const char* test, const char* part);
 void print_tests(FILE* stream);
 
 /* Print lines in |buffer| as TAP diagnostics to |stream|. */
-void print_lines(const char* buffer, size_t size, FILE* stream);
+int print_lines(const char* buffer, size_t size, FILE* stream, int partial);
 
 /*
  * Stuff that should be implemented by test-runner-<platform>.h


### PR DESCRIPTION
This commit updates the test runner's print_lines() logic to better handle partial lines.

Prior to this change, I was seeing output like this (you can observe this in the CI as well):

```
# uv_os_getpid: 62220
# uv_os_getp
# pid: 62203
```

After this change, I'm seeing:

```
# uv_os_getpid: 66695
# uv_os_getppid: 66681
```