### PR TITLE
linux: align CPU quota calculation with Rust's cgroup heuristics

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -2023,14 +2023,11 @@ unsigned int uv_available_parallelism(void) {
 
 #ifdef __linux__
   {
-    double rc_with_cgroup;
-    uv__cpu_constraint c = {0, 0, 0.0};
+    long long quota = 0;
 
-    if (uv__get_constrained_cpu(&c) == 0 && c.period_length > 0) {
-      rc_with_cgroup = (double)c.quota_per_period / c.period_length * c.proportions;
-      if (rc_with_cgroup < rc)
-        rc = (long)rc_with_cgroup; /* Casting is safe since rc_with_cgroup < rc < LONG_MAX */
-    }
+    if (uv__get_constrained_cpu(&quota) == 0)
+      if (quota > 0 && quota < rc)
+        rc = quota;
   }
 #endif  /* __linux__ */
 

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -489,13 +489,7 @@ uv__fs_copy_file_range(int fd_in,
 #endif
 
 #ifdef __linux__
-typedef struct {
-  long long quota_per_period;
-  long long period_length;
-  double proportions;
-} uv__cpu_constraint;
-
-int uv__get_constrained_cpu(uv__cpu_constraint* constraint);
+int uv__get_constrained_cpu(long long* quota);
 #endif
 
 #if defined(__sun) && !defined(__illumos__)


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/4740