### PR TITLE
pipe2: support pipe2 on solaris and illumos

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -496,7 +496,9 @@ int uv_pipe(uv_os_fd_t fds[2], int read_flags, int write_flags) {
     defined(__FreeBSD__) || \
     defined(__OpenBSD__) || \
     defined(__DragonFly__) || \
-    defined(__NetBSD__)
+    defined(__NetBSD__) || \
+    defined(__illumos__) || \
+    (defined(UV__SOLARIS_11_4) && UV__SOLARIS_11_4)
   int flags = O_CLOEXEC;
 
   if ((read_flags & UV_NONBLOCK_PIPE) && (write_flags & UV_NONBLOCK_PIPE))


### PR DESCRIPTION
Solaris implemented pipe2 in 11.4 and illumos have had it since 2013.

Ref:
https://docs.oracle.com/cd/E88353_01/html/E37841/pipe2-2.html
https://illumos.org/man/2/pipe2
https://www.illumos.org/issues/3714