### PR TITLE
Use uint32 vs. uint32_t for Haiku API

### DIFF
--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -120,7 +120,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   int i;
   status_t status;
   system_info system;
-  uint32_t topology_count;
+  uint32 topology_count;  /* Haiku expects address of uint32, not uint32_t */
   uint64_t cpuspeed;
   uv_cpu_info_t* cpu_info;
 


### PR DESCRIPTION
Haiku has parallel types to `stdint.h`, and their APIs use these types.  In the Haiku-specific `haiku.h` file, it is passing an address of a `uint32_t` to `get_cpu_topology_info()`, that expects the other `uint32`:

https://github.com/haiku/haiku/blob/648fa5897c28d5a4c8a5b4992dbf9b9d410434c8/src/system/libroot/os/system_info.cpp#L187

You get an "incompatible-pointer-types" warning in gcc if the warnings are turned up.  But if you pass the pointer to Haiku's notion of `uint32`, then the warning goes away.