### PR TITLE
doc: update thread pool stack size comment

### DIFF
--- a/docs/src/threadpool.rst
+++ b/docs/src/threadpool.rst
@@ -20,10 +20,10 @@ is 1024).
 .. versionchanged:: 1.50.0 threads now have a default name of libuv-worker.
 
 The threadpool is global and shared across all event loops. When a particular
-function makes use of the threadpool (i.e. when using :c:func:`uv_queue_work`)
+function makes use of the threadpool (e.g. when using :c:func:`uv_queue_work`)
 libuv preallocates and initializes the maximum number of threads allowed by
-``UV_THREADPOOL_SIZE``. This causes a relatively minor memory overhead
-(~1MB for 128 threads) but increases the performance of threading at runtime.
+``UV_THREADPOOL_SIZE``. More threads usually means more throughput but a higher
+memory footprint. Thread stacks grow lazily on most platforms though.
 
 .. note::
     Note that even though a global thread pool which is shared across all events


### PR DESCRIPTION
I changed the default stack size in commit 73b0c1f94 from October 2022 and although I added a versionchanged note, I didn't update the blurb a few lines below.

It wasn't accurate before that change either though, because even with musl libc's ~80kb thread stacks, 128 threads works out to 10 MB.

Refs: https://github.com/nodejs/node/issues/57911