### PR TITLE
sunos: use uv__io_init_start to simplify fs event watcher setup

### DIFF
--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -546,8 +546,15 @@ int uv_fs_event_start(uv_fs_event_t* handle,
   }
 
   if (first_run) {
-    uv__io_init(&handle->loop->fs_event_watcher, uv__fs_event_read, portfd);
-    uv__io_start(handle->loop, &handle->loop->fs_event_watcher, POLLIN);
+    err = uv__io_init_start(handle->loop,
+                             &handle->loop->fs_event_watcher,
+                             uv__fs_event_read,
+                             portfd,
+                             POLLIN);
+    if (err)
+      uv__handle_stop(handle);
+
+    return err;
   }
 
   return 0;


### PR DESCRIPTION
---
Sadly I don't have a SunOS, but I believe this is what we should be doing.