### PR TITLE
build: add shorter instructions for CMake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,7 @@ $ make install
 To build with [CMake][]:
 
 ```bash
-$ mkdir -p build
-
-$ (cd build && cmake .. -DBUILD_TESTING=ON) # generate project with tests
+$ cmake -B build -DBUILD_TESTING=ON         # generate project with tests
 $ cmake --build build                       # add `-j <n>` with cmake >= 3.12
 
 # Run tests:


### PR DESCRIPTION
---
This is quite irrelevant, but I have this believe of having simpler instructions to compile will reduce a bit the friction for new contributors and stuff.