### PR TITLE
src: remove unused include of <assert.h> in timer.c

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -22,7 +22,6 @@
 #include "uv-common.h"
 #include "heap-inl.h"
 
-#include <assert.h>
 #include <limits.h>
 
 


### PR DESCRIPTION
---
Another day, another trivial patch.