### PR TITLE
build: deduplicate sanitizer jobs using matrix strategy

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -51,7 +51,7 @@ jobs:
           disable-animations: true
           script: |
             echo "::group::Configure"
-            cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="x86_64" -DANDROID_PLATFORM=android-30
+            cmake -B build -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI="x86_64" -DANDROID_PLATFORM=android-30
             echo "::endgroup::"
 
             echo "::group::Build"
@@ -95,9 +95,7 @@ jobs:
           brew install ninja automake libtool
       - name: Configure
         run: |
-          mkdir build
-          cd build
-          cmake .. -DBUILD_TESTING=ON -G Ninja
+          cmake -B build -DBUILD_TESTING=ON -G Ninja
       - name: Build
         run: |
           cmake --build build
@@ -129,9 +127,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure
         run: |
-          mkdir build-ios
-          cd build-ios
-          cmake .. -GXcode -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DCMAKE_CONFIGURATION_TYPES:STRING=Release
+          cmake -B build-ios -GXcode -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DCMAKE_CONFIGURATION_TYPES:STRING=Release
       - name: Build
         run: |
           cmake --build build-ios
@@ -170,9 +166,7 @@ jobs:
           sudo apt install qemu-user qemu-user-binfmt ${{ matrix.config.toolchain }} -y
       - name: Configure with ${{ matrix.config.cc }}
         run: |
-          mkdir build
-          cd build
-          cmake .. -DBUILD_TESTING=ON -DQEMU=ON -DCMAKE_C_COMPILER=${{ matrix.config.cc }}
+          cmake -B build -DBUILD_TESTING=ON -DQEMU=ON -DCMAKE_C_COMPILER=${{ matrix.config.cc }}
       - name: Build
         run: |
           cmake --build build

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -86,7 +86,7 @@ jobs:
           sudo apt install mingw-w64 ninja-build -y
       - name: Build
         run: |
-          cmake -S . -B build -G Ninja -DHOST_ARCH=${{ matrix.config.arch }} -DBUILD_TESTING=ON -DCMAKE_TOOLCHAIN_FILE=cmake-toolchains/cross-mingw32.cmake
+          cmake -B build -G Ninja -DHOST_ARCH=${{ matrix.config.arch }} -DBUILD_TESTING=ON -DCMAKE_TOOLCHAIN_FILE=cmake-toolchains/cross-mingw32.cmake
           cmake --build build
           cmake --install build --prefix "`pwd`/build/usr"
           mkdir -p build/usr/test build/usr/bin

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -15,6 +15,17 @@ on:
 jobs:
   sanitizers-linux:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        config:
+          - name: ASAN
+            flags: -DASAN=ON -DCMAKE_BUILD_TYPE=Debug
+          - name: MSAN
+            flags: -DMSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang
+          - name: TSAN
+            flags: -DTSAN=ON -DCMAKE_BUILD_TYPE=Release
+          - name: UBSAN
+            flags: -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -28,78 +39,44 @@ jobs:
         run: |
           sudo sysctl -w kernel.randomize_va_space=0
 
-      - name: ASAN Build
+      - name: Build ${{ matrix.config.name }}
         run: |
-          mkdir build-asan
-          (cd build-asan && cmake .. -G Ninja -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug)
-          cmake --build build-asan
-      - name: ASAN Test
-        run: |
-          ./build-asan/uv_run_tests_a
+          cmake -B build -G Ninja -DBUILD_TESTING=ON ${{ matrix.config.flags }}
+          cmake --build build
 
-      - name: MSAN Build
+      - name: Test ${{ matrix.config.name }}
         run: |
-          mkdir build-msan
-          (cd build-msan && cmake .. -G Ninja -DBUILD_TESTING=ON -DMSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang)
-          cmake --build build-msan
-      - name: MSAN Test
-        run: |
-          ./build-msan/uv_run_tests_a
-
-      - name: TSAN Build
-        run: |
-          mkdir build-tsan
-          (cd build-tsan && cmake .. -G Ninja -DBUILD_TESTING=ON -DTSAN=ON -DCMAKE_BUILD_TYPE=Release)
-          cmake --build build-tsan
-      - name: TSAN Test
-        # Note: path must be absolute because some tests chdir.
-        # TSan exits with an error when it can't find the file.
-        run: |
-          env TSAN_OPTIONS="suppressions=$PWD/tsansupp.txt" ./build-tsan/uv_run_tests_a
-
-      - name: UBSAN Build
-        run: |
-          mkdir build-ubsan
-          (cd build-ubsan && cmake .. -G Ninja -DBUILD_TESTING=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang)
-          cmake --build build-ubsan
-      - name: UBSAN Test
-        run: |
-          ./build-ubsan/uv_run_tests_a
+          # Note: path must be absolute because some tests chdir.
+          # TSan exits with an error when it can't find the file.
+          if [ "${{ matrix.config.name }}" = "TSAN" ]; then
+            env TSAN_OPTIONS="suppressions=$PWD/tsansupp.txt" ./build/uv_run_tests_a
+          else
+            ./build/uv_run_tests_a
+          fi
 
   sanitizers-macos:
     runs-on: macos-13
+    strategy:
+      matrix:
+        config:
+          - name: ASAN
+            flags: -DASAN=ON -DCMAKE_BUILD_TYPE=Debug
+          - name: TSAN
+            flags: -DTSAN=ON -DCMAKE_BUILD_TYPE=Release
+          - name: UBSAN
+            flags: -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug
     steps:
       - uses: actions/checkout@v4
 
       - name: Envinfo
         run: npx envinfo
 
-      - name: ASAN Build
+      - name: Build ${{ matrix.config.name }}
         run: |
-          mkdir build-asan
-          (cd build-asan && cmake .. -DBUILD_TESTING=ON -DASAN=ON -DCMAKE_BUILD_TYPE=Debug)
-          cmake --build build-asan
-      - name: ASAN Test
-        run: |
-          ./build-asan/uv_run_tests_a
-
-      - name: TSAN Build
-        run: |
-          mkdir build-tsan
-          (cd build-tsan && cmake .. -DBUILD_TESTING=ON -DTSAN=ON -DCMAKE_BUILD_TYPE=Release)
-          cmake --build build-tsan
-      - name: TSAN Test
-        run: |
-          ./build-tsan/uv_run_tests_a
-
-      - name: UBSAN Build
-        run: |
-          mkdir build-ubsan
-          (cd build-ubsan && cmake .. -DBUILD_TESTING=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug)
-          cmake --build build-ubsan
-      - name: UBSAN Test
-        run: |
-          ./build-ubsan/uv_run_tests_a
+          cmake -B build -DBUILD_TESTING=ON ${{ matrix.config.flags }}
+          cmake --build build
+      - name: Test ${{ matrix.config.name }}
+        run: ./build/uv_run_tests_a
 
   sanitizers-windows:
     runs-on: windows-2022
@@ -120,7 +97,6 @@ jobs:
 
       - name: UBSAN Build
         run: |
-          mkdir build-ubsan
           cmake -B build-ubsan -G Ninja -DBUILD_TESTING=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang
           cmake --build build-ubsan
       - name: UBSAN Test


### PR DESCRIPTION
---
This is gonna make the gh-actions pipelines a bit shorter and will use our latest cmake build instructions.