### PR TITLE
unix: fix uv_thread_{get,set}priority returning incorrect error codes

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1656,7 +1656,7 @@ int uv_thread_getpriority(uv_thread_t tid, int* priority) {
 
   r = pthread_getschedparam(tid, &policy, &param);
   if (r != 0)
-    return UV__ERR(errno);
+    return UV__ERR(r);
 
 #ifdef __linux__
   if (SCHED_OTHER == policy && pthread_equal(tid, pthread_self())) {
@@ -1709,7 +1709,7 @@ int uv_thread_setpriority(uv_thread_t tid, int priority) {
 
   r = pthread_getschedparam(tid, &policy, &param);
   if (r != 0)
-    return UV__ERR(errno);
+    return UV__ERR(r);
 
 #ifdef __linux__
 /**
@@ -1757,7 +1757,7 @@ int uv_thread_setpriority(uv_thread_t tid, int priority) {
     param.sched_priority = prio;
     r = pthread_setschedparam(tid, policy, &param);
     if (r != 0)
-      return UV__ERR(errno);
+      return UV__ERR(r);
   }
 
   return 0;

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1519,20 +1519,26 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
 }
 
 int uv_thread_getpriority(uv_thread_t tid, int* priority) {
+  DWORD err;
   int r;
 
   if (priority == NULL)
     return UV_EINVAL;
 
   r = GetThreadPriority(tid);
-  if (r == THREAD_PRIORITY_ERROR_RETURN)
-    return uv_translate_sys_error(GetLastError());
+  if (r == THREAD_PRIORITY_ERROR_RETURN) {
+    err = GetLastError();
+    if (err == ERROR_INVALID_HANDLE)
+      return UV_ESRCH;
+    return uv_translate_sys_error(err);
+  }
 
   *priority = r;
   return 0;
 }
 
 int uv_thread_setpriority(uv_thread_t tid, int priority) {
+  DWORD err;
   int r;
 
   switch (priority) {
@@ -1555,8 +1561,12 @@ int uv_thread_setpriority(uv_thread_t tid, int priority) {
       return 0;
   }
 
-  if (r == 0)
-    return uv_translate_sys_error(GetLastError());
+  if (r == 0) {
+    err = GetLastError();
+    if (err == ERROR_INVALID_HANDLE)
+      return UV_ESRCH;
+    return uv_translate_sys_error(err);
+  }
 
   return 0;
 }

--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -102,10 +102,7 @@ TEST_IMPL(thread_priority) {
   uv_sem_destroy(&sem);
 
   /* Now that the thread no longer exists, verify that the relevant error is returned */
-#ifdef _WIN32
-  ASSERT_EQ(UV_EBADF, uv_thread_getpriority(task_id, &priority));
-  ASSERT_EQ(UV_EBADF, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
-#elif !defined(__ANDROID__)
+#if !defined(__ANDROID__)
   ASSERT_EQ(UV_ESRCH, uv_thread_getpriority(task_id, &priority));
   ASSERT_EQ(UV_ESRCH, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
 #endif

--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -101,5 +101,14 @@ TEST_IMPL(thread_priority) {
 
   uv_sem_destroy(&sem);
 
+  /* Now that the thread no longer exists, verify that the relevant error is returned */
+#ifdef _WIN32
+  ASSERT_EQ(UV_EBADF, uv_thread_getpriority(task_id, &priority));
+  ASSERT_EQ(UV_EBADF, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
+#elif !defined(__ANDROID__)
+  ASSERT_EQ(UV_ESRCH, uv_thread_getpriority(task_id, &priority));
+  ASSERT_EQ(UV_ESRCH, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
+#endif
+
   return 0;
 }


### PR DESCRIPTION
pthread_getschedparam and pthread_setschedparam do not use errno but instead return the error code directly.

https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_getschedparam.html