### PR TITLE
Fix documentation to say UV_LOOP_USE_IO_URING_SQPOLL  instead of  UV_LOOP_ENABLE_IO_URING_SQPOLL

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -19,7 +19,7 @@ observable behavior. Libuv reverts to using its threadpool when the necessary
 kernel features are unavailable or unsuitable. Starting with libuv v1.49.0 this
 behavior was reverted and Libuv on Linux by default will be using the threadpool
 again. In order to enable io_uring the :c:type:`uv_loop_t` instance must be
-configured with the :c:type:`UV_LOOP_ENABLE_IO_URING_SQPOLL` option.
+configured with the :c:type:`UV_LOOP_USE_IO_URING_SQPOLL` option.
 
 .. note::
      On Windows `uv_fs_*` functions use utf-8 encoding.

--- a/docs/src/loop.rst
+++ b/docs/src/loop.rst
@@ -86,12 +86,12 @@ API
 
       This option is necessary to use :c:func:`uv_metrics_idle_time`.
 
-    - UV_LOOP_ENABLE_IO_URING_SQPOLL: Enable SQPOLL io_uring instance to handle
+    - UV_LOOP_USE_IO_URING_SQPOLL: Enable SQPOLL io_uring instance to handle
       asynchronous file system operations.
 
     .. versionchanged:: 1.39.0 added the UV_METRICS_IDLE_TIME option.
 
-    .. versionchanged:: 1.49.0 added the UV_LOOP_ENABLE_IO_URING_SQPOLL option.
+    .. versionchanged:: 1.49.0 added the UV_LOOP_USE_IO_URING_SQPOLL option.
 
 .. c:function:: int uv_loop_close(uv_loop_t* loop)
 


### PR DESCRIPTION
The documentation is referring to an internal name - UV_LOOP_ENABLE_IO_URING_SQPOLL - in several places, fix this by using the public UV_LOOP_USE_IO_URING_SQPOLL name instead.