### PR TITLE
doc: update ncurses link

### DIFF
--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -435,7 +435,7 @@ As you can see this is very useful to produce nicely formatted output, or even
 console based arcade games if that tickles your fancy. For fancier control you
 can try `ncurses`_.
 
-.. _ncurses: https://www.gnu.org/software/ncurses/ncurses.html
+.. _ncurses: https://invisible-island.net/ncurses/announce.html
 
 .. versionchanged:: 1.23.1: the `readable` parameter is now unused and ignored.
                     The appropriate value will now be auto-detected from the kernel.


### PR DESCRIPTION
The link at gnu.org is a redirect now and the docs linter breaks some times.