### PR TITLE
include: remove unused private macro undefs from uv.h

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1969,7 +1969,6 @@ UV_EXTERN void uv_wtf8_to_utf16(const char* wtf8,
                                 size_t utf16_len);
 
 /* Don't export the private CPP symbols. */
-#undef UV_HANDLE_TYPE_PRIVATE
 #undef UV_REQ_TYPE_PRIVATE
 #undef UV_REQ_PRIVATE_FIELDS
 #undef UV_STREAM_PRIVATE_FIELDS
@@ -1981,12 +1980,10 @@ UV_EXTERN void uv_wtf8_to_utf16(const char* wtf8,
 #undef UV_TIMER_PRIVATE_FIELDS
 #undef UV_GETADDRINFO_PRIVATE_FIELDS
 #undef UV_GETNAMEINFO_PRIVATE_FIELDS
-#undef UV_FS_REQ_PRIVATE_FIELDS
 #undef UV_WORK_PRIVATE_FIELDS
 #undef UV_FS_EVENT_PRIVATE_FIELDS
 #undef UV_SIGNAL_PRIVATE_FIELDS
 #undef UV_LOOP_PRIVATE_FIELDS
-#undef UV_LOOP_PRIVATE_PLATFORM_FIELDS
 #undef UV__ERR
 
 #ifdef __cplusplus


### PR DESCRIPTION
These macros are not defined in the public headers