### PR TITLE
Fix potential null dereference in uv__print_handles() when uv_default_loop() fails

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -575,16 +575,16 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
   struct uv__queue* q;
   uv_handle_t* h;
 
+  if (stream == NULL)
+    stream = stderr;
+
   if (loop == NULL) {
     loop = uv_default_loop();
     if (loop == NULL) {
-      fprintf(stderr, "uv_default_loop() failed\n");
+      fprintf(stream, "uv_default_loop() failed\n");
       return;
     }
   }
-
-  if (stream == NULL)
-    stream = stderr;
 
   uv__queue_foreach(q, &loop->handle_queue) {
     h = uv__queue_data(q, uv_handle_t, handle_queue);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -575,8 +575,13 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
   struct uv__queue* q;
   uv_handle_t* h;
 
-  if (loop == NULL)
+  if (loop == NULL) {
     loop = uv_default_loop();
+    if (loop == NULL) {
+      fprintf(stderr, "uv_default_loop() failed\n");
+      return;
+    }
+  }
 
   if (stream == NULL)
     stream = stderr;


### PR DESCRIPTION
### Describe the bug

Hi, 
This patch fixes a potential null pointer dereference in `src/uv-common.c` inside the `uv__print_handles()` function.

When `loop` is `NULL`, it falls back to `uv_default_loop()`, but the return value is not checked. As a result, if `uv_default_loop()` returns `NULL`, the subsequent call to `uv__queue_foreach(q, &loop->handle_queue)` will dereference a null pointer, leading to undefined behavior or a crash.

### Version

Main branch (as of b00c5d)

### Expected behavior

In `src/uv-common.c`, the function `uv__print_handles()` attempts to use `uv_default_loop()` when the input `loop` parameter is `NULL`. This occurs at line 579:

```c
if (loop == NULL)
  loop = uv_default_loop();
```

However, `uv_default_loop()` can return `NULL` if `uv_loop_init()` fails internally. This leads to a potential null pointer dereference at line 584:

```c
uv__queue_foreach(q, &loop->handle_queue);
```

If `loop` remains `NULL`, the expression `&loop->handle_queue` results in undefined behavior and possible crash due to null dereference.

If `uv_default_loop()` fails and returns `NULL`, `uv__print_handles()` should detect this and handle the failure gracefully before dereferencing `loop`.

### Actual behavior

`uv__print_handles()` does not check whether `uv_default_loop()` returned `NULL`, which can result in null pointer dereference when `uv__queue_foreach(q, &loop->handle_queue)` is accessed.

### How to Reproduce

If the `loop` parameter passed to `uv__print_handles()` is `NULL`, it is assigned using `loop = uv_default_loop();`.
According to the implementation of `uv_default_loop()`, it may return `NULL` if `uv_loop_init()` fails internally.
However, there is no check to verify whether `loop` is still `NULL` after this assignment.
As a result, calling `uv__queue_foreach(q, &loop->handle_queue)` can lead to a null pointer dereference and cause undefined behavior.
Thanks for reviewing.