### PR TITLE
build: Use Ninja generate in the Windows GitHub-Actions workflow.

### DIFF
--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -43,10 +43,6 @@ jobs:
 
           cmake --build build
 
-          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.exe" -Destination "build\\"' || '' }}
-
-          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.dll" -Destination "build\\"' || '' }}
-
           ls -l build
       - name: platform_output_a
         if: ${{ matrix.config.arch != 'arm64' }}

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -43,13 +43,11 @@ jobs:
 
           cmake --build build
 
-          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.exe" -Destination "build\\RelWithDebInfo\\"' || '' }}
+          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.exe" -Destination "build\\"' || '' }}
 
-          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.dll" -Destination "build\\RelWithDebInfo\\"' || '' }}
+          ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.dll" -Destination "build\\"' || '' }}
 
           ls -l build
-          
-          ls -l build\\RelWithDebInfo
       - name: platform_output_a
         if: ${{ matrix.config.arch != 'arm64' }}
         shell: cmd

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -52,12 +52,12 @@ jobs:
         if: ${{ matrix.config.arch != 'arm64' }}
         shell: cmd
         run:
-          build\\RelWithDebInfo\\uv_run_tests_a.exe platform_output
+          build\\uv_run_tests_a.exe platform_output
       - name: platform_output
         if: ${{ matrix.config.arch != 'arm64' }}
         shell: cmd
         run:
-          build\\RelWithDebInfo\\uv_run_tests.exe platform_output
+          build\\uv_run_tests.exe platform_output
       - name: Test
         # only valid with libuv-master with the fix for
         # https://github.com/libuv/leps/blob/master/005-windows-handles-not-fd.md
@@ -66,12 +66,12 @@ jobs:
         run:
           cd build
 
-          ctest -C RelWithDebInfo -V
+          ctest -V
       - name: Test only static
         if: ${{ matrix.config.config == 'ASAN' && matrix.config.arch != 'arm64' }}
         shell: cmd
         run:
-          build\\RelWithDebInfo\\uv_run_tests_a.exe
+          build\\uv_run_tests_a.exe
 
   build-mingw:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Build
         run:
           $root = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+
           Import-Module "$root\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+
           Enter-VsDevShell -VsInstallPath $root -DevCmdArguments "-arch=${{ matrix.config.arch }}"
 
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -33,7 +33,7 @@ jobs:
         run:
           $root = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           Import-Module "$root\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-          Enter-VsDevShell -VsInstallPath $root -DevCmdArguments "-arch=${{ matrix.arch }}"
+          Enter-VsDevShell -VsInstallPath $root -DevCmdArguments "-arch=${{ matrix.config.arch }}"
 
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
             -G "${{ matrix.config.toolchain }}"

--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -21,21 +21,25 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {toolchain: Visual Studio 17 2022, arch: Win32, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: ASAN}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: UBSAN}
-          - {toolchain: Visual Studio 17 2022, arch: arm64, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2025}
+          - {toolchain: Ninja, arch: x86, server: 2022}
+          - {toolchain: Ninja, arch: x64, server: 2022}
+          - {toolchain: Ninja, arch: x64, server: 2022, config: ASAN}
+          - {toolchain: Ninja, arch: x64, server: 2022, config: UBSAN}
+          - {toolchain: Ninja, arch: arm64, server: 2022}
+          - {toolchain: Ninja, arch: x64, server: 2025}
     steps:
       - uses: actions/checkout@v4
       - name: Build
         run:
-          cmake -S . -B build -DBUILD_TESTING=ON
-            -G "${{ matrix.config.toolchain }}" -A ${{ matrix.config.arch }}
+          $root = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          Import-Module "$root\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $root -DevCmdArguments "-arch=${{ matrix.arch }}"
+
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON
+            -G "${{ matrix.config.toolchain }}"
             ${{ matrix.config.config == 'ASAN' && '-DASAN=on -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded' || '' }}
 
-          cmake --build build --config RelWithDebInfo
+          cmake --build build
 
           ${{ matrix.config.config == 'ASAN' && 'Copy-Item -Path "build\\*.exe" -Destination "build\\RelWithDebInfo\\"' || '' }}
 


### PR DESCRIPTION
Ninja generator will build the project much faster because of its great support for parallel build.

Also it's much more reliable and straightforward when used in automation scripts. 

* .github/workflows/CI-win.yml
  (build-windows::matrix): Change toolchain to `Ninja` and fixup arch name of Win32 to x86, since this is how the DevShell accepts it.
  (build-windows::Build):
  - Enter the VsDevShell mode to access compiler.
  - Explicitly specify CMAKE_BUILD_TYPE because Ninja is a single-config generator.
  - The arch is now determined by the dev-shell and there is no need to specify it as `-A`.
  (build-windows): Remove all references of config name replacing it with just `build`.