### PR TITLE
win: remove obsolete comment

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1946,7 +1946,6 @@ INLINE static void fs__stat_assign_statbuf(uv_stat_t* statbuf,
 INLINE static void fs__stat_prepare_path(WCHAR* pathw) {
   size_t len = wcslen(pathw);
 
-  /* TODO: ignore namespaced paths. */
   if (len > 1 && pathw[len - 2] != L':' &&
       (pathw[len - 1] == L'\\' || pathw[len - 1] == L'/')) {
     pathw[len - 1] = '\0';


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/security/advisories/GHSA-qf6p-jg38-9f4x#advisory-comment-131127