### PR TITLE
unix: handle possible `ENOMEM` in `uv__pipe_listen`

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -171,8 +171,7 @@ int uv__pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
 
   handle->connection_cb = cb;
   handle->io_watcher.cb = uv__server_io;
-  uv__io_start(handle->loop, &handle->io_watcher, POLLIN);
-  return 0;
+  return uv__io_start(handle->loop, &handle->io_watcher, POLLIN);
 }
 
 


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/issues/4755