### PR TITLE
unix: deduplicate uv_free_interface_addresses across platforms

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1288,12 +1288,6 @@ cleanup:
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
-  uv__free(addresses);
-}
-
-
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
   struct pollfd* events;
   uintptr_t i;

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -155,10 +155,3 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   return 0;
 }
-
-
-/* TODO(bnoordhuis) share with linux.c */
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
-  uv__free(addresses);
-}

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -505,11 +505,6 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
-  uv__free(addresses);
-}
-
 char** uv_setup_args(int argc, char** argv) {
   char exepath[UV__PATH_MAX];
   char* s;

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -2045,13 +2045,6 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-/* TODO(bnoordhuis) share with bsd-ifaddrs.c */
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
-  uv__free(addresses);
-}
-
-
 void uv__set_process_title(const char* title) {
 #if defined(PR_SET_NAME)
   prctl(PR_SET_NAME, title);  /* Only copies first 16 characters. */

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -898,11 +898,6 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 #endif  /* SUNOS_NO_IFADDRS */
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
-  uv__free(addresses);
-}
-
 
 #if !defined(_POSIX_VERSION) || _POSIX_VERSION < 200809L
 size_t strnlen(const char* s, size_t maxlen) {

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -1054,3 +1054,11 @@ uint64_t uv_metrics_idle_time(uv_loop_t* loop) {
     idle_time += uv_hrtime() - entry_time;
   return idle_time;
 }
+
+/* OS390 needs a different implementation, already provided in os390.c. */
+#ifndef __MVS__
+void uv_free_interface_addresses(uv_interface_address_t* addresses,
+                                 int count) {
+  uv__free(addresses);
+}
+#endif  /* !__MVS__ */

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -872,12 +872,6 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-    int count) {
-  uv__free(addresses);
-}
-
-
 int uv_getrusage(uv_rusage_t *uv_rusage) {
   FILETIME create_time, exit_time, kernel_time, user_time;
   SYSTEMTIME kernel_system_time, user_system_time;


### PR DESCRIPTION
---
This fixes a pending to do of sharing the function across different platforms.

Refs: https://github.com/libuv/libuv/pull/4818/files#diff-f94aad28d2cd4f6da2805a265c6645b8ae63cc49c9c1cb74ac7fadb9ba152733L160