### PR TITLE
test: skip slow process title test on asan+macos

### DIFF
--- a/test/test-process-title-threadsafe.c
+++ b/test/test-process-title-threadsafe.c
@@ -89,6 +89,14 @@ TEST_IMPL(process_title_threadsafe) {
   RETURN_SKIP("uv_(get|set)_process_title is not implemented.");
 #endif
 
+#if defined(__ASAN__) && defined(__APPLE__)
+  /* uv_set_process_title loads and unloads a bunch of dynamic libraries,
+   * and that's quite slow and prone to time out when running concurrently
+   * under AddressSanitizer.
+   */
+  RETURN_SKIP("too slow under ASAN");
+#endif
+
   ASSERT_OK(uv_set_process_title(titles[0]));
 
   ASSERT_OK(uv_sem_init(&getter_sem, 0));


### PR DESCRIPTION
uv_set_process_title loads and unloads a bunch of dynamic libraries, and that's quite slow and prone to time out when running concurrently under AddressSanitizer.