### PR TITLE
win: move uv__insert_pending_req to core.c

### DIFF
--- a/src/win/req-inl.h
+++ b/src/win/req-inl.h
@@ -81,27 +81,6 @@
     uv_fatal_error(GetLastError(), "PostQueuedCompletionStatus");       \
   }
 
-INLINE static void uv__insert_pending_req(uv_loop_t* loop, uv_req_t* req) {
-  req->next_req = NULL;
-  if (loop->pending_reqs_tail) {
-#ifdef _DEBUG
-    /* Ensure the request is not already in the queue, or the queue
-     * will get corrupted.
-     */
-    uv_req_t* current = loop->pending_reqs_tail;
-    do {
-      assert(req != current);
-      current = current->next_req;
-    } while(current != loop->pending_reqs_tail);
-#endif
-
-    req->next_req = loop->pending_reqs_tail->next_req;
-    loop->pending_reqs_tail->next_req = req;
-    loop->pending_reqs_tail = req;
-  } else {
-    req->next_req = req;
-    loop->pending_reqs_tail = req;
-  }
-}
+void uv__insert_pending_req(uv_loop_t* loop, uv_req_t* req);
 
 #endif /* UV_WIN_REQ_INL_H_ */


### PR DESCRIPTION
Large-ish functions with many call sites should not be `static inline`, that just results in lots of code duplication which the linker may or may not deduplicate. When it does, the linker has to do extra work; when it doesn't, binaries get bigger.

Refs: https://github.com/libuv/libuv/issues/4819