### PR TITLE
build: add -Werror when testing -Wflags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 
 CC_ATTRIBUTE_VISIBILITY([default], [
-  CC_FLAG_VISIBILITY([CFLAGS="${CFLAGS} -fvisibility=hidden"])
+  CC_CHECK_CFLAG_APPEND([-fvisibility=hidden])
 ])
 # Xlc has a flag "-f<filename>". Need to use CC_CHECK_FLAG_SUPPORTED_APPEND so
 # we exclude -fno-strict-aliasing for xlc

--- a/m4/libuv-check-flags.m4
+++ b/m4/libuv-check-flags.m4
@@ -50,6 +50,24 @@ AC_DEFUN([CC_CHECK_CFLAGS_SILENT], [
     [$2], [$3])
 ])
 
+dnl Check if the flag is supported by compiler with werror
+dnl CC_CHECK_CFLAGS_SILENT_WERROR([FLAG], [ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND])
+
+AC_DEFUN([CC_CHECK_CFLAGS_SILENT_WERROR], [
+  AC_REQUIRE([CC_CHECK_WERROR])
+  AC_CACHE_VAL(AS_TR_SH([cc_cv_cflags_werror_$1]),
+    [ac_save_CFLAGS="$CFLAGS"
+     CFLAGS="$CFLAGS $cc_cv_werror $1"
+     AC_COMPILE_IFELSE([AC_LANG_SOURCE([int a;])],
+       [eval "AS_TR_SH([cc_cv_cflags_werror_$1])='yes'"],
+       [eval "AS_TR_SH([cc_cv_cflags_werror_$1])='no'"])
+     CFLAGS="$ac_save_CFLAGS"
+    ])
+
+  AS_IF([eval test x$]AS_TR_SH([cc_cv_cflags_werror_$1])[ = xyes],
+    [$2], [$3])
+])
+
 dnl Check if the flag is supported by compiler (cacheable)
 dnl CC_CHECK_CFLAGS([FLAG], [ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND])
 
@@ -67,11 +85,11 @@ dnl CC_CHECK_CFLAG_APPEND(FLAG, [action-if-found], [action-if-not-found])
 dnl Check for CFLAG and appends them to AM_CFLAGS if supported
 AC_DEFUN([CC_CHECK_CFLAG_APPEND], [
   AC_CACHE_CHECK([if $CC supports $1 flag],
-    AS_TR_SH([cc_cv_cflags_$1]),
-    CC_CHECK_CFLAGS_SILENT([$1]) dnl Don't execute actions here!
+    AS_TR_SH([cc_cv_cflags_werror_$1]),
+    CC_CHECK_CFLAGS_SILENT_WERROR([$1]) dnl Don't execute actions here!
   )
 
-  AS_IF([eval test x$]AS_TR_SH([cc_cv_cflags_$1])[ = xyes],
+  AS_IF([eval test x$]AS_TR_SH([cc_cv_cflags_werror_$1])[ = xyes],
     [AM_CFLAGS="$AM_CFLAGS $1"; DEBUG_CFLAGS="$DEBUG_CFLAGS $1"; $2], [$3])
 
   AC_SUBST([AM_CFLAGS])
@@ -266,24 +284,6 @@ AC_DEFUN([CC_ATTRIBUTE_CONST], [
     [const], ,
     [int __attribute__((const)) twopow(int n) { return 1 << n; } ],
     [$1], [$2])
-])
-
-AC_DEFUN([CC_FLAG_VISIBILITY], [
-  AC_REQUIRE([CC_CHECK_WERROR])
-  AC_CACHE_CHECK([if $CC supports -fvisibility=hidden],
-    [cc_cv_flag_visibility],
-    [cc_flag_visibility_save_CFLAGS="$CFLAGS"
-     CFLAGS="$CFLAGS $cc_cv_werror"
-     CC_CHECK_CFLAGS_SILENT([-fvisibility=hidden],
-	cc_cv_flag_visibility='yes',
-	cc_cv_flag_visibility='no')
-     CFLAGS="$cc_flag_visibility_save_CFLAGS"])
-
-  AS_IF([test "x$cc_cv_flag_visibility" = "xyes"],
-    [AC_DEFINE([SUPPORT_FLAG_VISIBILITY], 1,
-       [Define this if the compiler supports the -fvisibility flag])
-     $1],
-    [$2])
 ])
 
 AC_DEFUN([CC_FUNC_EXPECT], [


### PR DESCRIPTION
I noticed that without `-Werror=unknown-warning-option`, these conditional argument additions were not working as it seems they were intended, since the compiler would warn, but autoconf still treats that as success (cmake treats that as a failure), causing that warning to print on every subsequent file being built. I noticed this when trying to activate some new warnings that are only present in the (as yet unreleased) clang 21 and was doing testing against other compilers.

(PR written almost entirely by Claude, since my knowledge of m4 is quite limited at best)