### PR TITLE
Fix const-correctness warning in linux.c

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1850,7 +1850,7 @@ parts:
     if (*parts) {
       p = memmem(parts, sizeof(parts) - 1, p, n + 1);
       if (p == NULL)
-        p = "unknown";
+        p = (char*)"unknown";  /* mutable cast (will be copied, safe to use literal) */
       else
         p += n + 1;
       n = (int) strcspn(p, "\n");


### PR DESCRIPTION
Addresses issue #4814 by adding explicit cast when assigning string literal "unknown" to mutable char* pointer. The cast is safe because the string is only read from, never modified.

This eliminates compiler warnings when building with strict const-correctness flags like -Wwrite-strings.