### PR TITLE
win,fs: workaround for incorrect stat results under FSLogix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ check_c_compiler_flag(-Wstrict-prototypes UV_LINT_STRICT_PROTOTYPES)
 check_c_compiler_flag(-Wextra UV_LINT_EXTRA)
 
 check_c_compiler_flag(/utf-8 UV_LINT_UTF8_MSVC)
+check_c_compiler_flag(/experimental:c11atomics UV_LINT_C11ATOMICS_MSVC)
 
 set(lint-no-unused-parameter $<$<BOOL:${UV_LINT_NO_UNUSED_PARAMETER}>:-Wno-unused-parameter>)
 set(lint-strict-prototypes $<$<BOOL:${UV_LINT_STRICT_PROTOTYPES}>:-Wstrict-prototypes>)
@@ -161,7 +162,7 @@ list(APPEND uv_cflags ${lint-no-hides-param-msvc})
 list(APPEND uv_cflags ${lint-no-hides-global-msvc})
 list(APPEND uv_cflags ${lint-no-conditional-assignment-msvc})
 list(APPEND uv_cflags ${lint-no-unsafe-msvc})
-list(APPEND uv_cflags ${lint-utf8-msvc} )
+list(APPEND uv_cflags ${lint-utf8-msvc})
 
 check_c_compiler_flag(-fno-strict-aliasing UV_F_STRICT_ALIASING)
 list(APPEND uv_cflags $<$<BOOL:${UV_F_STRICT_ALIASING}>:-fno-strict-aliasing>)
@@ -169,6 +170,12 @@ list(APPEND uv_cflags $<$<BOOL:${UV_F_STRICT_ALIASING}>:-fno-strict-aliasing>)
 if (MSVC)
   # Error on calling undeclared functions.
   list(APPEND uv_cflags "/we4013")
+  if (UV_LINT_C11ATOMICS_MSVC)
+    list(APPEND uv_cflags "/experimental:c11atomics")
+    # /experimental:c11atomics still defines __STDC_NO_ATOMICS__
+    # so we need alternate way to check in sources.
+    list(APPEND uv_defines _STDC_ATOMICS_MSVC)
+  endif()
 endif()
 
 set(uv_sources

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -30,6 +30,10 @@
 #include <sys/utime.h>
 #include <stdio.h>
 
+#if defined(_STDC_ATOMICS_MSVC)
+#include <stdatomic.h>
+#endif
+
 #include "uv.h"
 
 /* <winioctl.h> requires <windows.h>, included via "uv.h" above, but needs to
@@ -182,6 +186,51 @@ void uv__fs_init(void) {
   uv__fd_hash_init();
 }
 
+/*
+ * Check if the current environment is FSLogix
+ * by checking for the existence of the
+ * HKEY_LOCAL_MACHINE\SOFTWARE\FSLogix registry key.
+ */
+INLINE static int fs__fslogix_environment() {
+#if defined(_STDC_ATOMICS_MSVC)
+  static _Atomic int cached_is_fslogix = -1;
+#else
+  static int cached_is_fslogix = -1;
+#endif
+  int is_fslogix;
+  int err;
+  HKEY fslogix_key;
+
+#if defined(_STDC_ATOMICS_MSVC)
+  is_fslogix = atomic_load_explicit(&cached_is_fslogix, memory_order_relaxed);
+  if (is_fslogix != -1)
+    return is_fslogix;
+#else
+  if (cached_is_fslogix != -1)
+    return cached_is_fslogix;
+#endif
+
+  err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                      L"SOFTWARE\\FSLogix",
+                      0,
+                      KEY_QUERY_VALUE | KEY_WOW64_64KEY,
+                      &fslogix_key);
+  if (err != ERROR_SUCCESS) {
+    is_fslogix = 0;
+  } else {
+    is_fslogix = 1;
+    RegCloseKey(fslogix_key);
+  }
+
+#if defined(_STDC_ATOMICS_MSVC)
+  atomic_store_explicit(&cached_is_fslogix, is_fslogix, memory_order_relaxed);
+#else
+  InterlockedExchange(
+      (volatile LONG*) &cached_is_fslogix, is_fslogix);
+#endif
+
+  return is_fslogix;
+}
 
 static int fs__readlink_handle(HANDLE handle,
                                char** target_ptr,
@@ -1719,6 +1768,15 @@ static fs__stat_path_return_t fs__stat_path(WCHAR* path,
     switch(GetLastError()) {
       case ERROR_FILE_NOT_FOUND:
       case ERROR_PATH_NOT_FOUND:
+        /* Accessing files under user profile directory
+         * fails with ERROR_FILE_NOT_FOUND/ERROR_PATH_NOT_FOUND
+         * when working with FSLogix profile containers. Retry
+         * with the slow path.
+         * Refs https://github.com/libuv/libuv/issues/4844
+         */
+        if (fs__fslogix_environment()) {
+          return FS__STAT_PATH_TRY_SLOW;
+        }
       case ERROR_NOT_READY:
       case ERROR_BAD_NET_NAME:
         /* These errors aren't worth retrying with the slow path. */

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -187,9 +187,8 @@ void uv__fs_init(void) {
 }
 
 /*
- * Check if the current environment is FSLogix
- * by checking for the existence of the
- * HKEY_LOCAL_MACHINE\SOFTWARE\FSLogix registry key.
+ * Check if the current environment is FSLogix by checking for the existence
+ * of the HKEY_LOCAL_MACHINE\SOFTWARE\FSLogix registry key.
  */
 INLINE static int fs__fslogix_environment() {
 #if defined(_STDC_ATOMICS_MSVC)
@@ -225,8 +224,7 @@ INLINE static int fs__fslogix_environment() {
 #if defined(_STDC_ATOMICS_MSVC)
   atomic_store_explicit(&cached_is_fslogix, is_fslogix, memory_order_relaxed);
 #else
-  InterlockedExchange(
-      (volatile LONG*) &cached_is_fslogix, is_fslogix);
+  InterlockedExchange((volatile LONG*) &cached_is_fslogix, is_fslogix);
 #endif
 
   return is_fslogix;
@@ -1768,10 +1766,9 @@ static fs__stat_path_return_t fs__stat_path(WCHAR* path,
     switch(GetLastError()) {
       case ERROR_FILE_NOT_FOUND:
       case ERROR_PATH_NOT_FOUND:
-        /* Accessing files under user profile directory
-         * fails with ERROR_FILE_NOT_FOUND/ERROR_PATH_NOT_FOUND
-         * when working with FSLogix profile containers. Retry
-         * with the slow path.
+        /* Accessing files under user profile directory fails with
+         * ERROR_FILE_NOT_FOUND/ERROR_PATH_NOT_FOUND when working with
+         * FSLogix profile containers. Retry with the slow path.
          * Refs https://github.com/libuv/libuv/issues/4844
          */
         if (fs__fslogix_environment()) {


### PR DESCRIPTION
FSLogix has a bug when GetFileInformationByName is called on any path under a user profile directory by a non-admin user results in ERROR_FILE_NOT_FOUND/ERROR_PATH_NOT_FOUND. This change adds a workaround by retrying the slow path based on NtQueryVolumeInformationFile.

Fixes https://github.com/libuv/libuv/issues/4844