### PR TITLE
unix: fix udp sendmmsg fallback path

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -661,10 +661,10 @@ int uv__udp_try_send(uv_udp_t* handle,
   }
 
   err = uv__udp_sendmsg1(handle->io_watcher.fd, bufs, nbufs, addr);
-  if (err > 0)
-    return uv__count_bufs(bufs, nbufs);
+  if (err)
+    return err;
 
-  return err;
+  return uv__count_bufs(bufs, nbufs);
 }
 
 
@@ -1295,7 +1295,7 @@ static int uv__udp_sendmsg1(int fd,
   /* UDP sockets don't EOF so we don't have to handle r=0 specially,
    * that only happens when the input was a zero-sized buffer.
    */
-  return 1;
+  return 0;
 }
 
 


### PR DESCRIPTION
Fix a logic bug in the fallback code for platforms that don't have a sendmmsg-like system call. It only sent at most one packet, even when there were more available, and that was observable through a failing test on such systems.

Fixes: https://github.com/libuv/libuv/issues/4848