### PR TITLE
test: use relative paths for pipes and Unix sockets

### DIFF
--- a/docs/code/pipe-echo-server/main.c
+++ b/docs/code/pipe-echo-server/main.c
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #define PIPENAME "\\\\?\\pipe\\echo.sock"
 #else
-#define PIPENAME "/tmp/echo.sock"
+#define PIPENAME "echo.sock"
 #endif
 
 uv_loop_t *loop;

--- a/test/task.h
+++ b/test/task.h
@@ -53,14 +53,10 @@
 # define TEST_PIPENAME "\\\\.\\pipe\\uv-test"
 # define TEST_PIPENAME_2 "\\\\.\\pipe\\uv-test2"
 # define TEST_PIPENAME_3 "\\\\.\\pipe\\uv-test3"
-#elif __ANDROID__
-# define TEST_PIPENAME "/data/local/tmp/uv-test-sock"
-# define TEST_PIPENAME_2 "/data/local/tmp/uv-test-sock2"
-# define TEST_PIPENAME_3 "/data/local/tmp/uv-test-sock3"
 #else
-# define TEST_PIPENAME "/tmp/uv-test-sock"
-# define TEST_PIPENAME_2 "/tmp/uv-test-sock2"
-# define TEST_PIPENAME_3 "/tmp/uv-test-sock3"
+# define TEST_PIPENAME "uv-test-sock"
+# define TEST_PIPENAME_2 "uv-test-sock2"
+# define TEST_PIPENAME_3 "uv-test-sock3"
 #endif
 
 #ifdef _WIN32

--- a/test/test-poll.c
+++ b/test/test-poll.c
@@ -633,7 +633,7 @@ TEST_IMPL(poll_unidirectional) {
  * In addition to regular files, we also disallow FIFOs on Darwin.
  */
 #ifdef __APPLE__
-#define TEST_POLL_FIFO_PATH "/tmp/uv-test-poll-fifo"
+#define TEST_POLL_FIFO_PATH "uv-test-poll-fifo"
 #endif
 TEST_IMPL(poll_bad_fdtype) {
 #if !defined(__sun) && \


### PR DESCRIPTION
This fixes the test suite in environments where `/tmp` is not writable or does not allow the use of Unix sockets, and matches the use of relative paths elsewhere in the tests.

---

I have only tested this change on macOS. If relative paths are unsuitable here for some reason, then another option would be using `uv_os_tmpdir`, but given the use of relative paths elsewhere in the test suite I hope that it should be fine.