### PR TITLE
linux: handle cgroups cpu.max with limit < period

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -2363,6 +2363,8 @@ static int uv__get_cgroupv2_constrained_cpu(const char* cgroup,
       goto next;
 
     *quota = limit / period;
+    if (*quota == 0)
+        *quota = 1;
     if (*quota < min_quota)
       min_quota = *quota;
 


### PR DESCRIPTION
This apparently manifests when one passes `--cpu=.5` to docker because then /sys/fs/cgroup/cpu.max looks like `50000 100000`, and 50000 divided by 100000 is zero when using integer math.

Return 1 in that case, indicating there is at least one CPU available. Returning 0 makes no sense because there is always at least one CPU available, otherwise the program wouldn't be running.

Fixes: https://github.com/nodejs/node/issues/59200