### PR TITLE
win: add flag to open file with only FILE_SHARE_READ sharing mode

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -684,6 +684,7 @@ typedef struct {
 #define UV_FS_O_TEMPORARY    _O_TEMPORARY
 #define UV_FS_O_TRUNC        _O_TRUNC
 #define UV_FS_O_WRONLY       _O_WRONLY
+#define UV_FS_O_SHARE_RDONLY 0x40000000 /* READ ONLY SHARING MODE */
 
 /* fs open() flags supported on other platforms (or mapped on this platform): */
 #define UV_FS_O_DIRECT       0x02000000 /* FILE_FLAG_NO_BUFFERING */

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -482,6 +482,8 @@ void fs__open(uv_fs_t* req) {
    */
   if (flags & UV_FS_O_EXLOCK) {
     share = 0;
+  }  else if (flags & UV_FS_O_SHARE_RDONLY) {
+    share = FILE_SHARE_READ;
   } else {
     share = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
   }


### PR DESCRIPTION
In order to support file integrity verification and mitigate risk of TOC/TOU vulnerabilities, allow callers to open the file with read only sharing mode.

### Context
Windows only change.

Presently fs__open will either open a file with no sharing mode or all sharing modes (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).

I currently have a [PR with Node.js](https://github.com/nodejs/node/pull/54364) to add support for script file integrity verification on Windows. The high-level flow for this is:

Open a file handle to the file intended to be loaded.
Pass the file handle to a Windows API to verify that the file has not been modified since signing time.
Read the contents of the file.
Close the file handle.
Execute the contents (if integrity checks pass).

In order to mitigate the risk of a time-of-check time-of-use vulnerability, we need to open the file with FILE_SHARE_READ mode only. Otherwise, the contents of the file could be modified between the call to the integrity verification API and when the file is read off disk for execution.

Unfortunately, with the current behavior, opening the file with no sharing mode (`UV_FS_O_EXLOCK`) causes other problems when other call sites try to read the file.

### Changes
+ Add UV_FS_O_SHARE_RDONLY flag
+ `fs_open`  will check for this flag and open the file with only `FILE_SHARE_READ` sharing mode if present.