### PR TITLE
doc: remove nodeuv from LINKS.md

### DIFF
--- a/LINKS.md
+++ b/LINKS.md
@@ -30,7 +30,6 @@
 * [node9](https://github.com/jvburnes/node9): A portable, hybrid, distributed OS based on Inferno, LuaJIT and Libuv
 * [node.js](http://www.nodejs.org/): Javascript (using Google's V8) + libuv
 * [node.native](https://github.com/d5/node.native): node.js-like API for C++11
-* [nodeuv](https://github.com/nodeuv): An organization with several c++ wrappers for libs which are used in node.js.
 * [phastlight](https://github.com/phastlight/phastlight): Command line tool and web server written in PHP 5.3+ inspired by Node.js
 * [pilight](https://www.pilight.org/): home automation ("domotica")
 * [pixie](https://github.com/pixie-lang/pixie): clojure-inspired lisp with a tracing JIT


### PR DESCRIPTION
The original repository was deleted and the URL is now owned by someone else.

Refs: https://hackerone.com/bugs?report_id=3295855