### PR TITLE
style: remove trailing whitespace in unix, win, and test sources

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -242,6 +242,7 @@ Martin Bark <martin@barkynet.com>
 Dave <dave@jut.io>
 Alexis Murzeau <amubtdx@gmail.com>
 Didiet <lynxluna@gmail.com>
+Muhammad Arief Rahman <insomnius.studio@gmail.com>
 Nan Xiang <514580344@qq.com>
 Samuel Lorétan <sloretan@riotgames.com>
 Nándor István Krácser <bonifaido@gmail.com>

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -906,7 +906,7 @@ char** uv_setup_args(int argc, char** argv) {
   size = sizeof(exepath);
   if (uv__search_path(argv[0], exepath, &size) == 0) {
     uv_once(&process_title_mutex_once, init_process_title_mutex_once);
-    uv_mutex_lock(&process_title_mutex); 
+    uv_mutex_lock(&process_title_mutex);
     original_exepath = uv__strdup(exepath);
     uv_mutex_unlock(&process_title_mutex);
   }

--- a/src/unix/hurd.c
+++ b/src/unix/hurd.c
@@ -82,12 +82,12 @@ int uv_resident_set_memory(size_t* rss) {
 uint64_t uv_get_free_memory(void) {
   kern_return_t err;
   struct vm_statistics vmstats;
-  
+
   err = vm_statistics(mach_task_self(), &vmstats);
 
   if (err)
     return 0;
-  
+
   return vmstats.free_count * vm_page_size;
 }
 
@@ -96,9 +96,9 @@ uint64_t uv_get_total_memory(void) {
   kern_return_t err;
   host_basic_info_data_t hbi;
   mach_msg_type_number_t cnt;
-  
+
   cnt = HOST_BASIC_INFO_COUNT;
-  err = host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &hbi, &cnt); 
+  err = host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &hbi, &cnt);
 
   if (err)
     return 0;
@@ -135,10 +135,10 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   kern_return_t err;
   host_basic_info_data_t hbi;
   mach_msg_type_number_t cnt;
-  
+
   /* Get count of cpus  */
   cnt = HOST_BASIC_INFO_COUNT;
-  err = host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &hbi, &cnt); 
+  err = host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &hbi, &cnt);
 
   if (err) {
     err = UV__ERR(err);
@@ -155,7 +155,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *count = hbi.avail_cpus;
 
   return 0;
-  
+
  abort:
   *cpu_infos = NULL;
   *count = 0;

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -109,7 +109,7 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
    *
    * On Darwin, DragonFlyBSD, NetBSD and OpenBSD, kqueue reports ready events for
    * regular files as readable and writable only once, acting like an EV_ONESHOT.
-   * 
+   *
    * Neither of the above cases should be added to the kqueue.
    */
   if (S_ISREG(sb.st_mode) || S_ISDIR(sb.st_mode))
@@ -119,9 +119,9 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   /* On Darwin (both macOS and iOS), in addition to regular files, FIFOs also don't
    * work properly with kqueue: the disconnection from the last writer won't trigger
    * an event for kqueue in spite of what the man pages say. Thus, we also disallow
-   * the case of S_IFIFO. */ 
+   * the case of S_IFIFO. */
   if (S_ISFIFO(sb.st_mode)) {
-    /* File descriptors of FIFO, pipe and kqueue share the same type of file, 
+    /* File descriptors of FIFO, pipe and kqueue share the same type of file,
      * therefore there is no way to tell them apart via stat.st_mode&S_IFMT.
      * Fortunately, FIFO is the only one that has a persisted file on filesystem,
      * from which we're able to make the distinction for it. */

--- a/src/unix/os390-syscalls.c
+++ b/src/unix/os390-syscalls.c
@@ -249,7 +249,7 @@ int epoll_ctl(uv__os390_epoll* lst,
   } else if (op == EPOLL_CTL_ADD) {
 
     /* Resizing to 'fd + 1' would expand the list to contain at least
-     * 'fd'. But we need to guarantee that the last index on the list 
+     * 'fd'. But we need to guarantee that the last index on the list
      * is reserved for the message queue. So specify 'fd + 2' instead.
      */
     maybe_resize(lst, fd + 2);

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -260,7 +260,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->model = uv__malloc(ZOSCPU_MODEL_LENGTH + 1);
     if (cpu_info->model == NULL) {
       uv_free_cpu_info(*cpu_infos, idx);
-      return UV_ENOMEM; 
+      return UV_ENOMEM;
     }
     __get_cpu_model(cpu_info->model, ZOSCPU_MODEL_LENGTH + 1);
     cpu_info->cpu_times.user = cpu_usage_avg;

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -52,7 +52,7 @@
  */
 static int isreallyatty(int file) {
   int rc;
- 
+
   rc = !ioctl(file, TXISATTY + 0x81, NULL);
   if (!rc && errno != EBADF)
       errno = ENOTTY;

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -813,7 +813,7 @@ int uv_udp_set_source_membership(uv_udp_t* handle,
                                           src_addr6,
                                           membership);
   }
-  
+
   err = uv_ip4_addr(source_addr, 0, src_addr4);
   if (err)
     return err;

--- a/test/test-thread.c
+++ b/test/test-thread.c
@@ -167,7 +167,7 @@ TEST_IMPL(threadpool_multiple_event_loops) {
 #if defined(__QEMU__)
   RETURN_SKIP("Test does not currently work in QEMU");
 #endif
-  
+
   struct test_thread threads[8];
   size_t i;
   int r;

--- a/test/test-udp-multicast-join.c
+++ b/test/test-udp-multicast-join.c
@@ -73,7 +73,7 @@ static void sv_send_cb(uv_udp_send_t* req, int status) {
 static int do_send(uv_udp_send_t* send_req) {
   uv_buf_t buf;
   struct sockaddr_in addr;
-  
+
   buf = uv_buf_init("PING", 4);
 
   ASSERT_OK(uv_ip4_addr(MULTICAST_ADDR, TEST_PORT, &addr));

--- a/test/test-udp-multicast-join6.c
+++ b/test/test-udp-multicast-join6.c
@@ -87,7 +87,7 @@ static void sv_send_cb(uv_udp_send_t* req, int status) {
 static int do_send(uv_udp_send_t* send_req) {
   uv_buf_t buf;
   struct sockaddr_in6 addr;
-  
+
   buf = uv_buf_init("PING", 4);
 
   ASSERT_OK(uv_ip6_addr(MULTICAST_ADDR, TEST_PORT, &addr));
@@ -208,7 +208,7 @@ TEST_IMPL(udp_multicast_join6) {
 #endif
   r = uv_udp_recv_start(&server, alloc_cb, cl_recv_cb);
   ASSERT_OK(r);
-  
+
   r = do_send(&req);
   ASSERT_OK(r);
 


### PR DESCRIPTION
**Overview**

- **What**: Remove trailing whitespace across 10 files. No functional changes.
- **Why**: Improves consistency and adheres to libuv style guidelines.

**Notes**
- No behavior changes, just formatting.
- Contributor already listed in `AUTHORS`.