### PR TITLE
unix: Improve uv__cpu_relax() on Arm

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -409,7 +409,7 @@ static void uv__cpu_relax(void) {
 #if defined(__i386__) || defined(__x86_64__)
   __asm__ __volatile__ ("rep; nop" ::: "memory");  /* a.k.a. PAUSE */
 #elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
-  __asm__ __volatile__ ("yield" ::: "memory");
+  __asm__ __volatile__ ("isb" ::: "memory");
 #elif (defined(__ppc__) || defined(__ppc64__)) && defined(__APPLE__)
   __asm volatile ("" : : : "memory");
 #elif !defined(__APPLE__) && (defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__))


### PR DESCRIPTION
The AArch64 `YIELD` instruction affects processors that support symmetric multithreading, while on other implementations (which are the majority on the market) it is equivalent to `NOP`, thus failing to achieve the desired delay effect inside `uv__async_spin()`. Instead, use the `ISB` instruction, following one of [Arm's recommendations](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/multi-threaded-applications-arm).