### PR TITLE
unix: fix build on the bsds

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -297,7 +297,11 @@ void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int events);
 #define uv__ahafs_event(loop, w, events) UNREACHABLE()
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) &&                                                    \
+    !defined(__DragonFly__) &&                                                \
+    !defined(__FreeBSD__) &&                                                  \
+    !defined(__NetBSD__) &&                                                   \
+    !defined(__OpenBSD__)
 #define uv__fs_event(loop, w, events) UNREACHABLE()
 #endif
 


### PR DESCRIPTION
Fix build breakage introduced a couple of days ago in commit 3813460d ("unix: replace uv__io_t callback pointer with enum"). Mea culpa.

Fixes: https://github.com/libuv/libuv/issues/4864