### PR TITLE
unix: remove UV__SIGNAL_EVENT dispatch from uv__io_cb

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -923,9 +923,6 @@ void uv__io_cb(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   case UV__POLL_IO:
     uv__poll_io(loop, w, events);
     break;
-  case UV__SIGNAL_EVENT:
-    uv__signal_event(loop, w, events);
-    break;
   case UV__SERVER_IO:
     uv__server_io(loop, w, events);
     break;


### PR DESCRIPTION
uv__signal_event() is invoked directly from uv__io_poll(), so the UV__SIGNAL_EVENT case in uv__io_cb() is never reached.

Refs: https://github.com/libuv/libuv/pull/4854#discussion_r2246110177