### PR TITLE
unix: fix uv__signal_loop_cleanup call in init

### DIFF
--- a/src/unix/loop.c
+++ b/src/unix/loop.c
@@ -83,7 +83,7 @@ int uv_loop_init(uv_loop_t* loop) {
   uv__signal_global_once_init();
   err = uv__process_init(loop);
   if (err)
-    goto fail_signal_init;
+    goto fail_process_init;
   uv__queue_init(&loop->process_handles);
 
   err = uv_rwlock_init(&loop->cloexec_lock);
@@ -110,9 +110,8 @@ fail_mutex_init:
   uv_rwlock_destroy(&loop->cloexec_lock);
 
 fail_rwlock_init:
+fail_process_init:
   uv__signal_loop_cleanup(loop);
-
-fail_signal_init:
   uv__platform_loop_delete(loop);
 
   if (loop->backend_fd != -1) {


### PR DESCRIPTION
While very highly unlikely that this fails (since it is implemented to call `abort()` instead of actually return an error code), we would theoretically leak this state. The process state init doesn't actually have a cleanup, and just awkwardly relies on uv_signal_close being unnecessary (which is likely true though).

Found while working on an earlier version of https://github.com/libuv/libuv/pull/4875 (I don't know if the current version would catch it as easily, since I used to require an explicit `uv_release_once` call here, which forbid the `uv__signal_loop_cleanup` from being missed after calling a function that used the `once` earlier, but I found that design cumbersome, even though it did find this bug, so I changed to an annotation which does an implicit release, and I didn't test if that would still detect this.)