### PR TITLE
win: fix path size calculation

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1220,7 +1220,7 @@ static int uv__kill(HANDLE process_handle, int signum) {
                              NULL,
                              &localappdata);
         _snwprintf_s(dump_folder,
-                     sizeof(dump_folder),
+                     ARRAY_SIZE(dump_folder),
                      _TRUNCATE,
                      L"%ls\\CrashDumps",
                      localappdata);
@@ -1233,7 +1233,7 @@ static int uv__kill(HANDLE process_handle, int signum) {
 
       /* Construct dump filename from process name and PID. */
       _snwprintf_s(dump_name,
-                   sizeof(dump_name),
+                   ARRAY_SIZE(dump_name),
                    _TRUNCATE,
                    L"%ls\\%ls.%d.dmp",
                    dump_folder,


### PR DESCRIPTION
_snwprintf_s takes its length argument in characters, not bytes.

Does not appear to be a security issue because the paths are not under an attacker's control unless the system has been compromised beyond salvation: requires a combination of being able to set the name of the executable and/or changing %LOCALAPPDATA% or a registry key.

Refs: https://github.com/libuv/libuv/security/advisories/GHSA-jjrx-vr7q-7732