### PR TITLE
doc: correct uv_cancel return value

### DIFF
--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -258,7 +258,8 @@ up a signal handler for termination.
     :lines: 43-
 
 When the user triggers the signal by pressing ``Ctrl+C`` we send
-``uv_cancel()`` to all the workers. ``uv_cancel()`` will return ``0`` for those that are already executing or finished.
+``uv_cancel()`` to all the workers. ``uv_cancel()`` will return ``0`` for those
+tasks that are pending execution and could be cancelled.
 
 .. rubric:: queue-cancel/main.c
 .. literalinclude:: ../../code/queue-cancel/main.c


### PR DESCRIPTION
There is a minor error about the return value of uv_cancel for tasks that are already executing. All other parts of the documentation correctly states that uv_cancel will fail.