### PR TITLE
fix: inconsistency in getting thread pool size from environment variable UV_THREADPOOL_SIZE on Windows.

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -192,19 +192,56 @@ void uv__threadpool_cleanup(void) {
 
 
 static void init_threads(void) {
+  const char env_name[] = "UV_THREADPOOL_SIZE";
+
   uv_thread_options_t config;
   unsigned int i;
+
+  size_t bufsize;
+  /* a size of 5 should work quite fine, as there won't be many threads 
+   * and the MAX_THREADPOOL_SIZE is 1024
+   */
+  char fastvarbuf[5];
+  char* varbuf;
   const char* val;
+
   uv_sem_t sem;
 
   nthreads = ARRAY_SIZE(default_threads);
-  val = getenv("UV_THREADPOOL_SIZE");
+
+  bufsize = ARRAY_SIZE(fastvarbuf);
+  varbuf = NULL;
+
+  int err = uv_os_getenv(env_name, fastvarbuf, &bufsize);
+  if (err == 0)
+    val = fastvarbuf;
+  else if (err == UV_ENOBUFS) {
+    /* this should not happen, but just in case */
+    varbuf = uv__malloc(bufsize);
+    val = varbuf;
+    err = uv_os_getenv(env_name, varbuf, &bufsize);
+
+    if (err != 0) {
+      /* failed again */
+      val = NULL;
+      uv__free(varbuf);
+    }
+  } else {
+    /* UV_ENOENT and other err */
+    val = NULL;
+  }
+  
   if (val != NULL)
     nthreads = atoi(val);
   if (nthreads == 0)
     nthreads = 1;
   if (nthreads > MAX_THREADPOOL_SIZE)
     nthreads = MAX_THREADPOOL_SIZE;
+
+  if (varbuf != NULL) {
+    uv__free(varbuf);
+    varbuf = NULL;
+  }
 
   threads = default_threads;
   if (nthreads > ARRAY_SIZE(default_threads)) {

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -194,24 +194,20 @@ void uv__threadpool_cleanup(void) {
 static void init_threads(void) {
   uv_thread_options_t config;
   unsigned int i;
-
-  size_t bufsize;
-  char fastvarbuf[16];
+  size_t buflen;
+  char buf[16];
   const char* val;
-
   int err;
 
   uv_sem_t sem;
 
   nthreads = ARRAY_SIZE(default_threads);
 
-  bufsize = ARRAY_SIZE(fastvarbuf);
-
-  err = uv_os_getenv("UV_THREADPOOL_SIZE", fastvarbuf, &bufsize);
+  buflen = ARRAY_SIZE(buf);
+  err = uv_os_getenv("UV_THREADPOOL_SIZE", buf, &buflen);
+  val = NULL;
   if (err == 0)
-    val = fastvarbuf;
-  else
-    val = NULL; /* UV_ENOBUFS, UV_ENOENT and other err */
+    val = buf;
   
   if (val != NULL)
     nthreads = atoi(val);

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -192,44 +192,26 @@ void uv__threadpool_cleanup(void) {
 
 
 static void init_threads(void) {
-  const char env_name[] = "UV_THREADPOOL_SIZE";
-
   uv_thread_options_t config;
   unsigned int i;
 
   size_t bufsize;
-  /* a size of 5 should work quite fine, as there won't be many threads 
-   * and the MAX_THREADPOOL_SIZE is 1024
-   */
-  char fastvarbuf[5];
-  char* varbuf;
+  char fastvarbuf[16];
   const char* val;
+
+  int err;
 
   uv_sem_t sem;
 
   nthreads = ARRAY_SIZE(default_threads);
 
   bufsize = ARRAY_SIZE(fastvarbuf);
-  varbuf = NULL;
 
-  int err = uv_os_getenv(env_name, fastvarbuf, &bufsize);
+  err = uv_os_getenv("UV_THREADPOOL_SIZE", fastvarbuf, &bufsize);
   if (err == 0)
     val = fastvarbuf;
-  else if (err == UV_ENOBUFS) {
-    /* this should not happen, but just in case */
-    varbuf = uv__malloc(bufsize);
-    val = varbuf;
-    err = uv_os_getenv(env_name, varbuf, &bufsize);
-
-    if (err != 0) {
-      /* failed again */
-      val = NULL;
-      uv__free(varbuf);
-    }
-  } else {
-    /* UV_ENOENT and other err */
-    val = NULL;
-  }
+  else
+    val = NULL; /* UV_ENOBUFS, UV_ENOENT and other err */
   
   if (val != NULL)
     nthreads = atoi(val);
@@ -237,11 +219,6 @@ static void init_threads(void) {
     nthreads = 1;
   if (nthreads > MAX_THREADPOOL_SIZE)
     nthreads = MAX_THREADPOOL_SIZE;
-
-  if (varbuf != NULL) {
-    uv__free(varbuf);
-    varbuf = NULL;
-  }
 
   threads = default_threads;
   if (nthreads > ARRAY_SIZE(default_threads)) {


### PR DESCRIPTION
Use libuv's own OS-independent implementation to get env var UV_THREADPOOL_SIZE.

Fixes: #4887