### PR TITLE
unix: fix feelings

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -452,6 +452,7 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
     uv__run_prepare(loop);
 
     timeout = 0;
+    uv__update_time(loop);
     if ((mode == UV_RUN_ONCE && can_sleep) || mode == UV_RUN_DEFAULT)
       timeout = uv__backend_timeout(loop);
 


### PR DESCRIPTION
Current documentation have feelings, [uv_timer_t](https://docs.libuv.org/en/v1.x/timer.html). this pr makes it at least not misleading.

``` C
#include <stdio.h>
#include <time.h>
#include <assert.h>

#include <unistd.h>

#include "uv.h"

#define TIMESCALE 1
// #define TIMESCALE 50

static int64_t base;

static int64_t now_ms(void) {
    struct timespec ts;
    clock_gettime(CLOCK_MONOTONIC, &ts);
    return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
}

static void busy_20ms(void)
{
    int64_t timestamp = now_ms();

    while (now_ms() - timestamp < 20) ;
}

static void sleep_20ms(void) {
    struct timespec req = { .tv_sec = 0, .tv_nsec = 20 * 1000 * 1000 }; // 20 ms
    while (nanosleep(&req, &req) == -1) ;
}

static void tick(uv_timer_t* handle)
{
    uv_timer_again(handle);
    printf("begin: %ld\n", now_ms() - base);
    // usleep(500);
    // sleep(1);
    // sleep_20ms();
    busy_20ms();
    printf("end:   %ld\n", now_ms() - base);
}

static void done(uv_timer_t* handle)
{
    printf("done!\n");
}

int main(void)
{
    uv_loop_t *loop = uv_default_loop();

    uv_timer_t step;
    uv_timer_init(loop, &step);
    uv_unref((uv_handle_t *)&step);
    uv_timer_start(&step, tick, 0, 50 * TIMESCALE);

    uv_timer_t timeout;
    uv_timer_init(loop, &timeout);
    uv_timer_start(&timeout, done, 170 * TIMESCALE, 0);

    base = now_ms();

    return uv_run(loop, UV_RUN_DEFAULT);
}
```
result: 
```
$ ./feelings 
begin: 0
end:   20
begin: 50
end:   70
begin: 100
end:   120
begin: 150
end:   170
done!
```