### PR TITLE
aix: fix nullptr check in uv__skip_lines

### DIFF
--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -632,7 +632,7 @@ static int uv__skip_lines(char **p, int n) {
 
   while(n > 0) {
     *p = strchr(*p, '\n');
-    if (!p)
+    if (!*p)
       return lines;
 
     (*p)++;


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/4891

cc @libuv/aix