### PR TITLE
ibmi: fix undefined symbol uv__ahafs_event

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -905,9 +905,11 @@ static int maybe_resize(uv_loop_t* loop, unsigned int len) {
 
 void uv__io_cb(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
   switch (uv__io_cb_get(w)) {
+  #if ! defined(__PASE__)
   case UV__AHAFS_EVENT:
     uv__ahafs_event(loop, w, events);
     break;
+  #endif
   case UV__ASYNC_IO:
     uv__async_io(loop, w, events);
     break;


### PR DESCRIPTION
Fix below error on OS/400 (PASE for IBM i)

```
ld: 0711-317 ERROR: Undefined symbol: .uv__ahafs_event
ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
```