### PR TITLE
test: make `thread_priority` robust against system default nice levels

### DIFF
--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -88,8 +88,6 @@ TEST_IMPL(thread_priority) {
  * test set nice value for the calling thread with default schedule policy
 */
 #ifdef __linux__
-  ASSERT_OK(uv_thread_getpriority(pthread_self(), &priority));
-  ASSERT_EQ(priority, 0);
   ASSERT_OK(uv_thread_setpriority(pthread_self(), UV_THREAD_PRIORITY_LOWEST));
   ASSERT_OK(uv_thread_getpriority(pthread_self(), &priority));
   ASSERT_EQ(priority, (0 - UV_THREAD_PRIORITY_LOWEST * 2));


### PR DESCRIPTION
The test previously assumed a default nice value of 0, but this can vary depending on PAM configuration, /etc/security/limits.conf, or other environment settings.

Fixes: https://github.com/libuv/libuv/issues/4898

---
Based on:

> Seems to assume the priority is zero when in fact a default for a user can be set in /etc/security/limits.conf

By removing the 0 priority assumption, the test now asserts only on what we actually want to validate; that libuv can set and retrieve thread priority correctly. Rather than on environment-specific defaults.