### PR TITLE
ibmi: add stub function to satisfy linker

### DIFF
--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -538,3 +538,9 @@ int uv_get_process_title(char* buffer, size_t size) {
 
 void uv__process_title_cleanup(void) {
 }
+
+void uv__ahafs_event(uv_loop_t* loop,
+                     uv__io_t* event_watch,
+                     unsigned int fflags) {
+  /* Stub function to satisfy the linker. */
+}


### PR DESCRIPTION
Add a stub function for no-ahafs builds. src/unix/core.c won't actually call uv__ahafs_event but the linker still needs to see a symbol.

Like commit 87943b03 but for IBM i instead of AIX this time.