### PR TITLE
darwin: replace EV_OOBAND handling with EVFILT_EXCEPT + NOTE_OOB

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -229,7 +229,16 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     }
 
    if ((w->events & UV__POLLPRI) == 0 && (w->pevents & UV__POLLPRI) != 0) {
+#ifdef __APPLE__
+      /*
+       * Use EVFILT_EXCEPT+ NOTE_OOB for macOS since it defines this flag.
+       * FreeBSD does not.
+       * Refs: https://github.com/libuv/libuv/issues/3947
+       */
+      EV_SET(events + nevents, w->fd, EVFILT_EXCEPT, EV_ADD, NOTE_OOB, 0, 0);
+#else
       EV_SET(events + nevents, w->fd, EV_OOBAND, EV_ADD, 0, 0, 0);
+#endif
 
       if (++nevents == ARRAY_SIZE(events)) {
         if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
@@ -391,7 +400,12 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
           revents |= UV__POLLRDHUP;
       }
 
+#ifdef __APPLE__
+      /* Match EVFILT_EXCEPT used above for macOS. */
+      if (ev->filter == EVFILT_EXCEPT) {
+#else
       if (ev->filter == EV_OOBAND) {
+#endif
         if (w->pevents & UV__POLLPRI)
           revents |= UV__POLLPRI;
         else


### PR DESCRIPTION
Fixes: https://github.com/libuv/libuv/issues/3947

---

As https://github.com/libuv/libuv/pull/4597 got reverted and the respective issue closed, I'm reopening this one, tested on a FreeBSD machine and a macOS machine.