### PR TITLE
darwin: better heuristic for available memory

### DIFF
--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -134,7 +134,7 @@ uint64_t uv_get_available_memory(void) {
     return 0;
   }
 
-  return ((uint64_t) info.free_count + (uint64_t) info.inactive_count) * sysconf(_SC_PAGESIZE);
+  return ((uint64_t) info.free_count + (uint64_t) info.inactive_count + (uint64_t) info.purgeable_count) * sysconf(_SC_PAGESIZE);
 }
 
 


### PR DESCRIPTION
My attempt at resolving https://github.com/libuv/libuv/issues/3897.

This is not a perfectly accurate solution, but it returns a much more usable value, and I wanted this to be as easy as possible to review so that the PR doesn't stall. The code is copied from `uv_get_free_memory` three functions above but includes the inactive pages and the free pages in the calculation instead of just the truly free pages.

Refs: 
- https://github.com/JuliaLang/libuv/pull/34
- https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_free_memory
- https://apple.stackexchange.com/questions/4288/what-does-it-mean-if-i-have-lots-of-inactive-memory-at-the-end-of-a-work-day