### PR TITLE
test: skip connect_unspecified and udp_connect on FreeBSD >= 15.0

### DIFF
--- a/test/test-connect-unspecified.c
+++ b/test/test-connect-unspecified.c
@@ -27,6 +27,9 @@ static void connect_cb(uv_connect_t* req, int status) {
 }
 
 TEST_IMPL(connect_unspecified) {
+#if defined(__FreeBSD__) && __FreeBSD_version >= 1500043
+  RETURN_SKIP("FreeBSD >= 15.0 disables connect() to INADDR_ANY by default");
+#endif
   uv_loop_t* loop;
   uv_tcp_t socket4;
   struct sockaddr_in addr4;

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -101,6 +101,9 @@ TEST_IMPL(udp_connect) {
 #if defined(__OpenBSD__)
   RETURN_SKIP("Test does not currently work in OpenBSD");
 #endif
+#if defined(__FreeBSD__) && __FreeBSD_version >= 1500043
+  RETURN_SKIP("FreeBSD >= 15.0 disables connect() to INADDR_ANY by default");
+#endif
   uv_udp_send_t req;
   struct sockaddr_in ext_addr;
   struct sockaddr_in tmp_addr;


### PR DESCRIPTION
FreeBSD 15.0 (commit https://github.com/freebsd/freebsd-src/commit/cd240957d7ba43d819e9d59c6f6517fe915102c7) disabled connecting to INADDR_ANY by default. These two tests specifically test connecting to 0.0.0.0 and now fail with ENOBUFS on affected FreeBSD versions.

The new behavior is also documented in the release note [here](
https://github.com/freebsd/freebsd-src/blob/4fc1e7546f1289183ec5d0b80653cab090c60399/RELNOTES#L143)

**EDIT**: I noticed that there are some assertions about how this is handled per-platform. If desired, I can enhance the tests to check for ENOBUFS only if FreeBSD version is >= 1500043