### PR TITLE
Add copy button feature to documentation code blocks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # primary
 furo==2024.8.6
 Sphinx==7.0.1
+sphinx-copybutton==0.5.2
 
 # dependencies
 alabaster==0.7.16

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -48,7 +48,7 @@ sys.path.insert(0, os.path.abspath('sphinx-plugins'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['manpage']
+extensions = ['manpage', 'sphinx_copybutton']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['templates']
@@ -148,6 +148,12 @@ html_favicon = 'static/favicon.ico'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['static']
+
+# Add a tiny CSS override for the copy button so it positions nicely
+# and matches the docs' minimal style. The file lives under static/.
+html_css_files = [
+    'copybutton.css',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -325,6 +331,23 @@ epub_basename = u'libuv'
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+# ------------------------------------------------------------------
+# sphinx-copybutton configuration
+# Adds a small, accessible "Copy" button to code blocks in the HTML
+# output. Install with: pip install sphinx-copybutton
+# ------------------------------------------------------------------
+# Selector targets the <pre> elements created by the Pygments highlight
+# integration. Keep this selector minimal so it matches the project's
+# highlighted code blocks across themes.
+copybutton_selector = "div.highlight pre, div.highlighted pre, pre.literal-block"
+
+# Treat the prompt text as a regular expression so common REPL prompts
+# (>>>, $) are stripped when copying. This keeps copied snippets
+# clean for pasting into shells or editors.
+copybutton_prompt_text = r"^\s*(>>> |\$ |\.\.\. )"
+copybutton_prompt_is_regexp = True
+
 
 # The depth of the table of contents in toc.ncx.
 #epub_tocdepth = 3

--- a/docs/src/static/copybutton.css
+++ b/docs/src/static/copybutton.css
@@ -1,0 +1,50 @@
+/* Minimal, theme-agnostic styles for the copy button added by
+   sphinx-copybutton. Keeps the UI small and accessible. */
+
+/* Ensure the code block container is the positioning context */
+.highlight, .highlighted, pre.literal-block {
+  position: relative;
+}
+
+/* Target possible copy button class names used by extensions */
+button.copybutton, button.copybtn, .copybutton, .copybtn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  border-radius: 6px;
+  border: 1px solid rgba(0,0,0,0.12);
+  background: rgba(255,255,255,0.02);
+  color: inherit;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 120ms ease, transform 80ms ease;
+  /* Make sure it doesn't overlap long code selection */
+  z-index: 3;
+}
+
+button.copybutton:hover, button.copybtn:hover,
+.copybutton:hover, .copybtn:hover {
+  background: rgba(255,255,255,0.04);
+  transform: translateY(-1px);
+}
+
+/* Focus styles for keyboard users */
+button.copybutton:focus, button.copybtn:focus,
+.copybutton:focus, .copybtn:focus {
+  outline: 3px solid Highlight;
+  outline-offset: 2px;
+}
+
+/* Smaller visual footprint on narrow screens */
+@media (max-width: 520px) {
+  button.copybutton, button.copybtn, .copybutton, .copybtn {
+    top: 0.35rem;
+    right: 0.35rem;
+    padding: 0.25rem;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "libuv",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
#4926
<h2> <strong>Description</strong></h2>
<p>This PR adds a <strong>"Copy" button</strong> to all code examples on the documentation website (<a href="https://docs.libuv.org/en/v1.x/">https://docs.libuv.org/en/v1.x/</a>).</p>
<p>The button allows users to quickly copy code snippets without manually selecting text, improving the overall usability and developer experience.</p>
<hr>
<h2> <strong>Problem</strong></h2>
<ul>
<li>
<p>Users currently have to manually select and copy code, which can be inconvenient.</p>
</li>
<li>
<p>Manual copying increases the chance of including extra spaces or formatting errors.</p>
</li>
<li>
<p>Many developer documentation sites (like MDN, Node.js, and React) already provide this feature for better accessibility and user experience.</p>
</li>
</ul>
<hr>
<h2> <strong>Proposed Solution</strong></h2>
<ul>
<li>
<p>Add a <strong>"Copy" button</strong> to the top-right corner of every code block in the Sphinx-generated docs.</p>
</li>
<li>
<p>When clicked, it:</p>
<ul>
<li>
<p>Copies the code block content to the clipboard.</p>
</li>
<li>
<p>Displays a short confirmation message like <strong>“Copied!”</strong>.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h2>⚙️ <strong>Implementation Details</strong></h2>
<ul>
<li>
<p>Integrated the <a href="https://sphinx-copybutton.readthedocs.io/en/latest/"><code inline="">sphinx-copybutton</code></a> extension by adding it to <code inline="">docs/conf.py</code>:</p>
<pre><code class="language-python">extensions = [
    'sphinx.ext.autodoc',
    'sphinx.ext.viewcode',
    'sphinx_copybutton',
]
</code></pre>
</li>
<li>
<p>Installed the required dependency:</p>
<pre><code class="language-bash">pip install sphinx-copybutton
</code></pre>
</li>
<li>
<p>Optionally configured button behavior in <code inline="">conf.py</code>:</p>
<pre><code class="language-python">copybutton_prompt_text = r"&gt;&gt;&gt; |\$ |# "
copybutton_prompt_is_regexp = True
copybutton_remove_prompts = True
</code></pre>
</li>
<li>
<p>Rebuilt documentation using <code inline="">make html</code> to verify functionality locally.</p>
</li>
</ul>
<hr>







