### PR TITLE
unix: remove deprecated errno constants

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -156,7 +156,6 @@ struct uv__queue {
   XX(EFTYPE, "inappropriate file type or format")                             \
   XX(EILSEQ, "illegal byte sequence")                                         \
   XX(ESOCKTNOSUPPORT, "socket type not supported")                            \
-  XX(ENODATA, "no data available")                                            \
   XX(EUNATCH, "protocol driver not attached")                                 \
   XX(ENOEXEC, "exec format error")                                            \
 

--- a/include/uv/errno.h
+++ b/include/uv/errno.h
@@ -456,18 +456,6 @@
 # define UV__ESOCKTNOSUPPORT (-4025)
 #endif
 
-/* FreeBSD defines ENODATA in /usr/include/c++/v1/errno.h which is only visible
- * if C++ is being used. Define it directly to avoid problems when integrating
- * libuv in a C++ project.
- */
-#if defined(ENODATA) && !defined(_WIN32)
-# define UV__ENODATA UV__ERR(ENODATA)
-#elif defined(__FreeBSD__)
-# define UV__ENODATA (-9919)
-#else
-# define UV__ENODATA (-4024)
-#endif
-
 #if defined(EUNATCH) && !defined(_WIN32)
 # define UV__EUNATCH UV__ERR(EUNATCH)
 #else


### PR DESCRIPTION
Various errno constants were deprecated by POSIX. libc++ added deprecation markers on these constants.

This change removes the usage of these constants to fix a compilation failure due to mappings of those constants.

See: https://github.com/llvm/llvm-project/pull/80542