### PR TITLE
Replace sizeof(uv_loop_t) with uv_loop_size() in examples

### DIFF
--- a/docs/code/helloworld/main.c
+++ b/docs/code/helloworld/main.c
@@ -3,7 +3,7 @@
 #include <uv.h>
 
 int main() {
-    uv_loop_t *loop = malloc(sizeof(uv_loop_t));
+    uv_loop_t *loop = malloc(uv_loop_size());
     uv_loop_init(loop);
 
     printf("Now quitting.\n");

--- a/docs/code/signal/main.c
+++ b/docs/code/signal/main.c
@@ -5,7 +5,7 @@
 
 uv_loop_t* create_loop()
 {
-    uv_loop_t *loop = malloc(sizeof(uv_loop_t));
+    uv_loop_t *loop = malloc(uv_loop_size());
     if (loop) {
       uv_loop_init(loop);
     }


### PR DESCRIPTION
## Summary

Updates example code to use the recommended uv_loop_size() function instead of sizeof(uv_loop_t) when allocating memory for uv_loop_t structures.

## Problem

The example code currently uses malloc(sizeof(uv_loop_t)), which assumes a fixed structure size. However, uv_loop_t is an opaque type whose size can vary across platforms, architectures, and libuv versions.

## Solution

Replace sizeof(uv_loop_t) with uv_loop_size() in:
- docs/code/helloworld/main.c
- docs/code/signal/main.c

## Why This Matters

1. **Opaque Type Safety**: uv_loop_t is opaque; its size varies by platform/architecture/version
2. **ABI Stability**: uv_loop_size() returns the correct size for the current build
3. **Future-Proofing**: Automatically adapts if libuv's internal structure changes
4. **Consistency**: Aligns with test suite usage (test/test-getters-setters.c:64)
5. **Documentation**: Matches the recommended API pattern in docs/src/loop.rst

## Changes

**Before:**

c
uv_loop_t *loop = malloc(sizeof(uv_loop_t));


**After:**

c
uv_loop_t *loop = malloc(uv_loop_size());


## Testing

- ✅ No compilation errors
- ✅ No linter errors
- ✅ Follows same pattern as test suite

## References

- API Docs: docs/src/loop.rst (line 149-152)
- Test Example: test/test-getters-setters.c (line 64)
- API Header: include/uv.h (line 307)

## Type

- [x] Documentation/example code improvement
- [x] Code cleanup / Best practices 