### PR TITLE
fix: documentation error in uv_utf16_to_wtf8() function

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -913,7 +913,7 @@ is not complete.
     `utf16_len` count (in characters) gives the length of `utf16`. If `utf16`
     is NUL terminated, `utf16_len` can be set to -1, otherwise it must be
     specified. If `wtf8_ptr` is `NULL`, no result will be computed, but the
-    length (equal to `uv_utf16_length_as_wtf8`) will be stored in `wtf8_ptr`.
+    length (equal to `uv_utf16_length_as_wtf8`) will be stored in `wtf8_len_ptr`.
     If `*wtf8_ptr` is `NULL`, space for the conversion will be allocated and
     returned in `wtf8_ptr` and the length will be returned in `wtf8_len_ptr`.
     Otherwise, the length of `*wtf8_ptr` must be passed in `wtf8_len_ptr`. The


### PR DESCRIPTION
When `wtf8_ptr` is NULL, the length will be stored in `wtf8_len_ptr` (not in `wtf8_ptr`).

Fix https://github.com/libuv/libuv/issues/4934