### PR TITLE
win: rename minimal_windows10_version1709() for libuv's convention

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -52,7 +52,7 @@ static int uv__tcp_nodelay(uv_tcp_t* handle, SOCKET socket, int enable) {
 /*
  * Check if Windows version is 10.0.16299 (Windows 10, version 1709) or later.
  */
-static int minimal_windows10_version1709(void) {
+static int uv__windows10_version1709(void) {
   OSVERSIONINFOW os_info;
   if (!pRtlGetVersion)
     return 0;
@@ -89,7 +89,7 @@ static int uv__tcp_keepalive(uv_tcp_t* handle,
 
   /* Windows 10, version 1709 (build 10.0.16299) and later require second units
    * for TCP keepalive options. */
-  if (minimal_windows10_version1709()) {
+  if (uv__windows10_version1709()) {
     if (setsockopt(socket,
                    IPPROTO_TCP,
                    TCP_KEEPIDLE,
@@ -865,7 +865,7 @@ static int uv__tcp_try_connect(uv_connect_t* req,
    * is not reachable, instead of waiting for 2s. We do not care if this fails.
    * This only works on Windows version 10.0.16299 and later.
    */
-  if (minimal_windows10_version1709() && uv__is_loopback(&converted)) {
+  if (uv__windows10_version1709() && uv__is_loopback(&converted)) {
     memset(&retransmit_ioctl, 0, sizeof(retransmit_ioctl));
     retransmit_ioctl.Rtt = TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS;
     retransmit_ioctl.MaxSynRetransmissions = TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS;


### PR DESCRIPTION
This function was introduced by #4775 and it didn't strictly follow the naming convention of libuv function where internal functions should start with `uv__`.

---------

Signed-off-by: Andy Pan <i@andypan.me>