### PR TITLE
fs: Support nanosecond resolution in uv__fs_to_timespec

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -224,13 +224,6 @@ static struct timespec uv__fs_to_timespec(double time) {
   ts.tv_sec  = time;
   ts.tv_nsec = (time - ts.tv_sec) * 1e9;
 
- /* TODO(bnoordhuis) Remove this. utimesat() has nanosecond resolution but we
-  * stick to microsecond resolution for the sake of consistency with other
-  * platforms. I'm the original author of this compatibility hack but I'm
-  * less convinced it's useful nowadays.
-  */
-  ts.tv_nsec -= ts.tv_nsec % 1000;
-
   if (ts.tv_nsec < 0) {
     ts.tv_nsec += 1e9;
     ts.tv_sec -= 1;


### PR DESCRIPTION
Remove the microsecond truncation in uv__fs_to_timespec() function to enable full nanosecond resolution support. The utimensat() system call already supports nanosecond precision, so the artificial truncation to microseconds is no longer necessary.

This allows file modification and access times to be set with full nanosecond precision instead of being limited to microsecond resolution.

Fixes the TODO comment about removing the microsecond resolution limit.

Fixes: #4946
@juanarbol @bnoordhuis @saghul