### PR TITLE
win: handle sshfs-win quirk in uv_fs_readdir()

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1662,6 +1662,21 @@ void fs__readdir(uv_fs_t* req) {
   dir = req->ptr;
   dirents = dir->dirents;
   memset(dirents, 0, dir->nentries * sizeof(*dir->dirents));
+
+  /* Initial FindFirstFile can fail with ERROR_FILE_NOT_FOUND, meaning
+   * no matches, which leaves dir_handle set to INVALID_HANDLE_VALUE,
+   * see fs__opendir(). Not an actual error, just means no results.
+   *
+   * sshfs-win apparently works that way but reading an empty directory
+   * on a regular drive doesn't trigger that particular code path.
+   *
+   * See https://github.com/libuv/libuv/issues/4952
+   */
+  if (dir->dir_handle == INVALID_HANDLE_VALUE) {
+    SET_REQ_RESULT(req, 0);
+    return;
+  }
+
   find_data = &dir->find_data;
   dirent_idx = 0;
 


### PR DESCRIPTION
The initial FindFirstFile can fail with ERROR_FILE_NOT_FOUND, meaning no matches (read: empty directory), which leaves dir_handle set to INVALID_HANDLE_VALUE. Not an actual error, it just means no results.

I can't get FindFirstFile to work like that on regular file systems but it's been reported that it does under sshfs-win and the MSDN documentation clearly states it's possible. Handle it.

Fixes: https://github.com/libuv/libuv/issues/4952