### PR TITLE
doc: fix threading bugs in progress example

### DIFF
--- a/docs/code/progress/main.c
+++ b/docs/code/progress/main.c
@@ -23,6 +23,10 @@ void fake_download(uv_work_t *req) {
         downloaded += (200+random())%1000; // can only download max 1000bytes/sec,
                                            // but at least a 200;
     }
+    // Ensure final 100% progress update is sent
+    pct = 100.0;
+    atomic_store_explicit(&percentage, pct, memory_order_release);
+    uv_async_send(&async);
 }
 
 void after(uv_work_t *req, int status) {


### PR DESCRIPTION
Fixes #4386

Fixed race conditions and memory safety issues in the progress example by using C11 atomic operations for proper thread synchronization.

Changes:
- Changed percentage from double to _Atomic double
- Use atomic_store_explicit() with memory_order_release when writing
- Use atomic_load_explicit() with memory_order_acquire when reading
- Removed unsafe pointer passing via async.data

This ensures proper memory synchronization between the worker thread and async callback, preventing data races and dangling pointer issues.