### PR TITLE
fix: correct memory cleanup index in uv_os_environ error path

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1533,7 +1533,7 @@ int uv_os_environ(uv_env_item_t** envitems, int* count) {
 
 fail:
   for (i = 0; i < cnt; i++) {
-    envitem = &(*envitems)[cnt];
+    envitem = &(*envitems)[i];
     uv__free(envitem->name);
   }
   uv__free(*envitems);

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -1280,7 +1280,7 @@ fail:
   FreeEnvironmentStringsW(env);
 
   for (i = 0; i < cnt; i++) {
-    envitem = &(*envitems)[cnt];
+    envitem = &(*envitems)[i];
     uv__free(envitem->name);
   }
   uv__free(*envitems);


### PR DESCRIPTION
## Problem

The `uv_os_environ()` function had a memory cleanup bug in its error handling path. When memory allocation failed during environment variable processing, the cleanup loop was using the wrong index variable to free allocated memory.

## Root Cause

In the `fail:` cleanup block, the code was using `cnt` (the count of successfully allocated items) as the array index instead of `i` (the loop variable). This meant:
- The same memory could be freed multiple times (if `cnt < i`)
- Not all allocated items would be properly freed
- Potential crashes or undefined behavior

## Solution

Changed the cleanup loop to use the correct index variable `i` instead of `cnt`:
- `src/unix/core.c`: Line 1536
- `src/win/util.c`: Line 1283

## Impact

- Prevents double-free errors
- Ensures proper memory cleanup on allocation failure
- Improves reliability of error handling in `uv_os_environ()`

## Testing

The existing test suite (`test/test-env-vars.c`) covers `uv_os_environ()` functionality. This fix ensures proper cleanup when memory allocation fails during environment variable processing.