### PR TITLE
win: fix mkdir returning EPERM instead of EEXIST on network drives

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -1257,7 +1257,21 @@ void fs__mkdir(uv_fs_t* req) {
   if (CreateDirectoryW(req->file.pathw, NULL)) {
     SET_REQ_RESULT(req, 0);
   } else {
-    SET_REQ_WIN32_ERROR(req, GetLastError());
+    DWORD err = GetLastError();
+
+    /* Fix: On Windows network drives, CreateDirectoryW returns
+       ERROR_ACCESS_DENIED when the directory already exists. */
+    if (err == ERROR_ACCESS_DENIED) {
+      DWORD attr = GetFileAttributesW(req->file.pathw);
+      if (attr != INVALID_FILE_ATTRIBUTES &&
+          (attr & FILE_ATTRIBUTE_DIRECTORY)) {
+        req->result = UV_EEXIST;
+        return;
+      }
+    }
+
+    SET_REQ_WIN32_ERROR(req, err);
+
     if (req->sys_errno_ == ERROR_INVALID_NAME ||
         req->sys_errno_ == ERROR_DIRECTORY)
       req->result = UV_EINVAL;


### PR DESCRIPTION
### Summary

This PR fixes an issue where `uv_fs_mkdir()` returns `UV_EPERM` instead of
`UV_EEXIST` on Windows network-mounted filesystems (SSHFS, SMB, FTP, etc.)
when attempting to create a directory that already exists.

On NTFS, `CreateDirectoryW()` returns `ERROR_ALREADY_EXISTS (183)`, but on
network drives it often returns `ERROR_ACCESS_DENIED (5)` even when the
directory already exists. libuv currently maps `ERROR_ACCESS_DENIED` to
`UV_EPERM`, causing incorrect behavior.

This patch adds a check using `GetFileAttributesW()`: if the path exists and
is a directory, libuv now returns `UV_EEXIST`, matching expected semantics.

**This incorrect error code affects:**

- `fs.mkdir()` on Windows network drives  
- `fs.mkdir({ recursive: true })`  
- `fs-extra.ensureDir()`  
- any code relying on `EEXIST` to detect an existing directory  

Returning `EPERM` breaks application logic in many real scenarios.


### Fix

When `CreateDirectoryW()` fails with `ERROR_ACCESS_DENIED`, libuv now checks:

```c
DWORD attr = GetFileAttributesW(req->file.pathw);
if (attr != INVALID_FILE_ATTRIBUTES &&
    (attr & FILE_ATTRIBUTE_DIRECTORY)) {
  req->result = UV_EEXIST;
  return;
}
```

If the directory truly exists, return UV_EEXIST.
Otherwise, keep the original UV_EPERM behavior.

**Result:**
Network drive existing dir → returns UV_EEXIST (correct)
NTFS existing dir → unchanged
Real permission errors → unchanged
No changes to non-Windows platforms

**Related Issue:**
Fixes: #4959