### PR TITLE
docs: add example usage and note for uv_sleep()

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -890,6 +890,39 @@ API
 
     Causes the calling thread to sleep for `msec` milliseconds.
 
+    .. note::
+        This is a blocking call and will pause the calling thread for the
+        specified duration. It should not be used in the main event loop thread
+        as it will block the event loop. Consider using :c:type:`uv_timer_t`
+        for non-blocking delays in the event loop.
+
+    Example:
+
+    .. code-block:: c
+
+        #include <uv.h>
+        #include <stdio.h>
+
+        int main() {
+            uint64_t start, end;
+
+            // Get the start time
+            start = uv_hrtime();
+
+            printf("Sleeping for 1000 milliseconds...\n");
+
+            // Sleep for 1 second (1000 milliseconds)
+            uv_sleep(1000);
+
+            // Get the end time
+            end = uv_hrtime();
+
+            printf("Actual sleep duration: %llu ms\n",
+                   (unsigned long long)((end - start) / 1000000));
+
+            return 0;
+        }
+
     .. versionadded:: 1.34.0
 
 String manipulation functions


### PR DESCRIPTION
Fixes #4954

 Summary
This PR addresses the lack of example usage for the `uv_sleep()` function in the documentation. While other utility functions in `docs/src/misc.rst` include practical examples, `uv_sleep()` only had a basic function signature and brief description.

 Changes Made
- **Added comprehensive code example**: Demonstrates `uv_sleep()` usage with `uv_hrtime()` to measure actual sleep duration, providing a practical, runnable example for users
- **Added important usage note**: Clarifies that `uv_sleep()` is a blocking call that pauses the calling thread and should not be used in the main event loop thread
- **Included best practice recommendation**: Suggests using `uv_timer_t` for non-blocking delays within the event loop

Documentation Style
The example follows the established reStructuredText format used throughout the libuv documentation, using `.. code-block:: c` syntax and proper formatting consistent with other function examples in the same file.

Testing
The example code is based on actual usage patterns found in libuv's test suite (e.g., `test/test-hrtime.c`) and provides a clear, practical demonstration of the function's behavior.


This contribution helps new users understand when and how to properly use `uv_sleep()`, addressing the documentation gap identified in issue #4954.