### PR TITLE
unix: remove handle from queue on uv_spawn() error

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -1073,6 +1073,7 @@ int uv_spawn(uv_loop_t* loop,
   return exec_errorno;
 
 error:
+  uv__queue_remove(&process->handle_queue);
   if (pipes != NULL) {
     for (i = 0; i < stdio_count; i++) {
       if (i < options->stdio_count)


### PR DESCRIPTION
If uv_spawn() fails after uv__handle_init() has been called, the handle remains in loop->handle_queue. This causes bug if the handle is stack-allocated or freed, and a subsequent loop operation like uv_walk() accesses it.

This follows the same pattern as uv_tcp_init_ex() which explicitly removes the handle from the queue on error.