### PR TITLE
doc: remove hp-ux from supported platforms list

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -112,7 +112,6 @@ API
           - AIX
           - DragonFlyBSD
           - FreeBSD
-          - HP-UX
           - illumos
           - Linux
           - macOS


### PR DESCRIPTION
As of January 1, 2026, HP-UX is well and truly dead. Remove it.