### PR TITLE
Add socket type to Unix domain socket

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -871,6 +871,7 @@ struct uv_pipe_s {
   UV_HANDLE_FIELDS
   UV_STREAM_FIELDS
   int ipc; /* non-zero if this pipe is used for passing handles */
+  int socket_type; /* socket type from enum __socket_type */
   UV_PIPE_PRIVATE_FIELDS
 };
 

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -51,6 +51,7 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int ipc) {
   handle->connect_req = NULL;
   handle->pipe_fname = NULL;
   handle->ipc = ipc;
+  handle->socket_type = SOCK_STREAM;
   return 0;
 }
 
@@ -119,7 +120,7 @@ int uv_pipe_bind2(uv_pipe_t* handle,
     addrlen = sizeof saddr;
   }
 
-  err = uv__socket(AF_UNIX, SOCK_STREAM, 0);
+  err = uv__socket(AF_UNIX, handle->socket_type, 0);
   if (err < 0)
     goto err_socket;
   sockfd = err;
@@ -286,7 +287,7 @@ int uv_pipe_connect2(uv_connect_t* req,
   new_sock = (uv__stream_fd(handle) == -1);
 
   if (new_sock) {
-    err = uv__socket(AF_UNIX, SOCK_STREAM, 0);
+    err = uv__socket(AF_UNIX, handle->socket_type, 0);
     if (err < 0)
       goto out;
     handle->io_watcher.fd = err;


### PR DESCRIPTION
A `socket_type` element has been added to the `uv_pipe_t` struct. When `uv_pipe_t` is initialized, the `socket_type` is assigned the default value of `SOCK_STREAM`. The `socket_type` can be changed before subsequent calls to `uv_pipe_bind` or `uv_pipe_connect`.