### PR TITLE
test: fix -Wstringop-overread warning

### DIFF
--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -91,8 +91,8 @@ static void poll_cb(uv_poll_t* handle, int status, int events) {
       while (n == -1 && errno == EINTR);
       ASSERT(n >= 0 || errno != EINVAL);
       if (cli_rd_check == 1) {
-        ASSERT_OK(strncmp(buffer, "world", n));
         ASSERT_EQ(5, n);
+        ASSERT_OK(strncmp(buffer, "world", n));
         cli_rd_check = 2;
       }
       if (cli_rd_check == 0) {


### PR DESCRIPTION
Check the length before doing the compare like we do a few lines below, not the other way around. It's a false positive because the length is capped well below the maximum object size but it's an easy fix.

Fixes the following warning:

    test/test-poll-oob.c:94:19: warning: ‘strncmp’ specified bound
    [18446744071562067968, 18446744073709551615] exceeds maximum
    object size 9223372036854775807 [-Wstringop-overread]