### PR TITLE
test: disable udp_reuseport test under qemu

### DIFF
--- a/test/test-udp-reuseport.c
+++ b/test/test-udp-reuseport.c
@@ -215,6 +215,17 @@ TEST_IMPL(udp_reuseport) {
   int r;
   int i;
 
+#if defined(__QEMU__)
+  /* QEMU's user-mode emulator sometimes runs threads in sequence
+   * instead of in parallel and that throws off the test.
+   * See https://github.com/libuv/libuv/issues/4777.
+   */
+  RETURN_SKIP("Unreliable under QEMU");
+#endif  /* defined(__QEMU__) */
+
+  if (uv_available_parallelism() < 2)
+    RETURN_SKIP("Unreliable without thread parallelism");
+
   r = uv_mutex_init(&mutex);
   ASSERT_OK(r);
 


### PR DESCRIPTION
The test is multi-threaded and expects both threads to receive at least some of the incoming datagrams but there isn't always true parallelism under QEMU's user-mode emulator.

Single-core systems are also susceptible to that so also add a check that we have at least two cores to run on.

It's not perfect because a sufficiently dedicated test torturer could probably concoct a containerized setup where the core count > 1 but the available CPU slice is so small that the test effectively still runs sequentially, but it's better than nothing.

Fixes: https://github.com/libuv/libuv/issues/4777