### PR TITLE
test: disable tcp_reuseport test under qemu

### DIFF
--- a/test/test-tcp-reuseport.c
+++ b/test/test-tcp-reuseport.c
@@ -178,6 +178,17 @@ TEST_IMPL(tcp_reuseport) {
   int r;
   int i;
 
+#if defined(__QEMU__)
+  /* QEMU's user-mode emulator sometimes runs threads in sequence
+   * instead of in parallel and that throws off the test.
+   * See https://github.com/libuv/libuv/issues/4777.
+   */
+  RETURN_SKIP("Unreliable under QEMU");
+#endif  /* defined(__QEMU__) */
+
+  if (uv_available_parallelism() < 2)
+    RETURN_SKIP("Unreliable without thread parallelism");
+
   r = uv_mutex_init(&mutex);
   ASSERT_OK(r);
 


### PR DESCRIPTION
The test is multi-threaded and expects both threads to receive at least some of the incoming connections but there isn't always true parallelism under QEMU's user-mode emulator.

Single-core systems are also susceptible to that so also add a check that we have at least two cores to run on.

As mentioned in the change for the udp_reuseport test from a few days ago, the test is not perfect (there being > 1 core doesn't guarantee we actually get to run on them) but it's better than nothing.

Fixes: https://github.com/libuv/libuv/issues/5003