### PR TITLE
win: fix watch loop logic

### DIFF
--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -606,7 +606,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
     WCHAR path_buf[MAX_PATH];
     DWORD path_len = GetFinalPathNameByHandleW(handle->dir_handle,
                                                path_buf,
-                                               MAX_PATH,
+                                               ARRAY_SIZE(path_buf),
                                                FILE_NAME_NORMALIZED);
     
     if (path_len > 0 && path_len < MAX_PATH) {

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -433,6 +433,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
   WCHAR* filenamew = NULL;
   WCHAR* long_filenamew = NULL;
   DWORD offset = 0;
+  int dir_event_detected = 0;
 
   assert(req->type == UV_FS_EVENT_REQ);
   assert(handle->req_pending);
@@ -458,6 +459,10 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
         assert(!filename);
         assert(!filenamew);
         assert(!long_filenamew);
+
+        if (file_info->FileNameLength == 0) {
+          dir_event_detected = 1;
+        }
 
         /*
          * Fire the event only if we were asked to watch a directory,
@@ -587,6 +592,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
                                      sizeof(info)) &&
         info.Directory &&
         info.DeletePending) {
+      dir_event_detected = 1;
       uv__convert_utf16_to_utf8(handle->dirw, -1, &filename);
       handle->cb(handle, filename, UV_RENAME, 0);
       uv__free(filename);
@@ -600,22 +606,25 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
     uv__want_endgame(loop, (uv_handle_t*)handle);
   } else if (uv__is_active(handle)) {
     /*
-     * Check if the handle has become a zombie pointing to $Extend\$Deleted.
-     * If so, report as deleted and don't re-queue.
+     * Check if the handle has become a zombie pointing to \$Extend\$Deleted\.
+     * Only perform the check if we detected an event on the directory, which
+     * may indicate deletion.
      */
-    WCHAR path_buf[MAX_PATH];
-    DWORD path_len = GetFinalPathNameByHandleW(handle->dir_handle,
-                                               path_buf,
-                                               ARRAY_SIZE(path_buf),
-                                               FILE_NAME_NORMALIZED);
-    
-    if (path_len > 0 && path_len < MAX_PATH) {
-      if (wcsstr(path_buf, L"\\$Extend\\$Deleted\\") != NULL) {
-        handle->cb(handle, NULL, 0, UV_ENOENT);
-        return;
+    if (dir_event_detected) {
+      WCHAR path_buf[MAX_PATH];
+      DWORD path_len = GetFinalPathNameByHandleW(handle->dir_handle,
+                                                 path_buf,
+                                                 ARRAY_SIZE(path_buf),
+                                                 FILE_NAME_NORMALIZED);
+
+      if (path_len > 0 && path_len < MAX_PATH) {
+        if (wcsstr(path_buf, L"\\$Extend\\$Deleted\\") != NULL) {
+          handle->cb(handle, NULL, 0, UV_ENOENT);
+          return;
+        }
       }
     }
-    
+
     uv__fs_event_queue_readdirchanges(loop, handle);
   }
 }

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -617,7 +617,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
                                                  ARRAY_SIZE(path_buf),
                                                  FILE_NAME_NORMALIZED);
 
-      if (path_len > 0 && path_len < MAX_PATH) {
+      if (path_len > 0 && path_len < ARRAY_SIZE(path_buf)) {
         if (wcsstr(path_buf, L"\\$Extend\\$Deleted\\") != NULL) {
           handle->cb(handle, NULL, 0, UV_ENOENT);
           return;

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -610,7 +610,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
                                                FILE_NAME_NORMALIZED);
     
     if (path_len > 0 && path_len < MAX_PATH) {
-      if (wcsstr(path_buf, L"$Extend\\$Deleted") != NULL) {
+      if (wcsstr(path_buf, L"\\$Extend\\$Deleted\\") != NULL) {
         handle->cb(handle, NULL, 0, UV_ENOENT);
         return;
       }

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -615,7 +615,7 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
       DWORD path_len = GetFinalPathNameByHandleW(handle->dir_handle,
                                                  path_buf,
                                                  ARRAY_SIZE(path_buf),
-                                                 FILE_NAME_NORMALIZED);
+                                                 FILE_NAME_NORMALIZED | VOLUME_NAME_NONE);
 
       if (path_len > 0 && path_len < ARRAY_SIZE(path_buf)) {
         if (wcsstr(path_buf, L"\\$Extend\\$Deleted\\") != NULL) {

--- a/src/win/fs-event.c
+++ b/src/win/fs-event.c
@@ -599,6 +599,23 @@ void uv__process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
   if (handle->flags & UV_HANDLE_CLOSING) {
     uv__want_endgame(loop, (uv_handle_t*)handle);
   } else if (uv__is_active(handle)) {
+    /*
+     * Check if the handle has become a zombie pointing to $Extend\$Deleted.
+     * If so, report as deleted and don't re-queue.
+     */
+    WCHAR path_buf[MAX_PATH];
+    DWORD path_len = GetFinalPathNameByHandleW(handle->dir_handle,
+                                               path_buf,
+                                               MAX_PATH,
+                                               FILE_NAME_NORMALIZED);
+    
+    if (path_len > 0 && path_len < MAX_PATH) {
+      if (wcsstr(path_buf, L"$Extend\\$Deleted") != NULL) {
+        handle->cb(handle, NULL, 0, UV_ENOENT);
+        return;
+      }
+    }
+    
     uv__fs_event_queue_readdirchanges(loop, handle);
   }
 }

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -534,12 +534,6 @@ static void fs_event_cb_del_dir_perm(uv_fs_event_t* handle,
   }
 }
 
-static void timeout_cb_del_dir_perm(uv_timer_t* handle) {
-  uv_close((uv_handle_t*)&fs_event, NULL);
-  uv_close((uv_handle_t*)handle, NULL);
-  FATAL("Test timed out: fs_event watcher did not receive UV_ENOENT");
-}
-
 TEST_IMPL(fs_event_watch_delete_dir_win) {
   uv_loop_t* loop = uv_default_loop();
   int r;

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -521,7 +521,6 @@ TEST_IMPL(fs_event_watch_delete_dir) {
 
 #ifdef _WIN32
 static int fs_event_cb_del_dir_perm_got_enoent;
-static uv_timer_t timeout_timer;
 
 static void fs_event_cb_del_dir_perm(uv_fs_event_t* handle,
                                      const char* filename,
@@ -529,7 +528,6 @@ static void fs_event_cb_del_dir_perm(uv_fs_event_t* handle,
                                      int status) {
   if (status == UV_ENOENT) {
     fs_event_cb_del_dir_perm_got_enoent = 1;
-    uv_close((uv_handle_t*)&timeout_timer, close_cb);
     uv_close((uv_handle_t*)handle, close_cb);
   }
 }
@@ -556,7 +554,7 @@ TEST_IMPL(fs_event_watch_delete_dir_win) {
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(1, fs_event_cb_del_dir_perm_got_enoent);
-  ASSERT_EQ(3, close_cb_called);
+  ASSERT_EQ(2, close_cb_called);
 
   /* Cleanup */
   fs_event_unlink_files(NULL);

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -519,6 +519,65 @@ TEST_IMPL(fs_event_watch_delete_dir) {
   return 0;
 }
 
+#ifdef _WIN32
+static int fs_event_cb_del_dir_perm_got_enoent;
+static uv_timer_t timeout_timer;
+
+static void fs_event_cb_del_dir_perm(uv_fs_event_t* handle,
+                                     const char* filename,
+                                     int events,
+                                     int status) {
+  if (status == UV_ENOENT) {
+    fs_event_cb_del_dir_perm_got_enoent = 1;
+    uv_close((uv_handle_t*)&timeout_timer, close_cb);
+    uv_close((uv_handle_t*)handle, close_cb);
+  }
+}
+
+static void timeout_cb_del_dir_perm(uv_timer_t* handle) {
+  uv_close((uv_handle_t*)&fs_event, NULL);
+  uv_close((uv_handle_t*)handle, NULL);
+  FATAL("Test timed out: fs_event watcher did not receive UV_ENOENT");
+}
+
+TEST_IMPL(fs_event_watch_delete_dir_win) {
+  uv_loop_t* loop = uv_default_loop();
+  int r;
+
+  /* Setup */
+  fs_event_cb_del_dir_perm_got_enoent = 0;
+  fs_event_unlink_files(NULL);
+  delete_dir("watch_del_dir/");
+  create_dir("watch_del_dir");
+
+  r = uv_fs_event_init(loop, &fs_event);
+  ASSERT_OK(r);
+  r = uv_fs_event_start(&fs_event, fs_event_cb_del_dir_perm, "watch_del_dir", 0);
+  ASSERT_OK(r);
+  r = uv_timer_init(loop, &timer);
+  ASSERT_OK(r);
+  r = uv_timer_start(&timer, fs_event_del_dir, 100, 0);
+  ASSERT_OK(r);
+
+  /* Timeout timer fails the test if it takes too long (infinite loop bug) */
+  r = uv_timer_init(loop, &timeout_timer);
+  ASSERT_OK(r);
+  r = uv_timer_start(&timeout_timer, timeout_cb_del_dir_perm, 3000, 0);
+  ASSERT_OK(r);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT_EQ(1, fs_event_cb_del_dir_perm_got_enoent);
+  ASSERT_EQ(3, close_cb_called);
+
+  /* Cleanup */
+  fs_event_unlink_files(NULL);
+
+  MAKE_VALGRIND_HAPPY(loop);
+  return 0;
+}
+#endif
+
 
 TEST_IMPL(fs_event_watch_dir_recursive) {
 #if defined(__APPLE__) && defined(__TSAN__)

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -559,12 +559,6 @@ TEST_IMPL(fs_event_watch_delete_dir_win) {
   r = uv_timer_start(&timer, fs_event_del_dir, 100, 0);
   ASSERT_OK(r);
 
-  /* Timeout timer fails the test if it takes too long (infinite loop bug) */
-  r = uv_timer_init(loop, &timeout_timer);
-  ASSERT_OK(r);
-  r = uv_timer_start(&timeout_timer, timeout_cb_del_dir_perm, 3000, 0);
-  ASSERT_OK(r);
-
   uv_run(loop, UV_RUN_DEFAULT);
 
   ASSERT_EQ(1, fs_event_cb_del_dir_perm_got_enoent);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -409,6 +409,9 @@ TEST_FS_DECLARE   (fs_read_bufs)
 TEST_FS_DECLARE   (fs_read_file_eof)
 TEST_DECLARE   (fs_event_watch_dir)
 TEST_DECLARE   (fs_event_watch_delete_dir)
+#ifdef _WIN32
+TEST_DECLARE   (fs_event_watch_delete_dir_win)
+#endif
 TEST_DECLARE   (fs_event_watch_dir_recursive)
 #ifdef _WIN32
 TEST_DECLARE   (fs_event_watch_dir_short_path)
@@ -1140,6 +1143,9 @@ TASK_LIST_START
   TEST_FS_ENTRY  (fs_file_open_append)
   TEST_ENTRY  (fs_event_watch_dir)
   TEST_ENTRY  (fs_event_watch_delete_dir)
+#ifdef _WIN32
+  TEST_ENTRY  (fs_event_watch_delete_dir_win)
+#endif
   TEST_ENTRY  (fs_event_watch_dir_recursive)
 #ifdef _WIN32
   TEST_ENTRY  (fs_event_watch_dir_short_path)


### PR DESCRIPTION
As described in the original Node.js issue, and [my comment there](https://github.com/nodejs/node/issues/61398#issuecomment-3817738965), there is a bug when permanently deleting a watched file on Windows. This PR fixes it. I've tested this directly in Node.js before opening the PR.

Refs: https://github.com/nodejs/node/issues/61398