### PR TITLE
unix,win: check nbufs argument is reasonable

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1297,11 +1297,17 @@ static void uv__stream_connect(uv_stream_t* stream) {
 static int uv__check_before_write(uv_stream_t* stream,
                                   unsigned int nbufs,
                                   uv_stream_t* send_handle) {
-  assert(nbufs > 0);
   assert((stream->type == UV_TCP ||
           stream->type == UV_NAMED_PIPE ||
           stream->type == UV_TTY) &&
          "uv_write (unix) does not yet support other types of streams");
+
+  /* We're not beholden to IOV_MAX but limit the buffer count to catch sign
+   * conversion bugs where a caller passes in a signed negative number that
+   * then gets converted to a really large unsigned number.
+   */
+  if (nbufs < 1 || nbufs > 1024*1024)
+    return UV_EINVAL;
 
   if (uv__stream_fd(stream) < 0)
     return UV_EBADF;

--- a/test/test-tcp-write-fail.c
+++ b/test/test-tcp-write-fail.c
@@ -91,12 +91,27 @@ static void connect_cb(uv_connect_t* req, int status) {
 TEST_IMPL(tcp_write_fail) {
   struct sockaddr_in addr;
   uv_tcp_t client;
+  uv_buf_t buf;
   int r;
 
   ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
 
   r = uv_tcp_init(uv_default_loop(), &client);
   ASSERT_OK(r);
+
+  r = uv_write(&write_req,
+               (uv_stream_t*) &client,
+               &buf,
+               0,  /* Illegal. Worse, senseless. */
+               write_cb);
+  ASSERT_EQ(UV_EINVAL, r);
+
+  r = uv_write(&write_req,
+               (uv_stream_t*) &client,
+               &buf,
+               -42,  /* Undergoes sign conversion. */
+               write_cb);
+  ASSERT_EQ(UV_EINVAL, r);
 
   r = uv_tcp_connect(&connect_req,
                      &client,


### PR DESCRIPTION
Catch sign conversion bugs by introducing a bounds check that doubles as a sanity check.

Fixes: https://github.com/libuv/libuv/issues/5012