### PR TITLE
idna: fix assert in wtf8_to_utf16 conversion

### DIFF
--- a/src/idna.c
+++ b/src/idna.c
@@ -394,7 +394,7 @@ void uv_wtf8_to_utf16(const char* source_ptr,
     /* uv_wtf8_length_as_utf16 should have been called and checked first. */
     assert(code_point >= 0);
     if (code_point > 0xFFFF) {
-      assert(code_point < 0x10FFFF);
+      assert(code_point <= 0x10FFFF);
       *w_target++ = (((code_point - 0x10000) >> 10) + 0xD800);
       *w_target++ = ((code_point - 0x10000) & 0x3FF) + 0xDC00;
       w_target_len -= 2;

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -236,5 +236,13 @@ TEST_IMPL(wtf8) {
   ASSERT_GT(len, 0);
   ASSERT_LT(len, ARRAY_SIZE(buf));
   uv_wtf8_to_utf16(input, buf, len);
+
+  /* Test 0x10FFFF, max unicode character */
+  static const char input_max[] = "\xF4\x8F\xBF\xBF";
+
+  len = uv_wtf8_length_as_utf16(input_max);
+  ASSERT_GT(len, 0);
+  ASSERT_LT(len, ARRAY_SIZE(buf));
+  uv_wtf8_to_utf16(input_max, buf, len);
   return 0;
 }


### PR DESCRIPTION
0x10FFFF is the valid max unicode character, so the check should be inclusive.

This assert gets triggered because uv__wtf8_decode1 (used by uv_wtf8_length_as_utf16) has the correct code_point <= 0x10FFFF check, so the sequence is treated as valid and it will be passed into uv_wtf8_to_utf16, where the incorrect assert gets triggered:

```
src/idna.c:397: uv_wtf8_to_utf16: Assertion `code_point < 0x10FFFF' failed.
```