### PR TITLE
win: fix uv_get_process_title

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -376,17 +376,12 @@ done:
 
 
 static int uv__get_process_title(void) {
-  WCHAR title_w[MAX_TITLE_LENGTH];
+  WCHAR title_w[MAX_PATH];
   DWORD wlen;
-  DWORD err;
 
-  SetLastError(ERROR_SUCCESS);
-  wlen = GetConsoleTitleW(title_w, sizeof(title_w) / sizeof(WCHAR));
-  if (wlen == 0) {
-    err = GetLastError();
-    if (err != 0)
-      return uv_translate_sys_error(err);
-  }
+  wlen = GetModuleFileNameW(NULL, title_w, MAX_PATH);
+  if (wlen == 0)
+    return uv_translate_sys_error(GetLastError());
 
   return uv__convert_utf16_to_utf8(title_w, wlen, &process_title);
 }


### PR DESCRIPTION
After some discussion in [my initial PR](https://github.com/libuv/libuv/pull/5004), I decided to open this one, which doesn't change any behavior on Windows and changes as little code as possible.

Note to reviewers: I decided to use `GetModuleFileNameW()` instead of `CommandLineToArgvW(GetCommandLineW())`, as I think it is better to have a uniform return value `absoulte/path/to/app.exe` instead of various possibilities eg. `app`, `app.exe`, `./relative/path/to/app,exe`, etc. But I'm OK with using the other approach if it is more beneficial.

Fixes: https://github.com/libuv/libuv/issues/2667