### PR TITLE
unix,udp: fix -Wgnu-folding-constant warning

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -1456,7 +1456,7 @@ exit:
 
 
 static void uv__udp_sendmsg(uv_udp_t* handle) {
-  static const int N = 20;
+  enum { N = 20 };
   struct sockaddr* addrs[N];
   unsigned int nbufs[N];
   uv_buf_t* bufs[N];


### PR DESCRIPTION
~~~
/Users/saghul/src/libuv/src/unix/udp.c:1460:26: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1460 |   struct sockaddr* addrs[N];
      |                          ^
/Users/saghul/src/libuv/src/unix/udp.c:1461:22: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1461 |   unsigned int nbufs[N];
      |                      ^
/Users/saghul/src/libuv/src/unix/udp.c:1462:18: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1462 |   uv_buf_t* bufs[N];
      |                  ^
3 warnings generated.
/Users/saghul/src/libuv/src/unix/udp.c:1460:26: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1460 |   struct sockaddr* addrs[N];
      |                          ^
/Users/saghul/src/libuv/src/unix/udp.c:1461:22: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1461 |   unsigned int nbufs[N];
      |                      ^
/Users/saghul/src/libuv/src/unix/udp.c:1462:18: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 1462 |   uv_buf_t* bufs[N];
      |                  ^
~~~
