### PR TITLE
win: fix fs-fd-hash-inl.h missing from dist.tar.gz

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ libuv_la_SOURCES += src/win/async.c \
                     src/win/error.c \
                     src/win/fs-event.c \
                     src/win/fs.c \
+                    src/win/fs-fd-hash-inl.h \
                     src/win/getaddrinfo.c \
                     src/win/getnameinfo.c \
                     src/win/handle.c \


### PR DESCRIPTION
I downloaded the `libuv-v1.52.0-dist.tar.gz` file on windows and tried to build it, but it failed because `src/win/fs-fd-hash-inl.h` was missing:
```
libuv\src\win\fs.c(42,1): error C1083: Cannot open include file: 'fs-fd-hash-inl.h': No such file or directory
```

It has to be declared in the makefile in order to be included.

Similar to past patches like: c363cd0dbadc78f74096478f9379abd7edf0e4f5