### PR TITLE
unix,win: support NULL loop for sync uv_getaddrinfo

### DIFF
--- a/src/unix/getaddrinfo.c
+++ b/src/unix/getaddrinfo.c
@@ -107,7 +107,9 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   uv_getaddrinfo_t* req;
 
   req = container_of(w, uv_getaddrinfo_t, work_req);
-  uv__req_unregister(req->loop);
+
+  if (req->loop != NULL)
+    uv__req_unregister(req->loop);
 
   /* See initialization in uv_getaddrinfo(). */
   if (req->hints)
@@ -149,6 +151,8 @@ int uv_getaddrinfo(uv_loop_t* loop,
 
   if (req == NULL || (hostname == NULL && service == NULL))
     return UV_EINVAL;
+  if (loop == NULL && cb != NULL)
+    return UV_EINVAL;
 
   /* FIXME(bnoordhuis) IDNA does not seem to work z/OS,
    * probably because it uses EBCDIC rather than ASCII.
@@ -175,7 +179,10 @@ int uv_getaddrinfo(uv_loop_t* loop,
   if (buf == NULL)
     return UV_ENOMEM;
 
-  uv__req_init(loop, req, UV_GETADDRINFO);
+  UV_REQ_INIT(req, UV_GETADDRINFO);
+  if (loop != NULL)
+    uv__req_register(loop);
+
   req->loop = loop;
   req->cb = cb;
   req->addrinfo = NULL;

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -208,7 +208,8 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   }
 
 complete:
-  uv__req_unregister(req->loop);
+  if (req->loop != NULL)
+    uv__req_unregister(req->loop);
 
   /* finally do callback with converted result */
   if (req->getaddrinfo_cb)
@@ -239,7 +240,7 @@ void uv_freeaddrinfo(struct addrinfo* ai) {
  */
 int uv_getaddrinfo(uv_loop_t* loop,
                    uv_getaddrinfo_t* req,
-                   uv_getaddrinfo_cb getaddrinfo_cb,
+                   uv_getaddrinfo_cb cb,
                    const char* node,
                    const char* service,
                    const struct addrinfo* hints) {
@@ -252,12 +253,15 @@ int uv_getaddrinfo(uv_loop_t* loop,
   size_t hintoff = 0;
   ssize_t rc;
 
-  if (req == NULL || (node == NULL && service == NULL)) {
+  if (req == NULL || (node == NULL && service == NULL))
     return UV_EINVAL;
-  }
+  if (loop == NULL && cb != NULL)
+    return UV_EINVAL;
+
+  uv__once_init();
 
   UV_REQ_INIT(req, UV_GETADDRINFO);
-  req->getaddrinfo_cb = getaddrinfo_cb;
+  req->getaddrinfo_cb = cb;
   req->addrinfo = NULL;
   req->loop = loop;
   req->retcode = 0;
@@ -330,9 +334,10 @@ int uv_getaddrinfo(uv_loop_t* loop,
     req->addrinfow = NULL;
   }
 
-  uv__req_register(loop);
+  if (loop != NULL)
+    uv__req_register(loop);
 
-  if (getaddrinfo_cb) {
+  if (cb) {
     uv__work_submit(loop,
                     &req->work_req,
                     UV__WORK_SLOW_IO,

--- a/test/test-getaddrinfo.c
+++ b/test/test-getaddrinfo.c
@@ -119,7 +119,7 @@ TEST_IMPL(getaddrinfo_fail_sync) {
   uv_getaddrinfo_t req;
 
   /* Use a FQDN by ending in a period */
-  ASSERT_GT(0, uv_getaddrinfo(uv_default_loop(),
+  ASSERT_GT(0, uv_getaddrinfo(NULL,
                               &req,
                               NULL,
                               "example.invalid.",
@@ -165,15 +165,13 @@ TEST_IMPL(getaddrinfo_basic_sync) {
 #endif
   uv_getaddrinfo_t req;
 
-  ASSERT_OK(uv_getaddrinfo(uv_default_loop(),
+  ASSERT_OK(uv_getaddrinfo(NULL,
                            &req,
                            NULL,
                            name,
                            NULL,
                            NULL));
   uv_freeaddrinfo(req.addrinfo);
-
-  MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 


### PR DESCRIPTION
Brings symmetry with the uv_fs_xxx APIs.
