### PR TITLE
linux: prefer cpuinfo_cur_freq over scaling_cur_freq in uv_cpu_info()

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1867,10 +1867,19 @@ nocpuinfo:
       continue;
 
     n++;
+    /* Prefer cpuinfo_cur_freq: it reads a hardware-cached value and avoids
+     * slow ACPI/SMM round-trips that scaling_cur_freq triggers on some AMD
+     * CPUs (especially inside containers), which can take ~20ms per core.
+     * Fall back to scaling_cur_freq when cpuinfo_cur_freq is not available.
+     */
     snprintf(buf, sizeof(buf),
-             "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", cpu);
-
+             "/sys/devices/system/cpu/cpu%u/cpufreq/cpuinfo_cur_freq", cpu);
     fp = uv__open_file(buf);
+    if (fp == NULL) {
+      snprintf(buf, sizeof(buf),
+               "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", cpu);
+      fp = uv__open_file(buf);
+    }
     if (fp == NULL)
       continue;
 


### PR DESCRIPTION
## Summary

On Linux, `uv_cpu_info()` reads `/sys/devices/system/cpu/cpuN/cpufreq/scaling_cur_freq` for every online CPU core. On modern AMD CPUs (EPYC, Ryzen 9000 series) running inside Linux containers, each `open()` + `read()` of that file causes the kernel cpufreq driver to issue an ACPI call into System Management Mode (SMM), which suspends all CPUs while firmware runs. Inside a container the round-trip latency is amplified and regularly reaches **~20 ms per core**.

On a 32-core AMD EPYC system this makes a single `uv_cpu_info()` call take **500–600 ms**.

`cpuinfo_cur_freq` exposes the same current-frequency value but reads from a hardware-cached register, skipping the ACPI round-trip entirely. This patch prefers it when available and falls back to `scaling_cur_freq` for platforms that do not expose `cpuinfo_cur_freq`.

## Root cause

The regression was introduced in libuv when the implementation switched from `cpuinfo_cur_freq` to `scaling_cur_freq` (tracked in #4098). The slow path is triggered because:

1. AMD's ACPI cpufreq driver re-queries the hardware on every `scaling_cur_freq` read
2. SMM (System Management Mode) is a privileged firmware context — it halts all CPUs while executing
3. Container environments amplify the latency due to virtualisation overhead

Reproduction (requires AMD CPU + Docker on Linux):

```bash
# Fast (old behaviour)
docker run --rm node:20.2.0-alpine node -e "console.time('t'); os.cpus(); console.timeEnd('t')"
# cpus: 19ms

# Slow (current)
docker run --rm node:20.3.0-alpine node -e "console.time('t'); os.cpus(); console.timeEnd('t')"
# cpus: 356ms
```

## Fix

In the per-CPU frequency loop in `src/unix/linux.c`:

- Try `cpuinfo_cur_freq` first — reads a cached hardware register, consistently fast
- Fall back to `scaling_cur_freq` if `cpuinfo_cur_freq` is absent (non-x86 platforms, or systems without the cpufreq driver)

The change uses the same `if (fp == NULL) continue;` fallback pattern already present in the function, so it is safe on all currently supported platforms.

## Related

- https://github.com/libuv/libuv/issues/4098 (previously closed NOT_PLANNED)
- https://github.com/nodejs/node/issues/61998 (Node.js report with strace confirming the slow reads)
- https://github.com/nodejs/node/issues/48831 (earlier Node.js report)
- https://github.com/nodejs/performance/issues/93

Fixes: https://github.com/libuv/libuv/issues/4098