### PR TITLE
unix: fix compilation warnings with GCC 15

### DIFF
--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -473,7 +473,7 @@ UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {
 UV_UNUSED(static char* uv__basename_r(const char* path)) {
   char* s;
 
-  s = strrchr(path, '/');
+  s = strrchr((char*) path, '/');
   if (s == NULL)
     return (char*) path;
 

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1639,7 +1639,7 @@ done:
 
 int uv_resident_set_memory(size_t* rss) {
   char buf[1024];
-  const char* s;
+  char* s;
   long val;
   int rc;
   int i;
@@ -1900,7 +1900,7 @@ nocpuinfo:
     c = *cpus + cpu;
 
     (*ci)[i++] = (uv_cpu_info_t) {
-      .model     = p + c->model * sizeof(*model),
+      .model     = (char*) p + c->model * sizeof(*model),
       .speed     = c->freq / 1000,
       /* Note: sysconf(_SC_CLK_TCK) is fixed at 100 Hz,
        * therefore the multiplier is always 1000/100 = 10.
@@ -2374,7 +2374,7 @@ next:
 static char* uv__cgroup1_find_cpu_controller(const char* cgroup,
                                              int* cgroup_size) {
   /* Seek to the cpu controller line. */
-  char* cgroup_cpu = strstr(cgroup, ":cpu,");
+  char* cgroup_cpu = strstr((char*) cgroup, ":cpu,");
 
   if (cgroup_cpu != NULL) {
     /* Skip the controller prefix to the start of the cgroup path. */


### PR DESCRIPTION
~~~
libuv/src/unix/internal.h: In function ‘uv__basename_r’:
libuv/src/unix/internal.h:480:12: warning: return discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  480 |   return s + 1;

libuv/src/unix/linux.c: In function ‘uv__cgroup1_find_cpu_controller’:
libuv/src/unix/linux.c:2377:22: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2377 |   char* cgroup_cpu = strstr(cgroup, ":cpu,");
      |                      ^~~~~~

libuv/src/unix/linux.c: In function ‘uv_cpu_info’:
libuv/src/unix/linux.c:1903:20: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1903 |       .model     = p + c->model * sizeof(*model),
      |                    ^
~~~
