### PR TITLE
macos: use kevent64 and allow immediate return when no io is pending on event loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,6 @@ option(MSAN "Enable MemorySanitizer (MSan)" OFF)
 option(TSAN "Enable ThreadSanitizer (TSan)" OFF)
 option(UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
 
-option(USE_EV64 "Enable event64 support with fast return" OFF)
-if(APPLE AND USE_EV64)
-  add_compile_definitions(EV64)
-endif()
-
 if(MSAN AND NOT CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang")
   message(SEND_ERROR "MemorySanitizer requires clang. Try again with -DCMAKE_C_COMPILER=clang")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ option(MSAN "Enable MemorySanitizer (MSan)" OFF)
 option(TSAN "Enable ThreadSanitizer (TSan)" OFF)
 option(UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" OFF)
 
+option(USE_EV64 "Enable event64 support with fast return" OFF)
+if(APPLE AND USE_EV64)
+  add_compile_definitions(EV64)
+endif()
+
 if(MSAN AND NOT CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang")
   message(SEND_ERROR "MemorySanitizer requires clang. Try again with -DCMAKE_C_COMPILER=clang")
 endif()

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -45,17 +45,17 @@ static int kqueue_evfilt_user_support = 1;
 
 static void uv__kqueue_runtime_detection(void) {
   int kq;
-  KEVENT_S ev[2];
+  UV__KEVENT_S ev[2];
   struct timespec timeout = {0, 0};
 
   /* Perform the runtime detection to ensure that kqueue with
    * EVFILT_USER actually works. */
   kq = kqueue();
-  SET_EVENT(ev, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
+  UV__SET_EVENT(ev, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
          EV_ADD | EV_CLEAR, 0);
-  SET_EVENT(ev + 1, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
+  UV__SET_EVENT(ev + 1, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
          0, NOTE_TRIGGER);
-  if (KEVENT(kq, ev, 2, ev, 1, 0, &timeout) < 1 ||
+  if (UV__KEVENT(kq, ev, 2, ev, 1, 0, &timeout) < 1 ||
       ev[0].filter != EVFILT_USER ||
       ev[0].ident != UV__KQUEUE_EVFILT_USER_IDENT ||
       ev[0].flags & EV_ERROR)
@@ -234,12 +234,12 @@ static void uv__async_send(uv_loop_t* loop) {
     fd = loop->async_io_watcher.fd;  /* eventfd */
   }
 #elif UV__KQUEUE_EVFILT_USER
-  KEVENT_S ev;
+  UV__KEVENT_S ev;
 
   if (kqueue_evfilt_user_support) {
     fd = loop->async_io_watcher.fd; /* magic number for EVFILT_USER */
-    SET_EVENT(&ev, fd, EVFILT_USER, 0, NOTE_TRIGGER);
-    r = KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
+    UV__SET_EVENT(&ev, fd, EVFILT_USER, 0, NOTE_TRIGGER);
+    r = UV__KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
     if (r == 0)
       return;
     abort();
@@ -265,7 +265,7 @@ static int uv__async_start(uv_loop_t* loop) {
   int pipefd[2];
   int err;
 #if UV__KQUEUE_EVFILT_USER
-  KEVENT_S ev;
+  UV__KEVENT_S ev;
 #endif
 
   if (loop->async_io_watcher.fd != -1)
@@ -299,8 +299,8 @@ static int uv__async_start(uv_loop_t* loop) {
      * Since uv__async_send() may happen before uv__io_poll() with multi-threads,
      * we can't defer this registration of EVFILT_USER event as we did for other
      * events, but must perform it right away. */
-    SET_EVENT(&ev, err, EVFILT_USER, EV_ADD | EV_CLEAR, 0);
-    err = KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
+    UV__SET_EVENT(&ev, err, EVFILT_USER, EV_ADD | EV_CLEAR, 0);
+    err = UV__KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
     if (err < 0)
       return UV__ERR(errno);
   } else {

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -45,17 +45,17 @@ static int kqueue_evfilt_user_support = 1;
 
 static void uv__kqueue_runtime_detection(void) {
   int kq;
-  struct kevent ev[2];
+  KEVENT_S ev[2];
   struct timespec timeout = {0, 0};
 
   /* Perform the runtime detection to ensure that kqueue with
    * EVFILT_USER actually works. */
   kq = kqueue();
-  EV_SET(ev, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
-         EV_ADD | EV_CLEAR, 0, 0, 0);
-  EV_SET(ev + 1, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
-         0, NOTE_TRIGGER, 0, 0);
-  if (kevent(kq, ev, 2, ev, 1, &timeout) < 1 ||
+  SET_EVENT(ev, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
+         EV_ADD | EV_CLEAR, 0);
+  SET_EVENT(ev + 1, UV__KQUEUE_EVFILT_USER_IDENT, EVFILT_USER,
+         0, NOTE_TRIGGER);
+  if (KEVENT(kq, ev, 2, ev, 1, 0, &timeout) < 1 ||
       ev[0].filter != EVFILT_USER ||
       ev[0].ident != UV__KQUEUE_EVFILT_USER_IDENT ||
       ev[0].flags & EV_ERROR)
@@ -234,12 +234,12 @@ static void uv__async_send(uv_loop_t* loop) {
     fd = loop->async_io_watcher.fd;  /* eventfd */
   }
 #elif UV__KQUEUE_EVFILT_USER
-  struct kevent ev;
+  KEVENT_S ev;
 
   if (kqueue_evfilt_user_support) {
     fd = loop->async_io_watcher.fd; /* magic number for EVFILT_USER */
-    EV_SET(&ev, fd, EVFILT_USER, 0, NOTE_TRIGGER, 0, 0);
-    r = kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL);
+    SET_EVENT(&ev, fd, EVFILT_USER, 0, NOTE_TRIGGER);
+    r = KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
     if (r == 0)
       return;
     abort();
@@ -265,7 +265,7 @@ static int uv__async_start(uv_loop_t* loop) {
   int pipefd[2];
   int err;
 #if UV__KQUEUE_EVFILT_USER
-  struct kevent ev;
+  KEVENT_S ev;
 #endif
 
   if (loop->async_io_watcher.fd != -1)
@@ -294,13 +294,13 @@ static int uv__async_start(uv_loop_t* loop) {
     pipefd[1] = -1;
 
     /* When using EVFILT_USER event to wake up the kqueue, this event must be
-     * registered beforehand. Otherwise, calling kevent() to issue an
+     * registered beforehand. Otherwise, calling kevent64() to issue an
      * unregistered EVFILT_USER event will get an ENOENT.
      * Since uv__async_send() may happen before uv__io_poll() with multi-threads,
      * we can't defer this registration of EVFILT_USER event as we did for other
      * events, but must perform it right away. */
-    EV_SET(&ev, err, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, 0);
-    err = kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL);
+    SET_EVENT(&ev, err, EVFILT_USER, EV_ADD | EV_CLEAR, 0);
+    err = KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL);
     if (err < 0)
       return UV__ERR(errno);
   } else {

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -450,6 +450,22 @@ int uv__iou_fs_unlink(uv_loop_t* loop, uv_fs_t* req);
 #if defined(__APPLE__)
 int uv___stream_fd(const uv_stream_t* handle);
 #define uv__stream_fd(handle) (uv___stream_fd((const uv_stream_t*) (handle)))
+
+#ifdef EV64
+#define SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
+#define KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
+#define KEVENT_S struct kevent64_s
+#else
+#define SET_EVENT(a, b, c, d, e) EV_SET(a, b, c, d, e, 0, 0)
+#define KEVENT(a, b, c, d, e, f, g) kevent(a, b, c, d, e, g)
+#define KEVENT_S struct kevent
+#endif
+#ifndef KEVENT_FLAG_IMMEDIATE
+#define KEVENT_FLAG_IMMEDIATE 1
+#endif
+#ifndef KEVENT_FLAG_NONE
+#define KEVENT_FLAG_NONE 0
+#endif
 #else
 #define uv__stream_fd(handle) ((handle)->io_watcher.fd)
 #endif /* defined(__APPLE__) */

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -451,7 +451,7 @@ int uv__iou_fs_unlink(uv_loop_t* loop, uv_fs_t* req);
 int uv___stream_fd(const uv_stream_t* handle);
 #define uv__stream_fd(handle) (uv___stream_fd((const uv_stream_t*) (handle)))
 
-#if defined(EV64) && defined(__LP64__) && !defined(__i386__)
+#if defined(__LP64__) && !defined(__i386__)
 #define SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
 #define KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
 #define KEVENT_S struct kevent64_s

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -452,14 +452,14 @@ int uv___stream_fd(const uv_stream_t* handle);
 #define uv__stream_fd(handle) (uv___stream_fd((const uv_stream_t*) (handle)))
 
 #if defined(__LP64__)
-#define SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
-#define KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
-#define KEVENT_S struct kevent64_s
+#define UV__SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
+#define UV__KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
+#define UV__KEVENT_S struct kevent64_s
 #else
-#define SET_EVENT(a, b, c, d, e) EV_SET(a, b, c, d, e, 0, 0)
-#define KEVENT(a, b, c, d, e, f, g) kevent(a, b, c, d, e, g)
-#define KEVENT_S struct kevent
-#endif
+#define UV__SET_EVENT(a, b, c, d, e) EV_SET(a, b, c, d, e, 0, 0)
+#define UV__KEVENT(a, b, c, d, e, f, g) kevent(a, b, c, d, e, g)
+#define UV__KEVENT_S struct kevent
+#endif /* defined(__LP64__) */
 #ifndef KEVENT_FLAG_IMMEDIATE
 #define KEVENT_FLAG_IMMEDIATE 1
 #endif

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -451,7 +451,7 @@ int uv__iou_fs_unlink(uv_loop_t* loop, uv_fs_t* req);
 int uv___stream_fd(const uv_stream_t* handle);
 #define uv__stream_fd(handle) (uv___stream_fd((const uv_stream_t*) (handle)))
 
-#ifdef EV64
+#if defined(EV64) && defined(__LP64__) && !defined(__i386__)
 #define SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
 #define KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
 #define KEVENT_S struct kevent64_s

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -451,7 +451,7 @@ int uv__iou_fs_unlink(uv_loop_t* loop, uv_fs_t* req);
 int uv___stream_fd(const uv_stream_t* handle);
 #define uv__stream_fd(handle) (uv___stream_fd((const uv_stream_t*) (handle)))
 
-#if defined(__LP64__) && !defined(__i386__)
+#if defined(__LP64__)
 #define SET_EVENT(a, b, c, d, e) EV_SET64(a, b, c, d, e, 0, 0, 0, 0)
 #define KEVENT(a, b, c, d, e, f, g) kevent64(a, b, c, d, e, f, g)
 #define KEVENT_S struct kevent64_s

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -95,7 +95,7 @@ int uv__io_fork(uv_loop_t* loop) {
 
 
 int uv__io_check_fd(uv_loop_t* loop, int fd) {
-  struct kevent ev[2];
+  KEVENT_S ev[2];
   struct stat sb;
 #ifdef __APPLE__
   char path[MAXPATHLEN];
@@ -130,21 +130,21 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   }
 #endif
 
-  EV_SET(ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
-  EV_SET(ev + 1, fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
-  if (kevent(loop->backend_fd, ev, 2, NULL, 0, NULL))
+  SET_EVENT(ev, fd, EVFILT_READ, EV_ADD, 0);
+  SET_EVENT(ev + 1, fd, EVFILT_READ, EV_DELETE, 0);
+  if (KEVENT(loop->backend_fd, ev, 2, NULL, 0, 0, NULL))
     return UV__ERR(errno);
 
   return 0;
 }
 
 
-static void uv__kqueue_delete(int kqfd, const struct kevent *ev) {
-  struct kevent change;
+static void uv__kqueue_delete(int kqfd, const KEVENT_S *ev) {
+  KEVENT_S change;
 
-  EV_SET(&change, ev->ident, ev->filter, EV_DELETE, 0, 0, 0);
+  SET_EVENT(&change, ev->ident, ev->filter, EV_DELETE, 0);
 
-  if (0 == kevent(kqfd, &change, 1, NULL, 0, NULL))
+  if (0 == KEVENT(kqfd, &change, 1, NULL, 0, 0, NULL))
     return;
 
   if (errno == EBADF || errno == ENOENT)
@@ -156,8 +156,8 @@ static void uv__kqueue_delete(int kqfd, const struct kevent *ev) {
 
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   uv__loop_internal_fields_t* lfields;
-  struct kevent events[1024];
-  struct kevent* ev;
+  KEVENT_S events[1024];
+  KEVENT_S* ev;
   struct timespec spec;
   unsigned int nevents;
   unsigned int revents;
@@ -209,20 +209,20 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         op = EV_ADD | EV_ONESHOT; /* Stop the event from firing repeatedly. */
       }
 
-      EV_SET(events + nevents, w->fd, filter, op, fflags, 0, 0);
+      SET_EVENT(events + nevents, w->fd, filter, op, fflags);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
+        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
     }
 
     if ((w->events & POLLOUT) == 0 && (w->pevents & POLLOUT) != 0) {
-      EV_SET(events + nevents, w->fd, EVFILT_WRITE, EV_ADD, 0, 0, 0);
+      SET_EVENT(events + nevents, w->fd, EVFILT_WRITE, EV_ADD, 0);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
+        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -235,13 +235,13 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
        * FreeBSD does not.
        * Refs: https://github.com/libuv/libuv/issues/3947
        */
-      EV_SET(events + nevents, w->fd, EVFILT_EXCEPT, EV_ADD, NOTE_OOB, 0, 0);
+      SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, NOTE_OOB);
 #else
-      EV_SET(events + nevents, w->fd, EV_OOBAND, EV_ADD, 0, 0, 0);
+      SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, 0);
 #endif
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (kevent(loop->backend_fd, events, nevents, NULL, 0, NULL))
+        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -276,11 +276,12 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     }
 
     uv__io_poll_prepare(loop, pset, timeout);
-    nfds = kevent(loop->backend_fd,
+    nfds = KEVENT(loop->backend_fd,
                   events,
                   nevents,
                   events,
                   ARRAY_SIZE(events),
+                  timeout == 0 ? KEVENT_FLAG_IMMEDIATE : KEVENT_FLAG_NONE,
                   timeout == -1 ? NULL : &spec);
     uv__io_poll_check(loop, pset);
 
@@ -488,7 +489,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 
 void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
   uv_fs_event_t* handle;
-  struct kevent ev;
+  KEVENT_S ev;
   int events;
   const char* path;
 #if defined(F_GETPATH)
@@ -541,9 +542,9 @@ void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
   fflags = NOTE_ATTRIB | NOTE_WRITE  | NOTE_RENAME
          | NOTE_DELETE | NOTE_EXTEND | NOTE_REVOKE;
 
-  EV_SET(&ev, w->fd, EVFILT_VNODE, EV_ADD | EV_ONESHOT, fflags, 0, 0);
+  SET_EVENT(&ev, w->fd, EVFILT_VNODE, EV_ADD | EV_ONESHOT, fflags);
 
-  if (kevent(loop->backend_fd, &ev, 1, NULL, 0, NULL))
+  if (KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL))
     abort();
 }
 

--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -95,7 +95,7 @@ int uv__io_fork(uv_loop_t* loop) {
 
 
 int uv__io_check_fd(uv_loop_t* loop, int fd) {
-  KEVENT_S ev[2];
+  UV__KEVENT_S ev[2];
   struct stat sb;
 #ifdef __APPLE__
   char path[MAXPATHLEN];
@@ -130,21 +130,21 @@ int uv__io_check_fd(uv_loop_t* loop, int fd) {
   }
 #endif
 
-  SET_EVENT(ev, fd, EVFILT_READ, EV_ADD, 0);
-  SET_EVENT(ev + 1, fd, EVFILT_READ, EV_DELETE, 0);
-  if (KEVENT(loop->backend_fd, ev, 2, NULL, 0, 0, NULL))
+  UV__SET_EVENT(ev, fd, EVFILT_READ, EV_ADD, 0);
+  UV__SET_EVENT(ev + 1, fd, EVFILT_READ, EV_DELETE, 0);
+  if (UV__KEVENT(loop->backend_fd, ev, 2, NULL, 0, 0, NULL))
     return UV__ERR(errno);
 
   return 0;
 }
 
 
-static void uv__kqueue_delete(int kqfd, const KEVENT_S *ev) {
-  KEVENT_S change;
+static void uv__kqueue_delete(int kqfd, const UV__KEVENT_S *ev) {
+  UV__KEVENT_S change;
 
-  SET_EVENT(&change, ev->ident, ev->filter, EV_DELETE, 0);
+  UV__SET_EVENT(&change, ev->ident, ev->filter, EV_DELETE, 0);
 
-  if (0 == KEVENT(kqfd, &change, 1, NULL, 0, 0, NULL))
+  if (0 == UV__KEVENT(kqfd, &change, 1, NULL, 0, 0, NULL))
     return;
 
   if (errno == EBADF || errno == ENOENT)
@@ -156,8 +156,8 @@ static void uv__kqueue_delete(int kqfd, const KEVENT_S *ev) {
 
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   uv__loop_internal_fields_t* lfields;
-  KEVENT_S events[1024];
-  KEVENT_S* ev;
+  UV__KEVENT_S events[1024];
+  UV__KEVENT_S* ev;
   struct timespec spec;
   unsigned int nevents;
   unsigned int revents;
@@ -209,20 +209,20 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
         op = EV_ADD | EV_ONESHOT; /* Stop the event from firing repeatedly. */
       }
 
-      SET_EVENT(events + nevents, w->fd, filter, op, fflags);
+      UV__SET_EVENT(events + nevents, w->fd, filter, op, fflags);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
+        if (UV__KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
     }
 
     if ((w->events & POLLOUT) == 0 && (w->pevents & POLLOUT) != 0) {
-      SET_EVENT(events + nevents, w->fd, EVFILT_WRITE, EV_ADD, 0);
+      UV__SET_EVENT(events + nevents, w->fd, EVFILT_WRITE, EV_ADD, 0);
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
+        if (UV__KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -235,13 +235,13 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
        * FreeBSD does not.
        * Refs: https://github.com/libuv/libuv/issues/3947
        */
-      SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, NOTE_OOB);
+      UV__SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, NOTE_OOB);
 #else
-      SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, 0);
+      UV__SET_EVENT(events + nevents, w->fd, EV_OOBAND, EV_ADD, 0);
 #endif
 
       if (++nevents == ARRAY_SIZE(events)) {
-        if (KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
+        if (UV__KEVENT(loop->backend_fd, events, nevents, NULL, 0, 0, NULL))
           abort();
         nevents = 0;
       }
@@ -276,7 +276,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     }
 
     uv__io_poll_prepare(loop, pset, timeout);
-    nfds = KEVENT(loop->backend_fd,
+    nfds = UV__KEVENT(loop->backend_fd,
                   events,
                   nevents,
                   events,
@@ -489,7 +489,7 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 
 void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
   uv_fs_event_t* handle;
-  KEVENT_S ev;
+  UV__KEVENT_S ev;
   int events;
   const char* path;
 #if defined(F_GETPATH)
@@ -542,9 +542,9 @@ void uv__fs_event(uv_loop_t* loop, uv__io_t* w, unsigned int fflags) {
   fflags = NOTE_ATTRIB | NOTE_WRITE  | NOTE_RENAME
          | NOTE_DELETE | NOTE_EXTEND | NOTE_REVOKE;
 
-  SET_EVENT(&ev, w->fd, EVFILT_VNODE, EV_ADD | EV_ONESHOT, fflags);
+  UV__SET_EVENT(&ev, w->fd, EVFILT_VNODE, EV_ADD | EV_ONESHOT, fflags);
 
-  if (KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL))
+  if (UV__KEVENT(loop->backend_fd, &ev, 1, NULL, 0, 0, NULL))
     abort();
 }
 

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -1078,9 +1078,9 @@ int uv_spawn(uv_loop_t* loop,
    * with waitpid. */
   if (exec_errorno == 0) {
 #ifndef UV_USE_SIGCHLD
-    struct kevent event;
-    EV_SET(&event, pid, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT, 0, 0);
-    if (kevent(loop->backend_fd, &event, 1, NULL, 0, NULL)) {
+    KEVENT_S event;
+    SET_EVENT(&event, pid, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT);
+    if (KEVENT(loop->backend_fd, &event, 1, NULL, 0, 0, NULL)) {
       if (errno != ESRCH)
         abort();
       /* Process already exited. Call waitpid on the next loop iteration. */

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -1078,9 +1078,9 @@ int uv_spawn(uv_loop_t* loop,
    * with waitpid. */
   if (exec_errorno == 0) {
 #ifndef UV_USE_SIGCHLD
-    KEVENT_S event;
-    SET_EVENT(&event, pid, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT);
-    if (KEVENT(loop->backend_fd, &event, 1, NULL, 0, 0, NULL)) {
+    UV__KEVENT_S event;
+    UV__SET_EVENT(&event, pid, EVFILT_PROC, EV_ADD | EV_ONESHOT, NOTE_EXIT);
+    if (UV__KEVENT(loop->backend_fd, &event, 1, NULL, 0, 0, NULL)) {
       if (errno != ESRCH)
         abort();
       /* Process already exited. Call waitpid on the next loop iteration. */

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -276,8 +276,8 @@ int uv__stream_try_select(uv_stream_t* stream, int* fd) {
    * select(2) in separate thread for those fds
    */
 
-  struct kevent filter[1];
-  struct kevent events[1];
+  KEVENT_S filter[1];
+  KEVENT_S events[1];
   struct timespec timeout;
   uv__stream_select_t* s;
   int fds[2];
@@ -295,14 +295,14 @@ int uv__stream_try_select(uv_stream_t* stream, int* fd) {
     return UV__ERR(errno);
   }
 
-  EV_SET(&filter[0], *fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, 0);
+  SET_EVENT(&filter[0], *fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0);
 
   /* Use small timeout, because we only want to capture EINVALs */
   timeout.tv_sec = 0;
   timeout.tv_nsec = 1;
 
   do
-    ret = kevent(kq, filter, 1, events, 1, &timeout);
+    ret = KEVENT(kq, filter, 1, events, 1, 0, &timeout);
   while (ret == -1 && errno == EINTR);
 
   uv__close(kq);

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -276,8 +276,8 @@ int uv__stream_try_select(uv_stream_t* stream, int* fd) {
    * select(2) in separate thread for those fds
    */
 
-  KEVENT_S filter[1];
-  KEVENT_S events[1];
+  UV__KEVENT_S filter[1];
+  UV__KEVENT_S events[1];
   struct timespec timeout;
   uv__stream_select_t* s;
   int fds[2];
@@ -295,14 +295,14 @@ int uv__stream_try_select(uv_stream_t* stream, int* fd) {
     return UV__ERR(errno);
   }
 
-  SET_EVENT(&filter[0], *fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0);
+  UV__SET_EVENT(&filter[0], *fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0);
 
   /* Use small timeout, because we only want to capture EINVALs */
   timeout.tv_sec = 0;
   timeout.tv_nsec = 1;
 
   do
-    ret = KEVENT(kq, filter, 1, events, 1, 0, &timeout);
+    ret = UV__KEVENT(kq, filter, 1, events, 1, 0, &timeout);
   while (ret == -1 && errno == EINTR);
 
   uv__close(kq);


### PR DESCRIPTION
details in #5032 

This will use `kevent64` by default on macos/64bit and will set the `KEVENT_FLAG_IMMEDIATE` flag  in `uv__io_poll` when timeout is zero. this means kqueue will not block if there is no io pending which should improve performance significantly for use cases like `setImmediate` in node.js.

- tests are passing on macos but some benchmarks are failing, but they seem to fail both with and without these changes so assume it's environmental
- some benchmarks show a significant improvement but haven't done this repeatedly and haven't investigated if they are related to the changes

## before

```
ok 13 - loop_count_timed
# loop_count: 411620 ticks (82324 ticks/s)
```
## after
```
ok 13 - loop_count_timed
# loop_count: 22647393 ticks (4529479 ticks/s)
```
## before
```
ok 22 - pipe_pump100_client
# pipe_pump100_server: 89.0 gbit/s
# pipe_pump100_client: 89.0 gbit/s
ok 23 - pipe_pump1_client
# pipe_pump1_server: 7.9 gbit/s
# pipe_pump1_client: 7.9 gbit/s
```
## after
```
ok 22 - pipe_pump100_client
# pipe_pump100_server: 94.6 gbit/s
# pipe_pump100_client: 94.6 gbit/s
ok 23 - pipe_pump1_client
# pipe_pump1_server: 8.7 gbit/s
# pipe_pump1_client: 8.7 gbit/s
```
## before
```
ok 33 - tcp_pump1_client
# tcp_pump1_server: 21.9 gbit/s
# tcp_pump1_client: 21.9 gbit/s
```
## after
```
ok 33 - tcp_pump1_client
# tcp_pump1_server: 38.2 gbit/s
# tcp_pump1_client: 38.2 gbit/s
```