### PR TITLE
test: remove conditionals from `uv_thread_self` usage

### DIFF
--- a/test/test-thread-affinity.c
+++ b/test/test-thread-affinity.c
@@ -56,12 +56,7 @@ TEST_IMPL(thread_affinity) {
   int i;
   uv_thread_t threads[3];
 
-#ifdef _WIN32
-  /* uv_thread_self isn't defined for the main thread on Windows */
-  threads[0] = GetCurrentThread();
-#else
   threads[0] = uv_thread_self();
-#endif
   cpumasksize = uv_cpumask_size();
   ASSERT_GT(cpumasksize, 0);
 

--- a/test/test-thread-name.c
+++ b/test/test-thread-name.c
@@ -38,12 +38,7 @@ static void thread_run(void* arg) {
 
   sem = arg;
 
-#ifdef _WIN32
-  /* uv_thread_self isn't defined for the main thread on Windows. */
-  thread = GetCurrentThread();
-#else
   thread = uv_thread_self();
-#endif
 
   r = uv_thread_setname("worker-thread");
   ASSERT_OK(r);
@@ -82,12 +77,7 @@ TEST_IMPL(thread_name) {
   memset(long_thread_name, 'a', sizeof(long_thread_name) - 1);
   long_thread_name[sizeof(long_thread_name) - 1] = '\0';
 
-#ifdef _WIN32
-  /* uv_thread_self isn't defined for the main thread on Windows. */
-  threads[0] = GetCurrentThread();
-#else
   threads[0] = uv_thread_self();
-#endif
 
   r = uv_thread_getname(&threads[0], tn, sizeof(tn));
   ASSERT_OK(r);


### PR DESCRIPTION
The Windows limitation was fixed in: https://github.com/libuv/libuv/pull/3357.