### PR TITLE
unix: remove UV_HANDLE_READING flag

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -929,11 +929,16 @@ static void uv__write_callbacks(uv_stream_t* stream) {
 
 
 static void uv__stream_eof(uv_stream_t* stream, const uv_buf_t* buf) {
+  uv_read_cb read_cb;
+
   stream->flags |= UV_HANDLE_READ_EOF;
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
-  stream->read_cb(stream, UV_EOF, buf);
+  read_cb = stream->read_cb;
+  stream->read_cb = NULL;
+  stream->alloc_cb = NULL;
+  read_cb(stream, UV_EOF, buf);
 }
 
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -930,7 +930,6 @@ static void uv__write_callbacks(uv_stream_t* stream) {
 
 static void uv__stream_eof(uv_stream_t* stream, const uv_buf_t* buf) {
   stream->flags |= UV_HANDLE_READ_EOF;
-  stream->flags &= ~UV_HANDLE_READING;
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);
@@ -1037,11 +1036,7 @@ static void uv__read(uv_stream_t* stream) {
 
   is_ipc = stream->type == UV_NAMED_PIPE && ((uv_pipe_t*) stream)->ipc;
 
-  /* XXX: Maybe instead of having UV_HANDLE_READING we just test if
-   * tcp->read_cb is NULL or not?
-   */
   while (stream->read_cb
-      && (stream->flags & UV_HANDLE_READING)
       && (count-- > 0)) {
     assert(stream->alloc_cb != NULL);
 
@@ -1082,7 +1077,7 @@ static void uv__read(uv_stream_t* stream) {
       /* Error */
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         /* Wait for the next one. */
-        if (stream->flags & UV_HANDLE_READING) {
+        if (stream->read_cb != NULL) {
           uv__io_start(stream->loop, &stream->io_watcher, POLLIN);
           uv__stream_osx_interrupt_select(stream);
         }
@@ -1096,8 +1091,9 @@ static void uv__read(uv_stream_t* stream) {
         /* Error. User should call uv_close(). */
         stream->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
         stream->read_cb(stream, UV__ERR(errno), &buf);
-        if (stream->flags & UV_HANDLE_READING) {
-          stream->flags &= ~UV_HANDLE_READING;
+        if (stream->read_cb != NULL) {
+          stream->read_cb = NULL;
+          stream->alloc_cb = NULL;
           uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
           uv__handle_stop(stream);
           uv__stream_osx_interrupt_select(stream);
@@ -1220,7 +1216,7 @@ void uv__stream_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
    */
   if ((events & POLLHUP) &&
       !(events & POLLIN) &&
-      (stream->flags & UV_HANDLE_READING) &&
+      (stream->read_cb != NULL) &&
       !(stream->flags & UV_HANDLE_READ_EOF)) {
     uv_buf_t buf = { NULL, 0 };
     uv__stream_eof(stream, &buf);
@@ -1450,9 +1446,6 @@ int uv__read_start(uv_stream_t* stream,
   assert(stream->type == UV_TCP || stream->type == UV_NAMED_PIPE ||
       stream->type == UV_TTY);
 
-  /* The UV_HANDLE_READING flag is irrelevant of the state of the stream - it
-   * just expresses the desired state of the user. */
-  stream->flags |= UV_HANDLE_READING;
   stream->flags &= ~UV_HANDLE_READ_EOF;
 
   /* TODO: try to do the read inline? */
@@ -1471,10 +1464,9 @@ int uv__read_start(uv_stream_t* stream,
 
 
 int uv_read_stop(uv_stream_t* stream) {
-  if (!(stream->flags & UV_HANDLE_READING))
+  if (stream->read_cb == NULL)
     return 0;
 
-  stream->flags &= ~UV_HANDLE_READING;
   uv__io_stop(stream->loop, &stream->io_watcher, POLLIN);
   uv__handle_stop(stream);
   uv__stream_osx_interrupt_select(stream);

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -928,7 +928,7 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 
-  if (stream->read_cb != NULL)
+  if (stream->flags & UV_HANDLE_READING)
     return UV_EALREADY;
 
   if (!(stream->flags & UV_HANDLE_READABLE))

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -928,8 +928,13 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 
-  if (stream->flags & UV_HANDLE_READING)
+#ifdef _WIN32
+   if (stream->flags & UV_HANDLE_READING)
+     return UV_EALREADY;
+#else
+  if (stream->read_cb != NULL)
     return UV_EALREADY;
+#endif
 
   if (!(stream->flags & UV_HANDLE_READABLE))
     return UV_ENOTCONN;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -928,7 +928,7 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 
-  if (stream->flags & UV_HANDLE_READING)
+  if (stream->read_cb != NULL)
     return UV_EALREADY;
 
   if (!(stream->flags & UV_HANDLE_READABLE))


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/issues/4995

Replace `UV_HANDLE_READING` flag checks with `stream->read_cb != NULL` on the Unix side, removing redundant state that can get out of sync.