### PR TITLE
win: fix const correctness compiler errors

### DIFF
--- a/src/win/util.c
+++ b/src/win/util.c
@@ -627,7 +627,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
 
     uv__convert_utf16_to_utf8(cpu_brand,
                               cpu_brand_size / sizeof(WCHAR),
-                              &(cpu_info->model));
+                              (char**) &(cpu_info->model));
   }
 
   uv__free(sppi);


### PR DESCRIPTION
Compiling code for v1.52.1 using mingw64-gcc 15.2 on Windows results in an error:

```console
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2603/l/libuv/v1.52.1/source/src/win/util.c: In function 'uv_cpu_info':
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2603/l/libuv/v1.52.1/source/src/win/util.c:630:31: error: passing argument 3 of 'uv__convert_utf16_to_utf8' from incompatible pointer type [-Wincompatible-pointer-types]
  630 |                               &(cpu_info->model));
      |                               ^~~~~~~~~~~~~~~~~~
      |                               |
      |                               const char **
In file included from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2603/l/libuv/v1.52.1/source/src/win/util.c:31:
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2603/l/libuv/v1.52.1/source/src/win/internal.h:260:75: note: expected 'char **' but argument is of type 'const char **'
  260 | int uv__convert_utf16_to_utf8(const WCHAR* utf16, size_t utf16len, char** utf8);
      |                                                                    ~~~~~~~^~~~
```

This is due to GCC 15's more stringent type checking. We can suppress such errors by using explicit type casts.