### PR TITLE
doc: name function crosslinks consistently

### DIFF
--- a/docs/src/design.rst
+++ b/docs/src/design.rst
@@ -39,7 +39,7 @@ don't need a handle they run directly on the loop.
 Guidelines for dealing with handles and requests:
 
 1. If `uv_foo_init()` succeeds in initializing the handle, you must call
-   :c:func:`uv_close()`. If the handle's init function errors, you don't
+   :c:func:`uv_close`. If the handle's init function errors, you don't
    need to do anything.
 
 2. Only handles are closed, not requests. For example, :c:type:`uv_tcp_t`
@@ -49,16 +49,16 @@ Guidelines for dealing with handles and requests:
    :c:type:`uv_close_cb` or afterwards, not before.
 
 4. Most handles have init + start/stop functions; some handles don't.
-   Example: :c:type:`uv_tcp_t` vs. :c:type:`uv_process_t`; :c:func:`uv_spawn()`
+   Example: :c:type:`uv_tcp_t` vs. :c:type:`uv_process_t`; :c:func:`uv_spawn`
    combines handle initialization and process start into one.
 
 5. Requests are closed automatically when they complete, or when they are
-   cancelled with :c:func:`uv_cancel()`.
+   cancelled with :c:func:`uv_cancel`.
 
 6. No additional cleanup is needed except for :c:type:`uv_fs_t` and
    :c:type:`uv_getaddrinfo_t` requests. For :c:type:`uv_fs_t`, call
-   :c:func:`uv_fs_req_cleanup()` once you are done with it; for
-   :c:type:`uv_getaddrinfo_t`, that's :c:func:`uv_freeaddrinfo()`.
+   :c:func:`uv_fs_req_cleanup` once you are done with it; for
+   :c:type:`uv_getaddrinfo_t`, that's :c:func:`uv_freeaddrinfo`.
 
 7. The request's memory can only be reclaimed or reused from that point onward.
 

--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -166,8 +166,8 @@ Data types
 .. c:type:: uv_dir_t
 
     Data type used for streaming directory iteration.
-    Used by :c:func:`uv_fs_opendir()`, :c:func:`uv_fs_readdir()`, and
-    :c:func:`uv_fs_closedir()`. `dirents` represents a user provided array of
+    Used by :c:func:`uv_fs_opendir`, :c:func:`uv_fs_readdir`, and
+    :c:func:`uv_fs_closedir`. `dirents` represents a user provided array of
     `uv_dirent_t`s used to hold results. `nentries` is the user provided maximum
     array size of `dirents`.
 
@@ -391,7 +391,7 @@ API
       create a copy-on-write reflink. If the underlying platform does not
       support copy-on-write, or an error occurs while attempting to use
       copy-on-write, a fallback copy mechanism based on
-      :c:func:`uv_fs_sendfile()` is used.
+      :c:func:`uv_fs_sendfile` is used.
     - `UV_FS_COPYFILE_FICLONE_FORCE`: If present, `uv_fs_copyfile()` will
       attempt to create a copy-on-write reflink. If the underlying platform does
       not support copy-on-write, or an error occurs while attempting to use

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -281,13 +281,13 @@ API
     do so automatically when it is unloaded but it can be instructed to perform
     cleanup manually.
 
-    .. warning:: Only call :c:func:`uv_library_shutdown()` once.
+    .. warning:: Only call :c:func:`uv_library_shutdown` once.
 
-    .. warning:: Don't call :c:func:`uv_library_shutdown()` when there are
+    .. warning:: Don't call :c:func:`uv_library_shutdown` when there are
                  still event loops or I/O requests active.
 
     .. warning:: Don't call libuv functions after calling
-                 :c:func:`uv_library_shutdown()`.
+                 :c:func:`uv_library_shutdown`.
 
 .. c:function:: uv_buf_t uv_buf_init(char* base, unsigned int len)
 

--- a/docs/src/stream.rst
+++ b/docs/src/stream.rst
@@ -139,7 +139,7 @@ API
     be made several times until there is no more data to read or
     :c:func:`uv_read_stop` is called.
 
-    .. versionchanged:: 1.38.0 :c:func:`uv_read_start()` now consistently
+    .. versionchanged:: 1.38.0 :c:func:`uv_read_start` now consistently
       returns `UV_EALREADY` when called twice, and `UV_EINVAL` when the
       stream is closing. With older libuv versions, it returns `UV_EALREADY`
       on Windows but not UNIX, and `UV_EINVAL` on UNIX but not Windows.

--- a/docs/src/timer.rst
+++ b/docs/src/timer.rst
@@ -85,7 +85,7 @@ API
 .. c:function:: uint64_t uv_timer_get_due_in(const uv_timer_t* handle)
 
     Get the timer due value or 0 if it has expired. The time is relative to
-    :c:func:`uv_now()`.
+    :c:func:`uv_now`.
 
     .. versionadded:: 1.40.0
 

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -334,7 +334,7 @@ API
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
         been bound to an address explicitly with :c:func:`uv_udp_bind`, or
-        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
+        implicitly with :c:func:`uv_udp_send` or :c:func:`uv_udp_recv_start`.
 
     :param on: 1 for on, 0 for off.
 
@@ -347,7 +347,7 @@ API
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
         been bound to an address explicitly with :c:func:`uv_udp_bind`, or
-        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
+        implicitly with :c:func:`uv_udp_send` or :c:func:`uv_udp_recv_start`.
 
     :param ttl: 1 through 255.
 
@@ -360,7 +360,7 @@ API
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
         been bound to an address explicitly with :c:func:`uv_udp_bind`, or
-        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
+        implicitly with :c:func:`uv_udp_send` or :c:func:`uv_udp_recv_start`.
 
     :param interface_addr: interface address.
 
@@ -373,7 +373,7 @@ API
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
         been bound to an address explicitly with :c:func:`uv_udp_bind`, or
-        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
+        implicitly with :c:func:`uv_udp_send` or :c:func:`uv_udp_recv_start`.
 
     :param on: 1 for on, 0 for off.
 
@@ -386,7 +386,7 @@ API
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init_ex` as either ``AF_INET`` or ``AF_INET6``, or have
         been bound to an address explicitly with :c:func:`uv_udp_bind`, or
-        implicitly with :c:func:`uv_udp_send()` or :c:func:`uv_udp_recv_start`.
+        implicitly with :c:func:`uv_udp_send` or :c:func:`uv_udp_recv_start`.
 
     :param ttl: 1 through 255.
 


### PR DESCRIPTION
The documentation overwhelmingly uses :c:func:`foo`. Rewrite the few places that write it as c:func:`foo()` without the parentheses.