### PR TITLE
test: defer uv_clos'ing tcp_shutdown_after_write's socket until server performs uv_shutdown

### DIFF
--- a/test/echo-server.c
+++ b/test/echo-server.c
@@ -65,7 +65,8 @@ static void after_write(uv_write_t* req, int status) {
 
 
 static void after_shutdown(uv_shutdown_t* req, int status) {
-  ASSERT_OK(status);
+  if (status != 0)
+    ASSERT_EQ(status, UV_ENOTCONN);
   uv_close((uv_handle_t*) req->handle, on_close);
   free(req);
 }

--- a/test/test-tcp-shutdown-after-write.c
+++ b/test/test-tcp-shutdown-after-write.c
@@ -74,6 +74,8 @@ static void timer_cb(uv_timer_t* handle) {
 
 
 static void read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
+  if (nread == UV_EOF)
+    uv_close((uv_handle_t*)&conn, close_cb);
 }
 
 
@@ -97,7 +99,6 @@ static void write_cb(uv_write_t* req, int status) {
 static void shutdown_cb(uv_shutdown_t* req, int status) {
   ASSERT_OK(status);
   shutdown_cb_called++;
-  uv_close((uv_handle_t*)&conn, close_cb);
 }
 
 


### PR DESCRIPTION
Fixes #5060: ASSERT thrown in tcp4_echo_server observed during the tcp_shutdown_after_write test