### PR TITLE
win: fix some compiler warnings

### DIFF
--- a/include/uv/win.h
+++ b/include/uv/win.h
@@ -279,7 +279,7 @@ typedef struct {
   DWORD tls_index;
 } uv_key_t;
 
-#define UV_ONCE_INIT { 0, { NULL } }
+#define UV_ONCE_INIT { 0, INIT_ONCE_STATIC_INIT }
 
 typedef struct uv_once_s {
   unsigned char unused;

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -223,7 +223,7 @@ int uv__stdio_create(uv_loop_t* loop,
           if (err)
             goto error;
 
-		  memcpy(CHILD_STDIO_HANDLE(buffer, i), &nul, sizeof(HANDLE));
+          memcpy(CHILD_STDIO_HANDLE(buffer, i), &nul, sizeof(HANDLE));
           CHILD_STDIO_CRT_FLAGS(buffer, i) = FOPEN | FDEV;
         }
         break;
@@ -248,7 +248,7 @@ int uv__stdio_create(uv_loop_t* loop,
         if (err)
           goto error;
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_pipe, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_pipe, sizeof(HANDLE));
         CHILD_STDIO_CRT_FLAGS(buffer, i) = FOPEN | FPIPE;
         break;
       }
@@ -299,7 +299,7 @@ int uv__stdio_create(uv_loop_t* loop,
             return -1;
         }
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
         break;
       }
 
@@ -335,7 +335,7 @@ int uv__stdio_create(uv_loop_t* loop,
         if (err)
           goto error;
 
-		memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
+        memcpy(CHILD_STDIO_HANDLE(buffer, i), &child_handle, sizeof(HANDLE));
         CHILD_STDIO_CRT_FLAGS(buffer, i) = crt_flags;
         break;
       }

--- a/src/win/process-stdio.c
+++ b/src/win/process-stdio.c
@@ -215,7 +215,8 @@ int uv__stdio_create(uv_loop_t* loop,
          * handles in the stdio buffer are initialized with.
          * INVALID_HANDLE_VALUE, which should be okay. */
         if (i <= 2) {
-          HANDLE nul;
+          /* Redundantly initialize to make the compiler happy. */
+          HANDLE nul = INVALID_HANDLE_VALUE;
           DWORD access = (i == 0) ? FILE_GENERIC_READ :
                                     FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES;
 

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -508,8 +508,8 @@ int uv_uptime(double* uptime) {
 unsigned int uv_available_parallelism(void) {
   DWORD_PTR procmask;
   DWORD_PTR sysmask;
-  unsigned count;
-  unsigned i;
+  int count;
+  unsigned int i;
 
   /* TODO(bnoordhuis) Use GetLogicalProcessorInformationEx() to support systems
    * with > 64 CPUs? See https://github.com/libuv/libuv/pull/3458


### PR DESCRIPTION
These changes aren't sufficient to get a warning-free build with MinGW, but they clean things up a bit.

Rebase of #4586.