### PR TITLE
Increase required cmake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW) # Enable MSVC_RUNTIME_LIBRARY setting
@@ -81,7 +81,6 @@ if(TSAN)
 endif()
 
 if(UBSAN)
-  cmake_minimum_required(VERSION 3.13)
   list(APPEND uv_defines __UBSAN__=1)
   if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|GNU|Clang")
     add_compile_options("-fsanitize=undefined" "-fno-sanitize-recover=undefined")

--- a/docs/code/CMakeLists.txt
+++ b/docs/code/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(libuv_sample)
 


### PR DESCRIPTION
Increase required cmake version to 3.15:

No one seems to be using anything older than 3.15:
https://github.com/neovim/neovim/issues/24004#issuecomment-1587741071