### PR TITLE
docs: fix broken and redirected links

### DIFF
--- a/docs/src/fs.rst
+++ b/docs/src/fs.rst
@@ -471,7 +471,7 @@ API
 
 .. c:function:: int uv_fs_realpath(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb)
 
-    Equivalent to :man:`realpath(3)` on Unix. Windows uses `GetFinalPathNameByHandleW <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew>`_.
+    Equivalent to :man:`realpath(3)` on Unix. Windows uses `GetFinalPathNameByHandleW <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew>`_.
     The resulting string is stored in `req->ptr`.
 
     .. warning::
@@ -551,7 +551,7 @@ Helper functions
 .. c:function:: uv_os_fd_t uv_get_osfhandle(int fd)
 
    For a file descriptor in the C runtime, get the OS-dependent handle.
-   On UNIX, returns the ``fd`` intact. On Windows, this calls `_get_osfhandle <https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=vs-2019>`_.
+   On UNIX, returns the ``fd`` intact. On Windows, this calls `_get_osfhandle <https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=vs-2019>`_.
    Note that the return value is still owned by the C runtime,
    any attempts to close it or to use it after closing the fd may lead to malfunction.
 
@@ -560,7 +560,7 @@ Helper functions
 .. c:function:: int uv_open_osfhandle(uv_os_fd_t os_fd)
 
    For a OS-dependent handle, get the file descriptor in the C runtime.
-   On UNIX, returns the ``os_fd`` intact. On Windows, this calls `_open_osfhandle <https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=vs-2019>`_.
+   On UNIX, returns the ``os_fd`` intact. On Windows, this calls `_open_osfhandle <https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=vs-2019>`_.
    Note that this consumes the argument, any attempts to close it or to use it
    after closing the return value may lead to malfunction.
 
@@ -586,7 +586,7 @@ File open constants
 
     .. note::
         `UV_FS_O_DIRECT` is supported on Linux, and on Windows via
-        `FILE_FLAG_NO_BUFFERING <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
+        `FILE_FLAG_NO_BUFFERING <https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
         `UV_FS_O_DIRECT` is not supported on macOS.
 
 .. c:macro:: UV_FS_O_DIRECTORY
@@ -603,7 +603,7 @@ File open constants
 
     .. note::
         `UV_FS_O_DSYNC` is supported on Windows via
-        `FILE_FLAG_WRITE_THROUGH <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
+        `FILE_FLAG_WRITE_THROUGH <https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
 
 .. c:macro:: UV_FS_O_EXCL
 
@@ -670,7 +670,7 @@ File open constants
 
     .. note::
         `UV_FS_O_RANDOM` is only supported on Windows via
-        `FILE_FLAG_RANDOM_ACCESS <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
+        `FILE_FLAG_RANDOM_ACCESS <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
 
 .. c:macro:: UV_FS_O_RDONLY
 
@@ -687,7 +687,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SEQUENTIAL` is only supported on Windows via
-        `FILE_FLAG_SEQUENTIAL_SCAN <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
+        `FILE_FLAG_SEQUENTIAL_SCAN <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
 
 .. c:macro:: UV_FS_O_SHORT_LIVED
 
@@ -695,7 +695,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SHORT_LIVED` is only supported on Windows via
-        `FILE_ATTRIBUTE_TEMPORARY <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
+        `FILE_ATTRIBUTE_TEMPORARY <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
 
 .. c:macro:: UV_FS_O_SYMLINK
 
@@ -708,7 +708,7 @@ File open constants
 
     .. note::
         `UV_FS_O_SYNC` is supported on Windows via
-        `FILE_FLAG_WRITE_THROUGH <https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
+        `FILE_FLAG_WRITE_THROUGH <https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering>`_.
 
 .. c:macro:: UV_FS_O_TEMPORARY
 
@@ -716,7 +716,7 @@ File open constants
 
     .. note::
         `UV_FS_O_TEMPORARY` is only supported on Windows via
-        `FILE_ATTRIBUTE_TEMPORARY <https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
+        `FILE_ATTRIBUTE_TEMPORARY <https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew>`_.
 
 .. c:macro:: UV_FS_O_TRUNC
 

--- a/docs/src/fs_event.rst
+++ b/docs/src/fs_event.rst
@@ -23,8 +23,8 @@ the best backend for the job on each platform.
     creation/deletion within a directory that is being monitored.
     See the `IBM Knowledge centre`_ for more details.
 
-    .. _documentation: https://developer.ibm.com/articles/au-aix_event_infrastructure/
-    .. _`IBM Knowledge centre`: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.2.0/com.ibm.zos.v2r1.bpxb100/ioc.htm
+    .. _documentation: https://www.ibm.com/docs/en/aix/7.2?topic=management-aix-event-infrastructure-aix-aix-clusters-ahafs
+    .. _`IBM Knowledge centre`: https://www.ibm.com/docs/en/zos/2.2.0?topic=SSLTBW_2.2.0/com.ibm.zos.v2r1.bpxb100/ioc.html
 
 
 

--- a/docs/src/guide/introduction.rst
+++ b/docs/src/guide/introduction.rst
@@ -67,7 +67,7 @@ There is no need to ``make install``. To build the examples run ``make`` in the
 .. _V8: https://v8.dev
 .. _libev: http://software.schmorp.de/pkg/libev.html
 .. _libuv: https://github.com/libuv/libuv
-.. _node.js: https://www.nodejs.org
+.. _node.js: https://nodejs.org
 .. _libev was removed: https://github.com/joyent/libuv/issues/485
-.. _Rust: https://www.rust-lang.org
+.. _Rust: https://rust-lang.org/
 .. _variety: https://github.com/libuv/libuv/blob/v1.x/LINKS.md

--- a/docs/src/guide/networking.rst
+++ b/docs/src/guide/networking.rst
@@ -179,7 +179,7 @@ where ``membership`` is ``UV_JOIN_GROUP`` or ``UV_LEAVE_GROUP``.
 
 The concepts of multicasting are nicely explained in `this guide`_.
 
-.. _this guide: https://www.tldp.org/HOWTO/Multicast-HOWTO-2.html
+.. _this guide: https://tldp.org/HOWTO/Multicast-HOWTO-2.html
 
 Local loopback of multicast packets is enabled by default [#]_, use
 ``uv_udp_set_multicast_loop`` to switch it off.
@@ -221,7 +221,7 @@ call ``uv_freeaddrinfo`` in the callback.
 
 libuv also provides the inverse `uv_getnameinfo`_.
 
-.. _uv_getnameinfo: http://docs.libuv.org/en/v1.x/dns.html#c.uv_getnameinfo
+.. _uv_getnameinfo: https://docs.libuv.org/en/v1.x/dns.html#c.uv_getnameinfo
 
 Network interfaces
 ------------------
@@ -241,16 +241,16 @@ useful to allow your service to bind to IP addresses when it starts.
 interface has multiple IPv4/IPv6 addresses, the name will be reported multiple
 times, with each address being reported once.
 
-.. _c-ares: https://c-ares.haxx.se
+.. _c-ares: https://c-ares.org/
 .. _getaddrinfo: https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
 
 .. _User Datagram Protocol: https://en.wikipedia.org/wiki/User_Datagram_Protocol
-.. _DHCP: https://tools.ietf.org/html/rfc2131
+.. _DHCP: https://datatracker.ietf.org/doc/html/rfc2131
 
 ----
 
 .. [#] https://beej.us/guide/bgnet/html/#broadcast-packetshello-world
-.. [#] https://www.tldp.org/HOWTO/Multicast-HOWTO-6.html#ss6.1
+.. [#] https://tldp.org/HOWTO/Multicast-HOWTO-6.html#ss6.1
 .. [#] libuv use the system ``getaddrinfo`` in the libuv threadpool. libuv
     v0.8.0 and earlier also included c-ares_ as an alternative, but this has been
     removed in v0.9.0.

--- a/docs/src/guide/processes.rst
+++ b/docs/src/guide/processes.rst
@@ -135,7 +135,7 @@ Signals
 -------
 
 libuv provides wrappers around Unix signals with `some Windows support
-<http://docs.libuv.org/en/v1.x/signal.html#signal>`_ as well.
+<https://docs.libuv.org/en/v1.x/signal.html#signal>`_ as well.
 
 Use ``uv_signal_init()`` to initialize
 a handle and associate it with a loop. To listen for particular signals on
@@ -282,7 +282,7 @@ communicate with IPC. This is discussed below.
 .. _mkfifo(1): https://man7.org/linux/man-pages/man1/mkfifo.1.html
 .. _socketpair(2): https://man7.org/linux/man-pages/man2/socketpair.2.html
 .. _Unix Domain Socket: https://man7.org/linux/man-pages/man7/unix.7.html
-.. _Named Pipe: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
+.. _Named Pipe: https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipes
 
 
 Arbitrary process IPC

--- a/docs/src/guide/threads.rst
+++ b/docs/src/guide/threads.rst
@@ -183,7 +183,7 @@ After all threads are done, ``i == 1``.
 libuv v0.11.11 onwards also added a ``uv_key_t`` struct and api_ for
 thread-local storage.
 
-.. _api: http://docs.libuv.org/en/v1.x/threading.html#thread-local-storage
+.. _api: https://docs.libuv.org/en/v1.x/threading.html#thread-local-storage
 
 libuv work queue
 ----------------

--- a/docs/src/guide/utilities.rst
+++ b/docs/src/guide/utilities.rst
@@ -213,8 +213,8 @@ download files. Rather than give all control to libcurl, we'll instead be
 using the libuv event loop, and use the non-blocking, async multi_ interface to
 progress with the download whenever libuv notifies of I/O readiness.
 
-.. _libcurl: https://curl.haxx.se/libcurl/
-.. _multi: https://curl.haxx.se/libcurl/c/libcurl-multi.html
+.. _libcurl: https://curl.se/libcurl/
+.. _multi: https://curl.se/libcurl/c/libcurl-multi.html
 
 .. rubric:: uvwget/main.c - The setup
 .. literalinclude:: ../../code/uvwget/main.c
@@ -390,7 +390,7 @@ It is then best to use ``uv_tty_set_mode`` to set the mode to *normal*
 which enables most TTY formatting, flow-control and other settings. Other_ modes
 are also available.
 
-.. _Other: http://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_mode_t
+.. _Other: https://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_mode_t
 
 Remember to call ``uv_tty_reset_mode`` when your program exits to restore the
 state of the terminal. Just good manners. Another set of good manners is to be
@@ -444,7 +444,8 @@ can try `ncurses`_.
 
 .. [#] I was first introduced to the term baton in this context, in Konstantin
        Käfer's excellent slides on writing node.js bindings --
-       https://kkaefer.com/node-cpp-modules/#baton
+       https://kkaefer.github.io/node-cpp-modules/#baton
+       (`video <https://youtu.be/GajiVsJwSkY?list=PL37ZVnwpeshEVYiRemhMII6ORJmsJuqP7&t=1009>`_)
 .. [#] mfp is My Fancy Plugin
 
 .. _libev man page: http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#COMMON_OR_USEFUL_IDIOMS_OR_BOTH


### PR DESCRIPTION
- Replace dead developer.ibm.com AIX article with current IBM Docs URL
- Update IBM Knowledge Centre z/OS URL to new ibm.com/docs location
- Update docs.microsoft.com links to learn.microsoft.com
- Update curl.haxx.se links to curl.se
- Update c-ares.haxx.se to c-ares.org
- Update tools.ietf.org RFC link to datatracker.ietf.org
- Update www.tldp.org links to tldp.org (drop www)
- Update www.nodejs.org and www.rust-lang.org (drop www)
- Upgrade http://docs.libuv.org links to https
- Replace dead kkaefer.com link with GitHub Pages + YouTube video