### PR TITLE
win: use WSA_FLAG_NO_HANDLE_INHERIT in all WSASocketW

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -664,7 +664,7 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
                           FROM_PROTOCOL_INFO,
                           &xfer_queue_item->xfer_info.socket_info,
                           0,
-                          WSA_FLAG_OVERLAPPED);
+                          WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
       uv__free(xfer_queue_item);
 
       if (socket != INVALID_SOCKET)

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -163,10 +163,6 @@ static int uv__tcp_set_socket(uv_loop_t* loop,
     return WSAGetLastError();
   }
 
-  /* Make the socket non-inheritable */
-  if (!SetHandleInformation((HANDLE) socket, HANDLE_FLAG_INHERIT, 0))
-    return GetLastError();
-
   /* Associate it with the I/O completion port. Use uv_handle_t pointer as
    * completion key. */
   if (CreateIoCompletionPort((HANDLE)socket,
@@ -248,7 +244,8 @@ int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* handle, unsigned int flags) {
     SOCKET sock;
     DWORD err;
 
-    sock = socket(domain, SOCK_STREAM, 0);
+    sock = WSASocketW(domain, SOCK_STREAM, 0, NULL, 0,
+                      WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (sock == INVALID_SOCKET) {
       err = WSAGetLastError();
       uv__queue_remove(&handle->handle_queue);
@@ -375,7 +372,8 @@ static int uv__tcp_try_bind(uv_tcp_t* handle,
     if ((flags & UV_TCP_IPV6ONLY) && addr->sa_family != AF_INET6)
       return ERROR_INVALID_PARAMETER;
 
-    sock = socket(addr->sa_family, SOCK_STREAM, 0);
+    sock = WSASocketW(addr->sa_family, SOCK_STREAM, 0, NULL, 0,
+                      WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (sock == INVALID_SOCKET) {
       return WSAGetLastError();
     }
@@ -478,20 +476,12 @@ static void uv__tcp_queue_accept(uv_tcp_t* handle, uv_tcp_accept_t* req) {
   }
 
   /* Open a socket for the accepted connection. */
-  accept_socket = socket(family, SOCK_STREAM, 0);
+  accept_socket = WSASocketW(family, SOCK_STREAM, 0, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (accept_socket == INVALID_SOCKET) {
     SET_REQ_ERROR(req, WSAGetLastError());
     uv__insert_pending_req(loop, (uv_req_t*)req);
     handle->reqs_pending++;
-    return;
-  }
-
-  /* Make the socket non-inheritable */
-  if (!SetHandleInformation((HANDLE) accept_socket, HANDLE_FLAG_INHERIT, 0)) {
-    SET_REQ_ERROR(req, GetLastError());
-    uv__insert_pending_req(loop, (uv_req_t*)req);
-    handle->reqs_pending++;
-    closesocket(accept_socket);
     return;
   }
 
@@ -1347,7 +1337,7 @@ int uv__tcp_xfer_import(uv_tcp_t* tcp,
                       FROM_PROTOCOL_INFO,
                       &xfer_info->socket_info,
                       0,
-                      WSA_FLAG_OVERLAPPED);
+                      WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
 
   if (socket == INVALID_SOCKET) {
     return WSAGetLastError();
@@ -1652,8 +1642,6 @@ int uv_socketpair(int type, int protocol, uv_os_sock_t fds[2], int flags0, int f
                       WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (server == INVALID_SOCKET)
     goto wsaerror;
-  if (!SetHandleInformation((HANDLE) server, HANDLE_FLAG_INHERIT, 0))
-    goto error;
   name.sin_family = AF_INET;
   name.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   name.sin_port = 0;
@@ -1667,15 +1655,11 @@ int uv_socketpair(int type, int protocol, uv_os_sock_t fds[2], int flags0, int f
   client0 = WSASocketW(AF_INET, type, protocol, NULL, 0, client0_flags);
   if (client0 == INVALID_SOCKET)
     goto wsaerror;
-  if (!SetHandleInformation((HANDLE) client0, HANDLE_FLAG_INHERIT, 0))
-    goto error;
   if (connect(client0, (SOCKADDR*) &name, sizeof(name)) != 0)
     goto wsaerror;
   client1 = WSASocketW(AF_INET, type, protocol, NULL, 0, client1_flags);
   if (client1 == INVALID_SOCKET)
     goto wsaerror;
-  if (!SetHandleInformation((HANDLE) client1, HANDLE_FLAG_INHERIT, 0))
-    goto error;
   if (!uv__get_acceptex_function(server, &func_acceptex)) {
     err = WSAEAFNOSUPPORT;
     goto cleanup;
@@ -1719,10 +1703,6 @@ int uv_socketpair(int type, int protocol, uv_os_sock_t fds[2], int flags0, int f
 
  wsaerror:
     err = WSAGetLastError();
-    goto cleanup;
-
- error:
-    err = GetLastError();
     goto cleanup;
 
  cleanup:

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -69,11 +69,6 @@ static int uv__udp_set_socket(uv_loop_t* loop, uv_udp_t* handle, SOCKET socket,
     return WSAGetLastError();
   }
 
-  /* Make the socket non-inheritable */
-  if (!SetHandleInformation((HANDLE)socket, HANDLE_FLAG_INHERIT, 0)) {
-    return GetLastError();
-  }
-
   /* Associate it with the I/O completion port. Use uv_handle_t pointer as
    * completion key. */
   if (CreateIoCompletionPort((HANDLE)socket,
@@ -143,7 +138,8 @@ int uv__udp_init_ex(uv_loop_t* loop,
     SOCKET sock;
     DWORD err;
 
-    sock = socket(domain, SOCK_DGRAM, 0);
+    sock = WSASocketW(domain, SOCK_DGRAM, 0, NULL, 0,
+                      WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (sock == INVALID_SOCKET) {
       err = WSAGetLastError();
       uv__queue_remove(&handle->handle_queue);
@@ -212,7 +208,8 @@ static int uv__udp_maybe_bind(uv_udp_t* handle,
   }
 
   if (handle->socket == INVALID_SOCKET) {
-    SOCKET sock = socket(addr->sa_family, SOCK_DGRAM, 0);
+    SOCKET sock = WSASocketW(addr->sa_family, SOCK_DGRAM, 0, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (sock == INVALID_SOCKET) {
       return WSAGetLastError();
     }

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -102,7 +102,8 @@ void uv__winsock_init(void) {
 
   /* Try to detect non-IFS LSPs */
   uv_tcp_non_ifs_lsp_ipv4 = 1;
-  dummy = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+  dummy = WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_IP, NULL, 0,
+                     WSA_FLAG_NO_HANDLE_INHERIT);
   if (dummy != INVALID_SOCKET) {
     opt_len = (int) sizeof protocol_info;
     if (getsockopt(dummy,
@@ -118,7 +119,8 @@ void uv__winsock_init(void) {
 
   /* Try to detect IPV6 support and non-IFS LSPs */
   uv_tcp_non_ifs_lsp_ipv6 = 1;
-  dummy = socket(AF_INET6, SOCK_STREAM, IPPROTO_IP);
+  dummy = WSASocketW(AF_INET6, SOCK_STREAM, IPPROTO_IP, NULL, 0,
+                     WSA_FLAG_NO_HANDLE_INHERIT);
   if (dummy != INVALID_SOCKET) {
     opt_len = (int) sizeof protocol_info;
     if (getsockopt(dummy,


### PR DESCRIPTION
Like #4810, but for all socket calls.