### PR TITLE
win: use PROC_THREAD_ATTRIBUTE_HANDLE_LIST in uv_spawn

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -902,14 +902,20 @@ int uv_spawn(uv_loop_t* loop,
   BOOL result;
   WCHAR* application_path = NULL, *application = NULL, *arguments = NULL,
          *env = NULL, *cwd = NULL;
-  STARTUPINFOW startup;
+  STARTUPINFOEXW startup;
   PROCESS_INFORMATION info;
   DWORD process_flags, cwd_len;
   BYTE* child_stdio_buffer;
+  HANDLE* handle_list;
+  LPPROC_THREAD_ATTRIBUTE_LIST attr_list;
+  int attr_list_initialized;
 
   uv__process_init(loop, process);
   process->exit_cb = options->exit_cb;
   child_stdio_buffer = NULL;
+  handle_list = NULL;
+  attr_list = NULL;
+  attr_list_initialized = 0;
 
   if (options->flags & (UV_PROCESS_SETGID | UV_PROCESS_SETUID)) {
     return UV_ENOTSUP;
@@ -1022,20 +1028,67 @@ int uv_spawn(uv_loop_t* loop,
     goto done;
   }
 
-  startup.cb = sizeof(startup);
-  startup.lpReserved = NULL;
-  startup.lpDesktop = NULL;
-  startup.lpTitle = NULL;
-  startup.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+  memset(&startup, 0, sizeof startup);
+  startup.StartupInfo.cb = sizeof(startup);
+  startup.StartupInfo.lpReserved = NULL;
+  startup.StartupInfo.lpDesktop = NULL;
+  startup.StartupInfo.lpTitle = NULL;
+  startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
 
-  startup.cbReserved2 = uv__stdio_size(child_stdio_buffer);
-  startup.lpReserved2 = (BYTE*) child_stdio_buffer;
+  startup.StartupInfo.cbReserved2 = uv__stdio_size(child_stdio_buffer);
+  startup.StartupInfo.lpReserved2 = (BYTE*) child_stdio_buffer;
 
-  startup.hStdInput = uv__stdio_handle(child_stdio_buffer, 0);
-  startup.hStdOutput = uv__stdio_handle(child_stdio_buffer, 1);
-  startup.hStdError = uv__stdio_handle(child_stdio_buffer, 2);
+  startup.StartupInfo.hStdInput = uv__stdio_handle(child_stdio_buffer, 0);
+  startup.StartupInfo.hStdOutput = uv__stdio_handle(child_stdio_buffer, 1);
+  startup.StartupInfo.hStdError = uv__stdio_handle(child_stdio_buffer, 2);
 
-  process_flags = CREATE_UNICODE_ENVIRONMENT;
+  /* Build the list of handles to inherit. Using
+   * PROC_THREAD_ATTRIBUTE_HANDLE_LIST ensures only these specific handles are
+   * inherited, closing the race condition where concurrent uv_spawn calls
+   * could cause handles intended for one child to leak into another. */
+  {
+    int count = uv__stdio_size(child_stdio_buffer);
+    int n = 0;
+    SIZE_T attr_size = 0;
+
+    handle_list = (HANDLE*) uv__malloc(count * sizeof(HANDLE));
+    if (handle_list == NULL) {
+      err = ERROR_OUTOFMEMORY;
+      goto done;
+    }
+
+    for (i = 0; i < count; i++) {
+      HANDLE h = uv__stdio_handle(child_stdio_buffer, i);
+      if (h != INVALID_HANDLE_VALUE)
+        handle_list[n++] = h;
+    }
+
+    InitializeProcThreadAttributeList(NULL, 1, 0, &attr_size);
+    attr_list = (LPPROC_THREAD_ATTRIBUTE_LIST) uv__malloc(attr_size);
+    if (attr_list == NULL) {
+      err = ERROR_OUTOFMEMORY;
+      goto done;
+    }
+    if (!InitializeProcThreadAttributeList(attr_list, 1, 0, &attr_size)) {
+      err = GetLastError();
+      goto done;
+    }
+    attr_list_initialized = 1;
+    if (!UpdateProcThreadAttribute(attr_list,
+                                   0,
+                                   PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                   handle_list,
+                                   n * sizeof(HANDLE),
+                                   NULL,
+                                   NULL)) {
+      err = GetLastError();
+      goto done;
+    }
+  }
+
+  startup.lpAttributeList = attr_list;
+
+  process_flags = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
 
   if ((options->flags & UV_PROCESS_WINDOWS_HIDE_CONSOLE) ||
       (options->flags & UV_PROCESS_WINDOWS_HIDE)) {
@@ -1050,9 +1103,9 @@ int uv_spawn(uv_loop_t* loop,
   if ((options->flags & UV_PROCESS_WINDOWS_HIDE_GUI) ||
       (options->flags & UV_PROCESS_WINDOWS_HIDE)) {
     /* Use SW_HIDE to avoid any potential process window. */
-    startup.wShowWindow = SW_HIDE;
+    startup.StartupInfo.wShowWindow = SW_HIDE;
   } else {
-    startup.wShowWindow = SW_SHOWDEFAULT;
+    startup.StartupInfo.wShowWindow = SW_SHOWDEFAULT;
   }
 
   if (options->flags & UV_PROCESS_DETACHED) {
@@ -1078,7 +1131,7 @@ int uv_spawn(uv_loop_t* loop,
                      process_flags,
                      env,
                      cwd,
-                     &startup,
+                     &startup.StartupInfo,
                      &info)) {
     /* CreateProcessW failed. */
     err = GetLastError();
@@ -1160,6 +1213,14 @@ int uv_spawn(uv_loop_t* loop,
   uv__free(cwd);
   uv__free(env);
   uv__free(alloc_path);
+
+  if (attr_list != NULL) {
+    if (attr_list_initialized)
+      DeleteProcThreadAttributeList(attr_list);
+    uv__free(attr_list);
+    attr_list = NULL;
+  }
+  uv__free(handle_list);
 
   if (child_stdio_buffer != NULL) {
     /* Clean up child stdio handles. */

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -1047,7 +1047,10 @@ int uv_spawn(uv_loop_t* loop,
    * inherited, closing the race condition where concurrent uv_spawn calls
    * could cause handles intended for one child to leak into another. */
   {
-    int count = uv__stdio_size(child_stdio_buffer);
+#define CHILD_STDIO_COUNT(buffer)                   \
+    *((unsigned int*) (buffer))
+    int count = CHILD_STDIO_COUNT(child_stdio_buffer);
+#undef CHILD_STDIO_COUNT
     int n = 0;
     SIZE_T attr_size = 0;
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -211,25 +211,18 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "spawn_helper8") == 0) {
     uv_os_fd_t closed_fd;
     uv_os_fd_t open_fd;
-#ifdef _WIN32
-    DWORD flags;
-    HMODULE kernelbase_module;
-    union {
-      FARPROC proc;
-      sCompareObjectHandles pCompareObjectHandles; /* Windows >= 10 */
-    } u;
-#endif
     notify_parent_process();
     ASSERT_EQ(sizeof(closed_fd), read(0, &closed_fd, sizeof(closed_fd)));
     ASSERT_EQ(sizeof(open_fd), read(0, &open_fd, sizeof(open_fd)));
 #ifdef _WIN32
+    DWORD flags;
     ASSERT_GT((intptr_t) closed_fd, 0);
     ASSERT_GT((intptr_t) open_fd, 0);
-    ASSERT_NE(0, GetHandleInformation(open_fd, &flags));
-    kernelbase_module = GetModuleHandleW(L"kernelbase.dll");
-    u.proc = GetProcAddress(kernelbase_module, "CompareObjectHandles");
-    if (u.pCompareObjectHandles != NULL)
-      ASSERT_EQ(FALSE, u.pCompareObjectHandles(open_fd, closed_fd));
+    ASSERT_EQ(0, GetHandleInformation(open_fd, &flags));
+    ASSERT_EQ(ERROR_INVALID_HANDLE, GetLastError());
+    SetLastError(ERROR_SUCCESS);
+    ASSERT_EQ(0, GetHandleInformation(closed_fd, &flags));
+    ASSERT_EQ(ERROR_INVALID_HANDLE, GetLastError());
 #else
     ASSERT_GT(open_fd, 2);
     ASSERT_GT(closed_fd, 2);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -1677,11 +1677,6 @@ TEST_IMPL(spawn_fs_open) {
   uv_stdio_container_t stdio[1];
 #ifdef _WIN32
   const char dev_null[] = "NUL";
-  HMODULE kernelbase_module;
-  union {
-    FARPROC proc;
-    sCompareObjectHandles pCompareObjectHandles; /* Windows >= 10 */
-  } u;
 #else
   const char dev_null[] = "/dev/null";
 #endif
@@ -1704,10 +1699,6 @@ TEST_IMPL(spawn_fs_open) {
 #ifdef _WIN32
   ASSERT_NE(0, DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &dup_fd,
                                0, /* inherit */ TRUE, DUPLICATE_SAME_ACCESS));
-  kernelbase_module = GetModuleHandleW(L"kernelbase.dll");
-  u.proc = GetProcAddress(kernelbase_module, "CompareObjectHandles");
-  if (u.pCompareObjectHandles != NULL)
-    ASSERT_EQ(TRUE, u.pCompareObjectHandles(fd, dup_fd));
 #else
   dup_fd = dup(fd);
 #endif


### PR DESCRIPTION
Use STARTUPINFOEXW with PROC_THREAD_ATTRIBUTE_HANDLE_LIST so that only the stdio handles prepared for each child process are inherited by it. This closes the race condition where two concurrent uv_spawn calls could cause handles intended for one child to leak into another child process.

Fixes: https://github.com/libuv/libuv/issues/1490

I asked Claude an analyze whether we could do this even better (okay, I actually prompted very specifically to write this exact solution in this exact way despite it protesting), by implementing the feature wish list from #1490 for how `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` obviously should have been implemented, and it explained it is probably possible to emulate the correct behavior, though a bit tedious:

---

Problem: uv_spawn on Windows currently creates inheritable handles for child stdio, then calls CreateProcessW. Any concurrent CreateProcessW call anywhere in the process — from libuv or a third-party library — with bInheritHandles=TRUE will accidentally inherit those handles. PROC_THREAD_ATTRIBUTE_HANDLE_LIST (our current fix)   only controls what libuv's own CreateProcessW call inherits; it doesn't prevent other callers from picking up libuv's inheritable handles.                              

Fix: Never create inheritable handles in the parent at all.                                                                                                             
                                                                  
How:                                                                                                                                                                    

  1. Non-inheritable parent handles — change uv__duplicate_handle and uv__create_nul_handle to pass bInheritHandle=FALSE. The handles in child_stdio_buffer are now invisible to any CreateProcessW.                                
  2. Create child suspended — always add CREATE_SUSPENDED and bInheritHandles=FALSE to CreateProcessW. The child exists but hasn't run any code yet.
  3. Duplicate handles into child — call DuplicateHandle(GetCurrentProcess(), h, child_process, &child_h, 0, FALSE, DUPLICATE_SAME_ACCESS) for each valid handle in child_stdio_buffer, collecting the child-side handle values (which differ from the parent-side values).
  4. Patch child's stdio buffer — Windows copies lpReserved2 into the child's ProcessParameters->RuntimeData during CreateProcessW. Find that buffer via NtQueryInformationProcess → PEB → ReadProcessMemory, then WriteProcessMemory to overwrite the handle values at the CHILD_STDIO_HANDLE offsets with the child-side       
  values. Also patch ProcessParameters->StandardInput/Output/Error for the three primary stdio handles.
  5. Resume — ResumeThread. The child CRT reads GetStartupInfoW → lpReserved2 and sees valid, correct handle values.                                                      

  Result: The parent process holds no inheritable handles at any point during spawn, completely eliminating the race regardless of what other threads or libraries are doing.                                                                                                                                                                  

---

Here's what that code would look like. Libuv already has pNtQueryInformationProcess loaded, and the
  PROCESS_BASIC_INFORMATION struct in winapi.h, so it fits naturally:

    /* Partial RTL_USER_PROCESS_PARAMETERS, through RuntimeData.
     * Stable layout since XP; verified offsets:
     *   64-bit: StandardInput=0x020, RuntimeData=0x0E0
     *   32-bit: StandardInput=0x018, RuntimeData=0x088 */
    typedef struct {
      ULONG     MaximumLength;
      ULONG     Length;
      ULONG     Flags;
      ULONG     DebugFlags;
      HANDLE    ConsoleHandle;
      ULONG     ConsoleFlags;
    #ifdef _WIN64
      ULONG     _pad0;
    #endif
      HANDLE    StandardInput;
      HANDLE    StandardOutput;
      HANDLE    StandardError;
      /* CurrentDirectory (CURDIR = UNICODE_STRING + HANDLE) */
      UNICODE_STRING CurDirPath;
      HANDLE    CurDirHandle;
      /* DllPath, ImagePathName, CommandLine */
      UNICODE_STRING DllPath;
      UNICODE_STRING ImagePathName;
      UNICODE_STRING CommandLine;
      PVOID     Environment;
      ULONG     StartingX;
      ULONG     StartingY;
      ULONG     CountX;
      ULONG     CountY;
      ULONG     CountCharsX;
      ULONG     CountCharsY;
      ULONG     FillAttribute;
      ULONG     WindowFlags;
      ULONG     ShowWindowFlags;
    #ifdef _WIN64
      ULONG     _pad1;
    #endif
      UNICODE_STRING WindowTitle;
      UNICODE_STRING DesktopInfo;
      UNICODE_STRING ShellInfo;
      ANSI_STRING RuntimeData;   /* lpReserved2/cbReserved2 lives here */
    } uv__process_params_t;
  
    Then the retrieval function:
  
    static int uv__get_child_process_params(HANDLE process,
                                            uv__process_params_t* params,
                                            void** params_remote_addr) {
      PROCESS_BASIC_INFORMATION pbi;
      PVOID peb_addr;
      PVOID params_addr;
      SIZE_T n;
  
      /* Step 1: get PEB address from kernel */
      if (!NT_SUCCESS(pNtQueryInformationProcess(process,
                                                 ProcessBasicInformation,
                                                 &pbi, sizeof(pbi), NULL)))
        return GetLastError();
  
      peb_addr = pbi.PebBaseAddress;
  
      /* Step 2: read ProcessParameters pointer out of PEB.
       * It sits at offset 0x20 (64-bit) / 0x10 (32-bit) within PEB,
       * which is the fourth pointer-sized field. */
      if (!ReadProcessMemory(process,
                             (BYTE*)peb_addr + offsetof(PEB, ProcessParameters),
                             &params_addr, sizeof(params_addr), &n))
        return GetLastError();
  
      /* Step 3: read the params block itself */
      if (!ReadProcessMemory(process,
                             params_addr,
                             params, sizeof(*params), &n))
        return GetLastError();
  
      *params_remote_addr = params_addr;
      return 0;
    }

After this, params->RuntimeData.Buffer is the child-address pointer to the copied lpReserved2 buffer. You'd then iterate the child_stdio_buffer handle slots, write each DuplicateHandle result back with WriteProcessMemory at the corresponding offset within RuntimeData.Buffer, and also overwrite StandardInput/Output/Error in the params struct via  WriteProcessMemory at params_remote_addr + offsetof(uv__process_params_t, StandardInput).

PEB is already partially defined in winternl.h (which libuv pulls in via winapi.h), so offsetof(PEB, ProcessParameters) works without hardcoding the offset.