### PR TITLE
unix: handle cloexec failure in kqueue init

### DIFF
--- a/src/unix/kqueue.c
+++ b/src/unix/kqueue.c
@@ -50,12 +50,20 @@
 
 
 int uv__kqueue_init(uv_loop_t* loop) {
-  loop->backend_fd = kqueue();
-  if (loop->backend_fd == -1)
+  int fd;
+  int err;
+
+  fd = kqueue();
+  if (fd == -1)
     return UV__ERR(errno);
 
-  uv__cloexec(loop->backend_fd, 1);
+  err = uv__cloexec(fd, 1);
+  if (err) {
+    uv__close(fd);
+    return err;
+  }
 
+  loop->backend_fd = fd;
   return 0;
 }
 


### PR DESCRIPTION
Refactor uv__kqueue_init to use a temporary fd variable and properly handle errors from uv__cloexec. If setting CLOEXEC fails, close the kqueue fd and return the error instead of leaking the descriptor.

Fixes: https://github.com/libuv/libuv/issues/5081