### PR TITLE
stream: fix server stop accepting after uv_accept() error

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -547,7 +547,6 @@ int uv_accept(uv_stream_t* server, uv_stream_t* client) {
                             server->accepted_fd,
                             UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
       if (err) {
-        /* TODO handle error */
         uv__close(server->accepted_fd);
         goto done;
       }
@@ -590,8 +589,7 @@ done:
     }
   } else {
     server->accepted_fd = -1;
-    if (err == 0)
-      uv__io_start(server->loop, &server->io_watcher, POLLIN);
+    uv__io_start(server->loop, &server->io_watcher, POLLIN);
   }
   return err;
 }


### PR DESCRIPTION
## Problem

When `uv__stream_open()` fails inside `uv_accept()`, the accepted fd is
closed but POLLIN is never re-enabled on the server's IO watcher.

`uv__server_io()` stops POLLIN when a connection is pending (waiting for
the user to call `uv_accept()`). On the `uv_accept()` success path,
`uv__io_start()` restores POLLIN so the server can accept the next
connection. However, on the error path the `if (err == 0)` guard
prevents `uv__io_start()` from being called, leaving the server
permanently unable to accept new connections.

`uv__stream_open()` can fail with e.g. `UV_EBUSY` (stream already open),
or `UV__ERR(errno)` when `TCP_NODELAY` or `TCP_KEEPALIVE` setsockopt
calls fail.

## Fix

Remove the `err == 0` guard so POLLIN is re-enabled unconditionally
when no queued fds are present. `uv__io_start()` is idempotent, so
calling it on both the success and error paths is safe.

Also removes the `/* TODO handle error */` comment that acknowledged
the incomplete error handling.