### PR TITLE
win: properly initialize OSVERSIONINFOW

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -56,6 +56,8 @@ static int uv__windows10_version1709(void) {
   OSVERSIONINFOW os_info;
   if (!pRtlGetVersion)
     return 0;
+  os_info.dwOSVersionInfoSize = sizeof(os_info);
+  os_info.szCSDVersion[0] = L'\0';
   pRtlGetVersion(&os_info);
   if (os_info.dwMajorVersion < 10)
     return 0;


### PR DESCRIPTION
Otherwise calling `RtlGetVersion()` might produce UB. Problem was causing random crashes in the node.js test suite with stack traces like this one:
```
node.exe!__report_gsfailure(unsigned __int64 stack_cookie) Line 220
	at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\gs\gs_report.c(220)
node.exe!uv__tcp_keepalive(uv_tcp_s * socket, unsigned __int64 on, int idle, unsigned int intvl, unsigned int cnt, unsigned int) Line 109
	at E:\node\deps\uv\src\win\tcp.c(109)
[Inline Frame] node.exe!uv_tcp_keepalive_ex(uv_tcp_s * handle, int on, unsigned int idle, unsigned int intvl, unsigned int cnt) Line 1406
	at E:\node\deps\uv\src\win\tcp.c(1406)
node.exe!uv_tcp_keepalive(uv_tcp_s * handle, int on, unsigned int idle) Line 1395
	at E:\node\deps\uv\src\win\tcp.c(1395)
node.exe!node::TCPWrap::SetKeepAlive(const v8::FunctionCallbackInfo<v8::Value> & args) Line 213
	at E:\node\src\tcp_wrap.cc(213)
[External Code]
node.exe!v8::internal::`anonymous namespace'::Invoke(v8::internal::Isolate * isolate, const v8::internal::`anonymous namespace'::InvokeParams & params) Line 463
	at E:\node\deps\v8\src\execution\execution.cc(463)
node.exe!v8::internal::Execution::Call(v8::internal::Isolate * isolate, v8::internal::DirectHandle<v8::internal::Object> callable, v8::internal::DirectHandle<v8::internal::Object> receiver, v8::base::Vector<const v8::internal::DirectHandle<v8::internal::Object>> args) Line 532
	at E:\node\deps\v8\src\execution\execution.cc(532)
node.exe!v8::Function::Call(v8::Isolate * isolate, v8::Local<v8::Context> context, v8::Local<v8::Value> recv, int argc, v8::Local<v8::Value> * argv) Line 5374
	at E:\node\deps\v8\src\api\api.cc(5374)
node.exe!v8::Function::Call(v8::Local<v8::Context> context, v8::Local<v8::Value> recv, int argc, v8::Local<v8::Value> * argv) Line 5381
	at E:\node\deps\v8\src\api\api.cc(5381)
node.exe!node::InternalMakeCallback(node::Environment * env, v8::Local<v8::Object> resource, v8::Local<v8::Object> recv, const v8::Local<v8::Function> callback, int argc, v8::Local<v8::Value> * argv, node::async_context asyncContext, v8::Local<v8::Value> context_frame) Line 257
	at E:\node\src\api\callback.cc(257)
node.exe!node::AsyncWrap::MakeCallback(const v8::Local<v8::Function> cb, int argc, v8::Local<v8::Value> * argv) Line 695
	at E:\node\src\async_wrap.cc(695)
[Inline Frame] node.exe!node::AsyncWrap::MakeCallback(const v8::Local<v8::Name> symbol, int argc, v8::Local<v8::Value> * argv) Line 101
	at E:\node\src\async_wrap-inl.h(101)
[Inline Frame] node.exe!node::AsyncWrap::MakeCallback(const v8::Local<v8::String> symbol, int argc, v8::Local<v8::Value> * argv) Line 78
	at E:\node\src\async_wrap-inl.h(78)
node.exe!node::ConnectionWrap<node::TCPWrap,uv_tcp_s>::OnConnection(uv_stream_s * handle, int status) Line 73
	at E:\node\src\connection_wrap.cc(73)
node.exe!uv__process_tcp_accept_req(uv_loop_s * loop, uv_tcp_s * handle, uv_req_s * raw_req) Line 1245
	at E:\node\deps\uv\src\win\tcp.c(1245)
node.exe!uv__process_reqs(uv_loop_s * loop) Line 622
	at E:\node\deps\uv\src\win\core.c(622)
node.exe!uv_run(uv_loop_s * loop, <unnamed-tag> mode) Line 736
	at E:\node\deps\uv\src\win\core.c(736)
node.exe!node::SpinEventLoopInternal(node::Environment * env) Line 43
	at E:\node\src\api\embed_helpers.cc(43)
[Inline Frame] node.exe!node::NodeMainInstance::Run(node::ExitCode * exit_code, node::Environment * env) Line 109
	at E:\node\src\node_main_instance.cc(109)
node.exe!node::NodeMainInstance::Run() Line 99
	at E:\node\src\node_main_instance.cc(99)
[Inline Frame] node.exe!node::StartInternal(int argc, char * * argv) Line 1576
	at E:\node\src\node.cc(1576)
node.exe!node::Start(int argc, char * * argv) Line 1583
	at E:\node\src\node.cc(1583)
node.exe!wmain(int argc, wchar_t * * wargv) Line 91
	at E:\node\src\node_main.cc(91)
```

I think it might fix: https://github.com/libuv/libuv/issues/5106