### PR TITLE
win,pipe: don't discard bytes_read when reading more data from pipes

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2005,19 +2005,18 @@ static int uv__pipe_read_data(uv_loop_t* loop,
       if (r == ERROR_IO_PENDING) {
         r = CancelIoEx(handle->handle, &req->u.io.overlapped);
         assert(r || GetLastError() == ERROR_NOT_FOUND);
-        if (GetOverlappedResult(handle->handle, &req->u.io.overlapped, bytes_read, TRUE)) {
+        if (GetOverlappedResult(handle->handle, &req->u.io.overlapped, bytes_read, TRUE))
           r = ERROR_SUCCESS;
-        } else {
+        else
           r = GetLastError();
-          *bytes_read = 0;
-        }
       }
     }
     more = *bytes_read == max_bytes;
   }
 
   /* Call the read callback. */
-  if (r == ERROR_SUCCESS || r == ERROR_OPERATION_ABORTED)
+  if (r == ERROR_SUCCESS || r == ERROR_OPERATION_ABORTED ||
+      (r == ERROR_BROKEN_PIPE && *bytes_read > 0))
     handle->read_cb((uv_stream_t*) handle, *bytes_read, &buf);
   else
     uv__pipe_read_error_or_eof(loop, handle, r, buf);


### PR DESCRIPTION
Posix spec is very clear that this would have been right, but the MSDN documentation is a lot less precise than posix. But it is common API design in Windows for Read/Write to fail with errors when they succeeded partially. Such errors explicitly include ERROR_HANDLE_EOF and ERROR_BROKEN_PIPE, and so probably ERROR_OPERATION_ABORTED too.

Fixes: https://github.com/libuv/libuv/pull/5037