### PR TITLE
test: make `thread_priority` work with musl libc (#5117)

### DIFF
--- a/.github/workflows/CI-unix.yml
+++ b/.github/workflows/CI-unix.yml
@@ -27,6 +27,27 @@ jobs:
         run: |
           make -C build distcheck
 
+  build-musl:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.23
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup
+        run: |
+          apk add --no-cache build-base cmake linux-headers
+          adduser -D libuv
+          chown -R libuv:libuv "$GITHUB_WORKSPACE"
+      - name: Configure
+        run: |
+          su libuv -c 'cmake -B build -DBUILD_TESTING=ON'
+      - name: Build
+        run: |
+          su libuv -c 'cmake --build build'
+      - name: Test
+        run: |
+          su libuv -c 'cd build && ctest -V --output-on-failure'
+
   build-android:
     runs-on: ubuntu-latest
     env:

--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -100,7 +100,7 @@ TEST_IMPL(thread_priority) {
   uv_sem_destroy(&sem);
 
   /* Now that the thread no longer exists, verify that the relevant error is returned */
-#if !defined(__ANDROID__)
+#if defined (__GLIBC__) || !defined(__linux__) // exclude android and musl libc
   ASSERT_EQ(UV_ESRCH, uv_thread_getpriority(task_id, &priority));
   ASSERT_EQ(UV_ESRCH, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
 #endif

--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -99,8 +99,10 @@ TEST_IMPL(thread_priority) {
 
   uv_sem_destroy(&sem);
 
-  /* Now that the thread no longer exists, verify that the relevant error is returned */
-#if defined (__GLIBC__) || !defined(__linux__) // exclude android and musl libc
+  /* Now that the thread no longer exists, verify that the relevant error is
+   * returned. This is race-y and not guaranteed safe, but okay on most systems
+   * (excluding musl or android) since the runner here is single-threaded. */
+#if defined (__GLIBC__) || !defined(__linux__)
   ASSERT_EQ(UV_ESRCH, uv_thread_getpriority(task_id, &priority));
   ASSERT_EQ(UV_ESRCH, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
 #endif


### PR DESCRIPTION
Returning ESRCH is not mandatory in POSIX, only recommended. Only GNU libc is known to do this on Linux. Android and musl libc does not.

Assume all non-linux returns ESRCH.

Fixes: https://github.com/libuv/libuv/issues/5117