### PR TITLE
win: improve PATH search worst-case performance

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -61,6 +61,16 @@ static const env_var_t required_vars[] = { /* keep me sorted */
   E_V("WINDIR"),
 };
 
+typedef enum  {
+  PATHEXT_NONE,
+  PATHEXT_COM,
+  PATHEXT_EXE,
+  PATHEXT_BAT,
+  PATHEXT_CMD,
+} uv__supported_path_ext_t;
+
+#define MAX_PATH_EXT_LEN 4 /* including '.' */
+
 
 static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
@@ -122,6 +132,17 @@ static void uv__init_global_job_handle(void) {
 }
 
 
+static uv__supported_path_ext_t uv__get_path_ext(WCHAR* ext) {
+  if (wcslen(ext) == 4) {
+    if (CompareStringOrdinal(ext, 4, L".com", 4, TRUE) == CSTR_EQUAL) return PATHEXT_COM;
+    if (CompareStringOrdinal(ext, 4, L".exe", 4, TRUE) == CSTR_EQUAL) return PATHEXT_EXE;
+    if (CompareStringOrdinal(ext, 4, L".bat", 4, TRUE) == CSTR_EQUAL) return PATHEXT_BAT;
+    if (CompareStringOrdinal(ext, 4, L".cmd", 4, TRUE) == CSTR_EQUAL) return PATHEXT_CMD;
+  }
+  return PATHEXT_NONE;
+}
+
+
 static int uv__utf8_to_utf16_alloc(const char* s, WCHAR** ws_ptr) {
   return uv__convert_utf8_to_utf16(s, ws_ptr);
 }
@@ -152,12 +173,15 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t dir_len,
                                     const WCHAR* name,
                                     size_t name_len,
-                                    const WCHAR* ext,
-                                    size_t ext_len,
                                     const WCHAR* cwd,
-                                    size_t cwd_len) {
+                                    size_t cwd_len,
+                                    int allowed_exts) {
   WCHAR *result, *result_pos;
-  DWORD attrs;
+  HANDLE find;
+  WIN32_FIND_DATAW find_data;
+  int exts_seen = 0;
+  uv__supported_path_ext_t cur_pathext;
+  int exact_name_allowed = (allowed_exts & (1 << PATHEXT_NONE)) != 0;
   if (dir_len > 2 &&
       ((dir[0] == L'\\' || dir[0] == L'/') &&
        (dir[1] == L'\\' || dir[1] == L'/'))) {
@@ -187,7 +211,7 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
 
   /* Allocate buffer for output */
   result = result_pos = (WCHAR*)uv__malloc(sizeof(WCHAR) *
-      (cwd_len + 1 + dir_len + 1 + name_len + 1 + ext_len + 1));
+      (cwd_len + 1 + dir_len + 1 + name_len + 1 + MAX_PATH_EXT_LEN + 1));
 
   /* Copy cwd */
   wcsncpy(result_pos, cwd, cwd_len);
@@ -213,28 +237,73 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   wcsncpy(result_pos, name, name_len);
   result_pos += name_len;
 
-  if (ext_len) {
-    /* Add a dot if the filename didn't end with one */
-    if (name_len && result_pos[-1] != '.') {
+  /* If the exact name is disallowed, append a '.' before the wildcard
+   * to cut down on potential false positive matches. */
+  if (!exact_name_allowed) {
       result_pos[0] = L'.';
       result_pos++;
-    }
-
-    /* Copy extension */
-    wcsncpy(result_pos, ext, ext_len);
-    result_pos += ext_len;
   }
 
+  /* Wildcard */
+  result_pos[0] = L'*';
+  result_pos++;
   /* Null terminator */
   result_pos[0] = L'\0';
 
-  attrs = GetFileAttributesW(result);
+  find = FindFirstFileExW(result, FindExInfoBasic, &find_data, FindExSearchNameMatch, NULL, 0);
+  if (find == INVALID_HANDLE_VALUE) {
+    goto not_found;
+  }
+  do {
+    if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+    if (wcslen(find_data.cFileName) == name_len) {
+      /* The exact name is always prioritized if it's allowed,
+       * so an early return is possible. */
+      if (exact_name_allowed) {
+        /* Remove the wildcard */
+        result_pos--;
+        result_pos[0] = L'\0';
+        FindClose(find);
+        return result;
+      }
+    } else {
+      /* Can't early return in this branch.
+       * Order of iteration may be arbitrary depending on the filesystem */
+      cur_pathext = uv__get_path_ext(find_data.cFileName + name_len);
+      if (cur_pathext != PATHEXT_NONE) {
+        exts_seen |= 1 << cur_pathext;
+      }
+    }
+  } while (FindNextFileW(find, &find_data));
+  FindClose(find);
 
-  if (attrs != INVALID_FILE_ATTRIBUTES &&
-      !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
-    return result;
+  if (exts_seen == 0) {
+    goto not_found;
   }
 
+  /* Remove the wildcard and append the extension before returning. */
+  result_pos--;
+  /* Only append the '.' now if it wasn't already added earlier. */
+  if (exact_name_allowed) {
+      result_pos[0] = L'.';
+      result_pos++;
+  }
+  /* Prioritize using the standard PATHEXT order. */
+  if (exts_seen & (1 << PATHEXT_COM)) {
+    wcsncpy(result_pos, L"com", 4);
+  } else if (exts_seen & (1 << PATHEXT_EXE)) {
+    wcsncpy(result_pos, L"exe", 4);
+  } else if (exts_seen & (1 << PATHEXT_BAT)) {
+    wcsncpy(result_pos, L"bat", 4);
+  } else if (exts_seen & (1 << PATHEXT_CMD)) {
+    wcsncpy(result_pos, L"cmd", 4);
+  }
+  result_pos += 3;
+  /* Null terminator */
+  result_pos[0] = L'\0';
+  return result;
+
+not_found:
   uv__free(result);
   return NULL;
 }
@@ -251,32 +320,13 @@ static WCHAR* path_search_walk_ext(const WCHAR *dir,
                                    size_t cwd_len,
                                    int name_has_ext) {
   WCHAR* result;
+  int allowed_exts = (1 << PATHEXT_COM) | (1 << PATHEXT_EXE);
+  if (name_has_ext) allowed_exts |= (1 << PATHEXT_NONE);
 
-  /* If the name itself has a nonempty extension, try this extension first */
-  if (name_has_ext) {
-    result = search_path_join_test(dir, dir_len,
-                                   name, name_len,
-                                   L"", 0,
-                                   cwd, cwd_len);
-    if (result != NULL) {
-      return result;
-    }
-  }
-
-  /* Try .com extension */
   result = search_path_join_test(dir, dir_len,
                                  name, name_len,
-                                 L"com", 3,
-                                 cwd, cwd_len);
-  if (result != NULL) {
-    return result;
-  }
-
-  /* Try .exe extension */
-  result = search_path_join_test(dir, dir_len,
-                                 name, name_len,
-                                 L"exe", 3,
-                                 cwd, cwd_len);
+                                 cwd, cwd_len,
+                                 allowed_exts);
   if (result != NULL) {
     return result;
   }

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -61,6 +61,16 @@ static const env_var_t required_vars[] = { /* keep me sorted */
   E_V("WINDIR"),
 };
 
+typedef enum  {
+  PATHEXT_NONE,
+  PATHEXT_COM,
+  PATHEXT_EXE,
+  PATHEXT_BAT,
+  PATHEXT_CMD,
+} uv__supported_path_ext_t;
+
+#define MAX_PATH_EXT_LEN 4 /* including '.' */
+
 
 static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
@@ -146,18 +156,47 @@ static void uv__process_init(uv_loop_t* loop, uv_process_t* handle) {
  */
 
 /*
+ * Helper function for search_path_join_test
+ */
+static int search_path_ext_test(WCHAR* filepath,
+                                WCHAR* ext_pos,
+                                uv__supported_path_ext_t ext) {
+  DWORD attrs;
+  switch (ext) {
+  case PATHEXT_NONE:
+    break;
+  case PATHEXT_COM:
+    wcsncpy(ext_pos, L"com", 4);
+    break;
+  case PATHEXT_EXE:
+    wcsncpy(ext_pos, L"exe", 4);
+    break;
+  case PATHEXT_BAT:
+    wcsncpy(ext_pos, L"bat", 4);
+    break;
+  case PATHEXT_CMD:
+    wcsncpy(ext_pos, L"cmd", 4);
+    break;
+  }
+  attrs = GetFileAttributesW(filepath);
+  return attrs != INVALID_FILE_ATTRIBUTES &&
+      !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+/*
  * Helper function for search_path
  */
 static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t dir_len,
                                     const WCHAR* name,
                                     size_t name_len,
-                                    const WCHAR* ext,
-                                    size_t ext_len,
                                     const WCHAR* cwd,
-                                    size_t cwd_len) {
+                                    size_t cwd_len,
+                                    int allowed_exts) {
   WCHAR *result, *result_pos;
-  DWORD attrs;
+  HANDLE find;
+  WIN32_FIND_DATAW find_data;
+  int exact_name_allowed = (allowed_exts & (1 << PATHEXT_NONE)) != 0;
   if (dir_len > 2 &&
       ((dir[0] == L'\\' || dir[0] == L'/') &&
        (dir[1] == L'\\' || dir[1] == L'/'))) {
@@ -187,7 +226,7 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
 
   /* Allocate buffer for output */
   result = result_pos = (WCHAR*)uv__malloc(sizeof(WCHAR) *
-      (cwd_len + 1 + dir_len + 1 + name_len + 1 + ext_len + 1));
+      (cwd_len + 1 + dir_len + 1 + name_len + 1 + MAX_PATH_EXT_LEN + 1));
 
   /* Copy cwd */
   wcsncpy(result_pos, cwd, cwd_len);
@@ -213,28 +252,69 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   wcsncpy(result_pos, name, name_len);
   result_pos += name_len;
 
-  if (ext_len) {
-    /* Add a dot if the filename didn't end with one */
-    if (name_len && result_pos[-1] != '.') {
-      result_pos[0] = L'.';
-      result_pos++;
-    }
-
-    /* Copy extension */
-    wcsncpy(result_pos, ext, ext_len);
-    result_pos += ext_len;
+  /* If the exact name is disallowed, append a '.' before the wildcard
+   * to cut down on potential false positive matches. */
+  if (!exact_name_allowed) {
+    result_pos[0] = L'.';
+    result_pos++;
   }
 
+  /* Wildcard */
+  result_pos[0] = L'*';
+  result_pos++;
   /* Null terminator */
   result_pos[0] = L'\0';
 
-  attrs = GetFileAttributesW(result);
+  /* Use a wildcard search to rule out directories that don't have any
+   * possible matches. This is fast even if the directory has large numbers
+   * of entries (matching or non-matching). */
+  find = FindFirstFileExW(result,
+      FindExInfoBasic, &find_data, FindExSearchNameMatch, NULL, 0);
+  if (find == INVALID_HANDLE_VALUE) {
+    goto not_found;
+  }
+  /* Ignore the actual results of the wildcard search in order to avoid a
+   * possible worst-case scenario when there are a large number of matches.
+   * Instead, just check for the particular entries we're interested in now
+   * that it's known that those checks are worth it. */
+  FindClose(find);
 
-  if (attrs != INVALID_FILE_ATTRIBUTES &&
-      !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+  /* Remove the wildcard */
+  result_pos--;
+  result_pos[0] = L'\0';
+
+  if (exact_name_allowed) {
+    if (search_path_ext_test(result, result_pos, PATHEXT_NONE))
+      return result;
+
+    /* Append the '.' now since we know it wasn't added earlier. */
+    result_pos[0] = L'.';
+    result_pos++;
+  }
+
+  /* Check the allowed extensions in the order of their position in the default
+   * PATHEXT value. */
+  if (allowed_exts & (1 << PATHEXT_COM) &&
+      search_path_ext_test(result, result_pos, PATHEXT_COM)) {
     return result;
   }
 
+  if (allowed_exts & (1 << PATHEXT_EXE) &&
+      search_path_ext_test(result, result_pos, PATHEXT_EXE)) {
+    return result;
+  }
+
+  if (allowed_exts & (1 << PATHEXT_BAT) &&
+      search_path_ext_test(result, result_pos, PATHEXT_BAT)) {
+    return result;
+  }
+
+  if (allowed_exts & (1 << PATHEXT_CMD) &&
+      search_path_ext_test(result, result_pos, PATHEXT_CMD)) {
+    return result;
+  }
+
+not_found:
   uv__free(result);
   return NULL;
 }
@@ -251,32 +331,13 @@ static WCHAR* path_search_walk_ext(const WCHAR *dir,
                                    size_t cwd_len,
                                    int name_has_ext) {
   WCHAR* result;
+  int allowed_exts = (1 << PATHEXT_COM) | (1 << PATHEXT_EXE);
+  if (name_has_ext) allowed_exts |= (1 << PATHEXT_NONE);
 
-  /* If the name itself has a nonempty extension, try this extension first */
-  if (name_has_ext) {
-    result = search_path_join_test(dir, dir_len,
-                                   name, name_len,
-                                   L"", 0,
-                                   cwd, cwd_len);
-    if (result != NULL) {
-      return result;
-    }
-  }
-
-  /* Try .com extension */
   result = search_path_join_test(dir, dir_len,
                                  name, name_len,
-                                 L"com", 3,
-                                 cwd, cwd_len);
-  if (result != NULL) {
-    return result;
-  }
-
-  /* Try .exe extension */
-  result = search_path_join_test(dir, dir_len,
-                                 name, name_len,
-                                 L"exe", 3,
-                                 cwd, cwd_len);
+                                 cwd, cwd_len,
+                                 allowed_exts);
   if (result != NULL) {
     return result;
   }


### PR DESCRIPTION
Take advantage of FindFirstFileExW and wildcards to reduce the number of Win32 API calls used per-directory when searching the PATH. Instead of <number of allowed extensions> GetFileAttributesW calls per directory in the PATH, each entry is now first checked for viability using a FindFirstFileExW call, and then only if matches are found will it check each possibility using GetFileAttributesW.

This does not affect average case performance at all, but it does make an impact when both (a) many extensions are allowed, and (b) the file is not found early in the PATH search. The impact also scales with the size of the PATH (the more entries, the larger the potential impact).

---

<details>
<summary>benchmark code</summary>

```c
#include <stdio.h>
#include <stdint.h>
#include <inttypes.h>
#include "uv.h"

uv_loop_t *loop;
uv_process_t child_req;
uv_process_options_t options;

void on_exit(uv_process_t *req, int64_t exit_status, int term_signal) {
    uv_close((uv_handle_t*) req, NULL);
}

int main() {
    loop = uv_default_loop();

    for (int i=0; i<100; i++) {
        char* args[2];
        args[0] = "hello";
        args[1] = NULL;

        options.exit_cb = on_exit;
        options.file = "hello";
        options.args = args;

        int r;
        if ((r = uv_spawn(loop, &child_req, &options))) {
            fprintf(stderr, "%s\n", uv_strerror(r));
            return 1;
        }

        uv_run(loop, UV_RUN_DEFAULT);
    }

    return uv_run(loop, UV_RUN_DEFAULT);
}
```
</details>

For my testing, `hello.exe` is found in the 25th entry in `PATH`. 

No difference with default spawn flags:

```
Benchmark 1: bench-getattributes.exe
  Time (mean ± σ):     313.2 ms ±   1.7 ms    [User: 34.9 ms, System: 260.6 ms]
  Range (min … max):   311.5 ms … 316.6 ms    10 runs

Benchmark 2: bench-findfirst.exe
  Time (mean ± σ):     312.4 ms ±   3.6 ms    [User: 23.9 ms, System: 259.1 ms]
  Range (min … max):   308.1 ms … 321.0 ms    10 runs

Summary
  'bench-findfirst.exe' ran
    1.00 ± 0.01 times faster than 'bench-getattributes.exe'
```

With the changes in #5096 and `UV_PROCESS_WINDOWS_RESOLVE_BATCH` set, though, there is a difference since the extra 2 possible extensions add `2 * <number of path entries searched>` extra `GetFileAttributesW` calls:

```
Benchmark 1: bench-allpathext-getattributes.exe
  Time (mean ± σ):     394.7 ms ±   3.0 ms    [User: 60.6 ms, System: 327.2 ms]
  Range (min … max):   390.6 ms … 398.3 ms    10 runs

Benchmark 2: bench-allpathext-findfirst.exe
  Time (mean ± σ):     312.4 ms ±   3.6 ms    [User: 52.8 ms, System: 235.0 ms]
  Range (min … max):   309.1 ms … 318.8 ms    10 runs

Summary
  'bench-allpathext-findfirst.exe' ran
    1.26 ± 0.02 times faster than 'bench-allpathext-getattributes.exe'
```

---

The motivation for this is twofold:

- Improves the performance of the changes in #5096
- Provides a convenient way to mitigate part of BatBadBut since the wildcard matching naturally disallows spawning scripts when `options->file` has trailing `.` and space character(s).
  + See https://github.com/ziglang/zig/pull/23363 for context

---

I'm fairly certain the implementation could be further improved by swapping out `FindFirstFileExW`/etc for a `CreateFileW` + the lower-level `NtQueryDirectoryFile` since it allows for more control over the buffers used, memory allocated, etc. (and this is what Libuv's `scandir` already does). I'll probably try that out, but I don't think it needs to be a blocker.

EDIT: I tried this and it didn't affect performance at all