### PR TITLE
win: mitigate vulnerability from spawning batch scripts

### DIFF
--- a/src/win/process.c
+++ b/src/win/process.c
@@ -647,6 +647,203 @@ error:
 }
 
 
+/*
+ * Quotes an argument in order to mitigate an arbitrary command execution
+ * vulnerability when spawning .bat/.cmd scripts.
+ * Returns a pointer to the end (next char to be written) of the buffer
+ */
+WCHAR* quote_script_arg(const WCHAR *source, WCHAR *target) {
+  size_t len = wcslen(source);
+  size_t i;
+  int needs_quotes;
+  size_t backslash_i = 0;
+  size_t backslashes = 0;
+
+  /* Need quotes for empty arguments to avoid them being lost.
+   * Also quote if the last character is '\' to avoid accidental escaping
+   * in the batch script itself. For example, something like "%~2" in a
+   * batch script would cause the closing " to be escaped by the '\'. */
+  needs_quotes = len == 0 || source[len - 1] == L'\\';
+  if (!needs_quotes) {
+    for (i = 0; i < len; i++) {
+      WCHAR c = source[i];
+      /* Known good characters that don't need quotes */
+      if ((c >= L'A' && c <= L'Z') ||
+        (c >= L'a' && c <= L'z') ||
+        (c >= L'0' && c <= L'9') ||
+        c == L'#' || c == L'$' ||
+        c == L'*' || c == L'+' ||
+        c == L'-' || c == L'.' ||
+        c == L'/' || c == L':' ||
+        c == L'?' || c == L'@' ||
+        c == L'\\' || c == L'_') {
+        continue;
+      /* When in doubt, quote */
+      } else {
+        needs_quotes = 1;
+        break;
+      }
+    }
+  }
+
+  if (needs_quotes)
+    *(target++) = L'"';
+
+  for (i = 0; i < len; i++) {
+    switch (source[i]) {
+    case L'\\':
+      /* Backslashes may need to be escaped, but only backslashes that precede
+       * a double quote. So, keep track of how many consecutive backslashes are
+       * encountered in case the next character is a double quote. */
+      backslashes += 1;
+      break;
+    case L'"':
+      /* Double quotes are escaped by using two double quotes, e.g. " -> "".
+       * However, first, emit any deferred backslash escapes now that a double
+       * quote has been encountered. */
+      for (backslash_i = 0; backslash_i < backslashes; backslash_i++)
+        *(target++) = L'\\';
+      *(target++) = L'"';
+      backslashes = 0;
+      break;
+    case L'%':
+      /* Replace % with %%cd:~,%
+       *
+       * This takes advantage of the syntax to extract a substring from an
+       * environment variable via %foo:~<start_index>,<end_index>%. Therefore,
+       * %cd:~,% will always expand to an empty string since both the start and
+       * end indexes are blank, and it is assumed that %cd% is always available
+       * since it is a built-in variable that corresponds to the current
+       * directory.
+       *
+       * So, replacing %foo% with %%cd:~,%foo%%cd:~,% will stop %foo% from being
+       * expanded, and after environment variable expansion what remains will
+       * be the literal characters %foo%. */
+      wcscpy(target, L"%%cd:~,"); /* the last % is added outside the switch */
+      target += 7;
+      backslashes = 0;
+      break;
+    default:
+      /* Not a double quote, so reset the deferred backslash count */
+      backslashes = 0;
+      break;
+    }
+    *(target++) = source[i];
+  }
+
+  if (needs_quotes) {
+    for (backslash_i = 0; backslash_i < backslashes; backslash_i++)
+      *(target++) = L'\\';
+    *(target++) = L'"';
+  }
+  return target;
+}
+
+
+int make_safe_script_args(WCHAR* script_path, char** args, WCHAR** dst_ptr) {
+  char** arg;
+  WCHAR* dst = NULL;
+  WCHAR* temp_buffer = NULL;
+  size_t max_dst_len = 30; /* size of `cmd.exe /d /e:ON /v:OFF ""` + null */
+  size_t temp_buffer_len = 0;
+  size_t script_path_len = wcslen(script_path);
+  ssize_t arg_len;
+  WCHAR* pos;
+  int err = 0;
+
+  /* Count the required size. */
+  max_dst_len += script_path_len;
+  max_dst_len += 2; /* always quoted */
+  max_dst_len += 1; /* space separator or null terminator */
+  for (arg = args; *arg; arg++) {
+    arg_len = uv_wtf8_length_as_utf16(*arg);
+    if (arg_len < 0)
+      return arg_len;
+
+    /* These characters aren't necessarily a security issue, but they cannot
+     * be passed to .bat/.cmd files successfully, since \r gets stripped and
+     * \n acts as a terminator (so anything afterwards would be lost). */
+    if (strpbrk(*arg, "\r\n") != NULL) {
+      return UV_EINVAL;
+    }
+
+    if (strchr(*arg, '%')) {
+      /* Assume every character is '%', which each need to be transformed
+       * into an 8 character sequence. */
+      max_dst_len += arg_len * 8;
+    } else {
+      /* Assume every character needs escaping */
+      max_dst_len += arg_len * 2;
+    }
+    /* Assume the argument needs to be quoted */
+    max_dst_len += 2;
+    /* Space separator or null terminator */
+    max_dst_len += 1;
+
+    /* Enough room to store the WTF-8 version of the longest argument */
+    if ((size_t) arg_len > temp_buffer_len)
+      temp_buffer_len = arg_len;
+  }
+
+  /* Allocate buffer for the final command line. */
+  dst = uv__malloc(max_dst_len * sizeof(WCHAR));
+  if (dst == NULL) {
+    err = UV_ENOMEM;
+    goto error;
+  }
+
+  /* Allocate temporary working buffer. */
+  temp_buffer = uv__malloc(temp_buffer_len * sizeof(WCHAR));
+  if (temp_buffer == NULL) {
+    err = UV_ENOMEM;
+    goto error;
+  }
+
+  pos = dst;
+
+  wcscpy(pos, L"cmd.exe /d /e:ON /v:OFF /c \"");
+  pos += 28;
+
+  /* Quoted path to the script file. No need to escape anything since the path
+   * has been previously verified to exist, and therefore it's safe to assume
+   * that no escape-worthy characters are present since they are disallowed
+   * at the OS level. */
+  *pos++ = L'"';
+  wcscpy(pos, script_path);
+  pos += script_path_len;
+  *pos++ = L'"';
+
+  for (arg = args; *arg; arg++) {
+    /* Separate args with a space */
+    *pos++ = L' ';
+
+    /* Convert argument to wide char. */
+    arg_len = uv_wtf8_length_as_utf16(*arg);
+    assert(arg_len > 0); /* includes the null terminator */
+    assert(temp_buffer_len >= (size_t) arg_len);
+    uv_wtf8_to_utf16(*arg, temp_buffer, arg_len);
+
+    /* Quote/escape, if needed. */
+    pos = quote_script_arg(temp_buffer, pos);
+  }
+
+  /* End quote of the `cmd.exe ... /c ""` incantation */
+  *pos++ = L'"';
+  *pos++ = L'\0';
+  assert(pos <= dst + max_dst_len);
+
+  uv__free(temp_buffer);
+
+  *dst_ptr = dst;
+  return 0;
+
+error:
+  uv__free(dst);
+  uv__free(temp_buffer);
+  return err;
+}
+
+
 static int env_strncmp(const wchar_t* a, int na, const wchar_t* b) {
   wchar_t* a_eq;
   wchar_t* b_eq;
@@ -951,11 +1148,12 @@ int uv_spawn(uv_loop_t* loop,
   WCHAR* path = NULL, *alloc_path = NULL;
   BOOL result;
   WCHAR* application_path = NULL, *application = NULL, *arguments = NULL,
-         *env = NULL, *cwd = NULL;
+         *env = NULL, *cwd = NULL, *ext = NULL;
   STARTUPINFOW startup;
   PROCESS_INFORMATION info;
   DWORD process_flags, cwd_len;
   BYTE* child_stdio_buffer;
+  uv__supported_path_ext_t app_ext;
 
   uv__process_init(loop, process);
   process->exit_cb = options->exit_cb;
@@ -981,13 +1179,6 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
 
   err = uv__utf8_to_utf16_alloc(options->file, &application);
-  if (err)
-    goto done_uv;
-
-  err = make_program_args(
-      options->args,
-      options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
-      &arguments);
   if (err)
     goto done_uv;
 
@@ -1070,6 +1261,75 @@ int uv_spawn(uv_loop_t* loop,
     /* Not found. */
     err = ERROR_FILE_NOT_FOUND;
     goto done;
+  }
+
+  /* Need to wait until the application path is known in order to know how the
+   * args need to be escaped, since .bat and .cmd need special handling. */
+  ext = wcsrchr(application_path, '.');
+  app_ext = ext != NULL ? uv__get_path_ext(ext) : PATHEXT_NONE;
+  if (((options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS) == 0) &&
+    (app_ext == PATHEXT_BAT || app_ext == PATHEXT_CMD)) {
+    /* Zero args is enough of a special case that handling it separately
+     * avoids complicating the > 0 args case (the common case). */
+    if (options->args[0] == NULL) {
+      /* Pass an empty string as the command line, and let CreateProcessW
+       * take care of the cmd.exe spawning of the .bat/.cmd file since
+       * there's no risk of the command line being malicious. */
+      arguments = uv__malloc(sizeof(WCHAR)); /* null terminator */
+      if (arguments == NULL) {
+        err = UV_ENOMEM;
+        goto done_uv;
+      }
+      arguments[0] = L'\0';
+    } else {
+      UINT sys_dir_len;
+      size_t initial_app_len = wcslen(application_path);
+      size_t required_len;
+      WCHAR* path_buf;
+
+      err = make_safe_script_args(
+        application_path,
+        /* Skip the first argument since it's the .bat or .cmd name
+         * and we're going to use application_path instead. */
+        options->args + 1,
+        &arguments);
+      if (err)
+        goto done_uv;
+
+      /* Switch the application path to cmd.exe.
+       * Attempt to re-use the existing buffer. */
+      sys_dir_len = GetSystemDirectoryW(application_path,
+        initial_app_len);
+      if (sys_dir_len == 0) {
+        err = GetLastError();
+        goto done;
+      }
+
+      /* Need enough for <system32 path>\cmd.exe + terminator */
+      required_len = sys_dir_len + 9;
+      if (required_len > initial_app_len) {
+        path_buf = uv__realloc(application_path, required_len * sizeof(WCHAR));
+        if (path_buf == NULL) {
+          err = UV_ENOMEM;
+          goto done_uv;
+        }
+        application_path = path_buf;
+        sys_dir_len = GetSystemDirectoryW(application_path, required_len);
+        if (sys_dir_len == 0) {
+          err = GetLastError();
+          goto done;
+        }
+      }
+
+      wcscpy(application_path + sys_dir_len, L"\\cmd.exe");
+    }
+  } else {
+    err = make_program_args(
+        options->args,
+        options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
+        &arguments);
+    if (err)
+      goto done_uv;
   }
 
   startup.cb = sizeof(startup);

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -61,6 +61,16 @@ static const env_var_t required_vars[] = { /* keep me sorted */
   E_V("WINDIR"),
 };
 
+typedef enum  {
+  PATHEXT_NONE,
+  PATHEXT_COM,
+  PATHEXT_EXE,
+  PATHEXT_BAT,
+  PATHEXT_CMD,
+} uv__supported_path_ext_t;
+
+#define MAX_PATH_EXT_LEN 4 /* including '.' */
+
 
 static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
@@ -122,6 +132,17 @@ static void uv__init_global_job_handle(void) {
 }
 
 
+static uv__supported_path_ext_t uv__get_path_ext(WCHAR* ext) {
+  if (wcslen(ext) == 4) {
+    if (CompareStringOrdinal(ext, 4, L".com", 4, TRUE) == CSTR_EQUAL) return PATHEXT_COM;
+    if (CompareStringOrdinal(ext, 4, L".exe", 4, TRUE) == CSTR_EQUAL) return PATHEXT_EXE;
+    if (CompareStringOrdinal(ext, 4, L".bat", 4, TRUE) == CSTR_EQUAL) return PATHEXT_BAT;
+    if (CompareStringOrdinal(ext, 4, L".cmd", 4, TRUE) == CSTR_EQUAL) return PATHEXT_CMD;
+  }
+  return PATHEXT_NONE;
+}
+
+
 static int uv__utf8_to_utf16_alloc(const char* s, WCHAR** ws_ptr) {
   return uv__convert_utf8_to_utf16(s, ws_ptr);
 }
@@ -152,12 +173,15 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t dir_len,
                                     const WCHAR* name,
                                     size_t name_len,
-                                    const WCHAR* ext,
-                                    size_t ext_len,
                                     const WCHAR* cwd,
-                                    size_t cwd_len) {
+                                    size_t cwd_len,
+                                    int allowed_exts) {
   WCHAR *result, *result_pos;
-  DWORD attrs;
+  HANDLE find;
+  WIN32_FIND_DATAW find_data;
+  int exts_seen = 0;
+  uv__supported_path_ext_t cur_pathext;
+  int exact_name_allowed = (allowed_exts & (1 << PATHEXT_NONE)) != 0;
   if (dir_len > 2 &&
       ((dir[0] == L'\\' || dir[0] == L'/') &&
        (dir[1] == L'\\' || dir[1] == L'/'))) {
@@ -187,7 +211,7 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
 
   /* Allocate buffer for output */
   result = result_pos = (WCHAR*)uv__malloc(sizeof(WCHAR) *
-      (cwd_len + 1 + dir_len + 1 + name_len + 1 + ext_len + 1));
+      (cwd_len + 1 + dir_len + 1 + name_len + 1 + MAX_PATH_EXT_LEN + 1));
 
   /* Copy cwd */
   wcsncpy(result_pos, cwd, cwd_len);
@@ -213,28 +237,73 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   wcsncpy(result_pos, name, name_len);
   result_pos += name_len;
 
-  if (ext_len) {
-    /* Add a dot if the filename didn't end with one */
-    if (name_len && result_pos[-1] != '.') {
+  /* If the exact name is disallowed, append a '.' before the wildcard
+   * to cut down on potential false positive matches. */
+  if (!exact_name_allowed) {
       result_pos[0] = L'.';
       result_pos++;
-    }
-
-    /* Copy extension */
-    wcsncpy(result_pos, ext, ext_len);
-    result_pos += ext_len;
   }
 
+  /* Wildcard */
+  result_pos[0] = L'*';
+  result_pos++;
   /* Null terminator */
   result_pos[0] = L'\0';
 
-  attrs = GetFileAttributesW(result);
+  find = FindFirstFileExW(result, FindExInfoBasic, &find_data, FindExSearchNameMatch, NULL, 0);
+  if (find == INVALID_HANDLE_VALUE) {
+    goto not_found;
+  }
+  do {
+    if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+    if (wcslen(find_data.cFileName) == name_len) {
+      /* The exact name is always prioritized if it's allowed,
+       * so an early return is possible. */
+      if (exact_name_allowed) {
+        /* Remove the wildcard */
+        result_pos--;
+        result_pos[0] = L'\0';
+        FindClose(find);
+        return result;
+      }
+    } else {
+      /* Can't early return in this branch.
+       * Order of iteration may be arbitrary depending on the filesystem */
+      cur_pathext = uv__get_path_ext(find_data.cFileName + name_len);
+      if (cur_pathext != PATHEXT_NONE) {
+        exts_seen |= 1 << cur_pathext;
+      }
+    }
+  } while (FindNextFileW(find, &find_data));
+  FindClose(find);
 
-  if (attrs != INVALID_FILE_ATTRIBUTES &&
-      !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
-    return result;
+  if (exts_seen == 0) {
+    goto not_found;
   }
 
+  /* Remove the wildcard and append the extension before returning. */
+  result_pos--;
+  /* Only append the '.' now if it wasn't already added earlier. */
+  if (exact_name_allowed) {
+      result_pos[0] = L'.';
+      result_pos++;
+  }
+  /* Prioritize using the standard PATHEXT order. */
+  if (exts_seen & (1 << PATHEXT_COM)) {
+    wcsncpy(result_pos, L"com", 4);
+  } else if (exts_seen & (1 << PATHEXT_EXE)) {
+    wcsncpy(result_pos, L"exe", 4);
+  } else if (exts_seen & (1 << PATHEXT_BAT)) {
+    wcsncpy(result_pos, L"bat", 4);
+  } else if (exts_seen & (1 << PATHEXT_CMD)) {
+    wcsncpy(result_pos, L"cmd", 4);
+  }
+  result_pos += 3;
+  /* Null terminator */
+  result_pos[0] = L'\0';
+  return result;
+
+not_found:
   uv__free(result);
   return NULL;
 }
@@ -251,32 +320,13 @@ static WCHAR* path_search_walk_ext(const WCHAR *dir,
                                    size_t cwd_len,
                                    int name_has_ext) {
   WCHAR* result;
+  int allowed_exts = (1 << PATHEXT_COM) | (1 << PATHEXT_EXE);
+  if (name_has_ext) allowed_exts |= (1 << PATHEXT_NONE);
 
-  /* If the name itself has a nonempty extension, try this extension first */
-  if (name_has_ext) {
-    result = search_path_join_test(dir, dir_len,
-                                   name, name_len,
-                                   L"", 0,
-                                   cwd, cwd_len);
-    if (result != NULL) {
-      return result;
-    }
-  }
-
-  /* Try .com extension */
   result = search_path_join_test(dir, dir_len,
                                  name, name_len,
-                                 L"com", 3,
-                                 cwd, cwd_len);
-  if (result != NULL) {
-    return result;
-  }
-
-  /* Try .exe extension */
-  result = search_path_join_test(dir, dir_len,
-                                 name, name_len,
-                                 L"exe", 3,
-                                 cwd, cwd_len);
+                                 cwd, cwd_len,
+                                 allowed_exts);
   if (result != NULL) {
     return result;
   }

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -132,6 +132,17 @@ static void uv__init_global_job_handle(void) {
 }
 
 
+static uv__supported_path_ext_t uv__get_path_ext(WCHAR* ext) {
+  if (wcslen(ext) == 4) {
+    if (CompareStringOrdinal(ext, 4, L".com", 4, TRUE) == CSTR_EQUAL) return PATHEXT_COM;
+    if (CompareStringOrdinal(ext, 4, L".exe", 4, TRUE) == CSTR_EQUAL) return PATHEXT_EXE;
+    if (CompareStringOrdinal(ext, 4, L".bat", 4, TRUE) == CSTR_EQUAL) return PATHEXT_BAT;
+    if (CompareStringOrdinal(ext, 4, L".cmd", 4, TRUE) == CSTR_EQUAL) return PATHEXT_CMD;
+  }
+  return PATHEXT_NONE;
+}
+
+
 static int uv__utf8_to_utf16_alloc(const char* s, WCHAR** ws_ptr) {
   return uv__convert_utf8_to_utf16(s, ws_ptr);
 }
@@ -658,6 +669,203 @@ error:
 }
 
 
+/*
+ * Quotes an argument in order to mitigate an arbitrary command execution
+ * vulnerability when spawning .bat/.cmd scripts.
+ * Returns a pointer to the end (next char to be written) of the buffer
+ */
+WCHAR* quote_script_arg(const WCHAR *source, WCHAR *target) {
+  size_t len = wcslen(source);
+  size_t i;
+  int needs_quotes;
+  size_t backslash_i = 0;
+  size_t backslashes = 0;
+
+  /* Need quotes for empty arguments to avoid them being lost.
+   * Also quote if the last character is '\' to avoid accidental escaping
+   * in the batch script itself. For example, something like "%~2" in a
+   * batch script would cause the closing " to be escaped by the '\'. */
+  needs_quotes = len == 0 || source[len - 1] == L'\\';
+  if (!needs_quotes) {
+    for (i = 0; i < len; i++) {
+      WCHAR c = source[i];
+      /* Known good characters that don't need quotes */
+      if ((c >= L'A' && c <= L'Z') ||
+        (c >= L'a' && c <= L'z') ||
+        (c >= L'0' && c <= L'9') ||
+        c == L'#' || c == L'$' ||
+        c == L'*' || c == L'+' ||
+        c == L'-' || c == L'.' ||
+        c == L'/' || c == L':' ||
+        c == L'?' || c == L'@' ||
+        c == L'\\' || c == L'_') {
+        continue;
+      /* When in doubt, quote */
+      } else {
+        needs_quotes = 1;
+        break;
+      }
+    }
+  }
+
+  if (needs_quotes)
+    *(target++) = L'"';
+
+  for (i = 0; i < len; i++) {
+    switch (source[i]) {
+    case L'\\':
+      /* Backslashes may need to be escaped, but only backslashes that precede
+       * a double quote. So, keep track of how many consecutive backslashes are
+       * encountered in case the next character is a double quote. */
+      backslashes += 1;
+      break;
+    case L'"':
+      /* Double quotes are escaped by using two double quotes, e.g. " -> "".
+       * However, first, emit any deferred backslash escapes now that a double
+       * quote has been encountered. */
+      for (backslash_i = 0; backslash_i < backslashes; backslash_i++)
+        *(target++) = L'\\';
+      *(target++) = L'"';
+      backslashes = 0;
+      break;
+    case L'%':
+      /* Replace % with %%cd:~,%
+       *
+       * This takes advantage of the syntax to extract a substring from an
+       * environment variable via %foo:~<start_index>,<end_index>%. Therefore,
+       * %cd:~,% will always expand to an empty string since both the start and
+       * end indexes are blank, and it is assumed that %cd% is always available
+       * since it is a built-in variable that corresponds to the current
+       * directory.
+       *
+       * So, replacing %foo% with %%cd:~,%foo%%cd:~,% will stop %foo% from being
+       * expanded, and after environment variable expansion what remains will
+       * be the literal characters %foo%. */
+      wcscpy(target, L"%%cd:~,"); /* the last % is added outside the switch */
+      target += 7;
+      backslashes = 0;
+      break;
+    default:
+      /* Not a double quote, so reset the deferred backslash count */
+      backslashes = 0;
+      break;
+    }
+    *(target++) = source[i];
+  }
+
+  if (needs_quotes) {
+    for (backslash_i = 0; backslash_i < backslashes; backslash_i++)
+      *(target++) = L'\\';
+    *(target++) = L'"';
+  }
+  return target;
+}
+
+
+int make_safe_script_args(WCHAR* script_path, char** args, WCHAR** dst_ptr) {
+  char** arg;
+  WCHAR* dst = NULL;
+  WCHAR* temp_buffer = NULL;
+  size_t max_dst_len = 30; /* size of `cmd.exe /d /e:ON /v:OFF ""` + null */
+  size_t temp_buffer_len = 0;
+  size_t script_path_len = wcslen(script_path);
+  ssize_t arg_len;
+  WCHAR* pos;
+  int err = 0;
+
+  /* Count the required size. */
+  max_dst_len += script_path_len;
+  max_dst_len += 2; /* always quoted */
+  max_dst_len += 1; /* space separator or null terminator */
+  for (arg = args; *arg; arg++) {
+    arg_len = uv_wtf8_length_as_utf16(*arg);
+    if (arg_len < 0)
+      return arg_len;
+
+    /* These characters aren't necessarily a security issue, but they cannot
+     * be passed to .bat/.cmd files successfully, since \r gets stripped and
+     * \n acts as a terminator (so anything afterwards would be lost). */
+    if (strpbrk(*arg, "\r\n") != NULL) {
+      return UV_EINVAL;
+    }
+
+    if (strchr(*arg, '%')) {
+      /* Assume every character is '%', which each need to be transformed
+       * into an 8 character sequence. */
+      max_dst_len += arg_len * 8;
+    } else {
+      /* Assume every character needs escaping */
+      max_dst_len += arg_len * 2;
+    }
+    /* Assume the argument needs to be quoted */
+    max_dst_len += 2;
+    /* Space separator or null terminator */
+    max_dst_len += 1;
+
+    /* Enough room to store the WTF-8 version of the longest argument */
+    if ((size_t) arg_len > temp_buffer_len)
+      temp_buffer_len = arg_len;
+  }
+
+  /* Allocate buffer for the final command line. */
+  dst = uv__malloc(max_dst_len * sizeof(WCHAR));
+  if (dst == NULL) {
+    err = UV_ENOMEM;
+    goto error;
+  }
+
+  /* Allocate temporary working buffer. */
+  temp_buffer = uv__malloc(temp_buffer_len * sizeof(WCHAR));
+  if (temp_buffer == NULL) {
+    err = UV_ENOMEM;
+    goto error;
+  }
+
+  pos = dst;
+
+  wcscpy(pos, L"cmd.exe /d /e:ON /v:OFF /c \"");
+  pos += 28;
+
+  /* Quoted path to the script file. No need to escape anything since the path
+   * has been previously verified to exist, and therefore it's safe to assume
+   * that no escape-worthy characters are present since they are disallowed
+   * at the OS level. */
+  *pos++ = L'"';
+  wcscpy(pos, script_path);
+  pos += script_path_len;
+  *pos++ = L'"';
+
+  for (arg = args; *arg; arg++) {
+    /* Separate args with a space */
+    *pos++ = L' ';
+
+    /* Convert argument to wide char. */
+    arg_len = uv_wtf8_length_as_utf16(*arg);
+    assert(arg_len > 0); /* includes the null terminator */
+    assert(temp_buffer_len >= (size_t) arg_len);
+    uv_wtf8_to_utf16(*arg, temp_buffer, arg_len);
+
+    /* Quote/escape, if needed. */
+    pos = quote_script_arg(temp_buffer, pos);
+  }
+
+  /* End quote of the `cmd.exe ... /c ""` incantation */
+  *pos++ = L'"';
+  *pos++ = L'\0';
+  assert(pos <= dst + max_dst_len);
+
+  uv__free(temp_buffer);
+
+  *dst_ptr = dst;
+  return 0;
+
+error:
+  uv__free(dst);
+  uv__free(temp_buffer);
+  return err;
+}
+
+
 static int env_strncmp(const wchar_t* a, int na, const wchar_t* b) {
   wchar_t* a_eq;
   wchar_t* b_eq;
@@ -962,11 +1170,12 @@ int uv_spawn(uv_loop_t* loop,
   WCHAR* path = NULL, *alloc_path = NULL;
   BOOL result;
   WCHAR* application_path = NULL, *application = NULL, *arguments = NULL,
-         *env = NULL, *cwd = NULL;
+         *env = NULL, *cwd = NULL, *ext = NULL;
   STARTUPINFOW startup;
   PROCESS_INFORMATION info;
   DWORD process_flags, cwd_len;
   BYTE* child_stdio_buffer;
+  uv__supported_path_ext_t app_ext;
 
   uv__process_init(loop, process);
   process->exit_cb = options->exit_cb;
@@ -992,13 +1201,6 @@ int uv_spawn(uv_loop_t* loop,
                               UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS)));
 
   err = uv__utf8_to_utf16_alloc(options->file, &application);
-  if (err)
-    goto done_uv;
-
-  err = make_program_args(
-      options->args,
-      options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
-      &arguments);
   if (err)
     goto done_uv;
 
@@ -1081,6 +1283,75 @@ int uv_spawn(uv_loop_t* loop,
     /* Not found. */
     err = ERROR_FILE_NOT_FOUND;
     goto done;
+  }
+
+  /* Need to wait until the application path is known in order to know how the
+   * args need to be escaped, since .bat and .cmd need special handling. */
+  ext = wcsrchr(application_path, '.');
+  app_ext = ext != NULL ? uv__get_path_ext(ext) : PATHEXT_NONE;
+  if (((options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS) == 0) &&
+    (app_ext == PATHEXT_BAT || app_ext == PATHEXT_CMD)) {
+    /* Zero args is enough of a special case that handling it separately
+     * avoids complicating the > 0 args case (the common case). */
+    if (options->args[0] == NULL) {
+      /* Pass an empty string as the command line, and let CreateProcessW
+       * take care of the cmd.exe spawning of the .bat/.cmd file since
+       * there's no risk of the command line being malicious. */
+      arguments = uv__malloc(sizeof(WCHAR)); /* null terminator */
+      if (arguments == NULL) {
+        err = UV_ENOMEM;
+        goto done_uv;
+      }
+      arguments[0] = L'\0';
+    } else {
+      UINT sys_dir_len;
+      size_t initial_app_len = wcslen(application_path);
+      size_t required_len;
+      WCHAR* path_buf;
+
+      err = make_safe_script_args(
+        application_path,
+        /* Skip the first argument since it's the .bat or .cmd name
+         * and we're going to use application_path instead. */
+        options->args + 1,
+        &arguments);
+      if (err)
+        goto done_uv;
+
+      /* Switch the application path to cmd.exe.
+       * Attempt to re-use the existing buffer. */
+      sys_dir_len = GetSystemDirectoryW(application_path,
+        initial_app_len);
+      if (sys_dir_len == 0) {
+        err = GetLastError();
+        goto done;
+      }
+
+      /* Need enough for <system32 path>\cmd.exe + terminator */
+      required_len = sys_dir_len + 9;
+      if (required_len > initial_app_len) {
+        path_buf = uv__realloc(application_path, required_len * sizeof(WCHAR));
+        if (path_buf == NULL) {
+          err = UV_ENOMEM;
+          goto done_uv;
+        }
+        application_path = path_buf;
+        sys_dir_len = GetSystemDirectoryW(application_path, required_len);
+        if (sys_dir_len == 0) {
+          err = GetLastError();
+          goto done;
+        }
+      }
+
+      wcscpy(application_path + sys_dir_len, L"\\cmd.exe");
+    }
+  } else {
+    err = make_program_args(
+        options->args,
+        options->flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
+        &arguments);
+    if (err)
+      goto done_uv;
   }
 
   startup.cb = sizeof(startup);

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -61,6 +61,16 @@ static const env_var_t required_vars[] = { /* keep me sorted */
   E_V("WINDIR"),
 };
 
+typedef enum  {
+  PATHEXT_NONE,
+  PATHEXT_COM,
+  PATHEXT_EXE,
+  PATHEXT_BAT,
+  PATHEXT_CMD,
+} uv__supported_path_ext_t;
+
+#define MAX_PATH_EXT_LEN 4 /* including '.' */
+
 
 static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
@@ -146,18 +156,47 @@ static void uv__process_init(uv_loop_t* loop, uv_process_t* handle) {
  */
 
 /*
+ * Helper function for search_path_join_test
+ */
+static int search_path_ext_test(WCHAR* filepath,
+                                WCHAR* ext_pos,
+                                uv__supported_path_ext_t ext) {
+  DWORD attrs;
+  switch (ext) {
+  case PATHEXT_NONE:
+    break;
+  case PATHEXT_COM:
+    wcsncpy(ext_pos, L"com", 4);
+    break;
+  case PATHEXT_EXE:
+    wcsncpy(ext_pos, L"exe", 4);
+    break;
+  case PATHEXT_BAT:
+    wcsncpy(ext_pos, L"bat", 4);
+    break;
+  case PATHEXT_CMD:
+    wcsncpy(ext_pos, L"cmd", 4);
+    break;
+  }
+  attrs = GetFileAttributesW(filepath);
+  return attrs != INVALID_FILE_ATTRIBUTES &&
+      !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+/*
  * Helper function for search_path
  */
 static WCHAR* search_path_join_test(const WCHAR* dir,
                                     size_t dir_len,
                                     const WCHAR* name,
                                     size_t name_len,
-                                    const WCHAR* ext,
-                                    size_t ext_len,
                                     const WCHAR* cwd,
-                                    size_t cwd_len) {
+                                    size_t cwd_len,
+                                    int allowed_exts) {
   WCHAR *result, *result_pos;
-  DWORD attrs;
+  HANDLE find;
+  WIN32_FIND_DATAW find_data;
+  int exact_name_allowed = (allowed_exts & (1 << PATHEXT_NONE)) != 0;
   if (dir_len > 2 &&
       ((dir[0] == L'\\' || dir[0] == L'/') &&
        (dir[1] == L'\\' || dir[1] == L'/'))) {
@@ -187,7 +226,7 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
 
   /* Allocate buffer for output */
   result = result_pos = (WCHAR*)uv__malloc(sizeof(WCHAR) *
-      (cwd_len + 1 + dir_len + 1 + name_len + 1 + ext_len + 1));
+      (cwd_len + 1 + dir_len + 1 + name_len + 1 + MAX_PATH_EXT_LEN + 1));
 
   /* Copy cwd */
   wcsncpy(result_pos, cwd, cwd_len);
@@ -213,28 +252,69 @@ static WCHAR* search_path_join_test(const WCHAR* dir,
   wcsncpy(result_pos, name, name_len);
   result_pos += name_len;
 
-  if (ext_len) {
-    /* Add a dot if the filename didn't end with one */
-    if (name_len && result_pos[-1] != '.') {
-      result_pos[0] = L'.';
-      result_pos++;
-    }
-
-    /* Copy extension */
-    wcsncpy(result_pos, ext, ext_len);
-    result_pos += ext_len;
+  /* If the exact name is disallowed, append a '.' before the wildcard
+   * to cut down on potential false positive matches. */
+  if (!exact_name_allowed) {
+    result_pos[0] = L'.';
+    result_pos++;
   }
 
+  /* Wildcard */
+  result_pos[0] = L'*';
+  result_pos++;
   /* Null terminator */
   result_pos[0] = L'\0';
 
-  attrs = GetFileAttributesW(result);
+  /* Use a wildcard search to rule out directories that don't have any
+   * possible matches. This is fast even if the directory has large numbers
+   * of entries (matching or non-matching). */
+  find = FindFirstFileExW(result,
+      FindExInfoBasic, &find_data, FindExSearchNameMatch, NULL, 0);
+  if (find == INVALID_HANDLE_VALUE) {
+    goto not_found;
+  }
+  /* Ignore the actual results of the wildcard search in order to avoid a
+   * possible worst-case scenario when there are a large number of matches.
+   * Instead, just check for the particular entries we're interested in now
+   * that it's known that those checks are worth it. */
+  FindClose(find);
 
-  if (attrs != INVALID_FILE_ATTRIBUTES &&
-      !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+  /* Remove the wildcard */
+  result_pos--;
+  result_pos[0] = L'\0';
+
+  if (exact_name_allowed) {
+    if (search_path_ext_test(result, result_pos, PATHEXT_NONE))
+      return result;
+
+    /* Append the '.' now since we know it wasn't added earlier. */
+    result_pos[0] = L'.';
+    result_pos++;
+  }
+
+  /* Check the allowed extensions in the order of their position in the default
+   * PATHEXT value. */
+  if (allowed_exts & (1 << PATHEXT_COM) &&
+      search_path_ext_test(result, result_pos, PATHEXT_COM)) {
     return result;
   }
 
+  if (allowed_exts & (1 << PATHEXT_EXE) &&
+      search_path_ext_test(result, result_pos, PATHEXT_EXE)) {
+    return result;
+  }
+
+  if (allowed_exts & (1 << PATHEXT_BAT) &&
+      search_path_ext_test(result, result_pos, PATHEXT_BAT)) {
+    return result;
+  }
+
+  if (allowed_exts & (1 << PATHEXT_CMD) &&
+      search_path_ext_test(result, result_pos, PATHEXT_CMD)) {
+    return result;
+  }
+
+not_found:
   uv__free(result);
   return NULL;
 }
@@ -251,32 +331,13 @@ static WCHAR* path_search_walk_ext(const WCHAR *dir,
                                    size_t cwd_len,
                                    int name_has_ext) {
   WCHAR* result;
+  int allowed_exts = (1 << PATHEXT_COM) | (1 << PATHEXT_EXE);
+  if (name_has_ext) allowed_exts |= (1 << PATHEXT_NONE);
 
-  /* If the name itself has a nonempty extension, try this extension first */
-  if (name_has_ext) {
-    result = search_path_join_test(dir, dir_len,
-                                   name, name_len,
-                                   L"", 0,
-                                   cwd, cwd_len);
-    if (result != NULL) {
-      return result;
-    }
-  }
-
-  /* Try .com extension */
   result = search_path_join_test(dir, dir_len,
                                  name, name_len,
-                                 L"com", 3,
-                                 cwd, cwd_len);
-  if (result != NULL) {
-    return result;
-  }
-
-  /* Try .exe extension */
-  result = search_path_join_test(dir, dir_len,
-                                 name, name_len,
-                                 L"exe", 3,
-                                 cwd, cwd_len);
+                                 cwd, cwd_len,
+                                 allowed_exts);
   if (result != NULL) {
     return result;
   }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -56,6 +56,7 @@ int ipc_helper_send_zero(void);
 int stdio_over_pipes_helper(void);
 void spawn_stdin_stdout(void);
 void process_title_big_argv(void);
+void spawn_echo_args(int argc, char **argv);
 int spawn_tcp_server_helper(void);
 
 static int maybe_run_test(int argc, char **argv);
@@ -75,6 +76,12 @@ int main(int argc, char **argv) {
 
   platform_init(argc, argv);
   argv = uv_setup_args(argc, argv);
+
+  /* Special case since this needs to be able to forward arbitrary numbers of arguments */
+  if (argc > 1 && strcmp(argv[1], "spawn_helper_echo_args") == 0) {
+      spawn_echo_args(argc, argv);
+      return 1;
+  }
 
   switch (argc) {
   case 1: return run_tests(0);

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -26,11 +26,17 @@
  * libuv.dll and one in this translation unit, but it works out fine in
  * the end.
  */
+#ifndef USING_UV_SHARED
 #define UV_EXTERN
+#endif
 #include "task.h"
 #define uv__malloc malloc
+#ifndef USING_UV_SHARED
 #include "../src/idna.c"
+#endif
 #include <string.h>
+
+#ifndef USING_UV_SHARED
 
 TEST_IMPL(utf8_decode1) {
   const char* p;
@@ -226,6 +232,8 @@ TEST_IMPL(idna_toascii) {
 #undef T
 
 #endif  /* __MVS__ */
+
+#endif  /* ifndef USING_UV_SHARED */
 
 TEST_IMPL(wtf8) {
   static const char input[] = "ᜄȺy𐞲:𞢢𘴇𐀀'¥3̞[<i$";

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -352,6 +352,9 @@ TEST_DECLARE   (spawn_quoted_path)
 TEST_DECLARE   (spawn_tcp_server)
 TEST_DECLARE   (spawn_exercise_sigchld_issue)
 TEST_DECLARE   (spawn_relative_path)
+#ifdef _WIN32
+TEST_DECLARE   (spawn_batch_script_arguments)
+#endif
 TEST_DECLARE   (fs_poll)
 TEST_DECLARE   (fs_poll_getpath)
 TEST_DECLARE   (fs_poll_close_request)
@@ -1049,6 +1052,9 @@ TASK_LIST_START
   TEST_ENTRY  (spawn_tcp_server)
   TEST_ENTRY  (spawn_exercise_sigchld_issue)
   TEST_ENTRY  (spawn_relative_path)
+#ifdef _WIN32
+  TEST_ENTRY  (spawn_batch_script_arguments)
+#endif
   TEST_ENTRY  (fs_poll)
   TEST_ENTRY  (fs_poll_getpath)
   TEST_ENTRY  (fs_poll_close_request)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -597,9 +597,11 @@ TEST_DECLARE  (iouring_pollhup)
 
 TEST_DECLARE  (wtf8)
 TEST_DECLARE  (utf16_to_wtf8_exact_fill)
+#ifndef USING_UV_SHARED
 TEST_DECLARE  (idna_toascii)
 TEST_DECLARE  (utf8_decode1)
 TEST_DECLARE  (utf8_decode1_overrun)
+#endif
 TEST_DECLARE  (uname)
 
 TEST_DECLARE  (metrics_info_check)
@@ -1273,13 +1275,17 @@ TASK_LIST_START
 
   TEST_ENTRY  (wtf8)
   TEST_ENTRY  (utf16_to_wtf8_exact_fill)
+#ifndef USING_UV_SHARED
   TEST_ENTRY  (utf8_decode1)
   TEST_ENTRY  (utf8_decode1_overrun)
+#endif
   TEST_ENTRY  (uname)
 
 /* Doesn't work on z/OS because that platform uses EBCDIC, not ASCII. */
 #ifndef __MVS__
+#ifndef USING_UV_SHARED
   TEST_ENTRY  (idna_toascii)
+#endif
 #endif
 
   TEST_ENTRY    (not_writable_after_shutdown)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -352,7 +352,7 @@ TEST_DECLARE   (spawn_quoted_path)
 TEST_DECLARE   (spawn_tcp_server)
 TEST_DECLARE   (spawn_exercise_sigchld_issue)
 TEST_DECLARE   (spawn_relative_path)
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 TEST_DECLARE   (spawn_batch_script_arguments)
 #endif
 TEST_DECLARE   (fs_poll)
@@ -1054,7 +1054,7 @@ TASK_LIST_START
   TEST_ENTRY  (spawn_tcp_server)
   TEST_ENTRY  (spawn_exercise_sigchld_issue)
   TEST_ENTRY  (spawn_relative_path)
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
   TEST_ENTRY  (spawn_batch_script_arguments)
 #endif
   TEST_ENTRY  (fs_poll)

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -2111,3 +2111,304 @@ TEST_IMPL(spawn_relative_path) {
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
+
+#ifdef _WIN32
+static int test_batch_script(char* file, int argc, char** argv) {
+  uv_stdio_container_t stdio[2];
+  uv_pipe_t out;
+  int i, arg_i = 0;
+  const char* out_args;
+  int r;
+
+  output_used = exit_cb_called = close_cb_called = 0;
+
+  args[0] = file;
+  for (i=0; i<argc; i++) {
+    args[i+1] = argv[i];
+  }
+  args[i+1] = NULL;
+
+  r = uv_pipe_init(uv_default_loop(), &out, 0);
+  ASSERT_OK(r);
+
+  options.exit_cb = exit_cb;
+  options.file = file;
+  options.args = args;
+  options.stdio = stdio;
+  options.stdio[0].flags = UV_IGNORE;
+  options.stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+  options.stdio[1].data.stream = (uv_stream_t*) &out;
+  options.stdio_count = 2;
+  options.flags = 0;
+
+  r = uv_spawn(uv_default_loop(), &process, &options);
+  /* Return the error to allow checking for expected failure */
+  if (r != 0) {
+    /* Fully close the process and the pipe to avoid a dangling pointer to &out */
+    uv_close((uv_handle_t*)&process, NULL);
+    uv_close((uv_handle_t*)&out, NULL);
+    ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+    return r;
+  }
+
+  r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
+  ASSERT_OK(r);
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT_OK(r);
+
+  ASSERT_NE(0, output_used);
+  output[output_used] = '\0';
+
+  out_args = output;
+  do
+  {
+    const char* start = out_args;
+    out_args = strpbrk(out_args, "\r\n");
+    if (out_args) {
+      int len = out_args - start;
+      printf("out_args[%d] is: %.*s\n", arg_i, len, start);
+      ASSERT_MEM_EQ(argv[arg_i], start, len);
+      ASSERT_EQ(len, strlen(argv[arg_i]));
+      out_args += strspn(out_args, "\r\n");
+    }
+    arg_i++;
+  }
+  while(out_args && *out_args);
+
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(2, close_cb_called); /* Once for process once for the pipe. */
+  return 0;
+}
+
+TEST_IMPL(spawn_batch_script_arguments) {
+  char* batch_file = "args.bat";
+  uv_fs_t fs_req;
+  uv_file file;
+  char test_buf[1024];
+  size_t test_len;
+  uv_buf_t iov;
+
+  /* set-up */
+  unlink(batch_file);
+  unlink("file.txt");
+
+  int r = uv_exepath(exepath, &exepath_size);
+  ASSERT_OK(r);
+  exepath[exepath_size] = '\0';
+  test_len = snprintf(test_buf, sizeof(test_buf), 
+    "@echo off\r\n\"%s\" spawn_helper_echo_args %%*\r\n", exepath);
+
+  r = uv_fs_open(NULL, &fs_req, batch_file, UV_FS_O_WRONLY | UV_FS_O_CREAT,
+      S_IWUSR | S_IRUSR, NULL);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(fs_req.result, 0);
+  file = fs_req.result;
+  uv_fs_req_cleanup(&fs_req);
+
+  iov = uv_buf_init(test_buf, test_len);
+  r = uv_fs_write(NULL, &fs_req, file, &iov, 1, -1, NULL);
+  ASSERT_EQ(r, test_len);
+  ASSERT_EQ(fs_req.result, test_len);
+  uv_fs_req_cleanup(&fs_req);
+
+  uv_fs_close(uv_default_loop(), &fs_req, file, NULL);
+
+  /* test */
+  {
+    /* Trailing '.' and space characters are silently stripped in certain cases,
+     * so "foo.bat .. " could lead to batch script execution that evades
+     * BatBadBut mitigation if that possibility is not accounted for.
+     *
+     * This is currently handled safely somewhat by happenstance, since before
+     * calling CreateProcess, the file path is checked using a wildcard match,
+     * so any trailing characters will cause that wildcard match to fail
+     * (e.g. `foo.bat .. *` will not match `foo.bat`; only `foo.bat*` will). */
+    WCHAR wtf16_buf[MAX_PATH];
+    DWORD wtf16_len;
+    char* test_ptr = test_buf;
+
+    /* Relative path */
+    r = test_batch_script("args.bat .. ", 0, NULL);
+    ASSERT_EQ(r, UV_ENOENT);
+
+    /* Absolute path */
+    wtf16_len = GetFullPathNameW(L"args.bat", MAX_PATH, wtf16_buf, NULL);
+    ASSERT_NE(wtf16_len, 0);
+
+    test_len = uv_utf16_length_as_wtf8(wtf16_buf, wtf16_len);
+    ASSERT_GT(test_len, 0);
+    r = uv_utf16_to_wtf8(wtf16_buf, wtf16_len, &test_ptr, &test_len);
+    ASSERT_OK(r);
+    test_ptr += test_len;
+    *test_ptr++ = ' ';
+    *test_ptr++ = '.';
+    *test_ptr++ = '.';
+    *test_ptr++ = ' ';
+    *test_ptr++ = '\0';
+
+    r = test_batch_script(test_buf, 0, NULL);
+    ASSERT_EQ(r, UV_ENOENT);
+  }
+  {
+    /* \r is rejected since it can't round trip */
+    char* test_args[] = {"\r"};
+    r = test_batch_script("args.bat", 1, test_args);
+    ASSERT_EQ(r, UV_EINVAL);
+  }
+  {
+    /* \n is rejected since it can't round trip */
+    char* test_args[] = {"\n"};
+    r = test_batch_script("args.bat", 1, test_args);
+    ASSERT_EQ(r, UV_EINVAL);
+  }
+  {
+    char* test_args[2] = {"a", "b"};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[2] = {"c is for cat", "d is for dog"};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[2] = {"\"", " \""};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[2] = {"\\", "\\"};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[1] = {">file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {">file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"whoami.exe"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"&a.exe"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"&echo hello "};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[3] = {"&echo hello", "&whoami", ">file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 3, test_args));
+  }
+  {
+    char* test_args[1] = {"!TMP!"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=value"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"\"key=value\""};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key = value"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=[\"value\"]"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[2] = {"", "a=b"};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[1] = {"key=\"foo bar\""};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=[\"my_value]"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=[\"my_value\",\"other-value\"]"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key\\=value"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=\"&whoami\""};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=\"value\"=5"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"key=[\">file.txt\"]"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"%hello"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"%PATH%"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"%%cd:~,%"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"%PATH%PATH%"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"\">file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"abc\"&echo hello"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"123\">file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[1] = {"\"&echo hello&whoami.exe"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+  {
+    char* test_args[2] = {"\"hello^\"world\"", "hello &echo oh no >file.txt"};
+    ASSERT_OK(test_batch_script(batch_file, 2, test_args));
+  }
+  {
+    char* test_args[1] = {"&whoami.exe"};
+    ASSERT_OK(test_batch_script(batch_file, 1, test_args));
+  }
+
+  /* Ensure that file.txt was not created by any >file.txt arguments */
+  r = uv_fs_stat(NULL, &fs_req, "file.txt", NULL);
+  ASSERT_EQ(r, UV_ENOENT);
+  ASSERT_EQ(fs_req.result, UV_ENOENT);
+  uv_fs_req_cleanup(&fs_req);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+#endif
+
+/* Called by spawn_helper_echo_args. */
+void spawn_echo_args(int argc, char **argv) {
+  for (int i=2; i<argc; i++) {
+    printf("%s\n", argv[i]);
+  }
+}

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -2112,7 +2112,11 @@ TEST_IMPL(spawn_relative_path) {
   return 0;
 }
 
-#ifdef _WIN32
+/* This test relies on the newer incarnation of command line argument parsing.
+ * MinGW may link against msvcrt.dll which uses the old version of the parsing
+ * to maintain compatibility. This test would work when linking against ucrt
+ * using MinGW, though. */
+#if defined(_WIN32) && !defined(__MINGW32__)
 static int test_batch_script(char* file, int argc, char** argv) {
   uv_stdio_container_t stdio[2];
   uv_pipe_t out;
@@ -2404,7 +2408,7 @@ TEST_IMPL(spawn_batch_script_arguments) {
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
-#endif
+#endif /* _WIN32 && !__MINGW32__ */
 
 /* Called by spawn_helper_echo_args. */
 void spawn_echo_args(int argc, char **argv) {


### PR DESCRIPTION
If CreateProcessW is given a path to a .bat or .cmd script, it will internally spawn cmd.exe with the path to the script
and args like so:

```
cmd.exe /c script.bat arg1 arg2
```

This is a problem because (1) cmd.exe has its own, separate, parsing and escaping rules for arguments, and
(2) environment variables in arguments will be expanded before the cmd.exe parsing rules are applied.

Together, this means that maliciously constructed arguments can lead to arbitrary command execution via `uv_spawn`, and that escaping arguments according to the rules of cmd.exe and letting CreateProcessW handle giving that to cmd.exe is not enough on its own.

A simple example that will currently spawn `foo.bat` but also `calc.exe`:

```c
char* args[3];
args[0] = "foo.bat";
args[1] = "\"&calc.exe";
args[2] = NULL;

options.file = "foo.bat";
options.args = args;

uv_spawn(loop, &req, &options))) {
```

The mitigation implemented here follows the recommendations of the original reporting:

https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/

With the changes in this PR, when spawning a .bat or .cmd script (which can be detected by looking at the extension), CreateProcessW is called with an application path that is the absolute path to `cmd.exe`, and a command line with the flags `/d /e:ON /vOFF /c` and a command line string that is escaped using the recommended mitigation, with one change:

1. Replace percent sign (`%`) with `%%cd:~,%`.
3. Replace the backslash (`\`) in front of the double quote (") with two
backslashes (`\\`).
3. Replace the double quote (`"`) with two double quotes (`""`).
4. ~~Remove newline characters (\n).~~ Instead, \n and \r will cause EINVAL to be returned since those characters cannot be successfully passed through a batch file and be retrieved on the other side (they don't round-trip).
5. Enclose the argument with double quotes (`"`).

---

This implementation is largely based on https://github.com/ziglang/zig/pull/19698, see that for more details. There are likely other workable solutions, but I have not investigated other possibilities since (1) this mitigation works as far as I'm aware, and (2) it allows round-tripping of all possible code points through a .bat file and back to a compiled executable successfully.

---

This currently depends on https://github.com/libuv/libuv/pull/5120 (and its changes are included in this branch). Without those changes, trailing `.` and space characters would need to be detected or handled in some other way. For reference, the Rust implementation [went with calling `GetFullPathNameW` and then checking the extension of the result of that](https://github.com/rust-lang/rust/pull/129962).

---

Note that this does not attempt to handle users passing `cmd.exe` as the `file`. The position this implementation takes is that the user is on their own in that case and will need to mitigate any vulnerabilities themselves. If that position is acceptable, then that might warrant mentioning in the documentation.

---

In addition to the added test, I also tested using a more fuzz-like test to be more confident that all allowed code points round-trip through batch files losslessly:

<details>
<summary>test files</summary>

echoargs.c
```c
#include <stdio.h>
#include "uv.h"

int wmain(int argc, wchar_t *argv[]) {
	for (int i=1; i<argc; i++) {
    size_t wtf8_len = uv_utf16_length_as_wtf8(argv[i], -1);
    char* wtf8_buf = malloc(wtf8_len);
    uv_utf16_to_wtf8(argv[i], -1, &wtf8_buf, &wtf8_len);
		printf("%s\n", wtf8_buf);
	}
	return 0;
}
```

args1.bat
```
@echo off
echoargs.exe %*
```

args2.bat
```
@echo off
echoargs.exe %1 %2 %3 %4 %5 %6 %7 %8 %9
```

args3.bat
```
@echo off
echoargs.exe "%~1" "%~2" "%~3" "%~4" "%~5" "%~6" "%~7" "%~8" "%~9"
```

fuzz.c
```c
#include <stdio.h>
#include <stdint.h>
#include <inttypes.h>
#include <assert.h>
#include "uv.h"

uv_loop_t *loop;
uv_process_t child_req;
uv_process_options_t options;
const char* bats[3] = {"args1.bat", "args2.bat", "args3.bat"};

#define OUTPUT_SIZE 1024
static char output_stdout[OUTPUT_SIZE];
static int output_stdout_used;
static char output_stderr[OUTPUT_SIZE];
static int output_stderr_used;

void on_exit(uv_process_t *req, int64_t exit_status, int term_signal) {
    uv_close((uv_handle_t*) req, NULL);
}

static void on_alloc(uv_handle_t* handle,
                     size_t suggested_size,
                     uv_buf_t* buf) {
  if (handle->data == 1) {
    buf->base = output_stdout + output_stdout_used;
    buf->len = OUTPUT_SIZE - output_stdout_used;
  } else if (handle->data == 2) {
    buf->base = output_stderr + output_stderr_used;
    buf->len = OUTPUT_SIZE - output_stderr_used;
  } else {
    assert(0);
  }
}

static void close_cb(uv_handle_t* handle) {
}

static void on_read(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
  if (nread > 0) {
    if (((uv_handle_t*) stream)->data == 1)
      output_stdout_used += nread;
    else if (((uv_handle_t*) stream)->data == 2)
      output_stderr_used += nread;
  } else if (nread < 0) {
    assert(nread == UV_EOF);
    uv_close((uv_handle_t*) stream, close_cb);
  }
}

void test(int argc, const char** argv) {
  uv_stdio_container_t stdio[3];
  uv_pipe_t out;
  uv_pipe_t err;

  int i;
  const char* args[10];
  for (i=0; i<argc; i++) {
    args[i+1] = argv[i];
  }
  args[i+1] = NULL;

  for (i=0; i<3; i++) {
    output_stdout_used = output_stderr_used = 0;
    args[0] = bats[i];

    uv_pipe_init(loop, &out, 0);
    uv_pipe_init(loop, &err, 0);

    options.exit_cb = on_exit;
    options.file = bats[i];
    options.args = args;
    options.stdio = stdio;
    options.stdio[0].flags = UV_IGNORE;
    options.stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
    options.stdio[1].data.stream = (uv_stream_t*) &out;
    options.stdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
    options.stdio[2].data.stream = (uv_stream_t*) &err;
    options.stdio_count = 3;

    ((uv_stream_t*)&out)->data = 1;
    ((uv_stream_t*)&err)->data = 2;

    int r;
    if ((r = uv_spawn(loop, &child_req, &options))) {
      fprintf(stderr, "%s\n", uv_strerror(r));
      return 1;
    }

    r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
    if (r != 0) {
      fprintf(stderr, "%s\n", uv_strerror(r));
      return 1;
    }

    r = uv_read_start((uv_stream_t*) &err, on_alloc, on_read);
    if (r != 0) {
      fprintf(stderr, "%s\n", uv_strerror(r));
      return 1;
    }

    uv_run(loop, UV_RUN_DEFAULT);

    assert(output_stderr_used == 0);
    assert(output_stdout_used != 0);
    output_stdout[output_stdout_used] = '\0';

    int empty_trailing_args_allowed = i == 2; /* args3.bat */

    int arg_i = 0;
    const char* out_args = output_stdout;
    do
    {
      const char* start = out_args;
      out_args = strpbrk(out_args, "\r\n");
      if (out_args) {
        size_t len = out_args - start;
        if (len != strlen(argv[arg_i]) || memcmp(start, argv[arg_i], len) != 0) {
          printf("%d:\n%s\n%s\n", arg_i, argv[arg_i], start);
        }
        assert(len == strlen(argv[arg_i]));
        assert(memcmp(start, argv[arg_i], len) == 0);
        out_args += strspn(out_args, "\r\n");
      }
      arg_i++;
    }
    while(out_args && *out_args);

    assert(arg_i == argc);
  }
}

enum {
  CHOICE_BACKSLASH,
  CHOICE_PERCENT,
  CHOICE_QUOTE,
  CHOICE_SPACE,
  CHOICE_CONTROL,
  CHOICE_PRINTABLE,
  CHOICE_SURROGATE_HALF,
  CHOICE_NON_ASCII,
  CHOICE_MAX_VALUE
};

void random_arg(char* buf) {
  int choices = rand() % 256;

  size_t wtf8_len;
  uint16_t utf16_buf[3];
  char* wtf8_ptr = buf;
  uint32_t last_codepoint = 0;

  for (int i=0; i<choices; i++) {
    uint32_t c;
    int choice = rand() % CHOICE_MAX_VALUE;
    switch (choice) {
    case CHOICE_BACKSLASH:
      c = '\\';
      break;
    case CHOICE_PERCENT:
      c = '%';
      break;
    case CHOICE_QUOTE:
      c = '"';
      break;
    case CHOICE_SPACE:
      c = ' ';
      break;
    case CHOICE_CONTROL:
      c = rand() % 0x22;
      /* These code points can't roundtrip, so just swap to space */
      if (c == 0 || c == '\r' || c == '\n')
        c = ' ';
      else if (c == 0x21)
        c = '\x7F';
      break;
    case CHOICE_PRINTABLE:
      c = '!' + (rand() % ('~' - '!' + 1));
      break;
    case CHOICE_SURROGATE_HALF:
      c = 0xD800 + (rand() % (0xDFFF - 0xD800 + 1));
      break;
    case CHOICE_NON_ASCII:
      c = 0x80 + (rand() % (0x10FFFF - 0x80 + 1));
      break;
    default:
      assert(0);
      break;
    }

    /* Ensure well-formed WTF-8. This method is dumb but effective:
     * just skip encoding the low surrogate if the last code point
     * was an unpaired high surrogate. */
    if ((last_codepoint >= 0xD800 && last_codepoint < 0xDC00) && (c >= 0xDC00 && c <= 0xDFFF)) {
      continue;
    }

    if (c >= 0x10000) {
      utf16_buf[0] = ((c - 0x10000) >> 10) + 0xD800;
      utf16_buf[1] = ((c & 0x3FF)) + 0xDC00;
      utf16_buf[2] = 0;
      wtf8_len = uv_utf16_length_as_wtf8(utf16_buf, 2);
      assert(uv_utf16_to_wtf8(utf16_buf, 2, &wtf8_ptr, &wtf8_len) == 0);
    } else {
      utf16_buf[0] = c;
      utf16_buf[1] = 0;
      wtf8_len = uv_utf16_length_as_wtf8(utf16_buf, 1);
      assert(uv_utf16_to_wtf8(utf16_buf, 1, &wtf8_ptr, &wtf8_len) == 0);
    }

    wtf8_ptr += wtf8_len;
    last_codepoint = c;
  }
}

int main() {
  loop = uv_default_loop();

  // enough for each choice being encoded as 4 WTF-8 bytes + terminator
  char arg_buf1[1025];
  char arg_buf2[1025];
  char arg_buf3[1025];
  const char* args[3] = { arg_buf1, arg_buf2, arg_buf3 };

  for (int i=0; i<100; i++) {
    random_arg(arg_buf1);
    random_arg(arg_buf2);
    random_arg(arg_buf3);
    test(3, args);
  }

  return uv_run(loop, UV_RUN_DEFAULT);
}
```

</details>

Note that this differs from the added test case in that it relies on `wmain` in `echoargs.c` to support non-ASCII arguments. I thought about trying to get something that tests WTF-16 arguments into this branch but the two options that I could come up with for doing that didn't seem appealing:

- Compile a separate `echoargs.exe` that uses wmain, like this fuzzing-ish test does
- Get the command line from the PEB (instead of from the C runtime) and parse it manually the same way the C runtime does