### PR TITLE
misc: fix error code returned from uv_wtf8_length_as_utf16

### DIFF
--- a/src/idna.c
+++ b/src/idna.c
@@ -374,7 +374,7 @@ ssize_t uv_wtf8_length_as_utf16(const char* source_ptr) {
   do {
     code_point = uv__wtf8_decode1(&source_ptr);
     if (code_point < 0)
-      return -1;
+      return UV_EINVAL;
     if (code_point > 0xFFFF)
       w_target_len++;
     w_target_len++;

--- a/test/test-idna.c
+++ b/test/test-idna.c
@@ -244,6 +244,9 @@ TEST_IMPL(wtf8) {
   ASSERT_GT(len, 0);
   ASSERT_LT(len, ARRAY_SIZE(buf));
   uv_wtf8_to_utf16(input_max, buf, len);
+
+  /* Invalid start byte for UTF-8/WTF-8 sequence */
+  ASSERT_EQ(UV_EINVAL, uv_wtf8_length_as_utf16("\xFF"));
   return 0;
 }
 


### PR DESCRIPTION
Something random I noticed while working on #5121.

Also fixes the ad-hoc `-1` return value in a few usage sites that forward the return value:

https://github.com/libuv/libuv/blob/aabb7651de73ec2f1a74361ca3430eed1a62e402/src/win/process.c#L535-L537

https://github.com/libuv/libuv/blob/aabb7651de73ec2f1a74361ca3430eed1a62e402/src/win/process.c#L664-L666

https://github.com/libuv/libuv/blob/aabb7651de73ec2f1a74361ca3430eed1a62e402/src/win/getaddrinfo.c#L283-L285