### PR TITLE
linux: tolerate concurrent FD-close on EPOLL_CTL_ADD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-set-non-blocking.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
+       test/test-poll-close-fd-underneath.c
        test/test-poll-close.c
        test/test-poll-closesocket.c
        test/test-poll-multiple-handles.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -236,6 +236,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-poll.c \
                          test/test-poll-close.c \
                          test/test-poll-close-doesnt-corrupt-stack.c \
+                         test/test-poll-close-fd-underneath.c \
                          test/test-poll-closesocket.c \
                          test/test-poll-multiple-handles.c \
                          test/test-poll-oob.c \

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1340,6 +1340,16 @@ static void uv__epoll_ctl_flush(int epollfd,
     if (op != EPOLL_CTL_ADD)
       abort();
 
+    /* An -EBADF/-ENOENT/-EPERM/-EINVAL here means the FD was closed
+     * between staging and submission (concurrent close from another
+     * thread). Drop the registration silently — same spirit as the
+     * CTL_DEL "Ignore errors, may be racing with another thread"
+     * tolerance already applied above.
+     */
+    if (cqe->res == -EBADF || cqe->res == -ENOENT ||
+        cqe->res == -EPERM || cqe->res == -EINVAL)
+      continue;
+
     if (cqe->res != -EEXIST)
       abort();
 
@@ -1430,6 +1440,16 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     }
 
     if (!epoll_ctl(epollfd, op, fd, &e))
+      continue;
+
+    /* An EBADF/ENOENT/EPERM/EINVAL here means the FD was closed
+     * between staging and submission (concurrent close from another
+     * thread). Drop the registration silently — same spirit as the
+     * CTL_DEL "Ignore errors, may be racing with another thread"
+     * tolerance already applied in uv__epoll_ctl_prep.
+     */
+    if (errno == EBADF || errno == ENOENT ||
+        errno == EPERM || errno == EINVAL)
       continue;
 
     assert(op == EPOLL_CTL_ADD);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -504,6 +504,7 @@ TEST_DECLARE   (poll_oob)
 TEST_DECLARE   (poll_duplex)
 TEST_DECLARE   (poll_unidirectional)
 TEST_DECLARE   (poll_close)
+TEST_DECLARE   (poll_close_fd_underneath)
 TEST_DECLARE   (poll_bad_fdtype)
 #ifdef __linux__
 TEST_DECLARE   (poll_nested_epoll)
@@ -1003,6 +1004,9 @@ TASK_LIST_START
   TEST_ENTRY  (poll_duplex)
   TEST_ENTRY  (poll_unidirectional)
   TEST_ENTRY  (poll_close)
+#ifdef __linux__
+  TEST_ENTRY  (poll_close_fd_underneath)
+#endif
   TEST_ENTRY  (poll_bad_fdtype)
 #if (defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))) && \
     !defined(__sun)

--- a/test/test-poll-close-fd-underneath.c
+++ b/test/test-poll-close-fd-underneath.c
@@ -1,0 +1,134 @@
+/* Copyright libuv contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* Regression test: when a Python/C caller closes a file descriptor that is
+ * still registered with libuv's epoll (typically because the caller owns the
+ * Python socket object lifecycle while libuv only borrows the fd), the next
+ * epoll_ctl batch flush used to abort the whole process on Linux.
+ *
+ * Reproduces:
+ *  - Register many fds via uv_poll_init/uv_poll_start so the epoll_ctl_flush
+ *    batch contains real entries.
+ *  - Close the underlying fds directly with close(2), bypassing uv_close.
+ *  - Issue another uv_poll_start on each (changing event mask) so libuv
+ *    stages epoll_ctl(MOD) operations against the now-dead fds.
+ *  - Run the loop. The fds are dead; the CQEs (io_uring path) or the
+ *    classic epoll_ctl call will fail with EBADF.
+ *
+ * Before fix: abort() at src/unix/linux.c (either rc != n on short
+ *             submission, op != ADD, or cqe->res != -EEXIST).
+ * After  fix: libuv silently drops the dead watchers, process stays up.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <errno.h>
+
+#ifndef _WIN32
+# include <fcntl.h>
+# include <sys/socket.h>
+# include <unistd.h>
+#endif
+
+#define NUM_SOCKETS 64
+
+
+#ifndef _WIN32
+static void poll_cb(uv_poll_t* handle, int status, int events) {
+  /* No-op. We never expect this to fire on a closed fd — the fd is dead. */
+  (void) handle;
+  (void) status;
+  (void) events;
+}
+
+
+static void close_cb(uv_handle_t* handle) {
+  (void) handle;
+}
+
+
+TEST_IMPL(poll_close_fd_underneath) {
+  uv_loop_t* loop;
+  uv_poll_t handles[NUM_SOCKETS];
+  int fds[NUM_SOCKETS];
+  int i;
+  int r;
+
+  loop = uv_default_loop();
+
+  /* Create fds and register with uv_poll. */
+  for (i = 0; i < NUM_SOCKETS; i++) {
+    fds[i] = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(fds[i], 0);
+    r = uv_poll_init(loop, &handles[i], fds[i]);
+    ASSERT_OK(r);
+    r = uv_poll_start(&handles[i], UV_READABLE, poll_cb);
+    ASSERT_OK(r);
+  }
+
+  /* Run once so the ADD submissions flush through epoll_ctl. Returns 1
+   * because handles are still active; we just need the side effect. */
+  uv_run(loop, UV_RUN_NOWAIT);
+
+  /* Pull the rug out from under libuv: close the fds directly, bypassing
+   * uv_close. libuv's internal watcher table still references them. */
+  for (i = 0; i < NUM_SOCKETS; i++) {
+    ASSERT_OK(close(fds[i]));
+  }
+
+  /* Provoke a MOD submission against the now-dead fds. This is where the
+   * abort used to fire. */
+  for (i = 0; i < NUM_SOCKETS; i++) {
+    r = uv_poll_start(&handles[i], UV_WRITABLE, poll_cb);
+    /* uv_poll_start itself can't detect the fd is dead; the kernel will
+     * reject the staged epoll_ctl on submission. The return value depends
+     * on whether io_uring or classic epoll is in use, so don't assert. */
+    (void) r;
+  }
+
+  /* Tick the loop so the dead submissions are processed. In unpatched
+   * libuv this aborts. In patched libuv, it drops them silently. */
+  r = uv_run(loop, UV_RUN_NOWAIT);
+  /* Either 0 (nothing ready) or >0 (timers fired) — both fine. The point
+   * is that we got here at all. */
+  (void) r;
+
+  /* Clean up. uv_close is still safe; libuv will try another epoll_ctl(DEL)
+   * but that path already tolerates EBADF. */
+  for (i = 0; i < NUM_SOCKETS; i++) {
+    uv_close((uv_handle_t*) &handles[i], close_cb);
+  }
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT_OK(r);
+
+  MAKE_VALGRIND_HAPPY(loop);
+  return 0;
+}
+
+#else /* _WIN32 */
+
+TEST_IMPL(poll_close_fd_underneath) {
+  RETURN_SKIP("Linux-only regression test (libuv epoll_ctl race)");
+}
+
+#endif


### PR DESCRIPTION
Refs #5130

## Summary

`EPOLL_CTL_DEL` in `uv__epoll_ctl_prep` already treats "racing with another thread" as a silent drop (see the `if (op == EPOLL_CTL_DEL) continue;` branch and the existing `/* Ignore errors, may be racing with another thread. */` comment). `EPOLL_CTL_ADD` / `EPOLL_CTL_MOD` arbitrarily don't — if the target fd has been closed from another thread between libuv staging the ctl op and the kernel executing it, the kernel returns EBADF/ENOENT and libuv `abort()`s the whole process.

This is literally the same race: a thread that owns an fd's lifecycle (Python socket object being GC'd or explicitly closed; any wrapper that drops an fd it also handed off to an event loop) racing with libuv's next `epoll_ctl` on that fd. The correct response, already applied for `CTL_DEL`, is to drop the op silently — there's nothing to watch anymore.

This PR extends the same tolerance to the two places where libuv runs `EPOLL_CTL_ADD`:

1. **`uv__epoll_ctl_flush`** (io_uring CQE processing): accept `-EBADF / -ENOENT / -EPERM / -EINVAL` on a `CTL_ADD` CQE as "fd gone, drop and continue".
2. **`uv__io_poll`** (classic `epoll_ctl` path): same `EBADF / ENOENT / EPERM / EINVAL` handling before the existing `EEXIST` retry.

## Non-goals / preserved behavior

All other abort paths in these functions are preserved as-is:
- `if (rc != (int) n) abort();` (short io_uring submission) — stays loud. Not addressed here.
- `if (op != EPOLL_CTL_ADD) abort();` — stays loud. Internal consistency of libuv's CQE tagging.
- MOD retry failure — stays loud. If ADD returned EEXIST (we already watch this fd), a MOD failure is real corruption.

Non-racing workloads see zero behavior change. Workloads that were crashing from the race now drop a watcher silently — which, by the time we reach this path, is what the caller wanted (the fd is gone).

## Observed

Production workload: Python asyncio HTTP server (uvloop 0.22.1 → bundled libuv 1.48.0) with many concurrent WebSocket connections. Under steady ~30 WebSockets/sec churn on a 2-CPU pod, the process SIGABRT'd every 5–10 minutes. Core dumps landed on both the io_uring CQE path (`cqe->res != -EEXIST abort()`) and the classic `uv__io_poll` path (`assert(errno == EEXIST)` at the EEXIST retry site).

With this patch applied, the same workload ran 30+ minutes without incident.

## Regression test

Added `test/test-poll-close-fd-underneath.c` (Linux-only). Test:

1. Creates 64 sockets, registers each with `uv_poll_init` + `uv_poll_start`.
2. Runs the loop once to flush the ADDs through.
3. Closes the underlying fds directly with `close(2)`, bypassing `uv_close`.
4. Calls `uv_poll_start` again with a different event mask, staging `EPOLL_CTL_MOD` against the now-dead fds.
5. Runs the loop again.

Before this PR (against current `v1.x` HEAD):
```
not ok 1 - poll_close_fd_underneath
# uv_run_tests: src/unix/linux.c:1436: uv__io_poll: Assertion `errno == EEXIST' failed.
# exit code 6
```

After this PR:
```
ok 1 - poll_close_fd_underneath
# exit=0
```

## Related

- #5130 — companion issue describing the race and the philosophical question of where to apply the fix.
- [MagicStack/uvloop#738](https://github.com/MagicStack/uvloop/issues/738) — sibling user-visible bug: uvloop's `loop.create_connection(sock=sock)` doesn't detach the Python socket on cancellation, producing an fd double-close that hits a different libuv assertion. Different surface, same family.