### PR TITLE
unix: fix uv__udp_recvmsg crash

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -191,7 +191,7 @@ void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int revents) {
    * uv_udp_recv_stop + uv_close) already cleared recv_cb in the same
    * revents iteration.  uv__udp_recvmsg asserts recv_cb != NULL, so
    * calling it with a NULL recv_cb would be wrong regardless of POLLERR. */
-  if ((revents & POLLERR) && uv__is_active(handle))
+  if ((revents & POLLERR) && uv__is_active(handle) && handle->recv_cb != NULL)
     uv__udp_recvmsg(handle, MSG_ERRQUEUE);
 #endif
 


### PR DESCRIPTION
The handle can be actived when `handle->recv_cb` is `NULL`(interested in `POLLOUT` event, see uv__udp_recv_stop), so i think we should also check `handle->recv_cb`.

cc @juanarbol 

assert failed: https://github.com/nodejs/node/actions/runs/24960336330/job/73085918658?pr=62971

<img width="1944" height="290" alt="image" src="https://github.com/user-attachments/assets/30d502a0-ae71-421e-affe-26e58db64a2f" />
