### PR TITLE
src: implement EUI-64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-hrtime.c
        test/test-idle.c
        test/test-idna.c
+       test/test-interface-addresses.c
        test/test-iouring-pollhup.c
        test/test-ip4-addr.c
        test/test-ip6-addr.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -196,6 +196,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-hrtime.c \
                          test/test-idle.c \
                          test/test-idna.c \
+                         test/test-interface-addresses.c \
                          test/test-iouring-pollhup.c \
                          test/test-ip4-addr.c \
                          test/test-ip6-addr.c \

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -173,6 +173,46 @@ Data types
             } broadcast;
         } uv_interface_address_t;
 
+.. c:enum:: uv_phys_addr_family
+
+    Physical address family.
+
+    ::
+
+        typedef enum {
+            UV_PHYS_ADDR_UNKNOWN,
+            UV_PHYS_ADDR_MAC48,
+            UV_PHYS_ADDR_EUI64
+        } uv_phys_addr_family;
+
+    .. versionadded:: 2.0.0
+
+.. c:type:: uv_interface_address2_t
+
+    Data type for interface addresses.
+
+    ::
+
+        typedef struct uv_interface_address2_s {
+            char* name;
+            char phys_addr[8];
+            uv_phys_addr_family phys_addr_family;
+            int is_internal;
+            union {
+                struct sockaddr_in address4;
+                struct sockaddr_in6 address6;
+            } address;
+            union {
+                struct sockaddr_in netmask4;
+                struct sockaddr_in6 netmask6;
+            } netmask;
+            union {
+                struct sockaddr_in broadcast4;
+            } broadcast;
+        } uv_interface_address2_t;
+
+    .. versionadded:: 2.0.0
+
 .. c:type:: uv_passwd_t
 
     Data type for password file information.
@@ -423,6 +463,24 @@ API
 
     Free an array of :c:type:`uv_interface_address_t` which was returned by
     :c:func:`uv_interface_addresses`.
+
+.. c:function:: int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count)
+
+    Gets address information about the network interfaces on the system. An
+    array of `count` elements is allocated and returned in `addresses`. It must
+    be freed by the user, calling :c:func:`uv_free_interface_addresses2`.
+
+    Supports both MAC-48 and EUI-64 physical addresses. The
+    `phys_addr_family` field indicates the type of the physical address.
+
+    .. versionadded:: 2.0.0
+
+.. c:function:: void uv_free_interface_addresses2(uv_interface_address2_t* addresses, int count)
+
+    Free an array of :c:type:`uv_interface_address2_t` which was returned by
+    :c:func:`uv_interface_addresses2`.
+
+    .. versionadded:: 2.0.0
 
 .. c:function:: void uv_loadavg(double avg[3])
 

--- a/include/uv.h
+++ b/include/uv.h
@@ -251,6 +251,7 @@ typedef struct uv_random_s uv_random_t;
 typedef struct uv_env_item_s uv_env_item_t;
 typedef struct uv_cpu_info_s uv_cpu_info_t;
 typedef struct uv_interface_address_s uv_interface_address_t;
+typedef struct uv_interface_address2_s uv_interface_address2_t;
 typedef struct uv_dirent_s uv_dirent_t;
 typedef struct uv_passwd_s uv_passwd_t;
 typedef struct uv_group_s uv_group_t;
@@ -1290,6 +1291,30 @@ struct uv_interface_address_s {
   } broadcast;
 };
 
+typedef enum {
+  UV_PHYS_ADDR_UNKNOWN,
+  UV_PHYS_ADDR_MAC48,
+  UV_PHYS_ADDR_EUI64
+} uv_phys_addr_family;
+
+struct uv_interface_address2_s {
+  char* name;
+  char phys_addr[8];
+  uv_phys_addr_family phys_addr_family;
+  int is_internal;
+  union {
+    struct sockaddr_in address4;
+    struct sockaddr_in6 address6;
+  } address;
+  union {
+    struct sockaddr_in netmask4;
+    struct sockaddr_in6 netmask6;
+  } netmask;
+  union {
+    struct sockaddr_in broadcast4;
+  } broadcast;
+};
+
 struct uv_passwd_s {
   char* username;
   unsigned long uid;
@@ -1420,6 +1445,11 @@ UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses,
                                      int* count);
 UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
                                            int count);
+
+UV_EXTERN int uv_interface_addresses2(uv_interface_address2_t** addresses,
+                                      int* count);
+UV_EXTERN void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                            int count);
 
 struct uv_env_item_s {
   char* name;

--- a/src/unix/aix.c
+++ b/src/unix/aix.c
@@ -1113,8 +1113,8 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 }
 
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-  uv_interface_address_t* address;
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
+  uv_interface_address2_t* address;
   int sockfd, sock6fd, inet6, i, r, size = 1;
   struct ifconf ifc;
   struct ifreq *ifr, *p, flg;
@@ -1259,7 +1259,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     for (i = 0; i < *count; i++) {
       if (strcmp(address->name, p->ifr_name) == 0) {
         sa_addr = (struct sockaddr_dl*) &p->ifr_addr;
-        memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
+        if (sa_addr->sdl_alen <= sizeof(address->phys_addr)) {
+          memcpy(address->phys_addr, LLADDR(sa_addr), sa_addr->sdl_alen);
+          if (sa_addr->sdl_alen == 6)
+            address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+          else if (sa_addr->sdl_alen == 8)
+            address->phys_addr_family = UV_PHYS_ADDR_EUI64;
+        }
       }
       address++;
     }
@@ -1269,7 +1275,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   goto cleanup;
 
 syserror:
-  uv_free_interface_addresses(*addresses, *count);
+  uv_free_interface_addresses2(*addresses, *count);
   *addresses = NULL;
   *count = 0;
   r = UV_ENOSYS;
@@ -1284,8 +1290,8 @@ cleanup:
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-  int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
 
   for (i = 0; i < count; ++i) {

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -65,10 +65,10 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   return 0;
 }
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
   struct ifaddrs* addrs;
   struct ifaddrs* ent;
-  uv_interface_address_t* address;
+  uv_interface_address2_t* address;
 #if !(defined(__CYGWIN__) || defined(__MSYS__)) && !defined(__GNU__)
   int i;
 #endif
@@ -143,7 +143,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       if (strcmp(address->name, ent->ifa_name) == 0) {
         struct sockaddr_dl* sa_addr;
         sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
-        memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
+        if (sa_addr->sdl_alen <= sizeof(address->phys_addr)) {
+          memcpy(address->phys_addr, LLADDR(sa_addr), sa_addr->sdl_alen);
+          if (sa_addr->sdl_alen == 6)
+            address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+          else if (sa_addr->sdl_alen == 8)
+            address->phys_addr_family = UV_PHYS_ADDR_EUI64;
+        }
       }
       address++;
     }
@@ -156,8 +162,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
 
   for (i = 0; i < count; i++) {

--- a/src/unix/ibmi.c
+++ b/src/unix/ibmi.c
@@ -315,7 +315,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 }
 
 
-static int get_ibmi_physical_address(const char* line, char (*phys_addr)[6]) {
+static int get_ibmi_physical_address(const char* line, char (*phys_addr)[8]) {
   LIND0500 rcvr;
   /* rcvrlen is input parameter 2 to QDCRLIND */
   unsigned int rcvrlen = sizeof(rcvr);
@@ -391,8 +391,8 @@ static int get_ibmi_physical_address(const char* line, char (*phys_addr)[6]) {
 }
 
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-  uv_interface_address_t* address;
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
+  uv_interface_address2_t* address;
   struct ifaddrs_pase *ifap = NULL, *cur;
   int inet6, r = 0;
 
@@ -487,6 +487,9 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
         }
         uv__free(temp_name);
       }
+
+      if (rc == 0)
+        address->phys_addr_family = UV_PHYS_ADDR_MAC48;
     }
 
     address++;
@@ -497,7 +500,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses, int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
 
   for (i = 0; i < count; ++i) {

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1954,9 +1954,9 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   return !exclude_type;
 }
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
   struct ifaddrs *addrs, *ent;
-  uv_interface_address_t* address;
+  uv_interface_address2_t* address;
   int i;
   struct sockaddr_ll *sll;
 
@@ -2029,7 +2029,13 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       if (strncmp(address->name, ent->ifa_name, namelen) == 0 &&
           (address->name[namelen] == 0 || address->name[namelen] == ':')) {
         sll = (struct sockaddr_ll*)ent->ifa_addr;
-        memcpy(address->phys_addr, sll->sll_addr, sizeof(address->phys_addr));
+        if (sll->sll_halen <= sizeof(address->phys_addr)) {
+          memcpy(address->phys_addr, sll->sll_addr, sll->sll_halen);
+          if (sll->sll_halen == 6)
+            address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+          else if (sll->sll_halen == 8)
+            address->phys_addr_family = UV_PHYS_ADDR_EUI64;
+        }
       }
       address++;
     }
@@ -2041,8 +2047,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-  int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
 
   for (i = 0; i < count; i++) {

--- a/src/unix/os390.c
+++ b/src/unix/os390.c
@@ -260,7 +260,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     cpu_info->model = uv__malloc(ZOSCPU_MODEL_LENGTH + 1);
     if (cpu_info->model == NULL) {
       uv_free_cpu_info(*cpu_infos, idx);
-      return UV_ENOMEM; 
+      return UV_ENOMEM;
     }
     __get_cpu_model(cpu_info->model, ZOSCPU_MODEL_LENGTH + 1);
     cpu_info->cpu_times.user = cpu_usage_avg;
@@ -277,9 +277,9 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 }
 
 
-static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
+static int uv__interface_addresses_v6(uv_interface_address2_t** addresses,
                                       int* count) {
-  uv_interface_address_t* address;
+  uv_interface_address2_t* address;
   int sockfd;
   int maxsize;
   __net_ifconf6header_t ifc;
@@ -309,7 +309,8 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
   if (ioctl(sockfd, SIOCGIFCONF6, &ifc) == -1) {
     /* This will error on a system that does not support IPv6. However, we want
      * to treat this as there being 0 interfaces so we can continue to get IPv4
-     * interfaces in uv_interface_addresses(). So return 0 instead of the error.
+     * interfaces in uv_interface_addresses2(). So return 0 instead of the
+     * error.
      */
     uv__free(ifc.__nif6h_buffer);
     uv__close(sockfd);
@@ -338,7 +339,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
   }
 
   /* Alloc the return interface structs */
-  *addresses = uv__calloc(1, *count * sizeof(uv_interface_address_t));
+  *addresses = uv__calloc(1, *count * sizeof(uv_interface_address2_t));
   if (!(*addresses)) {
     uv__free(ifc.__nif6h_buffer);
     uv__close(sockfd);
@@ -368,7 +369,7 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
       ++i;
     address->name = uv__malloc(i + 1);
     if (address->name == NULL) {
-      uv_free_interface_addresses(*addresses, count_names);
+      uv_free_interface_addresses2(*addresses, count_names);
       uv__free(ifc.__nif6h_buffer);
       uv__close(sockfd);
       return UV_ENOMEM;
@@ -400,15 +401,15 @@ static int uv__interface_addresses_v6(uv_interface_address_t** addresses,
 }
 
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-  uv_interface_address_t* address;
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
+  uv_interface_address2_t* address;
   int sockfd;
   int maxsize;
   struct ifconf ifc;
   struct ifreq flg;
   struct ifreq* ifr;
   struct ifreq* p;
-  uv_interface_address_t* addresses_v6;
+  uv_interface_address2_t* addresses_v6;
   int count_v6;
   unsigned int i;
   int rc;
@@ -429,7 +430,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
   if (0 > sockfd) {
     if (count_v6)
-      uv_free_interface_addresses(addresses_v6, count_v6);
+      uv_free_interface_addresses2(addresses_v6, count_v6);
     return UV__ERR(errno);
   }
 
@@ -437,7 +438,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   if (ifc.ifc_req == NULL) {
     if (count_v6)
-      uv_free_interface_addresses(addresses_v6, count_v6);
+      uv_free_interface_addresses2(addresses_v6, count_v6);
     uv__close(sockfd);
     return UV_ENOMEM;
   }
@@ -446,7 +447,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   if (ioctl(sockfd, SIOCGIFCONF, &ifc) == -1) {
     if (count_v6)
-      uv_free_interface_addresses(addresses_v6, count_v6);
+      uv_free_interface_addresses2(addresses_v6, count_v6);
     uv__free(ifc.ifc_req);
     uv__close(sockfd);
     return UV__ERR(errno);
@@ -469,7 +470,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
       if (count_v6)
-        uv_free_interface_addresses(addresses_v6, count_v6);
+        uv_free_interface_addresses2(addresses_v6, count_v6);
       uv__free(ifc.ifc_req);
       uv__close(sockfd);
       return UV__ERR(errno);
@@ -489,11 +490,11 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   /* Alloc the return interface structs */
   *addresses = uv__calloc(1, (*count + count_v6) *
-                          sizeof(uv_interface_address_t));
+                          sizeof(uv_interface_address2_t));
 
   if (!(*addresses)) {
     if (count_v6)
-      uv_free_interface_addresses(addresses_v6, count_v6);
+      uv_free_interface_addresses2(addresses_v6, count_v6);
     uv__free(ifc.ifc_req);
     uv__close(sockfd);
     return UV_ENOMEM;
@@ -502,7 +503,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   /* copy over the ipv6 addresses if any are found */
   if (count_v6) {
-    memcpy(address, addresses_v6, count_v6 * sizeof(uv_interface_address_t));
+    memcpy(address, addresses_v6, count_v6 * sizeof(uv_interface_address2_t));
     address += count_v6;
     *count += count_v6;
     /* free ipv6 addresses, but keep address names */
@@ -522,7 +523,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
     memcpy(flg.ifr_name, p->ifr_name, sizeof(flg.ifr_name));
     if (ioctl(sockfd, SIOCGIFFLAGS, &flg) == -1) {
-      uv_free_interface_addresses(*addresses, count_names);
+      uv_free_interface_addresses2(*addresses, count_names);
       uv__free(ifc.ifc_req);
       uv__close(sockfd);
       return UV_ENOSYS;
@@ -541,7 +542,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
       ++i;
     address->name = uv__malloc(i + 1);
     if (address->name == NULL) {
-      uv_free_interface_addresses(*addresses, count_names);
+      uv_free_interface_addresses2(*addresses, count_names);
       uv__free(ifc.ifc_req);
       uv__close(sockfd);
       return UV_ENOMEM;
@@ -554,7 +555,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     address->address.address4 = *((struct sockaddr_in*) &p->ifr_addr);
 
     if (ioctl(sockfd, SIOCGIFNETMASK, p) == -1) {
-      uv_free_interface_addresses(*addresses, count_names);
+      uv_free_interface_addresses2(*addresses, count_names);
       uv__free(ifc.ifc_req);
       uv__close(sockfd);
       return UV__ERR(errno);
@@ -575,8 +576,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-                                 int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
   for (i = 0; i < count; ++i)
     uv__free(addresses[i].name);

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -757,75 +757,31 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
 
 #ifdef SUNOS_NO_IFADDRS
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
   *count = 0;
   *addresses = NULL;
   return UV_ENOSYS;
 }
 #else  /* SUNOS_NO_IFADDRS */
-/*
- * Inspired By:
- * https://blogs.oracle.com/paulie/entry/retrieving_mac_address_in_solaris
- * http://www.pauliesworld.org/project/getmac.c
- */
-static int uv__set_phys_addr(uv_interface_address_t* address,
-                             struct ifaddrs* ent) {
 
-  struct sockaddr_dl* sa_addr;
-  int sockfd;
-  size_t i;
-  struct arpreq arpreq;
-
-  /* This appears to only work as root */
-  sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
-  memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
-  for (i = 0; i < sizeof(address->phys_addr); i++) {
-    /* Check that all bytes of phys_addr are zero. */
-    if (address->phys_addr[i] != 0)
-      return 0;
-  }
-  memset(&arpreq, 0, sizeof(arpreq));
-  if (address->address.address4.sin_family == AF_INET) {
-    struct sockaddr_in* sin = ((struct sockaddr_in*)&arpreq.arp_pa);
-    sin->sin_addr.s_addr = address->address.address4.sin_addr.s_addr;
-  } else if (address->address.address4.sin_family == AF_INET6) {
-    struct sockaddr_in6* sin = ((struct sockaddr_in6*)&arpreq.arp_pa);
-    memcpy(sin->sin6_addr.s6_addr,
-           address->address.address6.sin6_addr.s6_addr,
-           sizeof(address->address.address6.sin6_addr.s6_addr));
-  } else {
-    return 0;
-  }
-
-  sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (sockfd < 0)
-    return UV__ERR(errno);
-
-  if (ioctl(sockfd, SIOCGARP, (char*)&arpreq) == -1) {
-    uv__close(sockfd);
-    return UV__ERR(errno);
-  }
-  memcpy(address->phys_addr, arpreq.arp_ha.sa_data, sizeof(address->phys_addr));
-  uv__close(sockfd);
-  return 0;
-}
-
-
-static int uv__ifaddr_exclude(struct ifaddrs *ent) {
+static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (!((ent->ifa_flags & IFF_UP) && (ent->ifa_flags & IFF_RUNNING)))
     return 1;
   if (ent->ifa_addr == NULL)
     return 1;
+  if (exclude_type == UV__EXCLUDE_IFPHYS)
+    return (ent->ifa_addr->sa_family != AF_LINK);
   if (ent->ifa_addr->sa_family != AF_INET &&
       ent->ifa_addr->sa_family != AF_INET6)
     return 1;
   return 0;
 }
 
-int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
-  uv_interface_address_t* address;
+int uv_interface_addresses2(uv_interface_address2_t** addresses, int* count) {
+  uv_interface_address2_t* address;
   struct ifaddrs* addrs;
   struct ifaddrs* ent;
+  int i;
 
   *count = 0;
   *addresses = NULL;
@@ -835,7 +791,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 
   /* Count the number of interfaces */
   for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
-    if (uv__ifaddr_exclude(ent))
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
       continue;
     (*count)++;
   }
@@ -845,7 +801,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     return 0;
   }
 
-  *addresses = uv__malloc(*count * sizeof(**addresses));
+  *addresses = uv__calloc(*count, sizeof(**addresses));
   if (!(*addresses)) {
     freeifaddrs(addrs);
     return UV_ENOMEM;
@@ -854,7 +810,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
   address = *addresses;
 
   for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
-    if (uv__ifaddr_exclude(ent))
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
       continue;
 
     address->name = uv__strdup(ent->ifa_name);
@@ -879,8 +835,60 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
     address->is_internal = !!((ent->ifa_flags & IFF_PRIVATE) ||
                            (ent->ifa_flags & IFF_LOOPBACK));
 
-    uv__set_phys_addr(address, ent);
     address++;
+  }
+
+  /* Fill in physical addresses for each interface */
+  for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+    if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFPHYS))
+      continue;
+
+    address = *addresses;
+
+    for (i = 0; i < *count; i++) {
+      if (strcmp(address->name, ent->ifa_name) == 0) {
+        struct sockaddr_dl* sa_addr;
+        sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
+        if (sa_addr->sdl_alen <= sizeof(address->phys_addr)) {
+          memcpy(address->phys_addr, LLADDR(sa_addr), sa_addr->sdl_alen);
+          if (sa_addr->sdl_alen == 6)
+            address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+          else if (sa_addr->sdl_alen == 8)
+            address->phys_addr_family = UV_PHYS_ADDR_EUI64;
+        }
+      }
+      address++;
+    }
+  }
+
+  /* AF_LINK may return all-zero addresses when not running as root.
+   * Fall back to SIOCGARP for any IPv4 interface that still has no address.
+   * SIOCGARP only works for IPv4 (ARP); IPv6 uses NDP instead.
+   */
+  {
+    int sockfd;
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd >= 0) {
+      address = *addresses;
+      for (i = 0; i < *count; i++) {
+        if (address->phys_addr_family == UV_PHYS_ADDR_UNKNOWN &&
+            address->address.address4.sin_family == AF_INET) {
+          struct arpreq arpreq;
+          struct sockaddr_in* sin;
+
+          memset(&arpreq, 0, sizeof(arpreq));
+          sin = (struct sockaddr_in*) &arpreq.arp_pa;
+          sin->sin_addr.s_addr = address->address.address4.sin_addr.s_addr;
+          if (ioctl(sockfd, SIOCGARP, (char*) &arpreq) == 0) {
+            memcpy(address->phys_addr, arpreq.arp_ha.sa_data, 6);
+            address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+          }
+        }
+        address++;
+      }
+      uv__close(sockfd);
+    }
   }
 
   freeifaddrs(addrs);
@@ -889,8 +897,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
 }
 #endif  /* SUNOS_NO_IFADDRS */
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
-  int count) {
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
+                                  int count) {
   int i;
 
   for (i = 0; i < count; i++) {

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -1053,3 +1053,62 @@ uint64_t uv_metrics_idle_time(uv_loop_t* loop) {
     idle_time += uv_hrtime() - entry_time;
   return idle_time;
 }
+
+
+int uv_interface_addresses(uv_interface_address_t** addresses, int* count) {
+  uv_interface_address2_t* addrs2;
+  int n;
+  int i;
+  int r;
+
+  r = uv_interface_addresses2(&addrs2, count);
+  if (r != 0)
+    return r;
+
+  n = *count;
+
+  if (n == 0) {
+    uv_free_interface_addresses2(addrs2, 0);
+    *addresses = NULL;
+    return 0;
+  }
+
+  *addresses = uv__calloc(n, sizeof(**addresses));
+  if (*addresses == NULL) {
+    uv_free_interface_addresses2(addrs2, n);
+    *count = 0;
+    return UV_ENOMEM;
+  }
+
+  for (i = 0; i < n; i++) {
+    (*addresses)[i].name = uv__strdup(addrs2[i].name);
+    if ((*addresses)[i].name == NULL) {
+      uv_free_interface_addresses(*addresses, i);
+      uv_free_interface_addresses2(addrs2, n);
+      *addresses = NULL;
+      *count = 0;
+      return UV_ENOMEM;
+    }
+    memcpy((*addresses)[i].phys_addr,
+           addrs2[i].phys_addr,
+           sizeof((*addresses)[i].phys_addr));
+    (*addresses)[i].is_internal = addrs2[i].is_internal;
+    (*addresses)[i].address.address6 = addrs2[i].address.address6;
+    (*addresses)[i].netmask.netmask6 = addrs2[i].netmask.netmask6;
+    (*addresses)[i].broadcast.broadcast4 = addrs2[i].broadcast.broadcast4;
+  }
+
+  uv_free_interface_addresses2(addrs2, n);
+  return 0;
+}
+
+
+void uv_free_interface_addresses(uv_interface_address_t* addresses,
+                                 int count) {
+  int i;
+
+  for (i = 0; i < count; i++)
+    uv__free(addresses[i].name);
+
+  uv__free(addresses);
+}

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -652,16 +652,16 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos_ptr, int* cpu_count_ptr) {
 }
 
 
-int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
+int uv_interface_addresses2(uv_interface_address2_t** addresses_ptr,
     int* count_ptr) {
   IP_ADAPTER_ADDRESSES* win_address_buf;
   ULONG win_address_buf_size;
   IP_ADAPTER_ADDRESSES* adapter;
 
-  uv_interface_address_t* uv_address_buf;
+  uv_interface_address2_t* uv_address_buf;
   char* name_buf;
   size_t uv_address_buf_size;
-  uv_interface_address_t* uv_address;
+  uv_interface_address2_t* uv_address;
 
   int count;
   ULONG flags;
@@ -767,7 +767,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
          unicast_address != NULL;
          unicast_address = unicast_address->Next) {
       count++;
-      uv_address_buf_size += sizeof(uv_interface_address_t);
+      uv_address_buf_size += sizeof(uv_interface_address2_t);
     }
   }
 
@@ -778,7 +778,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
     return UV_ENOMEM;
   }
 
-  /* Compute the start of the uv_interface_address_t array, and the place in
+  /* Compute the start of the uv_interface_address2_t array, and the place in
    * the buffer where the interface names will be stored. */
   uv_address = uv_address_buf;
   name_buf = (char*) (uv_address_buf + count);
@@ -808,7 +808,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
     }
     name_size += 1; /* Add NUL byte. */
 
-    /* Add an uv_interface_address_t element for every unicast address. */
+    /* Add an uv_interface_address2_t element for every unicast address. */
     for (unicast_address = (IP_ADAPTER_UNICAST_ADDRESS*)
                            adapter->FirstUnicastAddress;
          unicast_address != NULL;
@@ -825,10 +825,14 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
 
       uv_address->name = name_buf;
 
-      if (adapter->PhysicalAddressLength == sizeof(uv_address->phys_addr)) {
+      if (adapter->PhysicalAddressLength <= sizeof(uv_address->phys_addr)) {
         memcpy(uv_address->phys_addr,
                adapter->PhysicalAddress,
-               sizeof(uv_address->phys_addr));
+               adapter->PhysicalAddressLength);
+        if (adapter->PhysicalAddressLength == 6)
+          uv_address->phys_addr_family = UV_PHYS_ADDR_MAC48;
+        else if (adapter->PhysicalAddressLength == 8)
+          uv_address->phys_addr_family = UV_PHYS_ADDR_EUI64;
       }
 
       uv_address->is_internal =
@@ -877,7 +881,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
 }
 
 
-void uv_free_interface_addresses(uv_interface_address_t* addresses,
+void uv_free_interface_addresses2(uv_interface_address2_t* addresses,
     int count) {
   uv__free(addresses);
 }

--- a/test/test-interface-addresses.c
+++ b/test/test-interface-addresses.c
@@ -1,0 +1,142 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+#include <string.h>
+
+
+TEST_IMPL(interface_addresses) {
+  uv_interface_address_t* addrs;
+  int count;
+
+  ASSERT_OK(uv_interface_addresses(&addrs, &count));
+  ASSERT_GE(count, 0);
+
+  if (count > 0)
+    ASSERT_NOT_NULL(addrs);
+
+  uv_free_interface_addresses(addrs, count);
+  return 0;
+}
+
+
+TEST_IMPL(interface_addresses2) {
+  uv_interface_address2_t* addrs;
+  int count;
+  int i;
+  static const char zeros[8] = {0};
+
+  ASSERT_OK(uv_interface_addresses2(&addrs, &count));
+  ASSERT_GE(count, 0);
+
+  if (count > 0)
+    ASSERT_NOT_NULL(addrs);
+
+  for (i = 0; i < count; i++) {
+    ASSERT_NOT_NULL(addrs[i].name);
+
+    /* phys_addr_family must be a known value. */
+    ASSERT_GE(addrs[i].phys_addr_family, UV_PHYS_ADDR_UNKNOWN);
+    ASSERT_LE(addrs[i].phys_addr_family, UV_PHYS_ADDR_EUI64);
+
+    /* address family must be AF_INET or AF_INET6. */
+    ASSERT(addrs[i].address.address4.sin_family == AF_INET ||
+           addrs[i].address.address4.sin_family == AF_INET6);
+
+    if (addrs[i].phys_addr_family == UV_PHYS_ADDR_MAC48) {
+      /* Bytes 6 and 7 must be zero for MAC-48 addresses. */
+      ASSERT_EQ(addrs[i].phys_addr[6], 0);
+      ASSERT_EQ(addrs[i].phys_addr[7], 0);
+    }
+
+    if (addrs[i].phys_addr_family == UV_PHYS_ADDR_UNKNOWN) {
+      /* All bytes must be zero when the family is unknown. */
+      ASSERT_MEM_EQ(addrs[i].phys_addr, zeros, 8);
+    }
+  }
+
+  uv_free_interface_addresses2(addrs, count);
+  return 0;
+}
+
+
+TEST_IMPL(interface_addresses2_consistency) {
+  uv_interface_address_t* addrs;
+  uv_interface_address2_t* addrs2;
+  int count;
+  int count2;
+  int i;
+
+  ASSERT_OK(uv_interface_addresses(&addrs, &count));
+  ASSERT_OK(uv_interface_addresses2(&addrs2, &count2));
+
+  /* Both APIs must return the same number of interfaces. */
+  ASSERT_EQ(count, count2);
+
+  for (i = 0; i < count; i++) {
+    /* Names must match. */
+    ASSERT_STR_EQ(addrs[i].name, addrs2[i].name);
+
+    /* is_internal must match. */
+    ASSERT_EQ(addrs[i].is_internal, addrs2[i].is_internal);
+
+    /* First 6 bytes of phys_addr must match. */
+    ASSERT_MEM_EQ(addrs[i].phys_addr, addrs2[i].phys_addr, 6);
+
+    /* Address family must match. */
+    ASSERT_EQ(addrs[i].address.address4.sin_family,
+              addrs2[i].address.address4.sin_family);
+
+    /* Address data must match. */
+    if (addrs[i].address.address4.sin_family == AF_INET) {
+      ASSERT_OK(memcmp(&addrs[i].address.address4,
+                        &addrs2[i].address.address4,
+                        sizeof(struct sockaddr_in)));
+    } else {
+      ASSERT_OK(memcmp(&addrs[i].address.address6,
+                        &addrs2[i].address.address6,
+                        sizeof(struct sockaddr_in6)));
+    }
+
+    /* Netmask must match. */
+    if (addrs[i].netmask.netmask4.sin_family == AF_INET) {
+      ASSERT_OK(memcmp(&addrs[i].netmask.netmask4,
+                        &addrs2[i].netmask.netmask4,
+                        sizeof(struct sockaddr_in)));
+    } else if (addrs[i].netmask.netmask4.sin_family == AF_INET6) {
+      ASSERT_OK(memcmp(&addrs[i].netmask.netmask6,
+                        &addrs2[i].netmask.netmask6,
+                        sizeof(struct sockaddr_in6)));
+    }
+
+    /* Broadcast must match. */
+    if (addrs[i].broadcast.broadcast4.sin_family == AF_INET) {
+      ASSERT_OK(memcmp(&addrs[i].broadcast.broadcast4,
+                        &addrs2[i].broadcast.broadcast4,
+                        sizeof(struct sockaddr_in)));
+    }
+  }
+
+  uv_free_interface_addresses(addrs, count);
+  uv_free_interface_addresses2(addrs2, count2);
+  return 0;
+}

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -298,6 +298,9 @@ TEST_DECLARE   (process_title_big_argv)
 TEST_DECLARE   (process_title_threadsafe)
 TEST_DECLARE   (cwd_and_chdir)
 TEST_DECLARE   (get_memory)
+TEST_DECLARE   (interface_addresses)
+TEST_DECLARE   (interface_addresses2)
+TEST_DECLARE   (interface_addresses2_consistency)
 TEST_DECLARE   (get_passwd)
 TEST_DECLARE   (get_passwd2)
 TEST_DECLARE   (get_group)
@@ -959,6 +962,10 @@ TASK_LIST_START
   TEST_ENTRY  (cwd_and_chdir)
 
   TEST_ENTRY  (get_memory)
+
+  TEST_ENTRY  (interface_addresses)
+  TEST_ENTRY  (interface_addresses2)
+  TEST_ENTRY  (interface_addresses2_consistency)
 
   TEST_ENTRY  (get_passwd)
   TEST_ENTRY  (get_passwd2)

--- a/test/test-platform-output.c
+++ b/test/test-platform-output.c
@@ -34,6 +34,7 @@ TEST_IMPL(platform_output) {
   uv_rusage_t rusage;
   uv_cpu_info_t* cpus;
   uv_interface_address_t* interfaces;
+  uv_interface_address2_t* interfaces2;
   uv_passwd_t pwd;
   uv_group_t grp;
   uv_utsname_t uname;
@@ -193,6 +194,61 @@ TEST_IMPL(platform_output) {
     }
   }
   uv_free_interface_addresses(interfaces, count);
+
+  err = uv_interface_addresses2(&interfaces2, &count);
+  ASSERT_OK(err);
+
+  printf("uv_interface_addresses2:\n");
+  for (i = 0; i < count; i++) {
+    printf("  name: %s\n", interfaces2[i].name);
+    printf("  internal: %d\n", interfaces2[i].is_internal);
+    printf("  phys_addr_family: %d\n", interfaces2[i].phys_addr_family);
+    printf("  physical address: ");
+    if (interfaces2[i].phys_addr_family == UV_PHYS_ADDR_EUI64)
+      printf("%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n",
+             (unsigned char)interfaces2[i].phys_addr[0],
+             (unsigned char)interfaces2[i].phys_addr[1],
+             (unsigned char)interfaces2[i].phys_addr[2],
+             (unsigned char)interfaces2[i].phys_addr[3],
+             (unsigned char)interfaces2[i].phys_addr[4],
+             (unsigned char)interfaces2[i].phys_addr[5],
+             (unsigned char)interfaces2[i].phys_addr[6],
+             (unsigned char)interfaces2[i].phys_addr[7]);
+    else
+      printf("%02x:%02x:%02x:%02x:%02x:%02x\n",
+             (unsigned char)interfaces2[i].phys_addr[0],
+             (unsigned char)interfaces2[i].phys_addr[1],
+             (unsigned char)interfaces2[i].phys_addr[2],
+             (unsigned char)interfaces2[i].phys_addr[3],
+             (unsigned char)interfaces2[i].phys_addr[4],
+             (unsigned char)interfaces2[i].phys_addr[5]);
+
+    if (interfaces2[i].address.address4.sin_family == AF_INET) {
+      uv_ip4_name(&interfaces2[i].address.address4, buffer, sizeof(buffer));
+    } else if (interfaces2[i].address.address4.sin_family == AF_INET6) {
+      uv_ip6_name(&interfaces2[i].address.address6, buffer, sizeof(buffer));
+    }
+
+    printf("  address: %s\n", buffer);
+
+    if (interfaces2[i].netmask.netmask4.sin_family == AF_INET) {
+      uv_ip4_name(&interfaces2[i].netmask.netmask4, buffer, sizeof(buffer));
+      printf("  netmask: %s\n", buffer);
+    } else if (interfaces2[i].netmask.netmask4.sin_family == AF_INET6) {
+      uv_ip6_name(&interfaces2[i].netmask.netmask6, buffer, sizeof(buffer));
+      printf("  netmask: %s\n", buffer);
+    } else {
+      printf("  netmask: none\n");
+    }
+
+    if (interfaces2[i].broadcast.broadcast4.sin_family == AF_INET) {
+      uv_ip4_name(&interfaces2[i].broadcast.broadcast4, buffer, sizeof(buffer));
+      printf("  broadcast: %s\n", buffer);
+    } else {
+      printf("  broadcast: none\n");
+    }
+  }
+  uv_free_interface_addresses2(interfaces2, count);
 
   err = uv_os_get_passwd(&pwd);
   ASSERT_OK(err);


### PR DESCRIPTION
Add uv_interface_address2_t with an 8-byte phys_addr field and a uv_phys_addr_family enum (UNKNOWN, MAC48, EUI64) to support 64-bit MAC addresses (EUI-64) on IPv6 interfaces.
    
The existing uv_interface_addresses() is reimplemented as a cross-platform wrapper around the new function, avoiding per-platform code duplication for the old API.
    
Chose to add a new API rather than extend/modify the existing one to avoid breaking existing users of the old API and to allow for a cleaner migration path.
    
#829 is on the [v2.x milestone](https://github.com/libuv/libuv/issues/4622). This will be the first of a series of PRs meant to address v2.x milestone items.

Fixes a very old Node.js issue also: https://github.com/nodejs/node/issues/5629 https://github.com/nodejs/node/issues/498

Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/libuv/libuv/issues/829