### PR TITLE
unix: check SO_NOSIGPIPE setsockopt return value

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -532,7 +532,10 @@ int uv__socket(int domain, int type, int protocol) {
 #if defined(SO_NOSIGPIPE)
   {
     int on = 1;
-    setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+    if (setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on))) {
+      uv__close(sockfd);
+      return UV__ERR(errno);
+    }
   }
 #endif
 


### PR DESCRIPTION
The setsockopt cannot fail at this point but let's check the return code anyway, just in case.

Fixes: https://github.com/libuv/libuv/issues/5087