### PR TITLE
test: skip recvmsg unreachable test when no ipv6

### DIFF
--- a/test/test-udp-recvmsg-unreachable-error.c
+++ b/test/test-udp-recvmsg-unreachable-error.c
@@ -91,6 +91,9 @@ TEST_IMPL(udp_recvmsg_unreachable_error6) {
 #if !defined(__linux__)
   RETURN_SKIP("This test is Linux-specific");
 #endif
+  if (!can_ipv6())
+    RETURN_SKIP("IPv6 not supported");
+
   struct sockaddr_in6 server_addr, client_addr;
   uv_udp_t client;
   uv_timer_t timer;


### PR DESCRIPTION
Guard `udp_recvmsg_unreachable_error6` in case ipv6 is not supported.