### PR TITLE
win,pipe: unref stdio pipe handles on Windows Server 2025+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-server-close.c
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
+       test/test-pipe-stdio-no-keep-alive-win.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -232,6 +232,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
+                         test/test-pipe-stdio-no-keep-alive-win.c \
                          test/test-platform-output.c \
                          test/test-poll.c \
                          test/test-poll-close.c \

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2445,6 +2445,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
   IO_STATUS_BLOCK io_status;
   FILE_ACCESS_INFORMATION access;
   DWORD duplex_flags = 0;
+  int was_stdio;
   int err;
 
   if (os_handle == INVALID_HANDLE_VALUE)
@@ -2456,13 +2457,14 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
 
   uv__pipe_connection_init(pipe);
   uv__once_init();
+  was_stdio = (file >= 0 && file <= 2);
   /* In order to avoid closing a stdio file descriptor 0-2, duplicate the
    * underlying OS handle and forget about the original fd.
    * We could also opt to use the original OS handle and just never close it,
    * but then there would be no reliable way to cancel pending read operations
    * upon close.
    */
-  if (file <= 2) {
+  if (was_stdio) {
     if (!DuplicateHandle(INVALID_HANDLE_VALUE,
                          os_handle,
                          INVALID_HANDLE_VALUE,
@@ -2517,6 +2519,33 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
       GetNamedPipeServerProcessId(os_handle, &pipe->pipe.conn.ipc_remote_pid);
     }
     assert(pipe->pipe.conn.ipc_remote_pid != (DWORD)(uv_pid_t) -1);
+  }
+
+  /* Workaround for a Windows Server 2025 (NT build 26100+) regression:
+   * once a stdio pipe handle is associated with the loop's IOCP, libuv
+   * leaves it implicitly keeping the event loop alive even after its
+   * write queue has drained. This is not observed on Windows 10/2019
+   * (build < 22000) with the same code path. The symptom is that a
+   * piped Node.js process never exits after `console.log()` work
+   * completes when its parent (e.g., a CI agent, gulp, npm, sh) keeps
+   * the read end of the pipe open.
+   *
+   * As a minimally-invasive workaround, unref stdio pipes on Win2025+.
+   * Callers that need the original "stdio keeps loop alive" semantics
+   * can call uv_ref() on the handle explicitly. This matches what
+   * consumers (most notably Node.js) end up doing manually today via
+   * `process.stdout.unref()` + `process.stderr.unref()`.
+   *
+   * See https://github.com/libuv/libuv/issues/5147 for full reproducer and analysis.
+   */
+  if (was_stdio && !pipe->ipc) {
+    OSVERSIONINFOW os_info;
+    os_info.dwOSVersionInfoSize = sizeof(os_info);
+    if (pRtlGetVersion != NULL &&
+        pRtlGetVersion(&os_info) == 0 /* STATUS_SUCCESS */ &&
+        os_info.dwBuildNumber >= 26100) {
+      uv_unref((uv_handle_t*) pipe);
+    }
   }
   return 0;
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -285,6 +285,7 @@ TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
+TEST_DECLARE   (pipe_stdio_no_keep_alive_win)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
@@ -648,6 +649,7 @@ TASK_LIST_START
   /* Seems to be either about 0.5s or 5s, depending on the OS. */
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
+  TEST_ENTRY  (pipe_stdio_no_keep_alive_win)
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -1,0 +1,109 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+/*
+ * On Windows Server 2025 (NT build 26100+), opening stdio file descriptors
+ * with uv_pipe_open() leaves the resulting handle implicitly keeping the
+ * event loop alive even after all write work has drained — see
+ * https://github.com/libuv/libuv/issues/5147. The expected workaround in src/win/pipe.c is to
+ * unref the pipe handle when it wraps a stdio fd.
+ *
+ * This test verifies that contract on the running OS:
+ *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2}, the
+ *     resulting handle MUST report uv_has_ref() == 0.
+ *   - On older Windows (build < 26100), the handle MAY remain refed
+ *     (the original behavior); the test only asserts on Win2025+.
+ *
+ * Skipped on non-Windows.
+ *
+ * NB: this test deliberately does not actually drive any I/O through the
+ * inherited stdout pipe — that would interleave with the test runner's
+ * own output. We only need to observe the post-open ref state.
+ */
+
+static int is_win2025_or_newer(void) {
+  typedef LONG (WINAPI *RtlGetVersion_t)(OSVERSIONINFOW*);
+  HMODULE ntdll;
+  RtlGetVersion_t fn;
+  OSVERSIONINFOW os_info;
+
+  ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) return 0;
+  fn = (RtlGetVersion_t)(uintptr_t) GetProcAddress(ntdll, "RtlGetVersion");
+  if (fn == NULL) return 0;
+
+  os_info.dwOSVersionInfoSize = sizeof(os_info);
+  if (fn(&os_info) != 0 /* STATUS_SUCCESS */) return 0;
+
+  return os_info.dwBuildNumber >= 26100;
+}
+
+TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  uv_pipe_t pipe_stdout;
+  int r;
+
+  if (!is_win2025_or_newer()) {
+    fprintf(stderr, "Skipping: requires Windows Server 2025 (build >= 26100)\n");
+    fflush(stderr);
+    return 0;
+  }
+
+  /* Use fd 1 (stdout) — the duplicate-and-forget logic in uv_pipe_open
+   * means we are not at risk of disturbing the test runner's actual
+   * stdout because we never read/write through pipe_stdout here. */
+  r = uv_pipe_init(uv_default_loop(), &pipe_stdout, 0);
+  ASSERT_OK(r);
+
+  r = uv_pipe_open(&pipe_stdout, 1);
+  /* uv_pipe_open succeeds for stdio fds on Windows. */
+  ASSERT_OK(r);
+
+  /* After uv_pipe_open() on stdio fd, on Win2025+, the handle must NOT
+   * keep the loop alive. */
+  ASSERT_EQ(uv_has_ref((const uv_handle_t*) &pipe_stdout), 0);
+
+  /* And uv_run with UV_RUN_NOWAIT should not deadlock and should report
+   * the loop as having no other refed work. */
+  r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+  /* Returns 0 when the loop has nothing else to do. */
+  ASSERT_EQ(r, 0);
+
+  uv_close((uv_handle_t*) &pipe_stdout, NULL);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+#else /* _WIN32 */
+
+TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  RETURN_SKIP("Test is Windows-only.");
+}
+
+#endif /* _WIN32 */

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -25,25 +25,35 @@
 #ifdef _WIN32
 
 #include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <stdint.h>
 
 /*
  * On Windows Server 2025 (NT build 26100+), opening stdio file descriptors
  * with uv_pipe_open() leaves the resulting handle implicitly keeping the
  * event loop alive even after all write work has drained — see
- * https://github.com/libuv/libuv/issues/5147. The expected workaround in src/win/pipe.c is to
- * unref the pipe handle when it wraps a stdio fd.
+ * https://github.com/libuv/libuv/issues/5147. The expected workaround in
+ * src/win/pipe.c is to unref the pipe handle when it wraps a stdio fd.
  *
  * This test verifies that contract on the running OS:
- *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2}, the
- *     resulting handle MUST report uv_has_ref() == 0.
+ *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2} and the
+ *     underlying OS handle is a pipe, the resulting uv_pipe_t MUST
+ *     report uv_has_ref() == 0.
  *   - On older Windows (build < 26100), the handle MAY remain refed
  *     (the original behavior); the test only asserts on Win2025+.
  *
- * Skipped on non-Windows.
+ * Because the test runner inherits whatever stdout the harness was launched
+ * with — typically a console, a file, or a redirected handle that is not
+ * actually a Win32 named pipe — we cannot just call uv_pipe_open() on the
+ * inherited fd 1: uv__set_pipe_handle's SetNamedPipeHandleState would
+ * reject a non-pipe with UV_ENOTSOCK. So we manufacture a pipe with
+ * CreatePipe(), wrap its read end as a CRT fd with _open_osfhandle(),
+ * dup it onto fd 1 (saving the original so we can restore for the
+ * runner's TAP output), call uv_pipe_open() on fd 1, restore fd 1, and
+ * then make our assertions.
  *
- * NB: this test deliberately does not actually drive any I/O through the
- * inherited stdout pipe — that would interleave with the test runner's
- * own output. We only need to observe the post-open ref state.
+ * Skipped on non-Windows.
  */
 
 static int is_win2025_or_newer(void) {
@@ -64,37 +74,76 @@ static int is_win2025_or_newer(void) {
 }
 
 TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  HANDLE pipe_read = INVALID_HANDLE_VALUE;
+  HANDLE pipe_write = INVALID_HANDLE_VALUE;
+  int crt_fd = -1;
+  int saved_stdout_fd = -1;
   uv_pipe_t pipe_stdout;
-  int r;
+  int has_ref;
+  int run_result;
+  int open_result;
 
   if (!is_win2025_or_newer()) {
-    fprintf(stderr, "Skipping: requires Windows Server 2025 (build >= 26100)\n");
-    fflush(stderr);
-    return 0;
+    RETURN_SKIP("Test requires Windows Server 2025 (build >= 26100).");
   }
 
-  /* Use fd 1 (stdout) — the duplicate-and-forget logic in uv_pipe_open
-   * means we are not at risk of disturbing the test runner's actual
-   * stdout because we never read/write through pipe_stdout here. */
-  r = uv_pipe_init(uv_default_loop(), &pipe_stdout, 0);
-  ASSERT_OK(r);
+  /* Manufacture an overlapped pipe so uv_pipe_open's IOCP-attach path
+   * exercises the same code that the real stdio bug surfaces in. */
+  if (!CreatePipe(&pipe_read, &pipe_write, NULL, 0)) {
+    fprintf(stderr, "CreatePipe failed: %lu\n", GetLastError());
+    return TEST_SKIP;
+  }
 
-  r = uv_pipe_open(&pipe_stdout, 1);
-  /* uv_pipe_open succeeds for stdio fds on Windows. */
-  ASSERT_OK(r);
+  crt_fd = _open_osfhandle((intptr_t) pipe_read, _O_RDONLY | _O_BINARY);
+  if (crt_fd < 0) {
+    CloseHandle(pipe_read);
+    CloseHandle(pipe_write);
+    return TEST_SKIP;
+  }
+  /* _open_osfhandle takes ownership of pipe_read; it is closed via _close(crt_fd). */
+  pipe_read = INVALID_HANDLE_VALUE;
 
-  /* After uv_pipe_open() on stdio fd, on Win2025+, the handle must NOT
-   * keep the loop alive. */
-  ASSERT_EQ(uv_has_ref((const uv_handle_t*) &pipe_stdout), 0);
+  /* Save the runner's real stdout so we can restore for TAP output. */
+  saved_stdout_fd = _dup(1);
+  ASSERT_GE(saved_stdout_fd, 0);
 
-  /* And uv_run with UV_RUN_NOWAIT should not deadlock and should report
-   * the loop as having no other refed work. */
-  r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-  /* Returns 0 when the loop has nothing else to do. */
-  ASSERT_EQ(r, 0);
+  /* Swap our pipe onto fd 1. uv_pipe_open(pipe, 1) below will see file<=2,
+   * take the stdio code path (DuplicateHandle, was_stdio = 1), and exercise
+   * the Win2025 unref. */
+  if (_dup2(crt_fd, 1) != 0) {
+    _close(saved_stdout_fd);
+    _close(crt_fd);
+    CloseHandle(pipe_write);
+    return TEST_SKIP;
+  }
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_stdout, 0));
+  open_result = uv_pipe_open(&pipe_stdout, 1);
+
+  /* Restore stdout immediately so subsequent printf / ASSERT messages
+   * land in the runner's output rather than the manufactured pipe. */
+  _dup2(saved_stdout_fd, 1);
+  _close(saved_stdout_fd);
+  _close(crt_fd);
+
+  ASSERT_OK(open_result);
+
+  /* On Win2025+, the handle must not keep the loop alive. */
+  has_ref = uv_has_ref((const uv_handle_t*) &pipe_stdout);
+  ASSERT_EQ(has_ref, 0);
+
+  /* The loop should immediately report no remaining work. */
+  run_result = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+  ASSERT_EQ(run_result, 0);
 
   uv_close((uv_handle_t*) &pipe_stdout, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  /* uv_pipe_open duplicated the underlying handle and owns the duplicate;
+   * the OS handle we passed in via fd 1 / crt_fd was closed when we did
+   * _close(crt_fd) above. The write end of the manufactured pipe still
+   * needs to be cleaned up. */
+  CloseHandle(pipe_write);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;


### PR DESCRIPTION
### Summary

On Windows Server 2025 (NT build 26100+), `uv_pipe_open()` against stdio fds 0/1/2 produces a `uv_pipe_t` that implicitly keeps the loop alive forever, even after writes drain and there are no pending requests. The same code path on Windows 10 / Server 2019 returns to a quiescent loop in milliseconds. Downstream symptom is that piped Node.js processes never exit (e.g., a Mocha unit-test job ran 58 minutes on Win2025 vs. 11 minutes on Win2019 — same code, same Node, just the OS pool differs).

Full reproducer, debugging analysis, and triage details in the linked issue.

### Change

Add a Win2025+ build-number gate (`RtlGetVersion().dwBuildNumber >= 26100`) in `uv_pipe_open()` and, when wrapping a stdio fd (0/1/2), call `uv_unref()` on the resulting handle. Callers that want the original behavior can call `uv_ref()` explicitly. This mirrors the workaround every downstream consumer (Node via `process.stdout.unref()` + `process.stderr.unref()`) ends up implementing manually today.

The IPC path is excluded (`!pipe->ipc`) because the IPC pipe is duplex and the caller's expectations around it differ.

The OS-version gate is conservative on purpose: it limits the behavior change to the platform where the bug is observed. If maintainers prefer a less conservative approach (e.g., apply on all Windows), I'm happy to amend — but I'd want a maintainer's nod first, since I haven't audited every code path that opens stdio.

### Test

`test/test-pipe-stdio-no-keep-alive-win` asserts that on Win2025+ the handle returned by `uv_pipe_open(fd=1)` has `uv_has_ref() == 0` and that `uv_run(..., UV_RUN_NOWAIT)` returns 0 immediately after. The test skips on Win2019 / Windows 10 / non-Windows.

It does **not** drive I/O through the inherited stdout — that would interleave with the test runner's own output. Verifying the actual hang reproducer requires a Win2025 build agent.

### Honest caveat about the fix

This is a **workaround for the symptom**, not a fix at the actual fault location. The OS / IOCP interaction that leaves `uv__loop_alive()` returning non-zero on Win2025 in steady state is still under investigation — `process.report` doesn't surface enough of `uv_loop_t`'s internals to pinpoint which of `active_reqs.count` / `pending_reqs_tail` / `endgame_handles` is non-empty. The refed-but-inactive pipe handles in the dump cannot themselves be holding the loop open (per `uv__handle_init` / `uv__handle_start` macros), so something else is going on at a lower level that I couldn't drill into without an in-tree Win2025 build.

If a maintainer with that build environment finds the actual fault site and a smaller fix, I'd happily replace this patch with that. In the meantime, the in-process equivalent (`process.stdout.unref()` + `process.stderr.unref()` at startup) is already deployed as a workaround in our CI infrastructure — codifying it in libuv itself benefits every downstream consumer that's about to hit the same wall.

### Refs

- Issue: https://github.com/libuv/libuv/issues/5147
