### PR TITLE
async: make seq_cst the default

### DIFF
--- a/docs/src/async.rst
+++ b/docs/src/async.rst
@@ -7,6 +7,28 @@
 Async handles allow the user to "wakeup" the event loop and get a callback
 called from another thread.
 
+.. note::
+
+    :c:func:`uv_async_send` and the :c:type:`uv_async_cb` invocation are
+    sequentially consistent (seq_cst) operations for a given async handle: all
+    memory accesses (reads and writes) made before :c:func:`uv_async_send` are
+    visible to that callback.
+
+.. warning::
+    libuv will coalesce calls to :c:func:`uv_async_send`, that is, not every
+    call to it will yield an execution of the callback. For example: if
+    :c:func:`uv_async_send` is called 5 times in a row before the callback is
+    called, the callback will only be called once. If :c:func:`uv_async_send`
+    is called again after the callback was called, it will be called again.
+    However, since it is sequentially consistent, the values read or written in
+    that callback will always be the same (or newer) as those read or written
+    by the other thread.
+
+.. versionchanged:: 1.53.0
+    :c:func:`uv_async_send` and :c:type:`uv_async_cb` are sequentially
+    consistent. Prior to this version, any case where libuv might coalesce
+    calls probably requires a full `seq_cst` fence before it for correctness.
+
 
 Data types
 ----------
@@ -54,12 +76,11 @@ API
         :c:func:`uv_async_send` is `async-signal-safe <https://man7.org/linux/man-pages/man7/signal-safety.7.html>`_.
         It's safe to call this function from a signal handler.
 
-    .. warning::
-        libuv will coalesce calls to :c:func:`uv_async_send`, that is, not every call to it will
-        yield an execution of the callback. For example: if :c:func:`uv_async_send` is called 5
-        times in a row before the callback is called, the callback will only be called once. If
-        :c:func:`uv_async_send` is called again after the callback was called, it will be called
-        again.
+    .. note::
+        This is a full memory fence with respect to other calls and callbacks
+        using this same async handle, and so it will order all operations
+        around this call and the corresponding callback on the sending thread
+        and receiving thread.
 
 .. seealso::
     The :c:type:`uv_handle_t` API functions also apply.

--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -139,7 +139,11 @@ void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
     uv__queue_remove(q);
     uv__queue_insert_tail(&loop->async_handles, q);
 
-    /* Atomically clear the pending flag (bit 0) and check if it was set. */
+    /* Atomically clear the pending flag (bit 0) and check if it was set.
+     * The seq_cst (default order) synchronizes with the seq_cst CAS in
+     * uv_async_send, making all accesses before that call visible here and
+     * ensuring no access here can get reordered before this as visible to
+     * another thread. */
     pending = (_Atomic int*) &h->pending;
     if (!(atomic_fetch_and(pending, ~1) & 1))
       continue;

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -921,7 +921,16 @@ static void uv__cpu_relax(void) {
 
 /* Atomic helpers for the async pending field.
  * Bit 0: pending flag (notification sent or handle closing).
- * Bits 1+: busy counter (2 per in-flight uv_async_send call). */
+ * Bits 1+: busy counter (2 per in-flight uv_async_send call).
+ *
+ * uv__pending_cas and uv__pending_fetch_or are seq_cst (InterlockedXxx on
+ * MSVC, default memory_order_seq_cst on stdatomic). Their seq_cst pairing
+ * with the fetch_and/InterlockedAnd on the callback side makes uv_async_send
+ * and the uv_async_cb invocation sequentially consistent — all accesses
+ * (reads and writes) before uv_async_send are visible to the callback.
+ *
+ * uv__pending_load and uv__pending_fetch_add are relaxed; they touch only the
+ * busy counter and need not participate in that ordering. */
 #ifdef _MSC_VER
 
 static int uv__pending_cas(int* p, int* expected, int desired) {
@@ -937,17 +946,11 @@ static int uv__pending_cas(int* p, int* expected, int desired) {
   ((void) InterlockedExchangeAdd((LONG volatile*)(p), (LONG)(v)))
 #define uv__pending_fetch_or(p, v) \
   ((int) InterlockedOr((LONG volatile*)(p), (LONG)(v)))
-#define uv__pending_fetch_and(p, v) \
-  ((int) InterlockedAnd((LONG volatile*)(p), (LONG)(v)))
 
 #else  /* GCC / Clang / MinGW — use C11 stdatomic */
 
 static int uv__pending_cas(int* p, int* expected, int desired) {
-  return atomic_compare_exchange_weak_explicit((_Atomic int*) p,
-                                               expected,
-                                               desired,
-                                               memory_order_relaxed,
-                                               memory_order_relaxed);
+  return atomic_compare_exchange_weak((_Atomic int*) p, expected, desired);
 }
 
 #define uv__pending_load(p) \
@@ -955,24 +958,19 @@ static int uv__pending_cas(int* p, int* expected, int desired) {
 #define uv__pending_fetch_add(p, v) \
   ((void) atomic_fetch_add_explicit((_Atomic int*)(p), (v), memory_order_relaxed))
 #define uv__pending_fetch_or(p, v) \
-  ((int) atomic_fetch_or_explicit((_Atomic int*)(p), (v), memory_order_relaxed))
-#define uv__pending_fetch_and(p, v) \
-  ((int) atomic_fetch_and_explicit((_Atomic int*)(p), (v), memory_order_relaxed))
+  ((int) atomic_fetch_or((_Atomic int*)(p), (v)))
 
 #endif  /* _MSC_VER */
 
 
 int uv_async_send(uv_async_t* handle) {
-  int current;
-
-  /* Do a cheap read first. */
-  current = uv__pending_load(&handle->pending);
-  if (current & 1)
-    return 0;
+  int current = 0;
 
   /* Atomically set the pending flag (bit 0) and increment the busy counter
-   * (bits 1+). Adding 3 sets bit 0 and adds 2 to the busy counter at once,
-   * so both operations appear atomic to other threads. */
+   * (bits 1+). Adding 3 sets bit 0 and adds 2 to the busy counter at once.
+   * The seq_cst CAS synchronizes with the seq_cst fetch_and in the callback,
+   * making all accesses before this call visible to the callback (and vice
+   * versa from the callback). */
   while (!uv__pending_cas(&handle->pending, &current, current + 3))
     if (current & 1)
       return 0;
@@ -1115,6 +1113,14 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   uv__free(cpu_infos);
 #endif  /* __linux__ */
 }
+
+#ifdef _MSC_VER
+#define uv__exchange_int_relaxed(p, v)                                        \
+  InterlockedExchangeNoFence((LONG volatile*)(p), v)
+#else
+#define uv__exchange_int_relaxed(p, v)                                        \
+  atomic_exchange_explicit((_Atomic int*)(p), v, memory_order_relaxed)
+#endif
 
 
 /* Also covers __clang__ and __INTEL_COMPILER. Disabled on Windows because

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -66,14 +66,6 @@ extern int snprintf(char*, size_t, const char*, ...);
   void uv__static_assert(int static_assert_failed[1 - 2 * !(expr)])
 #endif
 
-#ifdef _MSC_VER
-#define uv__exchange_int_relaxed(p, v)                                        \
-  InterlockedExchangeNoFence((LONG volatile*)(p), v)
-#else
-#define uv__exchange_int_relaxed(p, v)                                        \
-  atomic_exchange_explicit((_Atomic int*)(p), v, memory_order_relaxed)
-#endif
-
 #define UV__UDP_DGRAM_MAXSIZE (64 * 1024)
 
 /* Handle flags. Some flags are specific to Windows or UNIX. */

--- a/src/win/async.c
+++ b/src/win/async.c
@@ -98,7 +98,10 @@ void uv__process_async_wakeup_req(uv_loop_t* loop, uv_async_t* handle,
   assert(handle->type == UV_ASYNC);
   assert(req->type == UV_WAKEUP);
 
-  /* Clear pending flag, retain busy counter. */
+  /* Clear pending flag, retain busy counter. The InterlockedAnd is seq_cst (a
+   * full barrier), and synchronizing with the seq_cst
+   * InterlockedCompareExchange in uv_async_send. This makes all accesses
+   * before that call visible here (and vice versa). */
   InterlockedAnd((LONG volatile*) &handle->pending, ~1);
 
   if (handle->flags & UV_HANDLE_CLOSING) {


### PR DESCRIPTION
The fast relaxed read makes this function very difficult and slow to use correctly, since it means many callers are required to have a fence instruction instead. Making this always a seq_cst barrier on the pending field should eliminate a unexpected source of concurrency bugs.