### PR TITLE
process,unix: avoid off-by-one in uv__spawn_resolve_and_spawn

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -730,7 +730,6 @@ static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
   const char *p;
   const char *z;
   const char *path;
-  size_t l;
   size_t k;
   int err;
   int seen_eacces;
@@ -776,19 +775,16 @@ static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
   if (k > NAME_MAX)
     return ENAMETOOLONG;
 
-  l = strnlen(path, PATH_MAX - 1) + 1;
-
-  for (p = path;; p = z) {
+  p = path;
+  do {
     /* Compose the new process file from the entry in the PATH
      * environment variable and the actual file name */
-    char b[PATH_MAX + NAME_MAX];
+    char b[PATH_MAX + NAME_MAX + 1];
     z = strchr(p, ':');
     if (!z)
       z = p + strlen(p);
-    if ((size_t)(z - p) >= l) {
-      if (!*z++)
-        break;
-
+    if ((size_t)(z - p) >= PATH_MAX) {
+      p = z + 1;
       continue;
     }
     memcpy(b, p, z - p);
@@ -812,10 +808,8 @@ static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
     default:
       return err;
     }
-
-    if (!*z++)
-      break;
-  }
+    p = z + 1;
+  } while (*z == ':');
 
   if (seen_eacces)
     return EACCES;

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -2114,4 +2114,5 @@ TEST_IMPL(spawn_empty_command_line) {
   ASSERT_EQ(1, close_cb_called);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
 }


### PR DESCRIPTION
With a environment larger than PATH_MAX, AI thinks the loop here could theoretically write a null byte after `b` when spawning a path of size NAME_MAX. Re-write this size-check to be a bit less confusing. The original musl code used a VLA of size `min(PATH_MAX, strlen(p)) + 1`.