### PR TITLE
unix,fs: fix potentialy copy busyloop

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -1396,11 +1396,10 @@ static int uv__fs_copyfile(uv_fs_t* req) {
   bytes_to_send = src_statsbuf.st_size;
   in_offset = 0;
   while (bytes_to_send != 0) {
-    bytes_chunk = SSIZE_MAX;
+    bytes_chunk = UV__IO_MAX_BYTES;
     if (bytes_to_send < (off_t) bytes_chunk)
       bytes_chunk = bytes_to_send;
-    uv_fs_sendfile(NULL, &fs_req, dstfd, srcfd, in_offset, bytes_chunk, NULL);
-    bytes_written = fs_req.result;
+    bytes_written = uv_fs_sendfile(NULL, &fs_req, dstfd, srcfd, in_offset, bytes_chunk, NULL);
     uv_fs_req_cleanup(&fs_req);
 
     if (bytes_written < 0) {


### PR DESCRIPTION
After the fix to limit the max size of uv_fs_sendfile (#5076), this code became more-incorrect and would busy-loop on large files. It was previously trying to work around the fact that the return value of uv_fs_sendfile was undefined when the input argument SSIZE_MAX > INT32_MAX, but that meant it had to ignore errors. Using the more correct UV__IO_MAX_BYTES value also avoids any UB with the checking the result of uv_fs_sendfile.