### PR TITLE
win,test: reproduce + diagnose the Windows Server 2025 stdio-pipe loop hang (#5147)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
        test/test-pipe-stdio-no-keep-alive-win.c
+       test/test-pipe-stdio-loop-alive-spawn-win.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-server-close.c
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
+       test/test-pipe-stdio-no-keep-alive-win.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -233,6 +233,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
                          test/test-pipe-stdio-no-keep-alive-win.c \
+                         test/test-pipe-stdio-loop-alive-spawn-win.c \
                          test/test-platform-output.c \
                          test/test-poll.c \
                          test/test-poll-close.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -232,6 +232,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
+                         test/test-pipe-stdio-no-keep-alive-win.c \
                          test/test-platform-output.c \
                          test/test-poll.c \
                          test/test-poll-close.c \

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -36,6 +36,35 @@
 #include "heap-inl.h"
 #include "req-inl.h"
 
+/* TEMPORARY: revert before merge — https://github.com/libuv/libuv/issues/5147
+ * Dumps the internal loop bookkeeping that uv__loop_alive() consults, so a
+ * Win2025 CI run can show which counter holds the residual ref that keeps the
+ * loop alive after a stdio pipe is opened. Not declared in any public header;
+ * tests extern-declare it. */
+static void uv__loop_debug_walk_cb(uv_handle_t* handle, void* arg) {
+  (void) arg;
+  fprintf(stderr,
+          "  handle=%p type=%s has_ref=%d is_active=%d is_closing=%d\n",
+          (void*) handle,
+          uv_handle_type_name(handle->type),
+          uv_has_ref(handle),
+          uv_is_active(handle),
+          uv_is_closing(handle));
+}
+
+void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {
+  fprintf(stderr,
+          "[uv__loop_debug_dump] %s: active_handles=%u active_reqs=%u "
+          "pending_reqs_tail=%s endgame_handles=%s\n",
+          tag,
+          loop->active_handles,
+          loop->active_reqs.count,
+          loop->pending_reqs_tail != NULL ? "non-NULL" : "NULL",
+          loop->endgame_handles != NULL ? "non-NULL" : "NULL");
+  uv_walk(loop, uv__loop_debug_walk_cb, NULL);
+  fflush(stderr);
+}
+
 /* uv_once initialization guards */
 static uv_once_t uv_init_guard_ = UV_ONCE_INIT;
 

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -55,7 +55,7 @@ static void uv__loop_debug_walk_cb(uv_handle_t* handle, void* arg) {
           (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) ? 1 : 0);
 }
 
-void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {
   fprintf(stderr,
           "[uv__loop_debug_dump] %s: active_handles=%u active_reqs=%u "
           "pending_reqs_tail=%s endgame_handles=%s\n",

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -43,8 +43,8 @@
  * the residual ref that keeps the loop alive after a stdio pipe is opened. Not
  * declared in any public header; tests extern-declare it. */
 static void uv__loop_debug_walk_cb(uv_handle_t* handle, void* arg) {
-  (void) arg;
-  fprintf(stderr,
+  FILE* stream = (FILE*) arg;
+  fprintf(stream,
           "  handle=%p type=%s has_ref=%d is_active=%d is_closing=%d "
           "non_overlapped_pipe=%d\n",
           (void*) handle,
@@ -55,8 +55,10 @@ static void uv__loop_debug_walk_cb(uv_handle_t* handle, void* arg) {
           (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) ? 1 : 0);
 }
 
-UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {
-  fprintf(stderr,
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop,
+                                   const char* tag,
+                                   FILE* stream) {
+  fprintf(stream,
           "[uv__loop_debug_dump] %s: active_handles=%u active_reqs=%u "
           "pending_reqs_tail=%s endgame_handles=%s\n",
           tag,
@@ -64,8 +66,8 @@ UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {
           loop->active_reqs.count,
           loop->pending_reqs_tail != NULL ? "non-NULL" : "NULL",
           loop->endgame_handles != NULL ? "non-NULL" : "NULL");
-  uv_walk(loop, uv__loop_debug_walk_cb, NULL);
-  fflush(stderr);
+  uv_walk(loop, uv__loop_debug_walk_cb, stream);
+  fflush(stream);
 }
 
 /* uv_once initialization guards */

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -38,18 +38,21 @@
 
 /* TEMPORARY: revert before merge — https://github.com/libuv/libuv/issues/5147
  * Dumps the internal loop bookkeeping that uv__loop_alive() consults, so a
- * Win2025 CI run can show which counter holds the residual ref that keeps the
- * loop alive after a stdio pipe is opened. Not declared in any public header;
- * tests extern-declare it. */
+ * Win2025 CI run can show which of uv__loop_alive's inputs (active_handles,
+ * active_reqs, pending_reqs_tail, endgame_handles) -- or which handle -- holds
+ * the residual ref that keeps the loop alive after a stdio pipe is opened. Not
+ * declared in any public header; tests extern-declare it. */
 static void uv__loop_debug_walk_cb(uv_handle_t* handle, void* arg) {
   (void) arg;
   fprintf(stderr,
-          "  handle=%p type=%s has_ref=%d is_active=%d is_closing=%d\n",
+          "  handle=%p type=%s has_ref=%d is_active=%d is_closing=%d "
+          "non_overlapped_pipe=%d\n",
           (void*) handle,
           uv_handle_type_name(handle->type),
           uv_has_ref(handle),
           uv_is_active(handle),
-          uv_is_closing(handle));
+          uv_is_closing(handle),
+          (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) ? 1 : 0);
 }
 
 void uv__loop_debug_dump(uv_loop_t* loop, const char* tag) {

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2521,14 +2521,18 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
     assert(pipe->pipe.conn.ipc_remote_pid != (DWORD)(uv_pid_t) -1);
   }
 
+  /* TEMPORARY: workaround disabled for root-cause diagnostics — #5147.
+   * With this off, the Win2025 CI run reproduces the hang and the
+   * reproducer tests emit uv__loop_debug_dump output. Re-enable (or
+   * replace with a targeted fix) once the residual ref is localized. */
   /* Workaround for a Windows Server 2025 (NT build 26100+) regression:
    * once a stdio pipe handle is associated with the loop's IOCP, libuv
    * leaves it implicitly keeping the event loop alive even after its
-   * write queue has drained. This is not observed on Windows 10/2019
-   * (build < 22000) with the same code path. The symptom is that a
-   * piped Node.js process never exits after `console.log()` work
-   * completes when its parent (e.g., a CI agent, gulp, npm, sh) keeps
-   * the read end of the pipe open.
+   * write queue has drained. This is not observed on older Windows
+   * (e.g. Windows Server 2019, build 17763) with the same code path.
+   * The symptom is that a piped Node.js process never exits after
+   * `console.log()` work completes when its parent (e.g., a CI agent,
+   * gulp, npm, sh) keeps the read end of the pipe open.
    *
    * As a minimally-invasive workaround, unref stdio pipes on Win2025+.
    * Callers that need the original "stdio keeps loop alive" semantics
@@ -2538,10 +2542,6 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
    *
    * See https://github.com/libuv/libuv/issues/5147 for full reproducer and analysis.
    */
-  /* TEMPORARY: workaround disabled for root-cause diagnostics — #5147.
-   * With this off, the Win2025 CI run reproduces the hang and the
-   * reproducer tests emit uv__loop_debug_dump output. Re-enable (or
-   * replace with a targeted fix) once the residual ref is localized. */
 #if 0
   if (was_stdio && !pipe->ipc) {
     OSVERSIONINFOW os_info;

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2538,6 +2538,11 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
    *
    * See https://github.com/libuv/libuv/issues/5147 for full reproducer and analysis.
    */
+  /* TEMPORARY: workaround disabled for root-cause diagnostics — #5147.
+   * With this off, the Win2025 CI run reproduces the hang and the
+   * reproducer tests emit uv__loop_debug_dump output. Re-enable (or
+   * replace with a targeted fix) once the residual ref is localized. */
+#if 0
   if (was_stdio && !pipe->ipc) {
     OSVERSIONINFOW os_info;
     os_info.dwOSVersionInfoSize = sizeof(os_info);
@@ -2547,6 +2552,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
       uv_unref((uv_handle_t*) pipe);
     }
   }
+#endif
   return 0;
 }
 

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2445,6 +2445,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
   IO_STATUS_BLOCK io_status;
   FILE_ACCESS_INFORMATION access;
   DWORD duplex_flags = 0;
+  int was_stdio;
   int err;
 
   if (os_handle == INVALID_HANDLE_VALUE)
@@ -2456,13 +2457,14 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
 
   uv__pipe_connection_init(pipe);
   uv__once_init();
+  was_stdio = (file >= 0 && file <= 2);
   /* In order to avoid closing a stdio file descriptor 0-2, duplicate the
    * underlying OS handle and forget about the original fd.
    * We could also opt to use the original OS handle and just never close it,
    * but then there would be no reliable way to cancel pending read operations
    * upon close.
    */
-  if (file <= 2) {
+  if (was_stdio) {
     if (!DuplicateHandle(INVALID_HANDLE_VALUE,
                          os_handle,
                          INVALID_HANDLE_VALUE,
@@ -2517,6 +2519,33 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
       GetNamedPipeServerProcessId(os_handle, &pipe->pipe.conn.ipc_remote_pid);
     }
     assert(pipe->pipe.conn.ipc_remote_pid != (DWORD)(uv_pid_t) -1);
+  }
+
+  /* Workaround for a Windows Server 2025 (NT build 26100+) regression:
+   * once a stdio pipe handle is associated with the loop's IOCP, libuv
+   * leaves it implicitly keeping the event loop alive even after its
+   * write queue has drained. This is not observed on Windows 10/2019
+   * (build < 22000) with the same code path. The symptom is that a
+   * piped Node.js process never exits after `console.log()` work
+   * completes when its parent (e.g., a CI agent, gulp, npm, sh) keeps
+   * the read end of the pipe open.
+   *
+   * As a minimally-invasive workaround, unref stdio pipes on Win2025+.
+   * Callers that need the original "stdio keeps loop alive" semantics
+   * can call uv_ref() on the handle explicitly. This matches what
+   * consumers (most notably Node.js) end up doing manually today via
+   * `process.stdout.unref()` + `process.stderr.unref()`.
+   *
+   * See https://github.com/libuv/libuv/issues/5147 for full reproducer and analysis.
+   */
+  if (was_stdio && !pipe->ipc) {
+    OSVERSIONINFOW os_info;
+    os_info.dwOSVersionInfoSize = sizeof(os_info);
+    if (pRtlGetVersion != NULL &&
+        pRtlGetVersion(&os_info) == 0 /* STATUS_SUCCESS */ &&
+        os_info.dwBuildNumber >= 26100) {
+      uv_unref((uv_handle_t*) pipe);
+    }
   }
   return 0;
 }

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -54,6 +54,9 @@ int ipc_send_recv_helper(void);
 int ipc_helper_bind_twice(void);
 int ipc_helper_send_zero(void);
 int stdio_over_pipes_helper(void);
+#ifdef _WIN32
+int pipe_stdio_loop_alive_helper_win(void);
+#endif
 void spawn_stdin_stdout(void);
 void process_title_big_argv(void);
 int spawn_tcp_server_helper(void);
@@ -126,6 +129,13 @@ static int maybe_run_test(int argc, char **argv) {
   if (strcmp(argv[1], "stdio_over_pipes_helper") == 0) {
     return stdio_over_pipes_helper();
   }
+
+#ifdef _WIN32
+  if (strcmp(argv[1], "pipe_stdio_loop_alive_helper_win") == 0) {
+    notify_parent_process();
+    return pipe_stdio_loop_alive_helper_win();
+  }
+#endif
 
   if (strcmp(argv[1], "spawn_helper1") == 0) {
     notify_parent_process();

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -132,7 +132,8 @@ static int maybe_run_test(int argc, char **argv) {
 
 #ifdef _WIN32
   if (strcmp(argv[1], "pipe_stdio_loop_alive_helper_win") == 0) {
-    notify_parent_process();
+    /* Spawned via uv_spawn (not the runner helper path), so there is no
+     * UV_TEST_RUNNER_FD ready-signal to send. */
     return pipe_stdio_loop_alive_helper_win();
   }
 #endif

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -285,7 +285,9 @@ TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
+#ifdef _WIN32
 TEST_DECLARE   (pipe_stdio_no_keep_alive_win)
+#endif
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
@@ -649,7 +651,9 @@ TASK_LIST_START
   /* Seems to be either about 0.5s or 5s, depending on the OS. */
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
+#ifdef _WIN32
   TEST_ENTRY  (pipe_stdio_no_keep_alive_win)
+#endif
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -287,6 +287,7 @@ TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
 #ifdef _WIN32
 TEST_DECLARE   (pipe_stdio_no_keep_alive_win)
+TEST_DECLARE   (pipe_stdio_loop_alive_spawn_win)
 #endif
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
@@ -652,7 +653,8 @@ TASK_LIST_START
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
 #ifdef _WIN32
-  TEST_ENTRY  (pipe_stdio_no_keep_alive_win)
+  TEST_ENTRY_CUSTOM (pipe_stdio_no_keep_alive_win, 0, 0, 20000)
+  TEST_ENTRY_CUSTOM (pipe_stdio_loop_alive_spawn_win, 0, 0, 20000)
 #endif
   TEST_ENTRY  (tty)
 #ifdef _WIN32

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -653,8 +653,8 @@ TASK_LIST_START
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
 #ifdef _WIN32
-  TEST_ENTRY_CUSTOM (pipe_stdio_no_keep_alive_win, 0, 0, 20000)
-  TEST_ENTRY_CUSTOM (pipe_stdio_loop_alive_spawn_win, 0, 0, 20000)
+  TEST_ENTRY_CUSTOM (pipe_stdio_no_keep_alive_win, 0, 0, 30000)
+  TEST_ENTRY_CUSTOM (pipe_stdio_loop_alive_spawn_win, 0, 0, 30000)
 #endif
   TEST_ENTRY  (tty)
 #ifdef _WIN32

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -285,6 +285,7 @@ TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
+TEST_DECLARE   (pipe_stdio_no_keep_alive_win)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
@@ -648,6 +649,7 @@ TASK_LIST_START
   /* Seems to be either about 0.5s or 5s, depending on the OS. */
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
+  TEST_ENTRY  (pipe_stdio_no_keep_alive_win)
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -653,8 +653,8 @@ TASK_LIST_START
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
 #ifdef _WIN32
-  TEST_ENTRY_CUSTOM (pipe_stdio_no_keep_alive_win, 0, 0, 30000)
-  TEST_ENTRY_CUSTOM (pipe_stdio_loop_alive_spawn_win, 0, 0, 30000)
+  TEST_ENTRY_CUSTOM (pipe_stdio_no_keep_alive_win, 0, 1, 30000)
+  TEST_ENTRY_CUSTOM (pipe_stdio_loop_alive_spawn_win, 0, 1, 30000)
 #endif
   TEST_ENTRY  (tty)
 #ifdef _WIN32

--- a/test/test-pipe-stdio-loop-alive-spawn-win.c
+++ b/test/test-pipe-stdio-loop-alive-spawn-win.c
@@ -27,6 +27,7 @@
 #include <windows.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 /*
  * Reproducer B (cross-process, faithful) for
@@ -36,19 +37,19 @@
  * overlapped pipe the parent holds the read end of (UV_CREATE_PIPE |
  * UV_WRITABLE_PIPE | UV_NONBLOCK_PIPE -- the nonblock flag makes the child's
  * inherited fd 1 overlapped so uv_pipe_open associates it with the loop's
- * IOCP, the path #5147 is attributed to). The child calls uv_pipe_open(1),
- * writes a few bytes (like console.log), leaves the pipe open, and runs its
- * loop:
+ * IOCP, the path we suspect is involved in #5147 (root cause unconfirmed)).
+ * The child calls uv_pipe_open(1), writes a few bytes (like console.log),
+ * leaves the pipe open, and runs its loop:
  *
  *   - Healthy OS: the idle stdout pipe does not keep the child loop alive, the
  *     child exits 0, its write end closes, the parent reads EOF and drains.
  *   - Win2025 (#5147, workaround disabled): the child loop never drains. The
- *     child's own unref'd watchdog (3s) fires, dumps child-side loop
+ *     child's own unref'd watchdog (8s) fires, dumps child-side loop
  *     diagnostics to inherited stderr (-> CI log), and exits 99. The parent
  *     observes a non-zero exit status -> assertion FAILS (intended canary).
  *
- * A parent-side kill watchdog (10s) is a backstop in case the child wedges so
- * hard it cannot run its own watchdog; it fires before the 20s runner budget.
+ * A parent-side kill watchdog (15s) is a backstop in case the child wedges so
+ * hard it cannot run its own watchdog; it fires before the 30s runner budget.
  * Skipped on Windows older than 26100.
  */
 
@@ -56,8 +57,8 @@
 void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
 
 #define CHILD_HELPER_NAME "pipe_stdio_loop_alive_helper_win"
-#define CHILD_DRAIN_TIMEOUT_MS 3000
-#define PARENT_KILL_TIMEOUT_MS 10000
+#define CHILD_DRAIN_TIMEOUT_MS 8000
+#define PARENT_KILL_TIMEOUT_MS 15000
 #define CHILD_STUCK_EXIT_CODE 99
 
 static int is_win2025_or_newer(void) {
@@ -89,7 +90,11 @@ static void child_watchdog_cb(uv_timer_t* handle) {
 
 static void child_write_cb(uv_write_t* req, int status) {
   (void) req;
-  (void) status;
+  if (status != 0) {
+    fprintf(stderr, "child: uv_write completed with error: %s\n",
+            uv_strerror(status));
+    fflush(stderr);
+  }
   /* Intentionally leave the stdout pipe open, like Node's process.stdout. */
 }
 
@@ -99,23 +104,44 @@ int pipe_stdio_loop_alive_helper_win(void) {
   uv_write_t write_req;
   uv_buf_t buf;
   uv_timer_t watchdog;
+  int err;
 
   loop = uv_default_loop();
 
-  if (uv_pipe_init(loop, &stdout_pipe, 0) != 0)
+  err = uv_pipe_init(loop, &stdout_pipe, 0);
+  if (err != 0) {
+    fprintf(stderr, "child: uv_pipe_init failed: %s\n", uv_strerror(err));
+    fflush(stderr);
     return 2;
-  if (uv_pipe_open(&stdout_pipe, 1) != 0)
+  }
+  err = uv_pipe_open(&stdout_pipe, 1);
+  if (err != 0) {
+    fprintf(stderr, "child: uv_pipe_open(1) failed: %s\n", uv_strerror(err));
+    fflush(stderr);
     return 3;
+  }
 
   buf = uv_buf_init("hi\n", 3);
-  if (uv_write(&write_req, (uv_stream_t*) &stdout_pipe, &buf, 1, child_write_cb) != 0)
+  err = uv_write(&write_req, (uv_stream_t*) &stdout_pipe, &buf, 1, child_write_cb);
+  if (err != 0) {
+    fprintf(stderr, "child: uv_write failed: %s\n", uv_strerror(err));
+    fflush(stderr);
     return 4;
+  }
 
   child_watchdog_fired = 0;
-  if (uv_timer_init(loop, &watchdog) != 0)
+  err = uv_timer_init(loop, &watchdog);
+  if (err != 0) {
+    fprintf(stderr, "child: uv_timer_init failed: %s\n", uv_strerror(err));
+    fflush(stderr);
     return 5;
-  if (uv_timer_start(&watchdog, child_watchdog_cb, CHILD_DRAIN_TIMEOUT_MS, 0) != 0)
+  }
+  err = uv_timer_start(&watchdog, child_watchdog_cb, CHILD_DRAIN_TIMEOUT_MS, 0);
+  if (err != 0) {
+    fprintf(stderr, "child: uv_timer_start failed: %s\n", uv_strerror(err));
+    fflush(stderr);
     return 6;
+  }
   uv_unref((uv_handle_t*) &watchdog);
 
   uv_run(loop, UV_RUN_DEFAULT);
@@ -142,6 +168,11 @@ static char* args[3];
 static void alloc_cb(uv_handle_t* handle, size_t suggested, uv_buf_t* buf) {
   (void) handle;
   (void) suggested;
+  if (child_output_used >= sizeof(child_output)) {
+    buf->base = NULL;
+    buf->len = 0;
+    return;
+  }
   buf->base = child_output + child_output_used;
   buf->len = (unsigned long) (sizeof(child_output) - child_output_used);
 }
@@ -151,6 +182,11 @@ static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
     child_output_used += (size_t) nread;
   } else if (nread < 0) {
+    if (nread != UV_EOF) {
+      fprintf(stderr, "parent: unexpected read error: %s\n",
+              uv_strerror((int) nread));
+      fflush(stderr);
+    }
     uv_close((uv_handle_t*) stream, NULL);
   }
 }
@@ -163,9 +199,14 @@ static void exit_cb(uv_process_t* proc, int64_t exit_status, int term_signal) {
 }
 
 static void kill_watchdog_cb(uv_timer_t* handle) {
+  int err;
   kill_watchdog_fired = 1;
   uv__loop_debug_dump(handle->loop, "reproducer B parent: child did not exit");
-  uv_process_kill(&process, SIGTERM);
+  err = uv_process_kill(&process, SIGTERM);
+  if (err != 0) {
+    fprintf(stderr, "parent: uv_process_kill failed: %s\n", uv_strerror(err));
+    fflush(stderr);
+  }
 }
 
 TEST_IMPL(pipe_stdio_loop_alive_spawn_win) {
@@ -204,7 +245,12 @@ TEST_IMPL(pipe_stdio_loop_alive_spawn_win) {
   kill_watchdog_fired = 0;
   child_output_used = 0;
 
-  ASSERT_OK(uv_spawn(uv_default_loop(), &process, &options));
+  r = uv_spawn(uv_default_loop(), &process, &options);
+  if (r != 0) {
+    fprintf(stderr, "reproducer B: uv_spawn failed: %s\n", uv_strerror(r));
+    fflush(stderr);
+  }
+  ASSERT_OK(r);
 
   /* Parent holds and drains the read end, like a shell consuming stdout. */
   ASSERT_OK(uv_read_start((uv_stream_t*) &child_stdout, alloc_cb, read_cb));
@@ -223,6 +269,7 @@ TEST_IMPL(pipe_stdio_loop_alive_spawn_win) {
    * to kill it). Re-tighten / remove when the fix lands. */
   ASSERT_EQ(0, kill_watchdog_fired);
   ASSERT_EQ(0, child_exit_status);
+  ASSERT_EQ(0, child_term_signal);
 
   uv_close((uv_handle_t*) &kill_watchdog, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/test-pipe-stdio-loop-alive-spawn-win.c
+++ b/test/test-pipe-stdio-loop-alive-spawn-win.c
@@ -53,8 +53,9 @@
  * Skipped on Windows older than 26100.
  */
 
-/* TEMPORARY: revert before merge -- #5147. Defined in src/win/core.c. */
-void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+/* TEMPORARY: revert before merge -- #5147. Defined in src/win/core.c and
+ * UV_EXTERN-exported there so this shared-lib-linked test can resolve it. */
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
 
 #define CHILD_HELPER_NAME "pipe_stdio_loop_alive_helper_win"
 #define CHILD_DRAIN_TIMEOUT_MS 8000

--- a/test/test-pipe-stdio-loop-alive-spawn-win.c
+++ b/test/test-pipe-stdio-loop-alive-spawn-win.c
@@ -55,7 +55,9 @@
 
 /* TEMPORARY: revert before merge -- #5147. Defined in src/win/core.c and
  * UV_EXTERN-exported there so this shared-lib-linked test can resolve it. */
-UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop,
+                                   const char* tag,
+                                   FILE* stream);
 
 #define CHILD_HELPER_NAME "pipe_stdio_loop_alive_helper_win"
 #define CHILD_DRAIN_TIMEOUT_MS 8000
@@ -85,7 +87,11 @@ static int child_watchdog_fired;
 
 static void child_watchdog_cb(uv_timer_t* handle) {
   child_watchdog_fired = 1;
-  uv__loop_debug_dump(handle->loop, "reproducer B child: loop still alive");
+  /* Child stdout is the pipe under test; write diagnostics to inherited
+   * stderr instead. */
+  uv__loop_debug_dump(handle->loop,
+                      "reproducer B child: loop still alive",
+                      stderr);
   uv_stop(handle->loop);
 }
 
@@ -202,7 +208,9 @@ static void exit_cb(uv_process_t* proc, int64_t exit_status, int term_signal) {
 static void kill_watchdog_cb(uv_timer_t* handle) {
   int err;
   kill_watchdog_fired = 1;
-  uv__loop_debug_dump(handle->loop, "reproducer B parent: child did not exit");
+  uv__loop_debug_dump(handle->loop,
+                      "reproducer B parent: child did not exit",
+                      stdout);
   err = uv_process_kill(&process, SIGTERM);
   if (err != 0) {
     fprintf(stderr, "parent: uv_process_kill failed: %s\n", uv_strerror(err));

--- a/test/test-pipe-stdio-loop-alive-spawn-win.c
+++ b/test/test-pipe-stdio-loop-alive-spawn-win.c
@@ -1,0 +1,238 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifdef _WIN32
+
+#include "uv.h"
+#include "task.h"
+
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Reproducer B (cross-process, faithful) for
+ * https://github.com/libuv/libuv/issues/5147.
+ *
+ * Mirrors the shell -> node shape: the parent spawns a child whose stdout is an
+ * overlapped pipe the parent holds the read end of (UV_CREATE_PIPE |
+ * UV_WRITABLE_PIPE | UV_NONBLOCK_PIPE -- the nonblock flag makes the child's
+ * inherited fd 1 overlapped so uv_pipe_open associates it with the loop's
+ * IOCP, the path #5147 is attributed to). The child calls uv_pipe_open(1),
+ * writes a few bytes (like console.log), leaves the pipe open, and runs its
+ * loop:
+ *
+ *   - Healthy OS: the idle stdout pipe does not keep the child loop alive, the
+ *     child exits 0, its write end closes, the parent reads EOF and drains.
+ *   - Win2025 (#5147, workaround disabled): the child loop never drains. The
+ *     child's own unref'd watchdog (3s) fires, dumps child-side loop
+ *     diagnostics to inherited stderr (-> CI log), and exits 99. The parent
+ *     observes a non-zero exit status -> assertion FAILS (intended canary).
+ *
+ * A parent-side kill watchdog (10s) is a backstop in case the child wedges so
+ * hard it cannot run its own watchdog; it fires before the 20s runner budget.
+ * Skipped on Windows older than 26100.
+ */
+
+/* TEMPORARY: revert before merge -- #5147. Defined in src/win/core.c. */
+void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+
+#define CHILD_HELPER_NAME "pipe_stdio_loop_alive_helper_win"
+#define CHILD_DRAIN_TIMEOUT_MS 3000
+#define PARENT_KILL_TIMEOUT_MS 10000
+#define CHILD_STUCK_EXIT_CODE 99
+
+static int is_win2025_or_newer(void) {
+  typedef LONG (WINAPI *RtlGetVersion_t)(OSVERSIONINFOW*);
+  HMODULE ntdll;
+  RtlGetVersion_t fn;
+  OSVERSIONINFOW os_info;
+
+  ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) return 0;
+  fn = (RtlGetVersion_t)(uintptr_t) GetProcAddress(ntdll, "RtlGetVersion");
+  if (fn == NULL) return 0;
+
+  os_info.dwOSVersionInfoSize = sizeof(os_info);
+  if (fn(&os_info) != 0 /* STATUS_SUCCESS */) return 0;
+
+  return os_info.dwBuildNumber >= 26100;
+}
+
+/* ----- child helper (runs in the spawned process) ----- */
+
+static int child_watchdog_fired;
+
+static void child_watchdog_cb(uv_timer_t* handle) {
+  child_watchdog_fired = 1;
+  uv__loop_debug_dump(handle->loop, "reproducer B child: loop still alive");
+  uv_stop(handle->loop);
+}
+
+static void child_write_cb(uv_write_t* req, int status) {
+  (void) req;
+  (void) status;
+  /* Intentionally leave the stdout pipe open, like Node's process.stdout. */
+}
+
+int pipe_stdio_loop_alive_helper_win(void) {
+  uv_loop_t* loop;
+  uv_pipe_t stdout_pipe;
+  uv_write_t write_req;
+  uv_buf_t buf;
+  uv_timer_t watchdog;
+
+  loop = uv_default_loop();
+
+  if (uv_pipe_init(loop, &stdout_pipe, 0) != 0)
+    return 2;
+  if (uv_pipe_open(&stdout_pipe, 1) != 0)
+    return 3;
+
+  buf = uv_buf_init("hi\n", 3);
+  if (uv_write(&write_req, (uv_stream_t*) &stdout_pipe, &buf, 1, child_write_cb) != 0)
+    return 4;
+
+  child_watchdog_fired = 0;
+  if (uv_timer_init(loop, &watchdog) != 0)
+    return 5;
+  if (uv_timer_start(&watchdog, child_watchdog_cb, CHILD_DRAIN_TIMEOUT_MS, 0) != 0)
+    return 6;
+  uv_unref((uv_handle_t*) &watchdog);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* If the watchdog fired the loop failed to drain (the #5147 hang). */
+  return child_watchdog_fired ? CHILD_STUCK_EXIT_CODE : 0;
+}
+
+/* ----- parent test ----- */
+
+static uv_process_t process;
+static uv_process_options_t options;
+static uv_pipe_t child_stdout;
+static char child_output[1024];
+static size_t child_output_used;
+static int exit_cb_called;
+static int64_t child_exit_status;
+static int child_term_signal;
+static int kill_watchdog_fired;
+static char exepath[1024];
+static size_t exepath_size = sizeof(exepath);
+static char* args[3];
+
+static void alloc_cb(uv_handle_t* handle, size_t suggested, uv_buf_t* buf) {
+  (void) handle;
+  (void) suggested;
+  buf->base = child_output + child_output_used;
+  buf->len = (unsigned long) (sizeof(child_output) - child_output_used);
+}
+
+static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
+  (void) buf;
+  if (nread > 0) {
+    child_output_used += (size_t) nread;
+  } else if (nread < 0) {
+    uv_close((uv_handle_t*) stream, NULL);
+  }
+}
+
+static void exit_cb(uv_process_t* proc, int64_t exit_status, int term_signal) {
+  exit_cb_called++;
+  child_exit_status = exit_status;
+  child_term_signal = term_signal;
+  uv_close((uv_handle_t*) proc, NULL);
+}
+
+static void kill_watchdog_cb(uv_timer_t* handle) {
+  kill_watchdog_fired = 1;
+  uv__loop_debug_dump(handle->loop, "reproducer B parent: child did not exit");
+  uv_process_kill(&process, SIGTERM);
+}
+
+TEST_IMPL(pipe_stdio_loop_alive_spawn_win) {
+  uv_stdio_container_t stdio[3];
+  uv_timer_t kill_watchdog;
+  int r;
+
+  if (!is_win2025_or_newer()) {
+    RETURN_SKIP("Test requires Windows Server 2025 (build >= 26100).");
+  }
+
+  r = uv_exepath(exepath, &exepath_size);
+  ASSERT_OK(r);
+  exepath[exepath_size] = '\0';
+  args[0] = exepath;
+  args[1] = CHILD_HELPER_NAME;
+  args[2] = NULL;
+
+  memset(&options, 0, sizeof(options));
+  options.file = exepath;
+  options.args = args;
+  options.exit_cb = exit_cb;
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &child_stdout, 0));
+  stdio[0].flags = UV_IGNORE;
+  stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE | UV_NONBLOCK_PIPE;
+  stdio[1].data.stream = (uv_stream_t*) &child_stdout;
+  stdio[2].flags = UV_INHERIT_FD;     /* child diagnostics -> our stderr -> CI log */
+  stdio[2].data.fd = 2;
+  options.stdio = stdio;
+  options.stdio_count = 3;
+
+  exit_cb_called = 0;
+  child_exit_status = -1;
+  child_term_signal = -1;
+  kill_watchdog_fired = 0;
+  child_output_used = 0;
+
+  ASSERT_OK(uv_spawn(uv_default_loop(), &process, &options));
+
+  /* Parent holds and drains the read end, like a shell consuming stdout. */
+  ASSERT_OK(uv_read_start((uv_stream_t*) &child_stdout, alloc_cb, read_cb));
+
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &kill_watchdog));
+  ASSERT_OK(uv_timer_start(&kill_watchdog, kill_watchdog_cb,
+                           PARENT_KILL_TIMEOUT_MS, 0));
+  uv_unref((uv_handle_t*) &kill_watchdog);
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT_EQ(1, exit_cb_called);
+
+  /* Canary: on Win2025 with the workaround disabled the child's loop hangs,
+   * its watchdog fires, and it exits CHILD_STUCK_EXIT_CODE (or the parent had
+   * to kill it). Re-tighten / remove when the fix lands. */
+  ASSERT_EQ(0, kill_watchdog_fired);
+  ASSERT_EQ(0, child_exit_status);
+
+  uv_close((uv_handle_t*) &kill_watchdog, NULL);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+#else /* _WIN32 */
+
+typedef int file_has_no_tests;  /* ISO C forbids an empty translation unit. */
+
+#endif /* _WIN32 */

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -26,28 +26,41 @@
 
 #include <windows.h>
 #include <io.h>
+#include <stdio.h>
 
 /*
  * Reproducer A (in-process) for https://github.com/libuv/libuv/issues/5147.
  *
- * On Windows Server 2025 (NT build 26100+), associating a stdio pipe handle
- * with the loop's IOCP via uv_pipe_open(fd in {0,1,2}) leaves the loop alive
- * even though the handle is inactive. This test manufactures a pipe, swaps it
- * onto fd 1, opens it with uv_pipe_open(), then drives uv_run(UV_RUN_DEFAULT)
- * under an UNREF'd watchdog timer:
+ * A minimal "open an overlapped stdio pipe and run the loop" test was found to
+ * drain cleanly on the Win2025 CI runner, so this version moves closer to the
+ * Node.js reproducer that actually hangs: it pipes BOTH stdout (fd 1) and
+ * stderr (fd 2) as overlapped pipes, writes to each (like console.log /
+ * console.error) and leaves them open, and runs an async filesystem request to
+ * completion (mirroring the in-flight I/O — https requests — in the Node
+ * repro, whose threadpool completions post to the same loop IOCP the stdio
+ * pipes are attached to).
  *
- *   - Healthy OS: the inactive pipe does not keep the loop alive, so uv_run
- *     returns before the watchdog fires -> PASS.
- *   - Win2025 with the workaround disabled (#5147): the loop stays alive, the
- *     watchdog fires, dumps loop diagnostics, and stops the loop -> the
- *     watchdog-fired assertion FAILS (intended canary; revert with the fix).
+ * The loop is then driven with uv_run(UV_RUN_DEFAULT) under an uv_unref'd
+ * watchdog timer:
+ *   - Healthy OS: everything completes, the idle pipes do not keep the loop
+ *     alive, uv_run returns before the watchdog fires -> PASS.
+ *   - Win2025 with the workaround disabled (#5147): if the residual ref the
+ *     issue describes is present, the loop stays alive, the watchdog fires,
+ *     dumps loop state to stdout (captured by the TAP runner) and stops the
+ *     loop -> the watchdog-fired assertion FAILS (intended canary).
+ *
+ * uv__loop_debug_dump is routed to stdout here (not stderr) because the libuv
+ * test runner only surfaces a test's stdout; fd 1/2 are restored to the real
+ * console before any dump so the output is not swallowed by the pipes.
  *
  * Skipped on Windows older than build 26100 (bug not present).
  */
 
 /* TEMPORARY: revert before merge — #5147. Defined in src/win/core.c and
  * UV_EXTERN-exported there so this shared-lib-linked test can resolve it. */
-UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop,
+                                   const char* tag,
+                                   FILE* stream);
 
 static int watchdog_fired;
 
@@ -68,51 +81,95 @@ static int is_win2025_or_newer(void) {
   return os_info.dwBuildNumber >= 26100;
 }
 
+static void noop_write_cb(uv_write_t* req, int status) {
+  (void) req;
+  (void) status;
+  /* Intentionally leave the pipe open, like Node's process.stdout/stderr. */
+}
+
+static void stat_cb(uv_fs_t* req) {
+  /* Just let the async (threadpool -> IOCP) request complete. */
+  uv_fs_req_cleanup(req);
+}
+
 static void watchdog_cb(uv_timer_t* handle) {
   watchdog_fired = 1;
-  uv__loop_debug_dump(handle->loop, "reproducer A: loop still alive at watchdog");
+  uv__loop_debug_dump(handle->loop,
+                      "reproducer A: loop still alive at watchdog",
+                      stdout);
   uv_stop(handle->loop);
 }
 
+/* Open the write end of an overlapped pipe onto stdio fd `target` (1 or 2) and
+ * wrap it in `pipe`. `fds` receives the pipe pair; the read end (fds[0]) is the
+ * peer and must stay open until after the loop run. `saved_fd` receives a dup
+ * of the original stdio fd so the caller can restore it. */
+static void open_stdio_pipe(uv_pipe_t* pipe,
+                            uv_file fds[2],
+                            int target,
+                            int* saved_fd) {
+  ASSERT_OK(uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
+  *saved_fd = _dup(target);
+  ASSERT_GE(*saved_fd, 0);
+  ASSERT_OK(_dup2(fds[1], target));
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), pipe, 0));
+  ASSERT_OK(uv_pipe_open(pipe, target));
+}
+
 TEST_IMPL(pipe_stdio_no_keep_alive_win) {
-  uv_file fds[2];
-  int saved_stdout_fd = -1;
-  uv_pipe_t pipe_stdout;
+  uv_file out_fds[2];
+  uv_file err_fds[2];
+  int saved_out = -1;
+  int saved_err = -1;
+  uv_pipe_t pipe_out;
+  uv_pipe_t pipe_err;
+  uv_write_t wr_out;
+  uv_write_t wr_err;
+  uv_buf_t buf_out;
+  uv_buf_t buf_err;
+  uv_fs_t stat_req;
+
   uv_timer_t watchdog;
-  int open_result;
 
   if (!is_win2025_or_newer()) {
     RETURN_SKIP("Test requires Windows Server 2025 (build >= 26100).");
   }
 
-  /* Manufacture an OVERLAPPED pipe (UV_NONBLOCK_PIPE => FILE_FLAG_OVERLAPPED)
-   * so uv_pipe_open's IOCP-attach path -- the path we suspect is involved
-   * in #5147 (root cause unconfirmed) -- is actually exercised. A plain
-   * CreatePipe() produces a synchronous pipe, which uv__set_pipe_handle
-   * routes through the non-overlapped branch that never associates with the
-   * loop's IOCP. */
-  ASSERT_OK(uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
-  /* fds[0] = read end, fds[1] = write end (like stdout). Keep the read end
-   * open as the peer holding the pipe; place the write end on fd 1 so
-   * uv_pipe_open(pipe, 1) takes the stdio code path (0 <= file <= 2). */
+  /* Overlapped stdio pipes on fd 1 and fd 2 (UV_NONBLOCK_PIPE =>
+   * FILE_FLAG_OVERLAPPED) so uv_pipe_open takes the IOCP-attach path we
+   * suspect is involved in #5147 (root cause unconfirmed). fd <= 2 makes
+   * uv_pipe_open use the stdio code path (0 <= file <= 2). */
+  open_stdio_pipe(&pipe_out, out_fds, 1, &saved_out);
+  open_stdio_pipe(&pipe_err, err_fds, 2, &saved_err);
 
-  saved_stdout_fd = _dup(1);
-  ASSERT_GE(saved_stdout_fd, 0);
-  ASSERT_OK(_dup2(fds[1], 1));
+  /* Restore the real console fds immediately so TAP output and the diagnostic
+   * dump below land in the runner's captured stdout, not the manufactured
+   * pipes. uv_pipe_open duplicated the underlying handles, so we can drop our
+   * own write-end fds now; the read ends (fds[0]) stay open as the peers. */
+  _dup2(saved_out, 1);
+  _close(saved_out);
+  _close(out_fds[1]);
+  _dup2(saved_err, 2);
+  _close(saved_err);
+  _close(err_fds[1]);
 
-  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_stdout, 0));
-  open_result = uv_pipe_open(&pipe_stdout, 1);
+  /* Write to both pipes (like console.log / console.error) and leave them
+   * open. The few bytes fit the pipe buffer, so the writes complete without a
+   * reader. */
+  buf_out = uv_buf_init("out\n", 4);
+  ASSERT_OK(uv_write(&wr_out, (uv_stream_t*) &pipe_out, &buf_out, 1,
+                     noop_write_cb));
+  buf_err = uv_buf_init("err\n", 4);
+  ASSERT_OK(uv_write(&wr_err, (uv_stream_t*) &pipe_err, &buf_err, 1,
+                     noop_write_cb));
 
-  /* Restore stdout immediately so subsequent printf / ASSERT messages land
-   * in the runner's output. uv_pipe_open duplicated the underlying handle, so
-   * we can drop our own write-end fd now. */
-  _dup2(saved_stdout_fd, 1);
-  _close(saved_stdout_fd);
-  _close(fds[1]);
+  /* In-flight async work that completes through the threadpool -> loop IOCP,
+   * mirroring the Node repro's https requests. */
+  ASSERT_OK(uv_fs_stat(uv_default_loop(), &stat_req, ".", stat_cb));
 
-  ASSERT_OK(open_result);
-
-  uv__loop_debug_dump(uv_default_loop(), "reproducer A: after uv_pipe_open(fd=1)");
+  uv__loop_debug_dump(uv_default_loop(),
+                      "reproducer A: before run (2 stdio pipes + writes + fs)",
+                      stdout);
 
   /* Unref'd watchdog: fires only if something else keeps the loop alive. */
   watchdog_fired = 0;
@@ -120,9 +177,12 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   ASSERT_OK(uv_timer_start(&watchdog, watchdog_cb, 5000, 0));
   uv_unref((uv_handle_t*) &watchdog);
 
-  /* Healthy: returns immediately (idle pipe does not keep loop alive).
-   * Win2025 (workaround off): stays alive until the watchdog fires. */
+  /* Healthy: returns once the writes + fs request complete (idle pipes do not
+   * keep the loop alive). Win2025 (workaround off): stays alive until the
+   * watchdog fires. */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  uv__loop_debug_dump(uv_default_loop(), "reproducer A: after run", stdout);
 
   /* Canary: on Win2025 with the workaround disabled this fails because the
    * loop did not drain. This assertion is the permanent contract; when the
@@ -131,10 +191,12 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   ASSERT_OK(watchdog_fired);
 
   uv_close((uv_handle_t*) &watchdog, NULL);
-  uv_close((uv_handle_t*) &pipe_stdout, NULL);
+  uv_close((uv_handle_t*) &pipe_out, NULL);
+  uv_close((uv_handle_t*) &pipe_err, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  _close(fds[0]);
+  _close(out_fds[0]);
+  _close(err_fds[0]);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -31,27 +31,25 @@
 /*
  * Reproducer A (in-process) for https://github.com/libuv/libuv/issues/5147.
  *
- * A minimal "open an overlapped stdio pipe and run the loop" test was found to
- * drain cleanly on the Win2025 CI runner, so this version moves closer to the
- * Node.js reproducer that actually hangs: it pipes BOTH stdout (fd 1) and
- * stderr (fd 2) as overlapped pipes, writes to each (like console.log /
- * console.error) and leaves them open, and runs an async filesystem request to
- * completion (mirroring the in-flight I/O — https requests — in the Node
- * repro, whose threadpool completions post to the same loop IOCP the stdio
- * pipes are attached to).
+ * Minimal single/dual overlapped stdio-pipe variants drained cleanly on the
+ * Win2025 CI runner, so this version mirrors the hanging Node.js repro as
+ * closely as is practical in-process:
+ *   - BOTH stdout (fd 1) and stderr (fd 2) are overlapped stdio pipes, written
+ *     to (like console.log / console.error) and left open;
+ *   - a real loopback TCP round-trip (connect -> 1 byte -> echo -> close) runs
+ *     to completion, so genuine socket IOCP completions interleave with the
+ *     stdio-pipe IOCP, standing in for the https requests the Node repro makes.
  *
- * The loop is then driven with uv_run(UV_RUN_DEFAULT) under an uv_unref'd
- * watchdog timer:
- *   - Healthy OS: everything completes, the idle pipes do not keep the loop
- *     alive, uv_run returns before the watchdog fires -> PASS.
+ * The loop is driven with uv_run(UV_RUN_DEFAULT) under an uv_unref'd watchdog:
+ *   - Healthy OS: everything completes, the idle stdio pipes do not keep the
+ *     loop alive, uv_run returns before the watchdog fires -> PASS.
  *   - Win2025 with the workaround disabled (#5147): if the residual ref the
  *     issue describes is present, the loop stays alive, the watchdog fires,
- *     dumps loop state to stdout (captured by the TAP runner) and stops the
- *     loop -> the watchdog-fired assertion FAILS (intended canary).
+ *     dumps loop state and stops the loop -> the assertion FAILS (canary).
  *
- * uv__loop_debug_dump is routed to stdout here (not stderr) because the libuv
- * test runner only surfaces a test's stdout; fd 1/2 are restored to the real
- * console before any dump so the output is not swallowed by the pipes.
+ * uv__loop_debug_dump is routed to stdout (fd 1/2 are restored to the console
+ * before any dump). The test entry is registered with show_output=1 so the
+ * runner echoes this stdout into the CI log on both pass and fail.
  *
  * Skipped on Windows older than build 26100 (bug not present).
  */
@@ -63,6 +61,13 @@ UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop,
                                    FILE* stream);
 
 static int watchdog_fired;
+
+/* TCP echo state. */
+static uv_tcp_t tcp_server;
+static uv_tcp_t tcp_client;
+static uv_tcp_t tcp_accepted;
+static uv_write_t tcp_write_req;
+static char tcp_slab[64];
 
 static int is_win2025_or_newer(void) {
   typedef LONG (WINAPI *RtlGetVersion_t)(OSVERSIONINFOW*);
@@ -84,12 +89,56 @@ static int is_win2025_or_newer(void) {
 static void noop_write_cb(uv_write_t* req, int status) {
   (void) req;
   (void) status;
-  /* Intentionally leave the pipe open, like Node's process.stdout/stderr. */
+  /* Intentionally leave the stdio pipe open, like Node's process.stdout. */
 }
 
-static void stat_cb(uv_fs_t* req) {
-  /* Just let the async (threadpool -> IOCP) request complete. */
-  uv_fs_req_cleanup(req);
+static void tcp_close_cb(uv_handle_t* handle) {
+  (void) handle;
+}
+
+static void tcp_alloc_cb(uv_handle_t* handle, size_t suggested, uv_buf_t* buf) {
+  (void) handle;
+  (void) suggested;
+  buf->base = tcp_slab;
+  buf->len = (unsigned long) sizeof(tcp_slab);
+}
+
+static void tcp_server_read_cb(uv_stream_t* stream,
+                               ssize_t nread,
+                               const uv_buf_t* buf) {
+  (void) stream;
+  (void) nread;
+  (void) buf;
+  /* read_start delivers the data callback and then UV_EOF; only tear down
+   * once (a second uv_close on a closing handle aborts in debug builds). */
+  if (uv_is_closing((uv_handle_t*) &tcp_accepted))
+    return;
+  uv_close((uv_handle_t*) &tcp_accepted, tcp_close_cb);
+  uv_close((uv_handle_t*) &tcp_server, tcp_close_cb);
+}
+
+static void tcp_connection_cb(uv_stream_t* server, int status) {
+  ASSERT_OK(status);
+  ASSERT_OK(uv_tcp_init(server->loop, &tcp_accepted));
+  ASSERT_OK(uv_accept(server, (uv_stream_t*) &tcp_accepted));
+  ASSERT_OK(uv_read_start((uv_stream_t*) &tcp_accepted,
+                          tcp_alloc_cb,
+                          tcp_server_read_cb));
+}
+
+static void tcp_client_write_cb(uv_write_t* req, int status) {
+  (void) req;
+  ASSERT_OK(status);
+  uv_close((uv_handle_t*) &tcp_client, tcp_close_cb);
+}
+
+static void tcp_connect_cb(uv_connect_t* req, int status) {
+  uv_buf_t b;
+  (void) req;
+  ASSERT_OK(status);
+  b = uv_buf_init("x", 1);
+  ASSERT_OK(uv_write(&tcp_write_req, (uv_stream_t*) &tcp_client, &b, 1,
+                     tcp_client_write_cb));
 }
 
 static void watchdog_cb(uv_timer_t* handle) {
@@ -127,8 +176,10 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   uv_write_t wr_err;
   uv_buf_t buf_out;
   uv_buf_t buf_err;
-  uv_fs_t stat_req;
-
+  struct sockaddr_in listen_addr;
+  struct sockaddr_in connect_addr;
+  uv_connect_t connect_req;
+  int namelen;
   uv_timer_t watchdog;
 
   if (!is_win2025_or_newer()) {
@@ -163,12 +214,26 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   ASSERT_OK(uv_write(&wr_err, (uv_stream_t*) &pipe_err, &buf_err, 1,
                      noop_write_cb));
 
-  /* In-flight async work that completes through the threadpool -> loop IOCP,
-   * mirroring the Node repro's https requests. */
-  ASSERT_OK(uv_fs_stat(uv_default_loop(), &stat_req, ".", stat_cb));
+  /* Real loopback TCP round-trip, standing in for the Node repro's https
+   * requests: bind+listen on an ephemeral port, connect, send one byte, the
+   * server reads it, then both sides close. Genuine socket IOCP completions
+   * interleave with the stdio-pipe IOCP. */
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", 0, &listen_addr));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &tcp_server));
+  ASSERT_OK(uv_tcp_bind(&tcp_server, (const struct sockaddr*) &listen_addr, 0));
+  namelen = sizeof(connect_addr);
+  ASSERT_OK(uv_tcp_getsockname(&tcp_server,
+                               (struct sockaddr*) &connect_addr,
+                               &namelen));
+  ASSERT_OK(uv_listen((uv_stream_t*) &tcp_server, 1, tcp_connection_cb));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &tcp_client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &tcp_client,
+                           (const struct sockaddr*) &connect_addr,
+                           tcp_connect_cb));
 
   uv__loop_debug_dump(uv_default_loop(),
-                      "reproducer A: before run (2 stdio pipes + writes + fs)",
+                      "reproducer A: before run (2 stdio pipes + writes + tcp)",
                       stdout);
 
   /* Unref'd watchdog: fires only if something else keeps the loop alive. */
@@ -177,9 +242,9 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   ASSERT_OK(uv_timer_start(&watchdog, watchdog_cb, 5000, 0));
   uv_unref((uv_handle_t*) &watchdog);
 
-  /* Healthy: returns once the writes + fs request complete (idle pipes do not
-   * keep the loop alive). Win2025 (workaround off): stays alive until the
-   * watchdog fires. */
+  /* Healthy: returns once the writes + TCP round-trip complete (idle stdio
+   * pipes do not keep the loop alive). Win2025 (workaround off): stays alive
+   * until the watchdog fires. */
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   uv__loop_debug_dump(uv_default_loop(), "reproducer A: after run", stdout);

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -85,14 +85,15 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   }
 
   /* Manufacture an OVERLAPPED pipe (UV_NONBLOCK_PIPE => FILE_FLAG_OVERLAPPED)
-   * so uv_pipe_open's IOCP-attach path -- the code the #5147 hang is
-   * attributed to -- is actually exercised. A plain CreatePipe() produces a
-   * synchronous pipe, which uv__set_pipe_handle routes through the
-   * non-overlapped branch that never associates with the loop's IOCP. */
+   * so uv_pipe_open's IOCP-attach path -- the path we suspect is involved
+   * in #5147 (root cause unconfirmed) -- is actually exercised. A plain
+   * CreatePipe() produces a synchronous pipe, which uv__set_pipe_handle
+   * routes through the non-overlapped branch that never associates with the
+   * loop's IOCP. */
   ASSERT_OK(uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
   /* fds[0] = read end, fds[1] = write end (like stdout). Keep the read end
    * open as the peer holding the pipe; place the write end on fd 1 so
-   * uv_pipe_open(pipe, 1) takes the stdio code path (file <= 2). */
+   * uv_pipe_open(pipe, 1) takes the stdio code path (0 <= file <= 2). */
 
   saved_stdout_fd = _dup(1);
   ASSERT_GE(saved_stdout_fd, 0);
@@ -123,7 +124,9 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   /* Canary: on Win2025 with the workaround disabled this fails because the
-   * loop did not drain. Re-tighten / remove when the fix lands. */
+   * loop did not drain. This assertion is the permanent contract; when the
+   * fix lands, what changes is the #if 0 workaround in src/win/pipe.c and the
+   * Win2025-only skip guard, not this assert. */
   ASSERT_OK(watchdog_fired);
 
   uv_close((uv_handle_t*) &watchdog, NULL);

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -19,42 +19,36 @@
  * IN THE SOFTWARE.
  */
 
+#ifdef _WIN32
+
 #include "uv.h"
 #include "task.h"
 
-#ifdef _WIN32
-
 #include <windows.h>
 #include <io.h>
-#include <fcntl.h>
-#include <stdint.h>
 
 /*
- * On Windows Server 2025 (NT build 26100+), opening stdio file descriptors
- * with uv_pipe_open() leaves the resulting handle implicitly keeping the
- * event loop alive even after all write work has drained — see
- * https://github.com/libuv/libuv/issues/5147. The expected workaround in
- * src/win/pipe.c is to unref the pipe handle when it wraps a stdio fd.
+ * Reproducer A (in-process) for https://github.com/libuv/libuv/issues/5147.
  *
- * This test verifies that contract on the running OS:
- *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2} and the
- *     underlying OS handle is a pipe, the resulting uv_pipe_t MUST
- *     report uv_has_ref() == 0.
- *   - On older Windows (build < 26100), the handle MAY remain refed
- *     (the original behavior); the test only asserts on Win2025+.
+ * On Windows Server 2025 (NT build 26100+), associating a stdio pipe handle
+ * with the loop's IOCP via uv_pipe_open(fd in {0,1,2}) leaves the loop alive
+ * even though the handle is inactive. This test manufactures a pipe, swaps it
+ * onto fd 1, opens it with uv_pipe_open(), then drives uv_run(UV_RUN_DEFAULT)
+ * under an UNREF'd watchdog timer:
  *
- * Because the test runner inherits whatever stdout the harness was launched
- * with — typically a console, a file, or a redirected handle that is not
- * actually a Win32 named pipe — we cannot just call uv_pipe_open() on the
- * inherited fd 1: uv__set_pipe_handle's SetNamedPipeHandleState would
- * reject a non-pipe with UV_ENOTSOCK. So we manufacture a pipe with
- * CreatePipe(), wrap its read end as a CRT fd with _open_osfhandle(),
- * dup it onto fd 1 (saving the original so we can restore for the
- * runner's TAP output), call uv_pipe_open() on fd 1, restore fd 1, and
- * then make our assertions.
+ *   - Healthy OS: the inactive pipe does not keep the loop alive, so uv_run
+ *     returns before the watchdog fires -> PASS.
+ *   - Win2025 with the workaround disabled (#5147): the loop stays alive, the
+ *     watchdog fires, dumps loop diagnostics, and stops the loop -> the
+ *     watchdog-fired assertion FAILS (intended canary; revert with the fix).
  *
- * Skipped on non-Windows.
+ * Skipped on Windows older than build 26100 (bug not present).
  */
+
+/* TEMPORARY: revert before merge — #5147. Defined in src/win/core.c. */
+void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+
+static int watchdog_fired;
 
 static int is_win2025_or_newer(void) {
   typedef LONG (WINAPI *RtlGetVersion_t)(OSVERSIONINFOW*);
@@ -73,77 +67,70 @@ static int is_win2025_or_newer(void) {
   return os_info.dwBuildNumber >= 26100;
 }
 
+static void watchdog_cb(uv_timer_t* handle) {
+  watchdog_fired = 1;
+  uv__loop_debug_dump(handle->loop, "reproducer A: loop still alive at watchdog");
+  uv_stop(handle->loop);
+}
+
 TEST_IMPL(pipe_stdio_no_keep_alive_win) {
-  HANDLE pipe_read = INVALID_HANDLE_VALUE;
-  HANDLE pipe_write = INVALID_HANDLE_VALUE;
-  int crt_fd = -1;
+  uv_file fds[2];
   int saved_stdout_fd = -1;
   uv_pipe_t pipe_stdout;
-  int has_ref;
-  int run_result;
+  uv_timer_t watchdog;
   int open_result;
 
   if (!is_win2025_or_newer()) {
     RETURN_SKIP("Test requires Windows Server 2025 (build >= 26100).");
   }
 
-  /* Manufacture an overlapped pipe so uv_pipe_open's IOCP-attach path
-   * exercises the same code that the real stdio bug surfaces in. */
-  if (!CreatePipe(&pipe_read, &pipe_write, NULL, 0)) {
-    fprintf(stderr, "CreatePipe failed: %lu\n", GetLastError());
-    return TEST_SKIP;
-  }
+  /* Manufacture an OVERLAPPED pipe (UV_NONBLOCK_PIPE => FILE_FLAG_OVERLAPPED)
+   * so uv_pipe_open's IOCP-attach path -- the code the #5147 hang is
+   * attributed to -- is actually exercised. A plain CreatePipe() produces a
+   * synchronous pipe, which uv__set_pipe_handle routes through the
+   * non-overlapped branch that never associates with the loop's IOCP. */
+  ASSERT_OK(uv_pipe(fds, UV_NONBLOCK_PIPE, UV_NONBLOCK_PIPE));
+  /* fds[0] = read end, fds[1] = write end (like stdout). Keep the read end
+   * open as the peer holding the pipe; place the write end on fd 1 so
+   * uv_pipe_open(pipe, 1) takes the stdio code path (file <= 2). */
 
-  crt_fd = _open_osfhandle((intptr_t) pipe_read, _O_RDONLY | _O_BINARY);
-  if (crt_fd < 0) {
-    CloseHandle(pipe_read);
-    CloseHandle(pipe_write);
-    return TEST_SKIP;
-  }
-  /* _open_osfhandle takes ownership of pipe_read; it is closed via _close(crt_fd). */
-  pipe_read = INVALID_HANDLE_VALUE;
-
-  /* Save the runner's real stdout so we can restore for TAP output. */
   saved_stdout_fd = _dup(1);
   ASSERT_GE(saved_stdout_fd, 0);
-
-  /* Swap our pipe onto fd 1. uv_pipe_open(pipe, 1) below will see file<=2,
-   * take the stdio code path (DuplicateHandle, was_stdio = 1), and exercise
-   * the Win2025 unref. */
-  if (_dup2(crt_fd, 1) != 0) {
-    _close(saved_stdout_fd);
-    _close(crt_fd);
-    CloseHandle(pipe_write);
-    return TEST_SKIP;
-  }
+  ASSERT_OK(_dup2(fds[1], 1));
 
   ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_stdout, 0));
   open_result = uv_pipe_open(&pipe_stdout, 1);
 
-  /* Restore stdout immediately so subsequent printf / ASSERT messages
-   * land in the runner's output rather than the manufactured pipe. */
+  /* Restore stdout immediately so subsequent printf / ASSERT messages land
+   * in the runner's output. uv_pipe_open duplicated the underlying handle, so
+   * we can drop our own write-end fd now. */
   _dup2(saved_stdout_fd, 1);
   _close(saved_stdout_fd);
-  _close(crt_fd);
+  _close(fds[1]);
 
   ASSERT_OK(open_result);
 
-  /* On Win2025+, the handle must not keep the loop alive. */
-  has_ref = uv_has_ref((const uv_handle_t*) &pipe_stdout);
-  ASSERT_EQ(has_ref, 0);
+  uv__loop_debug_dump(uv_default_loop(), "reproducer A: after uv_pipe_open(fd=1)");
 
-  /* The loop should immediately report no remaining work. */
-  run_result = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-  ASSERT_EQ(run_result, 0);
+  /* Unref'd watchdog: fires only if something else keeps the loop alive. */
+  watchdog_fired = 0;
+  ASSERT_OK(uv_timer_init(uv_default_loop(), &watchdog));
+  ASSERT_OK(uv_timer_start(&watchdog, watchdog_cb, 5000, 0));
+  uv_unref((uv_handle_t*) &watchdog);
 
+  /* Healthy: returns immediately (idle pipe does not keep loop alive).
+   * Win2025 (workaround off): stays alive until the watchdog fires. */
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  /* Canary: on Win2025 with the workaround disabled this fails because the
+   * loop did not drain. Re-tighten / remove when the fix lands. */
+  ASSERT_OK(watchdog_fired);
+
+  uv_close((uv_handle_t*) &watchdog, NULL);
   uv_close((uv_handle_t*) &pipe_stdout, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-  /* uv_pipe_open duplicated the underlying handle and owns the duplicate;
-   * the OS handle we passed in via fd 1 / crt_fd was closed when we did
-   * _close(crt_fd) above. The write end of the manufactured pipe still
-   * needs to be cleaned up. */
-  CloseHandle(pipe_write);
+  _close(fds[0]);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -151,8 +138,6 @@ TEST_IMPL(pipe_stdio_no_keep_alive_win) {
 
 #else /* _WIN32 */
 
-TEST_IMPL(pipe_stdio_no_keep_alive_win) {
-  RETURN_SKIP("Test is Windows-only.");
-}
+typedef int file_has_no_tests;  /* ISO C forbids an empty translation unit. */
 
 #endif /* _WIN32 */

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -1,0 +1,109 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+/*
+ * On Windows Server 2025 (NT build 26100+), opening stdio file descriptors
+ * with uv_pipe_open() leaves the resulting handle implicitly keeping the
+ * event loop alive even after all write work has drained — see
+ * https://github.com/libuv/libuv/issues/5147. The expected workaround in src/win/pipe.c is to
+ * unref the pipe handle when it wraps a stdio fd.
+ *
+ * This test verifies that contract on the running OS:
+ *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2}, the
+ *     resulting handle MUST report uv_has_ref() == 0.
+ *   - On older Windows (build < 26100), the handle MAY remain refed
+ *     (the original behavior); the test only asserts on Win2025+.
+ *
+ * Skipped on non-Windows.
+ *
+ * NB: this test deliberately does not actually drive any I/O through the
+ * inherited stdout pipe — that would interleave with the test runner's
+ * own output. We only need to observe the post-open ref state.
+ */
+
+static int is_win2025_or_newer(void) {
+  typedef LONG (WINAPI *RtlGetVersion_t)(OSVERSIONINFOW*);
+  HMODULE ntdll;
+  RtlGetVersion_t fn;
+  OSVERSIONINFOW os_info;
+
+  ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == NULL) return 0;
+  fn = (RtlGetVersion_t)(uintptr_t) GetProcAddress(ntdll, "RtlGetVersion");
+  if (fn == NULL) return 0;
+
+  os_info.dwOSVersionInfoSize = sizeof(os_info);
+  if (fn(&os_info) != 0 /* STATUS_SUCCESS */) return 0;
+
+  return os_info.dwBuildNumber >= 26100;
+}
+
+TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  uv_pipe_t pipe_stdout;
+  int r;
+
+  if (!is_win2025_or_newer()) {
+    fprintf(stderr, "Skipping: requires Windows Server 2025 (build >= 26100)\n");
+    fflush(stderr);
+    return 0;
+  }
+
+  /* Use fd 1 (stdout) — the duplicate-and-forget logic in uv_pipe_open
+   * means we are not at risk of disturbing the test runner's actual
+   * stdout because we never read/write through pipe_stdout here. */
+  r = uv_pipe_init(uv_default_loop(), &pipe_stdout, 0);
+  ASSERT_OK(r);
+
+  r = uv_pipe_open(&pipe_stdout, 1);
+  /* uv_pipe_open succeeds for stdio fds on Windows. */
+  ASSERT_OK(r);
+
+  /* After uv_pipe_open() on stdio fd, on Win2025+, the handle must NOT
+   * keep the loop alive. */
+  ASSERT_EQ(uv_has_ref((const uv_handle_t*) &pipe_stdout), 0);
+
+  /* And uv_run with UV_RUN_NOWAIT should not deadlock and should report
+   * the loop as having no other refed work. */
+  r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+  /* Returns 0 when the loop has nothing else to do. */
+  ASSERT_EQ(r, 0);
+
+  uv_close((uv_handle_t*) &pipe_stdout, NULL);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+#else /* _WIN32 */
+
+TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  RETURN_SKIP("Test is Windows-only.");
+}
+
+#endif /* _WIN32 */

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -25,25 +25,35 @@
 #ifdef _WIN32
 
 #include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <stdint.h>
 
 /*
  * On Windows Server 2025 (NT build 26100+), opening stdio file descriptors
  * with uv_pipe_open() leaves the resulting handle implicitly keeping the
  * event loop alive even after all write work has drained — see
- * https://github.com/libuv/libuv/issues/5147. The expected workaround in src/win/pipe.c is to
- * unref the pipe handle when it wraps a stdio fd.
+ * https://github.com/libuv/libuv/issues/5147. The expected workaround in
+ * src/win/pipe.c is to unref the pipe handle when it wraps a stdio fd.
  *
  * This test verifies that contract on the running OS:
- *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2}, the
- *     resulting handle MUST report uv_has_ref() == 0.
+ *   - On Win2025+, after uv_pipe_open(fd) where fd in {0,1,2} and the
+ *     underlying OS handle is a pipe, the resulting uv_pipe_t MUST
+ *     report uv_has_ref() == 0.
  *   - On older Windows (build < 26100), the handle MAY remain refed
  *     (the original behavior); the test only asserts on Win2025+.
  *
- * Skipped on non-Windows.
+ * Because the test runner inherits whatever stdout the harness was launched
+ * with — typically a console, a file, or a redirected handle that is not
+ * actually a Win32 named pipe — we cannot just call uv_pipe_open() on the
+ * inherited fd 1: uv__set_pipe_handle's SetNamedPipeHandleState would
+ * reject a non-pipe with UV_ENOTSOCK. So we manufacture a pipe with
+ * CreatePipe(), wrap its read end as a CRT fd with _open_osfhandle(),
+ * dup it onto fd 1 (saving the original so we can restore for the
+ * runner's TAP output), call uv_pipe_open() on fd 1, restore fd 1, and
+ * then make our assertions.
  *
- * NB: this test deliberately does not actually drive any I/O through the
- * inherited stdout pipe — that would interleave with the test runner's
- * own output. We only need to observe the post-open ref state.
+ * Skipped on non-Windows.
  */
 
 static int is_win2025_or_newer(void) {
@@ -64,37 +74,76 @@ static int is_win2025_or_newer(void) {
 }
 
 TEST_IMPL(pipe_stdio_no_keep_alive_win) {
+  HANDLE pipe_read = INVALID_HANDLE_VALUE;
+  HANDLE pipe_write = INVALID_HANDLE_VALUE;
+  int crt_fd = -1;
+  int saved_stdout_fd = -1;
   uv_pipe_t pipe_stdout;
-  int r;
+  int has_ref;
+  int run_result;
+  int open_result;
 
   if (!is_win2025_or_newer()) {
-    fprintf(stderr, "Skipping: requires Windows Server 2025 (build >= 26100)\n");
-    fflush(stderr);
-    return 0;
+    RETURN_SKIP("Test requires Windows Server 2025 (build >= 26100).");
   }
 
-  /* Use fd 1 (stdout) — the duplicate-and-forget logic in uv_pipe_open
-   * means we are not at risk of disturbing the test runner's actual
-   * stdout because we never read/write through pipe_stdout here. */
-  r = uv_pipe_init(uv_default_loop(), &pipe_stdout, 0);
-  ASSERT_OK(r);
+  /* Manufacture an overlapped pipe so uv_pipe_open's IOCP-attach path
+   * exercises the same code that the real stdio bug surfaces in. */
+  if (!CreatePipe(&pipe_read, &pipe_write, NULL, 0)) {
+    fprintf(stderr, "CreatePipe failed: %lu\n", GetLastError());
+    return TEST_SKIP;
+  }
 
-  r = uv_pipe_open(&pipe_stdout, 1);
-  /* uv_pipe_open succeeds for stdio fds on Windows. */
-  ASSERT_OK(r);
+  crt_fd = _open_osfhandle((intptr_t) pipe_read, _O_RDONLY | _O_BINARY);
+  if (crt_fd < 0) {
+    CloseHandle(pipe_read);
+    CloseHandle(pipe_write);
+    return TEST_SKIP;
+  }
+  /* _open_osfhandle takes ownership of pipe_read; it is closed via _close(crt_fd). */
+  pipe_read = INVALID_HANDLE_VALUE;
 
-  /* After uv_pipe_open() on stdio fd, on Win2025+, the handle must NOT
-   * keep the loop alive. */
-  ASSERT_EQ(uv_has_ref((const uv_handle_t*) &pipe_stdout), 0);
+  /* Save the runner's real stdout so we can restore for TAP output. */
+  saved_stdout_fd = _dup(1);
+  ASSERT_GE(saved_stdout_fd, 0);
 
-  /* And uv_run with UV_RUN_NOWAIT should not deadlock and should report
-   * the loop as having no other refed work. */
-  r = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-  /* Returns 0 when the loop has nothing else to do. */
-  ASSERT_EQ(r, 0);
+  /* Swap our pipe onto fd 1. uv_pipe_open(pipe, 1) below will see file<=2,
+   * take the stdio code path (DuplicateHandle, was_stdio = 1), and exercise
+   * the Win2025 unref. */
+  if (_dup2(crt_fd, 1) != 0) {
+    _close(saved_stdout_fd);
+    _close(crt_fd);
+    CloseHandle(pipe_write);
+    return TEST_SKIP;
+  }
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_stdout, 0));
+  open_result = uv_pipe_open(&pipe_stdout, 1);
+
+  /* Restore stdout immediately so subsequent printf / ASSERT messages
+   * land in the runner's output rather than the manufactured pipe. */
+  _dup2(saved_stdout_fd, 1);
+  _close(saved_stdout_fd);
+  _close(crt_fd);
+
+  ASSERT_OK(open_result);
+
+  /* On Win2025+, the handle must not keep the loop alive. */
+  has_ref = uv_has_ref((const uv_handle_t*) &pipe_stdout);
+  ASSERT_EQ(has_ref, 0);
+
+  /* The loop should immediately report no remaining work. */
+  run_result = uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+  ASSERT_EQ(run_result, 0);
 
   uv_close((uv_handle_t*) &pipe_stdout, NULL);
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  /* uv_pipe_open duplicated the underlying handle and owns the duplicate;
+   * the OS handle we passed in via fd 1 / crt_fd was closed when we did
+   * _close(crt_fd) above. The write end of the manufactured pipe still
+   * needs to be cleaned up. */
+  CloseHandle(pipe_write);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-pipe-stdio-no-keep-alive-win.c
+++ b/test/test-pipe-stdio-no-keep-alive-win.c
@@ -45,8 +45,9 @@
  * Skipped on Windows older than build 26100 (bug not present).
  */
 
-/* TEMPORARY: revert before merge — #5147. Defined in src/win/core.c. */
-void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
+/* TEMPORARY: revert before merge — #5147. Defined in src/win/core.c and
+ * UV_EXTERN-exported there so this shared-lib-linked test can resolve it. */
+UV_EXTERN void uv__loop_debug_dump(uv_loop_t* loop, const char* tag);
 
 static int watchdog_fired;
 


### PR DESCRIPTION
## What this is

A **repro-first, diagnostic** follow-up to #5148 (closed by @vtjnash as "not the correct approach to fixing it") for the Windows Server 2025 stdio-pipe event-loop hang in #5147.

The previous PR shipped a *symptomatic* workaround (`uv_unref()` stdio pipes on Win2025+) plus an observe-only test. @saghul's feedback was that this was "a shot in the dark" without knowing the root cause, and @vtjnash closed it on the same grounds. **This PR pivots to finding the root cause**: it makes the hang reproducible inside libuv's own CI and instruments the event loop so the residual ref can be localized. It does **not** propose a fix yet.

This is a **draft**, and the `build-Visual Studio 17 2022-x64-2025` job is **expected to fail** — that failing run, with the diagnostic dump in its log, is the deliverable.

## Changes

1. **Disable the symptomatic workaround** (`src/win/pipe.c`) — the `uv_unref()` block from #5148 is wrapped in `#if 0` so the hang is *observable* in CI rather than masked. Tagged `TEMPORARY #5147`.
2. **Temporary loop diagnostics** (`src/win/core.c`) — `uv__loop_debug_dump()` prints the four inputs `uv__loop_alive()` consults (`active_handles`, `active_reqs.count`, `pending_reqs_tail`, `endgame_handles`) plus a `uv_walk` inventory that now includes each handle's `non_overlapped_pipe` flag, so the log shows whether the IOCP-attach path was taken. Tagged `TEMPORARY #5147`.
3. **Reproducer A — in-process** (`test/test-pipe-stdio-no-keep-alive-win.c`, rewritten): manufactures an *overlapped* pipe via `uv_pipe(UV_NONBLOCK_PIPE, …)`, places the write end on fd 1, `uv_pipe_open(1)`, then drives `uv_run(UV_RUN_DEFAULT)` under an `uv_unref`'d watchdog. It asserts the loop drained; on Win2025 (workaround off) the watchdog fires and dumps loop state.
4. **Reproducer B — `uv_spawn` faithful** (`test/test-pipe-stdio-loop-alive-spawn-win.c`, new): mirrors the shell→node shape — the parent spawns a child whose stdout is an overlapped pipe (`UV_CREATE_PIPE | UV_WRITABLE_PIPE | UV_NONBLOCK_PIPE`) it holds the read end of; the child `uv_pipe_open(1)`s it, writes, and runs its loop under a self-watchdog, dumping child-side diagnostics to inherited stderr and exiting non-zero if it hangs. This is the libuv-level reproducer @saghul endorsed.

It also folds in the inline review feedback from #5148: the test is now Windows-only via the `#ifdef _WIN32 … #else typedef int file_has_no_tests; #endif` idiom, uses `uv_pipe()`/`uv_open_osfhandle()` instead of raw `_open_osfhandle()`, and uses hard `ASSERT`s for setup failures instead of `TEST_SKIP`.

## Why this is safe

- Every non-test change is either **disabling code** (the `#if 0` returns `uv_pipe_open()` to its exact pre-#5148 behavior on *all* platforms) or **Windows-only diagnostic instrumentation** that is not on any hot path.
- Both test files compile to `typedef int file_has_no_tests;` off Windows and `RETURN_SKIP` on Windows < build 26100, so non-Win2025 jobs are unaffected.
- All temporary scaffolding is tagged `TEMPORARY #5147` for a clean revert once the root cause is known.

## Question for maintainers

Given #5148 was closed, would you prefer (a) landing these reproducers + a brief diagnostic instrument so the Win2025 CI job characterizes the bug, or (b) just using this branch's CI run to gather the loop-state dump and then iterating toward the actual fix? Happy to go either way.

Refs #5147. Supersedes #5148.
