### PR TITLE
win,tty: preserve mouse and extended flags in raw mode

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -61,6 +61,12 @@
 #ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
 #define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
 #endif
+#ifndef ENABLE_MOUSE_INPUT
+#define ENABLE_MOUSE_INPUT 0x0010
+#endif
+#ifndef ENABLE_EXTENDED_FLAGS
+#define ENABLE_EXTENDED_FLAGS 0x0080
+#endif
 
 #define CURSOR_SIZE_SMALL     25
 #define CURSOR_SIZE_LARGE     100
@@ -367,6 +373,7 @@ static void uv__tty_capture_initial_style(
 int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   DWORD flags;
   DWORD try_set_flags;
+  DWORD current_mode;
   unsigned char was_reading;
   uv_alloc_cb alloc_cb;
   uv_read_cb read_cb;
@@ -391,6 +398,17 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
       /* fallthrough */
     case UV_TTY_MODE_RAW:
       flags = ENABLE_WINDOW_INPUT;
+      /*
+       * Raw mode only needs to clear the line discipline flags (echo, line
+       * input and processed input). Other input flags the application has
+       * enabled, in particular ENABLE_MOUSE_INPUT and ENABLE_EXTENDED_FLAGS,
+       * are orthogonal to cooked versus raw input and must be preserved.
+       * Otherwise entering raw mode silently turns off mouse reporting for
+       * TUI applications. See https://github.com/libuv/libuv/issues/4979.
+       */
+      if (GetConsoleMode(tty->handle, &current_mode)) {
+        flags |= current_mode & (ENABLE_MOUSE_INPUT | ENABLE_EXTENDED_FLAGS);
+      }
       break;
     case UV_TTY_MODE_IO:
       return UV_ENOTSUP;


### PR DESCRIPTION
### Summary

`uv_tty_set_mode()` sets a fixed flag set when entering raw mode:

```c
case UV_TTY_MODE_RAW:
  flags = ENABLE_WINDOW_INPUT;
```

and then calls `SetConsoleMode(tty->handle, flags | try_set_flags)`. Because it writes a fixed value instead of building on the current console mode, it clears `ENABLE_MOUSE_INPUT` and `ENABLE_EXTENDED_FLAGS`. A TUI application that enabled mouse input loses mouse reporting as soon as it puts stdin into raw mode.

This is the libuv side of oven-sh/bun#25663 (mouse input stops working in TUI apps on Windows after entering raw mode), which was traced to this function and filed here as #4979.

### Change

Read the current console mode with `GetConsoleMode()` and preserve `ENABLE_MOUSE_INPUT` and `ENABLE_EXTENDED_FLAGS`, which are orthogonal to the cooked versus raw line discipline, when computing the raw flag set. `NORMAL` and the VT input path are unchanged. Redirected (non-console) stdin is unaffected because `GetConsoleMode()` fails on a non-console handle, so the preserve step is skipped.

### Verification

This is a draft for review. The change is confined to the raw mode branch of `uv_tty_set_mode()`; `NORMAL` and VT input behavior are unchanged. libuv CI builds and runs the TTY tests on Windows for this PR. I can add a focused test (enable `ENABLE_MOUSE_INPUT`, enter raw mode, assert the flag survives) if that is the preferred shape.

Refs: https://github.com/libuv/libuv/issues/4979
