### PR TITLE
win,tty: validate cached console mode before fast path

### DIFF
--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -367,6 +367,7 @@ static void uv__tty_capture_initial_style(
 int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   DWORD flags;
   DWORD try_set_flags;
+  DWORD current_mode;
   unsigned char was_reading;
   uv_alloc_cb alloc_cb;
   uv_read_cb read_cb;
@@ -374,10 +375,6 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
 
   if (!(tty->flags & UV_HANDLE_TTY_READABLE)) {
     return UV_EINVAL;
-  }
-
-  if ((int)mode == tty->tty.rd.mode.mode) {
-    return 0;
   }
 
   try_set_flags = 0;
@@ -396,6 +393,26 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
       return UV_ENOTSUP;
     default:
       return UV_EINVAL;
+  }
+
+  /*
+   * Take the fast path only when the requested mode matches the mode we last
+   * set and the console still reflects it. A process that inherited the
+   * console, for example a spawned child, can switch it back to cooked mode
+   * behind our back. In that case the cached mode is stale and skipping
+   * SetConsoleMode() would leave the console in the wrong mode. Compare only
+   * the flags this function manages so that unrelated flags set by the
+   * application do not force a redundant re-apply.
+   * See https://github.com/libuv/libuv/issues/1292.
+   */
+  if ((int)mode == tty->tty.rd.mode.mode &&
+      GetConsoleMode(tty->handle, &current_mode)) {
+    DWORD managed = current_mode &
+        (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT |
+         ENABLE_WINDOW_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT);
+    if (managed == (flags | try_set_flags) || managed == flags) {
+      return 0;
+    }
   }
 
   /* If currently reading, stop, and restart reading. */


### PR DESCRIPTION
### Summary

`uv_tty_set_mode()` caches the last mode it applied and returns early when the same mode is requested again:

```c
if ((int)mode == tty->tty.rd.mode.mode) {
  return 0;
}
```

It never re-checks the OS. When another process that shares the console changes the mode (the original report in #1292 is a pty slave; on Windows the common trigger is a spawned child that inherited stdin and switched the console back to cooked mode, described in oven-sh/bun#31750), the cached value is stale and a later `uv_tty_set_mode()` with the same mode is a silent no-op. The console is left in the wrong mode, and the application cannot get raw mode back without toggling through another mode first.

### Change

Move the mode-to-flags computation ahead of the early return, then take the fast path only when the cached mode matches and the live console mode still reflects it. Only the flags this function manages are compared (`ENABLE_ECHO_INPUT`, `ENABLE_LINE_INPUT`, `ENABLE_PROCESSED_INPUT`, `ENABLE_WINDOW_INPUT`, `ENABLE_VIRTUAL_TERMINAL_INPUT`), so unrelated flags the application set do not force a redundant re-apply. When the OS state has drifted, the call falls through and re-applies the requested mode, which also restarts reading as before.

One behavior change worth calling out: because the mode validity check now runs before the early return, an invalid mode value is rejected with `UV_EINVAL` even if it happens to equal the cached mode, instead of returning 0. That looks like a small correctness improvement, but flagging it in case it is unwanted.

### Scope

This is a draft and covers the Windows side only, where the self-validating comparison is straightforward because the expected console flags are known. The unix path caches similarly, but reconstructing the expected termios to compare against is harder and is tangled with the underspecified `UV_TTY_MODE_NORMAL` behavior in #3988, so I left it out rather than guess. Feedback welcome on whether you would prefer the force-parameter approach floated in the issue instead of validating against the live mode.

Refs: https://github.com/libuv/libuv/issues/1292
