### PR TITLE
unix: restore prior signal disposition on stop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -634,3 +634,4 @@ Przemysław Sobala <przemyslaw.sobala@grupawp.pl>
 Quaylyn Rimer <31830590+killerdevildog@users.noreply.github.com>
 Yasser Nascimento <dev@yasser.email>
 Rudi Heitbaum <rudi@heitbaum.com>
+Philippe Laporte <philippe@distributive.network>

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -32,6 +32,27 @@
 # define SA_RESTART 0
 #endif
 
+/* Some libcs don't expose NSIG; 65 covers all standard and realtime signals on
+ * the platforms libuv supports. An out-of-range signum simply skips the
+ * save/restore path below and keeps the historical SIG_DFL behaviour.
+ */
+#ifndef NSIG
+# define NSIG 65
+#endif
+
+/* Remembers the signal disposition that was in effect before libuv first
+ * installed uv__signal_handler() for a given signum, so that
+ * uv__signal_unregister_handler() can restore it instead of blindly resetting
+ * to SIG_DFL. Restoring the prior handler is more correct than a reset, and on
+ * platforms where another runtime owns these signals -- e.g. Android's ART,
+ * whose libsigchain logs (and can be destabilised by) any reset of a claimed
+ * signal to SIG_DFL -- it avoids clobbering that handler. Indexed by signum and
+ * only accessed while the global signal lock is held, so it needs no
+ * synchronisation of its own.
+ */
+static struct sigaction uv__signal_saved_sa[NSIG];
+static unsigned char uv__signal_saved[NSIG];
+
 typedef struct {
   uv_signal_t* handle;
   int signum;
@@ -220,9 +241,10 @@ static void uv__signal_handler(int signum) {
 }
 
 
-static int uv__signal_register_handler(int signum, int oneshot) {
+static int uv__signal_register_handler(int signum, int oneshot, int save) {
   /* When this function is called, the signal lock must be held. */
   struct sigaction sa;
+  struct sigaction* oldp;
 
   /* XXX use a separate signal stack? */
   memset(&sa, 0, sizeof(sa));
@@ -233,9 +255,22 @@ static int uv__signal_register_handler(int signum, int oneshot) {
   if (oneshot)
     sa.sa_flags |= SA_RESETHAND;
 
-  /* XXX save old action so we can restore it later on? */
-  if (sigaction(signum, &sa, NULL))
+  /* Save the disposition that was in effect before we install our handler so
+   * uv__signal_unregister_handler() can restore it. `save` is set only on the
+   * transition from "no handler installed" to "handler installed" for this
+   * signum (see uv__signal_start); the oneshot re-registration paths pass
+   * save=0 so they don't overwrite the captured disposition with our own
+   * handler.
+   */
+  oldp = NULL;
+  if (save && signum > 0 && signum < NSIG)
+    oldp = &uv__signal_saved_sa[signum];
+
+  if (sigaction(signum, &sa, oldp))
     return UV__ERR(errno);
+
+  if (oldp != NULL)
+    uv__signal_saved[signum] = 1;
 
   return 0;
 }
@@ -245,8 +280,18 @@ static void uv__signal_unregister_handler(int signum) {
   /* When this function is called, the signal lock must be held. */
   struct sigaction sa;
 
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = SIG_DFL;
+  /* Restore the disposition captured when uv__signal_register_handler() first
+   * installed our handler for this signum, if we have it; otherwise reset to
+   * SIG_DFL as before. Restoring a non-default handler avoids clobbering a
+   * disposition another runtime relies on (e.g. ART's on Android).
+   */
+  if (signum > 0 && signum < NSIG && uv__signal_saved[signum]) {
+    sa = uv__signal_saved_sa[signum];
+    uv__signal_saved[signum] = 0;
+  } else {
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_DFL;
+  }
 
   /* sigaction can only fail with EINVAL or EFAULT; an attempt to deregister a
    * signal implies that it was successfully registered earlier, so EINVAL
@@ -412,7 +457,7 @@ static int uv__signal_start(uv_signal_t* handle,
   first_handle = uv__signal_first_handle(signum);
   if (first_handle == NULL ||
       (!oneshot && (first_handle->flags & UV_SIGNAL_ONE_SHOT))) {
-    err = uv__signal_register_handler(signum, oneshot);
+    err = uv__signal_register_handler(signum, oneshot, first_handle == NULL);
     if (err) {
       /* Registering the signal handler failed. Must be an invalid signal. */
       uv__signal_unlock_and_unblock(&saved_sigmask);
@@ -565,7 +610,7 @@ static void uv__signal_stop(uv_signal_t* handle) {
     rem_oneshot = handle->flags & UV_SIGNAL_ONE_SHOT;
     first_oneshot = first_handle->flags & UV_SIGNAL_ONE_SHOT;
     if (first_oneshot && !rem_oneshot) {
-      ret = uv__signal_register_handler(handle->signum, 1);
+      ret = uv__signal_register_handler(handle->signum, 1, 0);
       assert(ret == 0);
       (void)ret;
     }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -550,6 +550,7 @@ TEST_DECLARE   (we_get_signals_mixed)
 TEST_DECLARE   (signal_multiple_loops)
 TEST_DECLARE   (signal_pending_on_close)
 TEST_DECLARE   (signal_close_loop_alive)
+TEST_DECLARE   (signal_restore_disposition)
 #endif
 #ifdef __APPLE__
 TEST_DECLARE   (osx_select)
@@ -1093,6 +1094,7 @@ TASK_LIST_START
   TEST_ENTRY  (signal_multiple_loops)
   TEST_ENTRY  (signal_pending_on_close)
   TEST_ENTRY  (signal_close_loop_alive)
+  TEST_ENTRY  (signal_restore_disposition)
 #endif
 
 #ifdef __APPLE__

--- a/test/test-signal.c
+++ b/test/test-signal.c
@@ -24,6 +24,7 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+#include <signal.h>
 #endif
 
 TEST_IMPL(kill_invalid_signum) {
@@ -317,6 +318,62 @@ TEST_IMPL(we_get_signals_mixed) {
   ASSERT_EQ(1, sc[1].ncalls);
   ASSERT_OK(sc[2].ncalls);
   ASSERT_EQ(sc[3].ncalls, NSIGNALS);
+
+  MAKE_VALGRIND_HAPPY(loop);
+  return 0;
+}
+
+
+static void signal_restore_signal_cb(uv_signal_t* handle, int signum) {
+  (void) handle;
+  (void) signum;
+}
+
+static void signal_restore_prev_handler(int signum) {
+  /* Sentinel disposition installed before libuv; never actually invoked. */
+  (void) signum;
+}
+
+/* Starting then stopping a signal watcher must restore the signal disposition
+ * that was in effect beforehand, rather than resetting it to SIG_DFL.
+ */
+TEST_IMPL(signal_restore_disposition) {
+  struct sigaction sa;
+  struct sigaction actual;
+  uv_signal_t signal_handle;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+
+  /* Install a non-default disposition for SIGUSR2 before libuv touches it. */
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = signal_restore_prev_handler;
+  ASSERT_OK(sigemptyset(&sa.sa_mask));
+  ASSERT_OK(sigaction(SIGUSR2, &sa, NULL));
+
+  ASSERT_OK(uv_signal_init(loop, &signal_handle));
+  ASSERT_OK(uv_signal_start(&signal_handle, signal_restore_signal_cb, SIGUSR2));
+
+  /* While the watcher is active, libuv's own handler is installed. */
+  memset(&actual, 0, sizeof(actual));
+  ASSERT_OK(sigaction(SIGUSR2, NULL, &actual));
+  ASSERT(actual.sa_handler != signal_restore_prev_handler);
+  ASSERT(actual.sa_handler != SIG_DFL);
+
+  uv_close((uv_handle_t*) &signal_handle, NULL);
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
+
+  /* The last watcher is gone: the previous disposition must be restored, not
+   * reset to SIG_DFL.
+   */
+  memset(&actual, 0, sizeof(actual));
+  ASSERT_OK(sigaction(SIGUSR2, NULL, &actual));
+  ASSERT(actual.sa_handler == signal_restore_prev_handler);
+
+  /* Tidy up: reset SIGUSR2 to its default disposition. */
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = SIG_DFL;
+  ASSERT_OK(sigaction(SIGUSR2, &sa, NULL));
 
   MAKE_VALGRIND_HAPPY(loop);
   return 0;


### PR DESCRIPTION
### What

`uv__signal_unregister_handler()` resets a signal to `SIG_DFL` once its last
watcher is removed, discarding whatever disposition was installed before libuv
added its multiplexer. This resolves libuv's own long-standing
`/* XXX save old action so we can restore it later on? */` TODO: save the
previous disposition when the handler is first installed and restore it on the
last unwatch.

### Why

Resetting to `SIG_DFL` loses the prior handler, which is observably wrong for
any embedder that had its own disposition installed. It is especially harmful
on Android: ART claims `SIGSEGV`/`SIGBUS`/`SIGFPE`/`SIGILL`/`SIGTRAP`/`SIGABRT`
for implicit null-checks, stack-overflow detection, etc., managed through
`libsigchain`. When libuv resets one of these to `SIG_DFL` — which happens on
every embedded `node::FreeEnvironment()` as `UV_SIGNAL` handles are closed —
`libsigchain` emits an ERROR-level stack trace and ART's signal handling can be
left degraded:

```
E libsigchain: Setting SIGSEGV to SIG_DFL
E libsigchain:   #03 ... libnode.so (uv_close+...)
E libsigchain:   #05 ... node::Environment::CleanupHandles()
E libsigchain:   #07 ... node::FreeEnvironment(...)
```

### How

- `uv__signal_register_handler()` gains a `save` parameter and records the
  previous `struct sigaction` into a per-signum table on the genuine
  no-handler → handler transition. The one-shot ↔ regular re-registration
  paths pass `save = 0` so they never overwrite the captured disposition with
  libuv's own handler.
- `uv__signal_unregister_handler()` restores the saved disposition instead of
  forcing `SIG_DFL`, falling back to `SIG_DFL` only when nothing was captured
  (out-of-range signum, or never saved).
- The table is accessed only under the existing global signal lock, so it
  needs no synchronization of its own, and adds no hot-path cost (it runs only
  on the first register / last unregister per signum).

### Tests

Adds `signal_restore_disposition` in `test/test-signal.c` (registered in
`test/test-list.h`): installs a custom `SIGUSR2` handler, starts then stops a
`uv_signal_t`, and asserts the original handler is restored rather than
`SIG_DFL`. The test fails on `v1.x` without this change and passes with it; the
existing signal suite (`we_get_signal*`, `signal_*`, `fork_signal_*`) stays
green.
