### PR TITLE
win: replace monotonicity assertion in 'uv_update_time' for time-clamping workaround

### DIFF
--- a/src/win/core.c
+++ b/src/win/core.c
@@ -324,7 +324,17 @@ fail_metrics_mutex_init:
 
 void uv_update_time(uv_loop_t* loop) {
   uint64_t new_time = uv__hrtime(1000);
-  assert(new_time >= loop->time);
+  /* When a thread migrates between processors whose TSCs are not synchronized,
+   * QueryPerformanceCounter() risks non-monotonicity.
+   *
+   * Although the MSFT docs state that QueryPerformanceCounter() is monotonic,
+   * in practice, we have observed bugs violating this guarantee.
+   * The issue has been reported to Microsoft.
+   *
+   * As a workaround, if we detect non-monotonic time, we dismiss the backwards time
+   * and use the last time read instead. */
+  if (new_time < loop->time)
+    new_time = loop->time;
   loop->time = new_time;
 }
 


### PR DESCRIPTION
**Responds to:** #1633 

**Context:** Users on Windows have reported that their libuv processes may intermittently fail with the following error message:
> Assertion failed: new_time >= loop->time

This error suggests that the [QueryPerformanceCounter](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter) API is returning non-monotonic values, which goes against it's documented behavior [here](https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps) where it reads:

> **Is the performance counter monotonic (non-decreasing)?**
> Yes. QPC does not go backward

Given that the assertion disproves this guarantee, reports of this problem have been closed reporting (correctly) that this represents a bug in Windows. 

**I'm from Microsoft's MSVC C++ compiler team** (👋 ) and our engineering system recently started being affected by these assertion failures. After finding #1633, we reported this issue to the Windows team and are actively helping to them diagnose it. **In our case**, it _appears_ this issue manifests when a thread is moved between cores whose TSCs are, for some reason, not synchronized to guarantee monotonicity. To be clear and to tamper expectations, I can't say that this error we're seeing is the same as the one that others have reported. I also do not know how long the fix will take.

**This PR** aims to provide some relief to Windows libuv users facing this problem. It removes the assertion and instead "manually" guarantees monotonicity by keeping time 'static' if a lower `new_time` reading were to occur. The assumption is that time will eventually catch up and move forward again.

**Why not just wait for Windows to fix this?** Windows has a long release cycles, and servers are rarely in the bleeding edge. In the meantime, users of `libuv` often have very little control to mitigate this issue. I am hoping this PR offears a reasonable workaround with neglible performance impact. I am also happy to iterate and explore alternative ideas :) . 

In the meantime - I will continue pushing the Windows team for a fix of the issue that MSVC is able to reproduce.