### PR TITLE
win,unix: add uv_pipe_open_ex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-connect-multiple.c
        test/test-pipe-connect-prepare.c
        test/test-pipe-getsockname.c
+       test/test-pipe-open-ex.c
        test/test-pipe-pending-instances.c
        test/test-pipe-sendmsg.c
        test/test-pipe-server-close.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -226,6 +226,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-connect-multiple.c \
                          test/test-pipe-connect-prepare.c \
                          test/test-pipe-getsockname.c \
+                         test/test-pipe-open-ex.c \
                          test/test-pipe-pending-instances.c \
                          test/test-pipe-sendmsg.c \
                          test/test-pipe-server-close.c \

--- a/docs/src/pipe.rst
+++ b/docs/src/pipe.rst
@@ -51,6 +51,25 @@ API
         The passed file descriptor or HANDLE is not checked for its type, but
         it's required that it represents a valid pipe.
 
+.. c:function:: int uv_pipe_open_ex(uv_pipe_t* handle, uv_os_fd_t os_handle)
+
+    Open an existing OS handle (a ``HANDLE`` on Windows, a file descriptor on
+    Unix) as a pipe.
+
+    Unlike :c:func:`uv_pipe_open`, which interprets its argument as a CRT file
+    descriptor on Windows, this accepts the native OS handle directly. Use it
+    when you hold a raw ``HANDLE`` that has no associated CRT file descriptor,
+    such as an inherited anonymous pipe handle.
+
+    The handle is owned by the pipe after a successful call and is closed when
+    the pipe is closed with :c:func:`uv_close`.
+
+    .. versionadded:: 1.53.0
+
+    .. note::
+        The passed handle is not checked for its type, but it's required that
+        it represents a valid pipe.
+
 .. c:function:: int uv_pipe_bind(uv_pipe_t* handle, const char* name)
 
     Bind the pipe to a file path (Unix) or a name (Windows).

--- a/include/uv.h
+++ b/include/uv.h
@@ -875,6 +875,7 @@ struct uv_pipe_s {
 
 UV_EXTERN int uv_pipe_init(uv_loop_t*, uv_pipe_t* handle, int ipc);
 UV_EXTERN int uv_pipe_open(uv_pipe_t*, uv_file file);
+UV_EXTERN int uv_pipe_open_ex(uv_pipe_t* handle, uv_os_fd_t os_handle);
 UV_EXTERN int uv_pipe_bind(uv_pipe_t* handle, const char* name);
 UV_EXTERN int uv_pipe_bind2(uv_pipe_t* handle,
                             const char* name,

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -240,6 +240,14 @@ int uv_pipe_open(uv_pipe_t* handle, uv_file fd) {
 }
 
 
+int uv_pipe_open_ex(uv_pipe_t* handle, uv_os_fd_t os_handle) {
+  /* On Unix uv_os_fd_t is a file descriptor, so this is identical to
+   * uv_pipe_open(). The separate entry point exists for Windows, where the
+   * native handle and the CRT file descriptor are distinct namespaces. */
+  return uv_pipe_open(handle, os_handle);
+}
+
+
 void uv_pipe_connect(uv_connect_t* req,
                     uv_pipe_t* handle,
                     const char* name,

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -2439,12 +2439,14 @@ static void eof_timer_close_cb(uv_handle_t* handle) {
 }
 
 
-int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
-  HANDLE os_handle = uv__get_osfhandle(file);
+static int uv__pipe_open_handle(uv_pipe_t* pipe,
+                                HANDLE os_handle,
+                                uv_file file) {
   NTSTATUS nt_status;
   IO_STATUS_BLOCK io_status;
   FILE_ACCESS_INFORMATION access;
   DWORD duplex_flags = 0;
+  int duplicated = 0;
   int err;
 
   if (os_handle == INVALID_HANDLE_VALUE)
@@ -2461,8 +2463,10 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
    * We could also opt to use the original OS handle and just never close it,
    * but then there would be no reliable way to cancel pending read operations
    * upon close.
+   * A file value of -1 means there is no associated fd (e.g. when the handle
+   * was passed directly via uv_pipe_open_ex), so skip the duplication.
    */
-  if (file <= 2) {
+  if (file >= 0 && file <= 2) {
     if (!DuplicateHandle(INVALID_HANDLE_VALUE,
                          os_handle,
                          INVALID_HANDLE_VALUE,
@@ -2473,6 +2477,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
       return uv_translate_sys_error(GetLastError());
     assert(os_handle != INVALID_HANDLE_VALUE);
     file = -1;
+    duplicated = 1;
   }
 
   /* Determine what kind of permissions we have on this handle.
@@ -2505,7 +2510,10 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
                             file,
                             duplex_flags);
   if (err) {
-    if (file == -1)
+    /* Only close the handle if we duplicated it ourselves; a handle passed
+     * in by the caller (uv_pipe_open_ex) remains owned by the caller on
+     * failure. */
+    if (duplicated)
       CloseHandle(os_handle);
     return err;
   }
@@ -2519,6 +2527,18 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
     assert(pipe->pipe.conn.ipc_remote_pid != (DWORD)(uv_pid_t) -1);
   }
   return 0;
+}
+
+
+int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
+  return uv__pipe_open_handle(pipe, uv__get_osfhandle(file), file);
+}
+
+
+int uv_pipe_open_ex(uv_pipe_t* pipe, uv_os_fd_t os_handle) {
+  /* Pass file == -1: there is no CRT fd backing this handle, so libuv takes
+   * ownership of os_handle and closes it directly on uv_close(). */
+  return uv__pipe_open_handle(pipe, os_handle, -1);
 }
 
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -284,6 +284,7 @@ TEST_DECLARE   (pipe_ref4)
 TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
+TEST_DECLARE   (pipe_open_ex)
 TEST_DECLARE   (pipe_set_chmod)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
@@ -647,6 +648,7 @@ TASK_LIST_START
 #endif
   /* Seems to be either about 0.5s or 5s, depending on the OS. */
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
+  TEST_ENTRY  (pipe_open_ex)
   TEST_ENTRY  (pipe_set_chmod)
   TEST_ENTRY  (tty)
 #ifdef _WIN32

--- a/test/test-pipe-open-ex.c
+++ b/test/test-pipe-open-ex.c
@@ -1,0 +1,115 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#include <string.h> /* memcmp, memset */
+#ifndef _WIN32
+#include <unistd.h> /* close */
+#endif
+
+/* Verify that uv_pipe_open_ex() accepts a native OS handle directly.
+ *
+ * On Windows uv_pipe_open() treats its argument as a CRT file descriptor and
+ * converts it to a HANDLE via _get_osfhandle(). A raw HANDLE (e.g. an
+ * inherited anonymous pipe) is in a different namespace and fails with EBADF.
+ * uv_pipe_open_ex() takes the HANDLE as-is. On Unix uv_os_fd_t is the file
+ * descriptor itself, so the call is equivalent to uv_pipe_open().
+ */
+
+#ifdef _WIN32
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT_OK(status);
+  req->handle = NULL; /* signal completion of write_cb */
+}
+#endif
+
+
+TEST_IMPL(pipe_open_ex) {
+  uv_pipe_t pipe_handle;
+  uv_os_fd_t os_handle;
+  uv_buf_t buf;
+  char data[] = "test data";
+  char readbuf[64];
+#ifdef _WIN32
+  HANDLE read_handle;
+  DWORD bytes_read;
+  uv_write_t write_req;
+#else
+  uv_fs_t req;
+  uv_file fd[2];
+  int n;
+#endif
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+
+#ifdef _WIN32
+  /* CreatePipe() returns raw anonymous pipe HANDLEs that have no associated
+   * CRT file descriptor - the exact scenario uv_pipe_open_ex() exists for.
+   * The handles are synchronous, which also exercises the non-overlapped
+   * pipe code path. */
+  ASSERT(CreatePipe(&read_handle, &os_handle, NULL, 0));
+#else
+  ASSERT_OK(uv_pipe(fd, 0, 0));
+  os_handle = fd[1];
+#endif
+
+  /* Open the write end directly from its native OS handle. The handle is
+   * owned by pipe_handle after this call. */
+  ASSERT_OK(uv_pipe_open_ex(&pipe_handle, os_handle));
+  ASSERT_OK(uv_stream_set_blocking((uv_stream_t*) &pipe_handle, 1));
+
+  buf = uv_buf_init(data, sizeof(data));
+#ifdef _WIN32
+  /* uv_try_write() is not implemented for pipes on Windows. */
+  ASSERT_OK(uv_write(&write_req,
+                     (uv_stream_t*) &pipe_handle,
+                     &buf,
+                     1,
+                     write_cb));
+  ASSERT_NOT_NULL(write_req.handle);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_NULL(write_req.handle); /* signaled completion of write_cb */
+#else
+  n = uv_try_write((uv_stream_t*) &pipe_handle, &buf, 1);
+  ASSERT_EQ(n, (int) sizeof(data));
+#endif
+
+  /* Read the data back from the other end and verify it round-trips. */
+  memset(readbuf, 0, sizeof(readbuf));
+#ifdef _WIN32
+  ASSERT(ReadFile(read_handle, readbuf, sizeof(readbuf), &bytes_read, NULL));
+  ASSERT_EQ(bytes_read, (DWORD) sizeof(data));
+#else
+  buf = uv_buf_init(readbuf, sizeof(readbuf));
+  n = uv_fs_read(NULL, &req, fd[0], &buf, 1, -1, NULL);
+  ASSERT_EQ(n, (int) sizeof(data));
+  uv_fs_req_cleanup(&req);
+#endif
+  ASSERT_OK(memcmp(readbuf, data, sizeof(data)));
+
+  uv_close((uv_handle_t*) &pipe_handle, NULL);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+#ifdef _WIN32
+  ASSERT(CloseHandle(read_handle));
+#else
+  ASSERT_OK(close(fd[0]));
+#endif
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}


### PR DESCRIPTION
# win,unix: add uv_pipe_open_ex

Adds `uv_pipe_open_ex()`, which opens a pipe from a native OS handle (`HANDLE` on Windows, file descriptor on Unix).

On Windows, `uv_pipe_open()` interprets its argument as a CRT file descriptor via `_get_osfhandle()`. A raw `HANDLE` with no CRT fd, e.g. an inherited anonymous pipe handle (`CreatePipe`, .NET `AnonymousPipeServerStream`), fails with `UV_EBADF`, and no workaround exists since CRT fds are not inheritable. Implements the approach suggested in this [comment](https://github.com/nodejs/node/issues/57288#issuecomment-2695444117). On Unix the call is equivalent to `uv_pipe_open()`.

The handle is owned by libuv after a successful call; on failure it remains owned by the caller. Test covers a raw `CreatePipe()` handle (no CRT fd, non-overlapped) on Windows.

Refs: https://github.com/nodejs/node/issues/57288