### PR TITLE
unix: drain tty reads on POLLHUP without POLLIN

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1230,8 +1230,16 @@ void uv__stream_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
       !(events & POLLIN) &&
       (stream->read_cb != NULL) &&
       !(stream->flags & UV_HANDLE_READ_EOF)) {
-    uv_buf_t buf = { NULL, 0 };
-    uv__stream_eof(stream, &buf);
+    /* When a PTY reports POLLHUP without POLLIN, there might be still data
+     * buffered. Do one more read instead of signalling EOF immediately.
+     */
+    if (stream->type == UV_TTY) {
+      uv__read(stream);
+    } else {
+      uv_buf_t buf = { NULL, 0 };
+      uv__stream_eof(stream, &buf);
+    }
+
     if (uv__stream_fd(stream) == -1)
       return;  /* read_cb closed stream. */
   }

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -524,7 +524,7 @@ TEST_IMPL(tty_pty_partial) {
   /* This test is not 100% deterministic. If the bug it is testing for is
    * present, then it fails about 1 in 3 times, that's why it runs in a loop.
    */
-  for (i = 0; i < 10; i++) {
+  for (i = 0; i < 1000; i++) {
     if (openpty(&master_fd, &slave_fd, NULL, NULL, NULL))
       RETURN_SKIP("No pty available, skipping.");
 


### PR DESCRIPTION
When a PTY reports POLLHUP without POLLIN, there might be still data buffered. Do one final read instead of signalling EOF immediately.

Also, increase `tty_pty_partial` iterations to make the regression reproduce more reliably.