### PR TITLE
unix: return EINVAL for invalid tty modes

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -284,9 +284,9 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   int fd;
   int rc;
 
-  /* There is only a single raw TTY mode on UNIX. */
   switch (mode) {
     case UV_TTY_MODE_RAW_VT:
+      /* There is only a single raw TTY mode on UNIX. */
       mode = UV_TTY_MODE_RAW;
       break;
     case UV_TTY_MODE_NORMAL:

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -284,9 +284,17 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   int fd;
   int rc;
 
-  if (uv__is_raw_tty_mode(mode)) {
-    /* There is only a single raw TTY mode on UNIX. */
-    mode = UV_TTY_MODE_RAW;
+  /* There is only a single raw TTY mode on UNIX. */
+  switch (mode) {
+    case UV_TTY_MODE_RAW_VT:
+      mode = UV_TTY_MODE_RAW;
+      break;
+    case UV_TTY_MODE_NORMAL:
+    case UV_TTY_MODE_RAW:
+    case UV_TTY_MODE_IO:
+      break;
+    default:
+      return UV_EINVAL;
   }
 
   if (tty->mode == (int) mode)

--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -119,6 +119,9 @@ TEST_IMPL(tty) {
   ASSERT_GT(width, 0);
   ASSERT_GT(height, 0);
 
+  r = uv_tty_set_mode(&tty_in, (uv_tty_mode_t) -1);
+  ASSERT_EQ(r, UV_EINVAL);
+
   /* Turn on raw mode. */
   r = uv_tty_set_mode(&tty_in, UV_TTY_MODE_RAW);
   ASSERT_OK(r);
@@ -442,6 +445,10 @@ TEST_IMPL(tty_pty) {
   ASSERT(uv_is_writable((uv_stream_t*) &slave_tty));
   ASSERT(uv_is_readable((uv_stream_t*) &master_tty));
   ASSERT(uv_is_writable((uv_stream_t*) &master_tty));
+
+  r = uv_tty_set_mode(&slave_tty, (uv_tty_mode_t) -1);
+  ASSERT_EQ(r, UV_EINVAL);
+
   /* Check if the file descriptor was reopened. If it is,
    * UV_HANDLE_BLOCKING_WRITES (value 0x100000) isn't set on flags.
    */


### PR DESCRIPTION
Make the Unix `uv_tty_set_mode()` implementation return `UV_EINVAL` for unrecognized `uv_tty_mode_t` values instead of reaching `UNREACHABLE()`.

The Windows implementation already returns `UV_EINVAL` for invalid TTY modes, so this makes the behavior consistent across platforms and avoids treating caller-provided enum values as unreachable state.

Validation is performed before raw-mode normalization so invalid modes do not touch terminal state.

Refs: https://github.com/nodejs/node/pull/64140

Local verification:

```
cmake -S . -B build -DBUILD_TESTING=ON
cmake --build build --target uv_run_tests -j4
./build/uv_run_tests tty_pty
```

`tty_pty` passed locally. `tty` skipped locally because this environment has no controlling `/dev/tty`.
