### PR TITLE
unix: fix UV_FS_O_DIRECT on more Linux architectures

### DIFF
--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -408,7 +408,7 @@ typedef struct {
 # define UV_FS_O_CREAT        0
 #endif
 
-#if defined(__linux__) && defined(__arm__)
+#if defined(__linux__) && (defined(__arm__) || defined(__aarch64__))
 # define UV_FS_O_DIRECT       0x10000
 #elif defined(__linux__) && defined(__m68k__)
 # define UV_FS_O_DIRECT       0x10000
@@ -416,11 +416,9 @@ typedef struct {
 # define UV_FS_O_DIRECT       0x08000
 #elif defined(__linux__) && defined(__powerpc__)
 # define UV_FS_O_DIRECT       0x20000
-#elif defined(__linux__) && defined(__s390x__)
-# define UV_FS_O_DIRECT       0x04000
-#elif defined(__linux__) && defined(__x86_64__)
-# define UV_FS_O_DIRECT       0x04000
-#elif defined(__linux__) && defined(__loongarch__)
+#elif defined(__linux__) && defined(__sparc__)
+# define UV_FS_O_DIRECT       0x100000
+#elif defined(__linux__)
 # define UV_FS_O_DIRECT       0x04000
 #elif defined(O_DIRECT)
 # define UV_FS_O_DIRECT       O_DIRECT


### PR DESCRIPTION
  The existing architecture mapping missed some Linux targets where  `O_DIRECT` can otherwise fall back to `0`, notably `aarch64`, `i386`, and `riscv`.