### PR TITLE
doc: add UB warning to threading documentation

### DIFF
--- a/docs/src/threading.rst
+++ b/docs/src/threading.rst
@@ -157,6 +157,8 @@ Threads
     The buffer should be large enough to hold the name of the thread plus the trailing NUL, or it will be truncated to fit
     with the trailing NUL.
 
+    It's undefined behavior to call this after the thread has terminated.
+
     Not supported on Windows Server 2016, returns `UV_ENOSYS`.
 
     .. versionadded:: 1.50.0
@@ -171,6 +173,10 @@ Threads
     UV_THREAD_PRIORITY_ABOVE_NORMAL, UV_THREAD_PRIORITY_NORMAL, 
     UV_THREAD_PRIORITY_BELOW_NORMAL, UV_THREAD_PRIORITY_LOWEST.
 
+    It's undefined behavior to call this after the thread has terminated.
+
+    .. versionadded:: 1.48.0
+
 .. c:function:: int uv_thread_getpriority(uv_thread_t tid, int* priority)
 
     If the function succeeds, the return value is 0.
@@ -178,6 +184,10 @@ Threads
     Retrieves the scheduling priority of the thread specified by tid. The value in the
     output parameter priority is platform dependent.
     For Linux, when schedule policy is SCHED_OTHER (default), priority is 0.
+
+    It's undefined behavior to call this after the thread has terminated.
+
+    .. versionadded:: 1.48.0
 
 Thread-local storage
 ^^^^^^^^^^^^^^^^^^^^

--- a/test/test-thread-priority.c
+++ b/test/test-thread-priority.c
@@ -99,11 +99,5 @@ TEST_IMPL(thread_priority) {
 
   uv_sem_destroy(&sem);
 
-  /* Now that the thread no longer exists, verify that the relevant error is returned */
-#if !defined(__ANDROID__)
-  ASSERT_EQ(UV_ESRCH, uv_thread_getpriority(task_id, &priority));
-  ASSERT_EQ(UV_ESRCH, uv_thread_setpriority(task_id, UV_THREAD_PRIORITY_LOWEST));
-#endif
-
   return 0;
 }


### PR DESCRIPTION
It's unsound to call some of the threading functions after the target thread has terminated.

Fixes: https://github.com/libuv/libuv/issues/5117