### PR TITLE
unix,poll: fix callback event bits on error/hangup

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -62,9 +62,16 @@ void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
   /* On error or hangup, mix in events the user is interested in so the
    * appropriate read/write callbacks are invoked. */
-  if (events & (POLLERR | POLLHUP))
-    pevents |=
-      w->pevents & (UV_READABLE | UV_PRIORITIZED | UV_WRITABLE | UV_DISCONNECT);
+  if (events & (POLLERR | POLLHUP)) {
+    if (w->pevents & POLLIN)
+      pevents |= UV_READABLE;
+    if (w->pevents & UV__POLLPRI)
+      pevents |= UV_PRIORITIZED;
+    if (w->pevents & POLLOUT)
+      pevents |= UV_WRITABLE;
+    if (w->pevents & UV__POLLRDHUP)
+      pevents |= UV_DISCONNECT;
+  }
 
   handle->poll_cb(handle, 0, pevents);
 }


### PR DESCRIPTION
Commit 9f0101dcb81b9155e24c18c9dc91a47b3f11c62f (#3250) moved the error/hangup handling for poll watchers from `src/unix/linux.c` into `src/unix/poll.c`'s `uv__poll_io()`.

Before that change, the code operated on backend poll masks:

https://github.com/libuv/libuv/blob/14f6c4cc1f4166f6359b8cd6124501970a6fc2f2/src/unix/linux.c#L1534-L1536

After the move, `w->pevents` was still a backend poll mask, but the new code treated it as public `UV_*` event bits:

https://github.com/libuv/libuv/blob/9f0101dcb81b9155e24c18c9dc91a47b3f11c62f/src/unix/poll.c#L63-L67

This mixes backend `POLL*`/`UV__POLL*` bits with public `UV_*` event bits. On Linux, for example, `POLLOUT` is `0x4`, while `UV_WRITABLE` is `0x2` and `UV_DISCONNECT` is `0x4`. A poll handle interested in writability can therefore receive `UV_DISCONNECT` instead of `UV_WRITABLE` when the backend reports only `POLLHUP` or `POLLERR`.

Fix this by translating the backend poll bits in `w->pevents` back into the corresponding public `UV_*` event bits before adding them to the callback event mask.