### PR TITLE
sunos: use getrandom(2) for uv_random

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
   list(APPEND uv_libraries kstat nsl sendfile socket)
   list(APPEND uv_sources
        src/unix/no-proctitle.c
+       src/unix/random-getrandom.c
        src/unix/sunos.c)
 endif()
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -539,6 +539,7 @@ libuv_la_CFLAGS += -D__EXTENSIONS__ \
                    -D_XOPEN_SOURCE=500 \
                    -D_REENTRANT
 libuv_la_SOURCES += src/unix/no-proctitle.c \
+                    src/unix/random-getrandom.c \
                     src/unix/sunos.c
 endif
 

--- a/src/random.c
+++ b/src/random.c
@@ -42,7 +42,7 @@ static int uv__random(void* buf, size_t buflen) {
     rc = uv__random_devurandom(buf, buflen);
 #elif defined(__NetBSD__)
   rc = uv__random_sysctl(buf, buflen);
-#elif defined(__FreeBSD__) || defined(__linux__)
+#elif defined(__FreeBSD__) || defined(__linux__) || defined(__sun)
   rc = uv__random_getrandom(buf, buflen);
   if (rc == UV_ENOSYS)
     rc = uv__random_devurandom(buf, buflen);


### PR DESCRIPTION
Solaris provides getrandom(2), which is preferred over reading from /dev/urandom directly.

Build the shared getrandom backend on SunOS and select it before falling back to /dev/urandom when the symbol is unavailable.