### PR TITLE
unix: optimize trailing empty write buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-server-close.c
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
+       test/test-pipe-write.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -232,6 +232,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
+                         test/test-pipe-write.c \
                          test/test-platform-output.c \
                          test/test-poll.c \
                          test/test-poll-close.c \

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -702,6 +702,9 @@ static int uv__write_req_update(uv_stream_t* stream,
     n -= len;
   } while (n > 0);
 
+  while (buf < req->bufs + req->nbufs && buf->len == 0)
+    buf++;
+
   req->write_index = buf - req->bufs;
 
   return req->write_index == req->nbufs;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -289,6 +289,7 @@ TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
+TEST_DECLARE   (pipe_write_trailing_empty_buf)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
@@ -876,6 +877,7 @@ TASK_LIST_START
   TEST_ENTRY  (pipe_getsockname_long_path)
   TEST_ENTRY  (pipe_pending_instances)
   TEST_ENTRY  (pipe_sendmsg)
+  TEST_ENTRY  (pipe_write_trailing_empty_buf)
 
   TEST_ENTRY  (connection_fail)
   TEST_ENTRY  (connection_fail_doesnt_auto_close)

--- a/test/test-pipe-write.c
+++ b/test/test-pipe-write.c
@@ -1,0 +1,81 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+
+static int write_cb_called;
+static int close_cb_called;
+
+
+static void close_cb(uv_handle_t* handle) {
+  ASSERT_NOT_NULL(handle);
+  close_cb_called++;
+}
+
+
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT_NOT_NULL(req);
+  ASSERT_OK(status);
+  write_cb_called++;
+  uv_close((uv_handle_t*) req->handle, close_cb);
+}
+
+
+TEST_IMPL(pipe_write_trailing_empty_buf) {
+#ifdef _WIN32
+  RETURN_SKIP("Unix only test");
+#else
+  uv_pipe_t pipe_handle;
+  uv_write_t write_req;
+  uv_buf_t bufs[2];
+  int fd;
+
+  fd = open("/dev/null", O_WRONLY);
+  ASSERT_GE(fd, 0);
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &pipe_handle, 0));
+  ASSERT_OK(uv_pipe_open(&pipe_handle, fd));
+  fd = -1; /* fd is owned by pipe_handle now. */
+
+  bufs[0] = uv_buf_init("hello\n", 6);
+  bufs[1] = uv_buf_init(NULL, 0);
+  ASSERT_OK(uv_write(&write_req,
+                     (uv_stream_t*) &pipe_handle,
+                     bufs,
+                     ARRAY_SIZE(bufs),
+                     write_cb));
+
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, write_cb_called);
+  ASSERT_EQ(1, close_cb_called);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+#endif
+}


### PR DESCRIPTION
## Summary

This fixes the Unix write request bookkeeping when a write completes the last non-empty buffer but the request still has trailing zero-length buffers.

Previously `uv__write_req_update()` stopped on the first trailing empty buffer, left the write request incomplete, and caused the stream code to arm `POLLOUT` even though there were no bytes left to write. For non-pollable descriptors such as the `/dev/null` case reported in #5182, that can abort while trying to register the fd with the loop backend.

The fix advances the write index past empty buffers after accounting for the bytes written, so requests whose remaining buffers are all empty complete immediately.

Fixes #5182.

## Test Plan

- `cmake -S . -B build -G "Unix Makefiles" -DLIBUV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target uv_run_tests -j2`
- `./build/uv_run_tests pipe_write_trailing_empty_buf` *(verified this failed with exit 134 before the fix, then passed after the fix)*
- `./build/uv_run_tests pipe_set_non_blocking`
- `./build/uv_run_tests pipe_sendmsg`
- `./build/uv_run_tests pipe_connect_to_file`
- `./build/uv_run_tests tcp_try_write`
- `./build/uv_run_tests tcp_write_queue_order`
- `cmake --build build --target uv_run_tests_a -j2`
- `./build/uv_run_tests_a pipe_write_trailing_empty_buf`
- `ctest --test-dir build -R '^uv_test$' --output-on-failure`
- `ctest --test-dir build -R '^uv_test_a$' --output-on-failure`
- `git diff --check`
