### PR TITLE
linux: synthesize events for always-ready fds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-pipe-server-close.c
        test/test-pipe-set-fchmod.c
        test/test-pipe-set-non-blocking.c
+       test/test-pipe-dev-null.c
        test/test-platform-output.c
        test/test-poll-close-doesnt-corrupt-stack.c
        test/test-poll-close.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -232,6 +232,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-pipe-close-stdout-read-stdin.c \
                          test/test-pipe-set-non-blocking.c \
                          test/test-pipe-set-fchmod.c \
+                         test/test-pipe-dev-null.c \
                          test/test-platform-output.c \
                          test/test-poll.c \
                          test/test-poll-close.c \

--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -281,16 +281,20 @@ static int compare_watchers(const struct watcher_list* a,
 static void maybe_free_watcher_list(struct watcher_list* w,
                                     uv_loop_t* loop);
 
-static void uv__epoll_ctl_flush(int epollfd,
+static void uv__epoll_ctl_flush(uv_loop_t* loop,
+                                int epollfd,
                                 struct uv__iou* ctl,
                                 struct epoll_event (*events)[256]);
 
-static void uv__epoll_ctl_prep(int epollfd,
+static void uv__epoll_ctl_prep(uv_loop_t* loop,
+                               int epollfd,
                                struct uv__iou* ctl,
                                struct epoll_event (*events)[256],
                                int op,
                                int fd,
                                struct epoll_event* e);
+
+static void uv__epoll_requeue_always_ready(uv_loop_t* loop, int fd);
 
 RB_GENERATE_STATIC(watcher_root, watcher_list, entry, compare_watchers)
 
@@ -1265,7 +1269,8 @@ static void uv__poll_io_uring(uv_loop_t* loop, struct uv__iou* iou) {
  * executed immediately, otherwise the file descriptor may have been closed
  * by the time the kernel starts the operation.
  */
-static void uv__epoll_ctl_prep(int epollfd,
+static void uv__epoll_ctl_prep(uv_loop_t* loop,
+                               int epollfd,
                                struct uv__iou* ctl,
                                struct epoll_event (*events)[256],
                                int op,
@@ -1297,11 +1302,12 @@ static void uv__epoll_ctl_prep(int epollfd,
   sqe->user_data = op | slot << 2 | (int64_t) fd << 32;
 
   if ((*ctl->sqhead & mask) == (*ctl->sqtail & mask))
-    uv__epoll_ctl_flush(epollfd, ctl, events);
+    uv__epoll_ctl_flush(loop, epollfd, ctl, events);
 }
 
 
-static void uv__epoll_ctl_flush(int epollfd,
+static void uv__epoll_ctl_flush(uv_loop_t* loop,
+                                int epollfd,
                                 struct uv__iou* ctl,
                                 struct epoll_event (*events)[256]) {
   struct epoll_event oldevents[256];
@@ -1333,9 +1339,11 @@ static void uv__epoll_ctl_flush(int epollfd,
   memcpy(oldevents, *events, sizeof(*events));
 
   /* Failed submissions are either EPOLL_CTL_DEL commands for file descriptors
-   * that have been closed, or EPOLL_CTL_ADD commands for file descriptors
-   * that we are already watching. Ignore the former and retry the latter
-   * with EPOLL_CTL_MOD.
+   * that have been closed, EPOLL_CTL_ADD commands for file descriptors that
+   * we are already watching, or EPOLL_CTL_ADD commands for descriptors that
+   * epoll refuses because they are always ready (regular files, /dev/null).
+   * Ignore the first, retry the second with EPOLL_CTL_MOD, and fall back to
+   * synthesizing events for the third.
    */
   while (*ctl->cqhead != *ctl->cqtail) {
     slot = (*ctl->cqhead)++ & ctl->cqmask;
@@ -1356,16 +1364,46 @@ static void uv__epoll_ctl_flush(int epollfd,
     if (op != EPOLL_CTL_ADD)
       abort();
 
+    if (cqe->res == -EPERM) {
+      uv__epoll_requeue_always_ready(loop, fd);
+      continue;
+    }
+
     if (cqe->res != -EEXIST)
       abort();
 
-    uv__epoll_ctl_prep(epollfd,
+    uv__epoll_ctl_prep(loop,
+                       epollfd,
                        ctl,
                        events,
                        EPOLL_CTL_MOD,
                        fd,
                        &oldevents[oldslot]);
   }
+}
+
+
+/* The file descriptor cannot be registered with epoll because it is always
+ * ready for I/O (epoll returns EPERM for e.g. regular files and /dev/null).
+ * Put the watcher back on the loop's watcher_queue: uv__io_poll() pre-populates
+ * the events[] array from it every iteration (so its events are synthesized)
+ * and retries the registration on the next tick. Reset w->events so that retry
+ * is an EPOLL_CTL_ADD which keeps failing with EPERM, rather than an
+ * EPOLL_CTL_MOD on a descriptor that was never registered.
+ */
+static void uv__epoll_requeue_always_ready(uv_loop_t* loop, int fd) {
+  uv__io_t* w;
+
+  if (fd < 0 || (unsigned) fd >= loop->nwatchers)
+    return;
+
+  w = loop->watchers[fd];
+  if (w == NULL)
+    return;
+
+  w->events = 0;
+  if (uv__queue_empty(&w->watcher_queue))
+    uv__queue_insert_tail(&loop->watcher_queue, &w->watcher_queue);
 }
 
 
@@ -1380,6 +1418,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   struct uv__iou* iou;
   int real_timeout;
   struct uv__queue* q;
+  struct uv__queue wq;
   uv__io_t* w;
   sigset_t* sigmask;
   sigset_t sigset;
@@ -1390,6 +1429,9 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int epollfd;
   int count;
   int nfds;
+  int nready;
+  int synthesized;
+  int r;
   int fd;
   int op;
   int i;
@@ -1425,8 +1467,13 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
 
   memset(&e, 0, sizeof(e));
 
-  while (!uv__queue_empty(&loop->watcher_queue)) {
-    q = uv__queue_head(&loop->watcher_queue);
+  /* Drain a private copy: always-ready descriptors (see
+   * uv__epoll_requeue_always_ready) get put back on loop->watcher_queue and
+   * must not be reprocessed until the next tick.
+   */
+  uv__queue_move(&loop->watcher_queue, &wq);
+  while (!uv__queue_empty(&wq)) {
+    q = uv__queue_head(&wq);
     w = uv__queue_data(q, uv__io_t, watcher_queue);
     uv__queue_remove(q);
     uv__queue_init(q);
@@ -1447,12 +1494,21 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
     fd = w->fd;
 
     if (ctl->ringfd != -1) {
-      uv__epoll_ctl_prep(epollfd, ctl, &prep, op, fd, &e);
+      uv__epoll_ctl_prep(loop, epollfd, ctl, &prep, op, fd, &e);
       continue;
     }
 
     if (!epoll_ctl(epollfd, op, fd, &e))
       continue;
+
+    /* Always-ready descriptors (regular files, /dev/null, ...) cannot be
+     * registered with epoll; requeue them for retry-and-synthesize instead
+     * of aborting.
+     */
+    if (errno == EPERM) {
+      uv__epoll_requeue_always_ready(loop, fd);
+      continue;
+    }
 
     assert(op == EPOLL_CTL_ADD);
     assert(errno == EEXIST);
@@ -1466,6 +1522,8 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   inv.prep = &prep;
   inv.nfds = -1;
 
+  synthesized = 0;
+
   for (;;) {
     if (loop->nfds == 0)
       if (iou->in_flight == 0)
@@ -1476,23 +1534,70 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
      */
     if (ctl->ringfd != -1)
       while (*ctl->sqhead != *ctl->sqtail)
-        uv__epoll_ctl_flush(epollfd, ctl, &prep);
+        uv__epoll_ctl_flush(loop, epollfd, ctl, &prep);
+
+    /* Descriptors epoll refused as always-ready (regular files, /dev/null)
+     * were parked on loop->watcher_queue. Pre-populate the events[] array with
+     * synthesized events for them and shrink the range handed to epoll_pwait()
+     * accordingly, so the normal dispatch loop delivers them. Do this once,
+     * while the queue still holds only them: later passes of this loop may see
+     * watchers started by an I/O callback, which must not be synthesized. They
+     * stay on the queue so the next tick retries their (failing) registration.
+     */
+    nready = 0;
+    if (!synthesized) {
+      synthesized = 1;
+      /* Take a batch off the head of the queue, but reserve half of events[]
+       * for epoll_pwait() -- so it always gets a healthy number of slots (and
+       * never maxevents == 0) and real descriptors aren't starved. Rotate the
+       * batch to the tail so that, when more descriptors are always-ready than
+       * fit here, later ticks service the ones skipped now (epoll is
+       * level-triggered and round-robins its own overflow the same way).
+       */
+      while ((unsigned) nready < ARRAY_SIZE(events) / 2 &&
+             !uv__queue_empty(&loop->watcher_queue)) {
+        q = uv__queue_head(&loop->watcher_queue);
+        uv__queue_remove(q);
+        w = uv__queue_data(q, uv__io_t, watcher_queue);
+        events[nready].events = w->pevents;
+        events[nready].data.fd = w->fd;
+        nready++;
+        uv__queue_insert_tail(&wq, q);
+      }
+      while (!uv__queue_empty(&wq)) {
+        q = uv__queue_head(&wq);
+        uv__queue_remove(q);
+        uv__queue_insert_tail(&loop->watcher_queue, q);
+      }
+      if (nready > 0)
+        timeout = 0;  /* Always-ready work pending; don't block. */
+    }
 
     uv__io_poll_prepare(loop, NULL, timeout);
-    nfds = epoll_pwait(epollfd, events, ARRAY_SIZE(events), timeout, sigmask);
+    r = epoll_pwait(epollfd,
+                    events + nready,
+                    ARRAY_SIZE(events) - nready,
+                    timeout,
+                    sigmask);
     uv__io_poll_check(loop, NULL);
 
-    if (nfds == -1)
+    if (r == -1)
       assert(errno == EINTR);
-    else if (nfds == 0)
+    else if (r == 0 && nready == 0)
       /* Unlimited timeout should only return with events or signal. */
       assert(timeout != -1);
 
-    if (nfds == 0 || nfds == -1) {
+    /* Fold the synthesized events in front of what epoll_pwait() returned. */
+    nfds = (r < 0 ? 0 : r) + nready;
+
+    if (nfds == 0) {
+      /* Nothing to dispatch: a genuine empty poll (r == 0) returns, EINTR
+       * (r == -1) re-polls.
+       */
       if (reset_timeout != 0) {
         timeout = user_timeout;
         reset_timeout = 0;
-      } else if (nfds == 0) {
+      } else if (r == 0) {
         return;
       }
 
@@ -1609,7 +1714,7 @@ update_timeout:
 
   if (ctl->ringfd != -1)
     while (*ctl->sqhead != *ctl->sqtail)
-      uv__epoll_ctl_flush(epollfd, ctl, &prep);
+      uv__epoll_ctl_flush(loop, epollfd, ctl, &prep);
 }
 
 uint64_t uv__hrtime(uv_clocktype_t type) {

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -289,6 +289,8 @@ TEST_DECLARE   (pipe_close_stdout_read_stdin)
 #endif
 TEST_DECLARE   (pipe_set_non_blocking)
 TEST_DECLARE   (pipe_set_chmod)
+TEST_DECLARE   (pipe_write_dev_null)
+TEST_DECLARE   (pipe_read_dev_null)
 TEST_DECLARE   (process_ref)
 TEST_DECLARE   (process_priority)
 TEST_DECLARE   (has_ref)
@@ -653,6 +655,8 @@ TASK_LIST_START
   /* Seems to be either about 0.5s or 5s, depending on the OS. */
   TEST_ENTRY_CUSTOM (pipe_set_non_blocking, 0, 0, 20000)
   TEST_ENTRY  (pipe_set_chmod)
+  TEST_ENTRY  (pipe_write_dev_null)
+  TEST_ENTRY  (pipe_read_dev_null)
   TEST_ENTRY  (tty)
 #ifdef _WIN32
   TEST_ENTRY  (tty_raw)

--- a/test/test-pipe-dev-null.c
+++ b/test/test-pipe-dev-null.c
@@ -1,0 +1,130 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+/* The null device ("/dev/null" or "NUL") reports as UV_FILE and cannot be
+ * registered with epoll on Linux, which used to abort the event loop. Make
+ * sure both writing to and reading from it through a pipe behave: the write
+ * completes cleanly (even with a trailing zero-length buffer, which used to
+ * arm POLLOUT needlessly) and the read reports EOF.
+ */
+
+static int write_cb_called;
+static int read_cb_called;
+static int close_cb_called;
+static char read_buf[64];
+
+
+static void write_cb(uv_write_t* req, int status) {
+  ASSERT_NOT_NULL(req);
+  ASSERT_OK(status);
+  write_cb_called++;
+}
+
+
+static void close_cb(uv_handle_t* handle) {
+  ASSERT_NOT_NULL(handle);
+  close_cb_called++;
+}
+
+
+static void alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
+  *buf = uv_buf_init(read_buf, sizeof(read_buf));
+}
+
+
+static void read_cb(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
+  /* Reading from the null device yields immediate EOF. */
+  ASSERT_EQ(nread, UV_EOF);
+  read_cb_called++;
+  uv_close((uv_handle_t*) stream, close_cb);
+}
+
+
+static uv_file open_dev_null(int flags) {
+#ifdef _WIN32
+  const char dev_null[] = "NUL";
+#else
+  const char dev_null[] = "/dev/null";
+#endif
+  uv_fs_t fs_req;
+  uv_file fd;
+  int r;
+
+  r = uv_fs_open(NULL, &fs_req, dev_null, flags, 0, NULL);
+  ASSERT_NE(r, -1);
+  fd = (uv_file) fs_req.result;
+  uv_fs_req_cleanup(&fs_req);
+  return fd;
+}
+
+
+TEST_IMPL(pipe_write_dev_null) {
+  uv_pipe_t out;
+  uv_write_t req;
+  uv_buf_t bufs[2];
+
+#ifdef _WIN32
+  RETURN_SKIP("uv_pipe_open() does not accept the NUL device on Windows");
+#endif
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &out, 0));
+  ASSERT_OK(uv_pipe_open(&out, open_dev_null(UV_FS_O_WRONLY)));
+
+  bufs[0] = uv_buf_init("hello\n", 6);
+  bufs[1] = uv_buf_init(NULL, 0);  /* trailing zero-length buffer */
+
+  /* nbufs=2 used to raise SIGABRT on Linux. */
+  ASSERT_OK(uv_write(&req, (uv_stream_t*) &out, bufs, 2, write_cb));
+
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, write_cb_called);
+
+  uv_close((uv_handle_t*) &out, close_cb);
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, close_cb_called);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+
+TEST_IMPL(pipe_read_dev_null) {
+  uv_pipe_t in;
+
+#ifdef _WIN32
+  RETURN_SKIP("uv_pipe_open() does not accept the NUL device on Windows");
+#endif
+
+  ASSERT_OK(uv_pipe_init(uv_default_loop(), &in, 0));
+  ASSERT_OK(uv_pipe_open(&in, open_dev_null(UV_FS_O_RDONLY)));
+
+  ASSERT_OK(uv_read_start((uv_stream_t*) &in, alloc_cb, read_cb));
+
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, read_cb_called);
+  ASSERT_EQ(1, close_cb_called);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}


### PR DESCRIPTION
epoll rejects registration of file descriptors that are always ready for
I/O -- regular files, /dev/null, and similar character devices -- with
EPERM. libuv's io_uring-based epoll_ctl path aborted on that error, so
wrapping such an fd in a uv_pipe_t and reading from or writing to it
crashed the event loop. (uv_guess_handle() reports these as UV_FILE.)

Instead of aborting, park the watcher back on the loop's watcher_queue
and, on every iteration of uv__io_poll(), pre-populate the events[]
array with synthesized events for those descriptors before calling
epoll_pwait() (shrinking its range accordingly) so the normal dispatch
path delivers them. The watchers stay queued, so the next tick retries
the (failing) registration; uv__io_stop() evicts them via
uv__queue_remove() as usual.

The synthesized batch is limited to half of events[] so epoll_pwait() is
never called with maxevents == 0 and ordinary descriptors are not
starved, and the serviced batch is rotated to the tail of the queue so
that, when more descriptors are always-ready than fit at once, later
iterations pick up the ones skipped -- mirroring epoll's own
level-triggered round-robin.

Add test-pipe-dev-null.c covering both reading from and writing to the
null device (the write also exercises a trailing zero-length buffer). It
is skipped on Windows, where uv_pipe_open() does not accept the NUL
device.

Fix for #5182, although technically that is a user error so this is just a robustness change (failure to call uv_guess_handle will lead to UB, generally much worse on Windows than elsewhere).