### PR TITLE
unix: fix static declaration in nested block for AIX and IBM i PASE

### DIFF
--- a/src/unix/async.c
+++ b/src/unix/async.c
@@ -163,6 +163,9 @@ void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 static void uv__async_send(uv_loop_t* loop) {
   int fd;
   int r;
+#if !(defined(__linux__) || UV__KQUEUE_EVFILT_USER)
+  static char buf = '\0';
+#endif
 
 #if defined(__linux__)
   uint64_t val;
@@ -203,7 +206,6 @@ static void uv__async_send(uv_loop_t* loop) {
 #else
   fd = loop->async_wfd;
   do
-    static char buf = '\0';
     r = write(fd, &buf, 1);
   while (r == -1 && errno == EINTR);
 


### PR DESCRIPTION
After [commit](https://github.com/libuv/libuv/commit/076df9f50d74e169d0ed986974d2a4a00f96bc10), on AIX and IBMi we are getting this error:
```c
src/unix/async.c: In function 'uv__async_send':
src/unix/async.c:206:5: error: expected expression before 'static'
  206 |     static char buf = '\0';
      |     ^~~~~~
src/unix/async.c:207:5: error: expected 'while' before 'r'
  207 |     r = write(fd, &buf, 1);
      |     ^
src/unix/async.c:164:7: warning: variable 'fd' set but not used [-Wunused-but-set-variable]
  164 |   int fd;
      |       ^~
make: *** [Makefile:2482: src/unix/libuv_la-async.lo] Error 1

```

gcc on AIX and IBM i (PASE) rejects a static storage-class
declaration inside a nested compound statement block that follows
a prior statement in the outer function body.

Move the `static char buf` declaration to function scope, guarded
by a preprocessor condition so it is only compiled in the fallback
#else path used on AIX, IBM i PASE, and similar platforms.

After building with changes, error is gone on both AIX and IBMi
Test build has passed on AIX - https://ci.nodejs.org/job/libuv-test-commit-aix/3147/
Test build on IBMi where error is gone - https://ci.nodejs.org/job/libuv-test-commit-ibmi/nodes=ibmi74-ppc64/2204/console