### PR TITLE
udp: re-connect a connected handle in place

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -634,3 +634,4 @@ Przemysław Sobala <przemyslaw.sobala@grupawp.pl>
 Quaylyn Rimer <31830590+killerdevildog@users.noreply.github.com>
 Yasser Nascimento <dev@yasser.email>
 Rudi Heitbaum <rudi@heitbaum.com>
+Guy Bedford <guybedford@gmail.com>

--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -245,9 +245,13 @@ API
     Associate the UDP handle to a remote address and port, so every
     message sent by this handle is automatically sent to that destination.
     Calling this function with a `NULL` `addr` disconnects the handle.
-    Trying to call `uv_udp_connect()` on an already connected handle will result
-    in an `UV_EISCONN` error. Trying to disconnect a handle that is not
-    connected will return an `UV_ENOTCONN` error.
+    Calling `uv_udp_connect()` on an already connected handle re-points it at
+    the new peer, keeping the local binding where the platform allows an
+    in-place `connect(2)`. Trying to disconnect a handle that is not connected
+    will return an `UV_ENOTCONN` error.
+
+    .. versionchanged:: 1.53.0 re-connecting a connected handle re-points the
+        peer instead of returning `UV_EISCONN`.
 
     :param handle: UDP handle. Should have been initialized with
         :c:func:`uv_udp_init`.

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -418,6 +418,7 @@ int uv_tcp_connect(uv_connect_t* req,
 
 int uv_udp_connect(uv_udp_t* handle, const struct sockaddr* addr) {
   unsigned int addrlen;
+  int err;
 
   if (handle->type != UV_UDP)
     return UV_EINVAL;
@@ -437,8 +438,19 @@ int uv_udp_connect(uv_udp_t* handle, const struct sockaddr* addr) {
   else
     return UV_EINVAL;
 
-  if (handle->flags & UV_HANDLE_UDP_CONNECTED)
-    return UV_EISCONN;
+  /* Re-point an already connected handle at a new peer. connect(2) allows this
+   * in place, which keeps the local binding intact; some kernels reject a
+   * consecutive connect() (EINVAL), and there a disconnect must come first.
+   * Note that on those platforms disconnect() preserves the bound port anyway,
+   * whereas on Linux a disconnect of an ephemerally bound socket drops it - so
+   * preferring the in-place connect avoids losing the port there. */
+  if (handle->flags & UV_HANDLE_UDP_CONNECTED) {
+    if (uv__udp_connect(handle, addr, addrlen) == 0)
+      return 0;
+    err = uv__udp_disconnect(handle);
+    if (err)
+      return err;
+  }
 
   return uv__udp_connect(handle, addr, addrlen);
 }

--- a/test/test-udp-connect.c
+++ b/test/test-udp-connect.c
@@ -104,6 +104,8 @@ TEST_IMPL(udp_connect) {
   uv_udp_send_t req;
   struct sockaddr_in ext_addr;
   struct sockaddr_in tmp_addr;
+  struct sockaddr_in local_addr;
+  struct sockaddr_in reconnect_addr;
   int r;
   int addrlen;
 
@@ -139,8 +141,34 @@ TEST_IMPL(udp_connect) {
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
   ASSERT_OK(r);
-  r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
-  ASSERT_EQ(r, UV_EISCONN);
+
+  /* Re-connecting a connected handle re-points the peer in place, keeping the
+   * local binding. connect(2) permits this as long as the source address does
+   * not have to change; where a consecutive connect() is rejected
+   * uv_udp_connect() disconnects first. On Linux a disconnect drops an
+   * ephemerally bound port, so the in-place connect is what preserves it. */
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT_2, &reconnect_addr));
+
+  addrlen = sizeof(local_addr);
+  r = uv_udp_getsockname(&client, (struct sockaddr*) &local_addr, &addrlen);
+  ASSERT_OK(r);
+
+  r = uv_udp_connect(&client, (const struct sockaddr*) &reconnect_addr);
+  ASSERT_OK(r);
+
+  addrlen = sizeof(tmp_addr);
+  r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
+  ASSERT_OK(r);
+  ASSERT_EQ(tmp_addr.sin_port, reconnect_addr.sin_port);
+
+  addrlen = sizeof(tmp_addr);
+  r = uv_udp_getsockname(&client, (struct sockaddr*) &tmp_addr, &addrlen);
+  ASSERT_OK(r);
+  ASSERT_EQ(tmp_addr.sin_port, local_addr.sin_port);
+
+  /* Re-point back at the server for the remainder of the test. */
+  r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
+  ASSERT_OK(r);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);

--- a/test/test-udp-connect6.c
+++ b/test/test-udp-connect6.c
@@ -104,6 +104,8 @@ TEST_IMPL(udp_connect6) {
   uv_udp_send_t req;
   struct sockaddr_in6 ext_addr;
   struct sockaddr_in6 tmp_addr;
+  struct sockaddr_in6 local_addr;
+  struct sockaddr_in6 reconnect_addr;
   int r;
   int addrlen;
 
@@ -142,8 +144,34 @@ TEST_IMPL(udp_connect6) {
 
   r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
   ASSERT_OK(r);
-  r = uv_udp_connect(&client, (const struct sockaddr*) &ext_addr);
-  ASSERT_EQ(r, UV_EISCONN);
+
+  /* Re-connecting a connected handle re-points the peer in place, keeping the
+   * local binding. connect(2) permits this as long as the source address does
+   * not have to change; where a consecutive connect() is rejected
+   * uv_udp_connect() disconnects first. On Linux a disconnect drops an
+   * ephemerally bound port, so the in-place connect is what preserves it. */
+  ASSERT_OK(uv_ip6_addr("::1", TEST_PORT_2, &reconnect_addr));
+
+  addrlen = sizeof(local_addr);
+  r = uv_udp_getsockname(&client, (struct sockaddr*) &local_addr, &addrlen);
+  ASSERT_OK(r);
+
+  r = uv_udp_connect(&client, (const struct sockaddr*) &reconnect_addr);
+  ASSERT_OK(r);
+
+  addrlen = sizeof(tmp_addr);
+  r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);
+  ASSERT_OK(r);
+  ASSERT_EQ(tmp_addr.sin6_port, reconnect_addr.sin6_port);
+
+  addrlen = sizeof(tmp_addr);
+  r = uv_udp_getsockname(&client, (struct sockaddr*) &tmp_addr, &addrlen);
+  ASSERT_OK(r);
+  ASSERT_EQ(tmp_addr.sin6_port, local_addr.sin6_port);
+
+  /* Re-point back at the server for the remainder of the test. */
+  r = uv_udp_connect(&client, (const struct sockaddr*) &lo_addr);
+  ASSERT_OK(r);
 
   addrlen = sizeof(tmp_addr);
   r = uv_udp_getpeername(&client, (struct sockaddr*) &tmp_addr, &addrlen);


### PR DESCRIPTION
This allows re-connecting a connected socket, allowing the ability to retain an ephemeral port across a reconnect (as originally described in libuv/leps#10). It works by trying the repeated `connect(2)`, and only if rejected then falling back to the disconnect-then-connect path.

While it does change `uv_udp_connect()` to no longer return `UV_EISCONN` on a connected handle when this is successful, direct callers like Node.js should already guard `connect()` to reject reconnects, so it is not a breaking change for Node.js.

`test-udp-connect` / `test-udp-connect6` now assert the re-connect succeeds and the local port is preserved; the full suite passes.