### PR TITLE
solaris: fix build and test failures, add CI

### DIFF
--- a/.github/workflows/CI-solaris.yml
+++ b/.github/workflows/CI-solaris.yml
@@ -1,0 +1,46 @@
+name: CI-solaris
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-solaris.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-solaris:
+    runs-on: ubuntu-24.04
+    name: Build and test on Solaris
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Build and test
+        uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1.3.7
+        with:
+          release: '11.4-gcc'
+          usesh: true
+          copyback: false
+          prepare: uname -a
+          run: |
+            set -e -u -x
+            export LANG=C
+            export LC_ALL=C
+
+            ./autogen.sh
+            mkdir build
+            cd build
+            ../configure
+            gmake -j2
+            useradd -m -s /usr/bin/sh libuvci
+            # Keep source and destination ownership consistent for fs_copyfile.
+            ci_group=$(id -gn libuvci)
+            chown -R "libuvci:$ci_group" "$GITHUB_WORKSPACE"
+            su - libuvci -c "cd '$GITHUB_WORKSPACE/build' && gmake check"

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -42,6 +42,10 @@
 #elif defined(_AIX)
 #define _PATH_DEFPATH "/opt/freeware/bin:/usr/bin:/bin"
 #endif
+/* Some platforms (e.g. Solaris) do not define this in <paths.h>. */
+#ifndef _PATH_DEFPATH
+#define _PATH_DEFPATH "/usr/bin:/bin"
+#endif
 #ifndef NAME_MAX
 #define NAME_MAX 255
 #endif

--- a/src/unix/sunos.c
+++ b/src/unix/sunos.c
@@ -162,7 +162,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int count;
   int err;
   int fd;
-  int user_timeout;
+  int user_timeout = 0;
   int reset_timeout;
 
   if (loop->nfds == 0) {

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -154,7 +154,8 @@ static void fs_event_cb_del_dir(uv_fs_event_t* handle,
   ASSERT_OK(status);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
   /* The filename may be NULL when it cannot be determined. */
-  ASSERT(filename == NULL || strcmp(filename, "watch_del_dir") == 0);
+  if (filename != NULL)
+    ASSERT_STR_EQ(filename, "watch_del_dir");
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }

--- a/test/test-fs-event.c
+++ b/test/test-fs-event.c
@@ -153,14 +153,8 @@ static void fs_event_cb_del_dir(uv_fs_event_t* handle,
   ASSERT_PTR_EQ(handle, &fs_event);
   ASSERT_OK(status);
   ASSERT(events == UV_CHANGE || events == UV_RENAME);
-  /* There is a bug in the FreeBSD kernel where the filename is sometimes NULL.
-   * Refs: https://github.com/libuv/libuv/issues/4606
-   */
-  #if defined(__FreeBSD__)
+  /* The filename may be NULL when it cannot be determined. */
   ASSERT(filename == NULL || strcmp(filename, "watch_del_dir") == 0);
-  #else
-  ASSERT_OK(strcmp(filename, "watch_del_dir"));
-  #endif
   ASSERT_OK(uv_fs_event_stop(handle));
   uv_close((uv_handle_t*)handle, close_cb);
 }


### PR DESCRIPTION
Fix the Solaris build when <paths.h> does not define _PATH_DEFPATH, and initialize the event-loop timeout to silence a Solaris compiler warning.

Fix the Solaris fs_event_watch_delete_dir test crash by accepting NULL filenames from the fs-event callback; the backend uses NULL when it cannot determine a name.

Run the Solaris tests as a temporary non-root user. Make the checked-out tree owned by that user so fs_copyfile compares matching source and destination group IDs. Keep the workflow dependency-free because the Solaris VM image already includes the required build tools, and trigger it for the solaris branch as well as the usual branches.