### PR TITLE
linux: use scaling_max_freq in uv_cpu_info()

### DIFF
--- a/src/unix/linux.c
+++ b/src/unix/linux.c
@@ -1879,8 +1879,13 @@ nocpuinfo:
       continue;
 
     n++;
+    /* Use scaling_max_freq, not scaling_cur_freq: reading the latter takes
+     * ~20ms per core on some AMD CPUs because the ACPI cpufreq driver does
+     * a slow SMM round-trip on every read; scaling_max_freq is a plain
+     * policy value and, unlike cpuinfo_cur_freq, is world-readable.
+     */
     snprintf(buf, sizeof(buf),
-             "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", cpu);
+             "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_max_freq", cpu);
 
     fp = uv__open_file(buf);
     if (fp == NULL)


### PR DESCRIPTION
Takes over #5036, which has stalled. Implements the `scaling_max_freq` approach suggested in that thread.

On some modern AMD CPUs (EPYC, Ryzen), every read of `scaling_cur_freq` makes the ACPI cpufreq driver do a slow round-trip through SMM, costing ~20ms per core — amplified inside containers. On a 32-core EPYC this makes a single `uv_cpu_info()` call take 500–600ms. I reported this against Node.js in https://github.com/nodejs/node/issues/61998, with an strace showing the individual `scaling_cur_freq` reads each taking ~20ms.

The reported speed now reflects the max frequency the governor currently allows rather than a point-in-time sample - the trade-off discussed and accepted in #5036. This seems like the simplest solution, but happy to implement a fallback-type solution as per #5036 if preferred.

I've included @RajeshKumar11 in the attribution for this commit too, as per the original PR.

Fixes: https://github.com/libuv/libuv/issues/4098
Fixes: https://github.com/libuv/libuv/issues/5110
Refs: https://github.com/nodejs/node/issues/61998
Closes: https://github.com/libuv/libuv/pull/5036