### PR TITLE
darwin: close select fallback fd

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1575,7 +1575,6 @@ void uv__stream_close(uv_stream_t* handle) {
     uv_sem_destroy(&s->async_sem);
     if (s->fd > STDERR_FILENO)
       uv__close(s->fd);
-    uv__close(s->fake_fd);
     uv__close(s->int_fd);
     uv_close((uv_handle_t*) &s->async, uv__stream_osx_cb_close);
 

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1573,6 +1573,8 @@ void uv__stream_close(uv_stream_t* handle) {
     uv_thread_join(&s->thread);
     uv_sem_destroy(&s->close_sem);
     uv_sem_destroy(&s->async_sem);
+    if (s->fd > STDERR_FILENO)
+      uv__close(s->fd);
     uv__close(s->fake_fd);
     uv__close(s->int_fd);
     uv_close((uv_handle_t*) &s->async, uv__stream_osx_cb_close);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -566,6 +566,7 @@ TEST_DECLARE   (signal_close_loop_alive)
 #ifdef __APPLE__
 TEST_DECLARE   (osx_select)
 TEST_DECLARE   (osx_select_many_fds)
+TEST_DECLARE   (osx_select_close)
 #endif
 HELPER_DECLARE (tcp4_echo_server)
 HELPER_DECLARE (tcp6_echo_server)
@@ -1122,6 +1123,7 @@ TASK_LIST_START
 #ifdef __APPLE__
   TEST_ENTRY (osx_select)
   TEST_ENTRY (osx_select_many_fds)
+  TEST_ENTRY (osx_select_close)
 #endif
 
   TEST_FS_ENTRY  (fs_file_noent)

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -26,6 +26,8 @@
 
 #include <sys/ioctl.h>
 #include <string.h>
+#include <unistd.h>
+#include <util.h>
 
 static int read_count;
 
@@ -134,6 +136,42 @@ TEST_IMPL(osx_select_many_fds) {
   ASSERT_EQ(3, read_count);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+
+TEST_IMPL(osx_select_close) {
+  int master_fd;
+  int slave_fd;
+  int tty_fd;
+  uv_os_fd_t handle_fd;
+  uv_tty_t tty;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+
+  ASSERT_PTR_NE(SIG_ERR, signal(SIGHUP, SIG_IGN));
+  ASSERT_OK(openpty(&master_fd, &slave_fd, NULL, NULL, NULL));
+  ASSERT_NE(-1, setsid());
+  ASSERT_OK(ioctl(slave_fd, TIOCSCTTY, 0));
+  tty_fd = open("/dev/tty", O_RDONLY);
+  ASSERT_GE(tty_fd, 0);
+  ASSERT_OK(uv_tty_init(loop, &tty, tty_fd, 1));
+  ASSERT_OK(uv_fileno((uv_handle_t*) &tty, &handle_fd));
+  ASSERT_NE(tty_fd, handle_fd);
+  ASSERT_OK(close(tty_fd));
+
+  uv_close((uv_handle_t*) &tty, NULL);
+  ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));
+
+  errno = 0;
+  ASSERT_EQ(-1, fcntl(handle_fd, F_GETFD));
+  ASSERT_EQ(EBADF, errno);
+
+  ASSERT_OK(close(master_fd));
+  ASSERT_OK(close(slave_fd));
+  ASSERT_PTR_NE(SIG_ERR, signal(SIGHUP, SIG_DFL));
+  MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }
 

--- a/test/test-osx-select.c
+++ b/test/test-osx-select.c
@@ -148,18 +148,28 @@ TEST_IMPL(osx_select_close) {
   uv_tty_t tty;
   uv_loop_t* loop;
 
-  loop = uv_default_loop();
-
   ASSERT_PTR_NE(SIG_ERR, signal(SIGHUP, SIG_IGN));
   ASSERT_OK(openpty(&master_fd, &slave_fd, NULL, NULL, NULL));
-  ASSERT_NE(-1, setsid());
+
+  /* A new session is needed to acquire the pty as controlling terminal, but
+   * setsid() fails when this process is already a process group leader. That
+   * happens when the runner executes the test in-process instead of in a
+   * child process, so skip rather than fail.
+   */
+  if (setsid() == -1) {
+    ASSERT_OK(close(master_fd));
+    ASSERT_OK(close(slave_fd));
+    ASSERT_PTR_NE(SIG_ERR, signal(SIGHUP, SIG_DFL));
+    RETURN_SKIP("Cannot create a new session, already a group leader.");
+  }
+
   ASSERT_OK(ioctl(slave_fd, TIOCSCTTY, 0));
+  loop = uv_default_loop();
   tty_fd = open("/dev/tty", O_RDONLY);
   ASSERT_GE(tty_fd, 0);
   ASSERT_OK(uv_tty_init(loop, &tty, tty_fd, 1));
   ASSERT_OK(uv_fileno((uv_handle_t*) &tty, &handle_fd));
   ASSERT_NE(tty_fd, handle_fd);
-  ASSERT_OK(close(tty_fd));
 
   uv_close((uv_handle_t*) &tty, NULL);
   ASSERT_OK(uv_run(loop, UV_RUN_DEFAULT));


### PR DESCRIPTION
The Darwin select fallback keeps the original stream descriptor in `s->fd` while the I/O watcher uses a socketpair. Stream cleanup joins the selector thread and closes the socketpair, but did not close that original descriptor.

In this changeset, we close it after the thread has exited, with the same standard-descriptor guard used by the normal stream cleanup path.

The regression test creates a PTY and controlling terminal, initializes a TTY handle, closes it, and verifies that the fallback descriptor is no longer valid. It does not depend on an interactive test runner.

Tests:

- `cmake --build build --parallel 2`
- `./build/uv_run_tests osx_select_close`
- `./build/uv_run_tests`
- `./build/uv_run_tests_a`