### PR TITLE
test: close file descriptors leaked by tests

### DIFF
--- a/test/test-fork.c
+++ b/test/test-fork.c
@@ -161,6 +161,10 @@ TEST_IMPL(fork_socketpair) {
     ASSERT_EQ(1, socket_cb_called);
   }
 
+  /* uv_poll_init() does not take ownership of the socket. */
+  ASSERT_OK(close(socket_fds[0]));
+  ASSERT_OK(close(socket_fds[1]));
+
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -229,6 +233,12 @@ TEST_IMPL(fork_socketpair_started) {
     ASSERT_OK(strcmp("hi\n", socket_cb_read_buf));
   }
 
+  /* uv_poll_init() does not take ownership of the socket. */
+  ASSERT_OK(close(socket_fds[0]));
+  ASSERT_OK(close(socket_fds[1]));
+  ASSERT_OK(close(sync_pipe[0]));
+  ASSERT_OK(close(sync_pipe[1]));
+
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
@@ -291,6 +301,9 @@ TEST_IMPL(fork_signal_to_child) {
     ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_ONCE));
     ASSERT_EQ(SIGUSR1, fork_signal_cb_called);
   }
+
+  ASSERT_OK(close(sync_pipe[0]));
+  ASSERT_OK(close(sync_pipe[1]));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
@@ -370,6 +383,11 @@ TEST_IMPL(fork_signal_to_child_closed) {
      */
     exit(0);
   }
+
+  ASSERT_OK(close(sync_pipe[0]));
+  ASSERT_OK(close(sync_pipe[1]));
+  ASSERT_OK(close(sync_pipe2[0]));
+  ASSERT_OK(close(sync_pipe2[1]));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -470,6 +470,8 @@ static void open_cb(uv_fs_t* req) {
 
 
 static void open_cb_simple(uv_fs_t* req) {
+  uv_fs_t close_req;
+
   ASSERT_EQ(req->fs_type, UV_FS_OPEN);
   if (req->result < 0) {
     fprintf(stderr, "async open error: %d\n", (int) req->result);
@@ -477,6 +479,8 @@ static void open_cb_simple(uv_fs_t* req) {
   }
   open_cb_count++;
   ASSERT(req->path);
+  ASSERT_OK(uv_fs_close(NULL, &close_req, (uv_file) req->result, NULL));
+  uv_fs_req_cleanup(&close_req);
   uv_fs_req_cleanup(req);
 }
 
@@ -1376,6 +1380,10 @@ static int test_sendfile(void (*setup)(int), uv_fs_cb cb, size_t expected_size) 
     ASSERT_GE(req.result, 0);
     ASSERT_EQ(buf1[0], 'e'); /* 'e' from begin */
     uv_fs_req_cleanup(&req);
+
+    r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+    ASSERT_OK(r);
+    uv_fs_req_cleanup(&close_req);
   } else {
     ASSERT_UINT64_EQ(s1.st_size, s2.st_size);
   }
@@ -1686,6 +1694,8 @@ TEST_FS_IMPL(fs_fstat_st_dev) {
       S_IWUSR | S_IRUSR, NULL);
   ASSERT_GE(r, 0);
   ASSERT_GE(req.result, 0);
+  uv_fs_req_cleanup(&req);
+  ASSERT_OK(uv_fs_close(NULL, &req, r, NULL));
   uv_fs_req_cleanup(&req);
 
   // Create a symlink
@@ -3093,6 +3103,8 @@ TEST_FS_IMPL(fs_futime) {
   ASSERT_EQ(1, futime_cb_count);
 
   /* Cleanup. */
+  ASSERT_OK(uv_fs_close(NULL, &req, file, NULL));
+  uv_fs_req_cleanup(&req);
   unlink(path);
 
   MAKE_VALGRIND_HAPPY(loop);

--- a/test/test-metrics.c
+++ b/test/test-metrics.c
@@ -307,6 +307,7 @@ static void fs_addrinfo_cb(uv_getaddrinfo_t* req,
 
 TEST_IMPL(metrics_pool_events) {
   uv_buf_t iov;
+  uv_fs_t close_req;
   uv_fs_t open_req;
   uv_fs_t stat1_req;
   uv_fs_t stat2_req;
@@ -381,6 +382,9 @@ TEST_IMPL(metrics_pool_events) {
    * execute before sleep completes. */
   ASSERT_GE(metrics.events_waiting, 4);
   ASSERT_EQ(pool_events_counter, -42);
+
+  ASSERT_OK(uv_fs_close(NULL, &close_req, fd, NULL));
+  uv_fs_req_cleanup(&close_req);
 
   uv_fs_unlink(NULL, &unlink_req, "test_file", NULL);
   uv_fs_req_cleanup(&unlink_req);

--- a/test/test-pipe-close-stdout-read-stdin.c
+++ b/test/test-pipe-close-stdout-read-stdin.c
@@ -81,6 +81,8 @@ TEST_IMPL(pipe_close_stdout_read_stdin) {
     close(0);
     r = dup(fd[0]);
     ASSERT_NE(r, -1);
+    /* fd 0 is the descriptor uv_pipe_open() takes over below. */
+    ASSERT_OK(close(fd[0]));
 
     /* Create a stream that reads from the pipe. */
     r = uv_pipe_init(uv_default_loop(), (uv_pipe_t *)&stdin_pipe, 0);

--- a/test/test-pipe-sendmsg.c
+++ b/test/test-pipe-sendmsg.c
@@ -156,7 +156,11 @@ TEST_IMPL(pipe_sendmsg) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_EQ(ARRAY_SIZE(incoming), incoming_count);
   ASSERT_EQ(ARRAY_SIZE(incoming) + 1, close_called);
-  close(fds[0]);
+
+  /* sendmsg() duplicates the descriptors, it does not consume them. */
+  for (i = 0; i < ARRAY_SIZE(send_fds); i++)
+    ASSERT_OK(close(send_fds[i]));
+  ASSERT_OK(close(fds[0]));
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-close.c
+++ b/test/test-poll-close.c
@@ -41,6 +41,16 @@ static void close_cb(uv_handle_t* handle) {
 }
 
 
+/* uv_poll_init_socket() does not take ownership of the socket. */
+static void close_socket(uv_os_sock_t sock) {
+#ifdef _WIN32
+  ASSERT_OK(closesocket(sock));
+#else
+  ASSERT_OK(close(sock));
+#endif
+}
+
+
 TEST_IMPL(poll_close) {
   uv_os_sock_t sockets[NUM_SOCKETS];
   uv_poll_t poll_handles[NUM_SOCKETS];
@@ -67,6 +77,9 @@ TEST_IMPL(poll_close) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT_EQ(close_cb_called, NUM_SOCKETS);
+
+  for (i = 0; i < NUM_SOCKETS; i++)
+    close_socket(sockets[i]);
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-poll-multiple-handles.c
+++ b/test/test-poll-multiple-handles.c
@@ -99,6 +99,13 @@ TEST_IMPL(poll_multiple_handles) {
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_EQ(2, close_cb_called);
 
+  /* uv_poll_init_socket() does not take ownership of the socket. */
+#ifdef _WIN32
+  ASSERT_OK(closesocket(sock));
+#else
+  ASSERT_OK(close(sock));
+#endif
+
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }

--- a/test/test-poll-oob.c
+++ b/test/test-poll-oob.c
@@ -203,6 +203,9 @@ TEST_IMPL(poll_oob) {
    */
   ASSERT_EQ(1, srv_rd_check);
 
+  /* uv_poll_init() does not take ownership of the socket. */
+  ASSERT_OK(close(client_fd));
+
   MAKE_VALGRIND_HAPPY(loop);
   return 0;
 }

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -426,6 +426,7 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file) {
 TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
 #ifndef _WIN32
   int r;
+  int saved_stderr;
   uv_file file;
   uv_fs_t fs_req;
   uv_stdio_container_t stdio[3];
@@ -435,6 +436,13 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   unlink("stdout_file");
 
   init_process_options("spawn_helper6", exit_cb);
+
+  /* This test replaces fd 2, so stash the real stderr and put it back
+   * afterwards. Without that the process ends up with no stderr at all, which
+   * silently swallows the output of any later assertion failure.
+   */
+  saved_stderr = dup(STDERR_FILENO);
+  ASSERT_NE(saved_stderr, -1);
 
   /* Replace stderr with our file */
   r = uv_fs_open(NULL,
@@ -447,6 +455,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   uv_fs_req_cleanup(&fs_req);
   file = dup2(r, STDERR_FILENO);
   ASSERT_NE(file, -1);
+  /* dup2() put a copy on fd 2, the original descriptor is redundant now. */
+  ASSERT_OK(uv_fs_close(NULL, &fs_req, r, NULL));
+  uv_fs_req_cleanup(&fs_req);
 
   options.stdio = stdio;
   options.stdio[0].flags = UV_IGNORE;
@@ -470,9 +481,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
   ASSERT_EQ(27, r);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(NULL, &fs_req, file, NULL);
-  ASSERT_OK(r);
-  uv_fs_req_cleanup(&fs_req);
+  /* Putting the real stderr back also closes the file sitting on fd 2. */
+  ASSERT_NE(-1, dup2(saved_stderr, STDERR_FILENO));
+  ASSERT_OK(close(saved_stderr));
 
   printf("output is: %s", output);
   ASSERT_OK(strcmp("hello world\nhello errworld\n", output));
@@ -491,6 +502,8 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file2) {
 TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
 #ifndef _WIN32
   int r;
+  int saved_stdout;
+  int saved_stderr;
   uv_file stdout_file;
   uv_file stderr_file;
   uv_fs_t fs_req;
@@ -503,6 +516,15 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
 
   init_process_options("spawn_helper6", exit_cb);
 
+  /* This test replaces fds 1 and 2, so stash the real ones and put them back
+   * afterwards. Without that the process ends up with no stdout or stderr at
+   * all, which silently swallows anything printed from here on.
+   */
+  saved_stdout = dup(STDOUT_FILENO);
+  ASSERT_NE(saved_stdout, -1);
+  saved_stderr = dup(STDERR_FILENO);
+  ASSERT_NE(saved_stderr, -1);
+
   /* open 'stdout_file' and replace STDOUT_FILENO with it */
   r = uv_fs_open(NULL,
                  &fs_req,
@@ -514,6 +536,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   uv_fs_req_cleanup(&fs_req);
   stdout_file = dup2(r, STDOUT_FILENO);
   ASSERT_NE(stdout_file, -1);
+  /* dup2() put a copy on fd 1, the original descriptor is redundant now. */
+  ASSERT_OK(uv_fs_close(NULL, &fs_req, r, NULL));
+  uv_fs_req_cleanup(&fs_req);
 
   /* open 'stderr_file' and replace STDERR_FILENO with it */
   r = uv_fs_open(NULL, &fs_req, "stderr_file", O_CREAT | O_RDWR,
@@ -522,6 +547,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   uv_fs_req_cleanup(&fs_req);
   stderr_file = dup2(r, STDERR_FILENO);
   ASSERT_NE(stderr_file, -1);
+  /* dup2() put a copy on fd 2, the original descriptor is redundant now. */
+  ASSERT_OK(uv_fs_close(NULL, &fs_req, r, NULL));
+  uv_fs_req_cleanup(&fs_req);
 
   /* now we're going to swap them: the child process' stdout will be our
    * stderr_file and vice versa */
@@ -549,9 +577,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   ASSERT_GE(r, 15);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(NULL, &fs_req, stdout_file, NULL);
-  ASSERT_OK(r);
-  uv_fs_req_cleanup(&fs_req);
+  /* Putting the real stdout back also closes the file sitting on fd 1. */
+  ASSERT_NE(-1, dup2(saved_stdout, STDOUT_FILENO));
+  ASSERT_OK(close(saved_stdout));
 
   printf("output is: %s", output);
   ASSERT_OK(strncmp("hello errworld\n", output, 15));
@@ -561,9 +589,9 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
   ASSERT_GE(r, 12);
   uv_fs_req_cleanup(&fs_req);
 
-  r = uv_fs_close(NULL, &fs_req, stderr_file, NULL);
-  ASSERT_OK(r);
-  uv_fs_req_cleanup(&fs_req);
+  /* Putting the real stderr back also closes the file sitting on fd 2. */
+  ASSERT_NE(-1, dup2(saved_stderr, STDERR_FILENO));
+  ASSERT_OK(close(saved_stderr));
 
   printf("output is: %s", output);
   ASSERT_OK(strncmp("hello world\n", output, 12));
@@ -1747,6 +1775,11 @@ TEST_IMPL(spawn_fs_open) {
 
   ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
   ASSERT_OK(uv_fs_close(NULL, &fs_req, r, NULL));
+#ifdef _WIN32
+  ASSERT_NE(0, CloseHandle(dup_fd));
+#else
+  ASSERT_OK(close(dup_fd));
+#endif
 
   ASSERT_EQ(1, exit_cb_called);
   ASSERT_EQ(2, close_cb_called);  /* One for `in`, one for process */


### PR DESCRIPTION
None of these leaks affect the library, only the test process, but they stand in the way of checking for descriptor leaks automatically.

Most are simply a missing close: `uv_poll_init()`, `uv_poll_init_socket()` and `sendmsg()` do not take ownership of the descriptor they are handed, and several fs tests never close what they open (knowing process exit closes them).

The `spawn_stdout_and_stderr_to_file2` and
`spawn_stdout_and_stderr_to_file_swap` tests `dup2()` a file over fd stdout and/or stderr then close it, leaving the test process without. Anything printed afterwards - including the output of a failing assertion - would be silently discarded. Save the real descriptors and put them back instead.