### PR TITLE
win: actually cleanup all things on shutdown

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -1144,6 +1144,11 @@ void uv_library_shutdown(void) {
 #else
   uv__threadpool_cleanup();
 #endif
+#ifdef _WIN32
+  /* Last: the threadpool above is joined by now, so nothing is left that could
+   * still be using the process-wide state this releases. */
+  uv__once_cleanup();
+#endif
 }
 
 

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -246,6 +246,10 @@ void uv__timer_close(uv_timer_t* handle);
 
 void uv__process_title_cleanup(void);
 void uv__signal_cleanup(void);
+#ifdef _WIN32
+/* Undo the process-wide setup that uv__once_init() performs. */
+void uv__once_cleanup(void);
+#endif
 void uv__threadpool_cleanup(void);
 
 #define uv__has_active_reqs(loop)                                             \

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -254,7 +254,6 @@ void uv__once_cleanup(void) {
   uv__poll_cleanup();
   uv__process_cleanup();
   uv__detect_system_wakeup_cleanup();
-  uv__signals_cleanup();
   uv__fs_cleanup();
   uv__util_cleanup();
   uv__winsock_cleanup();

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -252,7 +252,10 @@ void uv__once_cleanup(void) {
   uv__console_cleanup();
 
   uv__poll_cleanup();
-  uv__process_cleanup();
+  /* The global job object is deliberately left open. Closing it terminates
+   * every process still assigned to it, which is what should happen when this
+   * process exits, not when it merely stops using libuv.
+   */
   uv__detect_system_wakeup_cleanup();
   uv__fs_cleanup();
   uv__util_cleanup();

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -251,10 +251,18 @@ void uv__once_cleanup(void) {
    * those threads use. */
   uv__console_cleanup();
 
-  uv__poll_cleanup();
-  /* The global job object is deliberately left open. Closing it terminates
-   * every process still assigned to it, which is what should happen when this
-   * process exits, not when it merely stops using libuv.
+  /* Two things are deliberately left for the process to exit with.
+   *
+   * The global job object: closing it terminates every process still assigned
+   * to it, which is what should happen when this process exits, not when it
+   * merely stops using libuv.
+   *
+   * The dummy overlapped and event in poll.c: uv__poll_close() submits a poll
+   * with them and accepts WSA_IO_PENDING, so that operation is not tracked by
+   * the handle, the loop, or anything else. The kernel can still be holding
+   * both when we get here, and reclaiming them under a live operation is how
+   * poll_closesocket died with STATUS_INVALID_HANDLE inside an AppContainer,
+   * where a stale handle raises instead of failing quietly.
    */
   uv__detect_system_wakeup_cleanup();
   uv__fs_cleanup();

--- a/src/win/core.c
+++ b/src/win/core.c
@@ -90,6 +90,15 @@ static void uv__loops_init(void) {
 }
 
 
+static void uv__loops_cleanup(void) {
+  uv__free(uv__loops);
+  uv__loops = NULL;
+  uv__loops_size = 0;
+  uv__loops_capacity = 0;
+  uv_mutex_destroy(&uv__loops_lock);
+}
+
+
 static int uv__loops_add(uv_loop_t* loop) {
   uv_loop_t** new_loops;
   int new_capacity, i;
@@ -221,6 +230,42 @@ static void uv__init(void) {
 
   /* Initialize system wakeup detection */
   uv__init_detect_system_wakeup();
+}
+
+
+void uv__once_cleanup(void) {
+  uv_once_t reset = UV_ONCE_INIT;
+  BOOL pending;
+
+  /* Nothing to undo if uv__init() never completed: uv_library_shutdown() can be
+   * called by a process that never used a loop, and the cleanups below would
+   * destroy locks that were never initialized.
+   */
+  if (!InitOnceBeginInitialize(&uv_init_guard_.init_once,
+                               INIT_ONCE_CHECK_ONLY,
+                               &pending,
+                               NULL))
+    return;
+
+  /* Bring down anything with a thread behind it before releasing the objects
+   * those threads use. */
+  uv__console_cleanup();
+
+  uv__poll_cleanup();
+  uv__process_cleanup();
+  uv__detect_system_wakeup_cleanup();
+  uv__signals_cleanup();
+  uv__fs_cleanup();
+  uv__util_cleanup();
+  uv__winsock_cleanup();
+  uv__thread_cleanup();
+  uv__loops_cleanup();
+
+  /* Let a later uv_loop_init() build all of this again, rather than leaving it
+   * half torn down, even though calling into libuv after
+   * uv_library_shutdown() is documented as not supported.
+   */
+  uv_init_guard_ = reset;
 }
 
 

--- a/src/win/detect-wakeup.c
+++ b/src/win/detect-wakeup.c
@@ -52,6 +52,7 @@ static void uv__register_system_resume_callback(void) {
 
   recipient.Callback = uv__system_resume_callback;
   recipient.Context = NULL;
+  registration_handle = NULL;
   if ((*pPowerRegisterSuspendResumeNotification)(DEVICE_NOTIFY_CALLBACK,
                                                  &recipient,
                                                  &registration_handle) ==

--- a/src/win/detect-wakeup.c
+++ b/src/win/detect-wakeup.c
@@ -23,6 +23,8 @@
 #include "internal.h"
 #include "winapi.h"
 
+static _HPOWERNOTIFY uv__system_wakeup_registration;
+
 static void uv__register_system_resume_callback(void);
 
 void uv__init_detect_system_wakeup(void) {
@@ -50,7 +52,22 @@ static void uv__register_system_resume_callback(void) {
 
   recipient.Callback = uv__system_resume_callback;
   recipient.Context = NULL;
-  (*pPowerRegisterSuspendResumeNotification)(DEVICE_NOTIFY_CALLBACK,
-                                             &recipient,
-                                             &registration_handle);
+  if ((*pPowerRegisterSuspendResumeNotification)(DEVICE_NOTIFY_CALLBACK,
+                                                 &recipient,
+                                                 &registration_handle) ==
+      ERROR_SUCCESS) {
+    uv__system_wakeup_registration = registration_handle;
+  }
+}
+
+
+void uv__detect_system_wakeup_cleanup(void) {
+  if (uv__system_wakeup_registration == NULL)
+    return;
+
+  if (pPowerUnregisterSuspendResumeNotification != NULL)
+    (*pPowerUnregisterSuspendResumeNotification)(
+        uv__system_wakeup_registration);
+
+  uv__system_wakeup_registration = NULL;
 }

--- a/src/win/fs-fd-hash-inl.h
+++ b/src/win/fs-fd-hash-inl.h
@@ -88,6 +88,11 @@ static void uv__fd_hash_init(void) {
   }
 }
 
+
+static void uv__fd_hash_cleanup(void) {
+  uv_mutex_destroy(&uv__fd_hash_mutex);
+}
+
 #define FIND_COMMON_VARIABLES                                                \
   unsigned i;                                                                \
   unsigned bucket = fd % ARRAY_SIZE(uv__fd_hash);                            \

--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -173,6 +173,11 @@ static void fs__stat_assign_statbuf(uv_stat_t* statbuf,
                                     int do_lstat);
 
 
+void uv__fs_cleanup(void) {
+  uv__fd_hash_cleanup();
+}
+
+
 void uv__fs_init(void) {
   SYSTEM_INFO system_info;
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -157,7 +157,6 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle);
 void uv__console_init(void);
 void uv__console_cleanup(void);
 void uv__poll_cleanup(void);
-void uv__process_cleanup(void);
 void uv__thread_cleanup(void);
 
 int uv__tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -155,6 +155,10 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle);
  * TTY
  */
 void uv__console_init(void);
+void uv__console_cleanup(void);
+void uv__poll_cleanup(void);
+void uv__process_cleanup(void);
+void uv__thread_cleanup(void);
 
 int uv__tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
     uv_read_cb read_cb);
@@ -214,6 +218,7 @@ void uv__process_async_wakeup_req(uv_loop_t* loop, uv_async_t* handle,
  * Signal watcher
  */
 void uv__signals_init(void);
+void uv__signals_cleanup(void);
 int uv__signal_dispatch(int signum);
 
 void uv__signal_close(uv_loop_t* loop, uv_signal_t* handle);
@@ -235,6 +240,7 @@ void uv__process_endgame(uv_loop_t* loop, uv_process_t* handle);
  * FS
  */
 void uv__fs_init(void);
+void uv__fs_cleanup(void);
 
 
 /*
@@ -256,6 +262,7 @@ void uv__fs_poll_endgame(uv_loop_t* loop, uv_fs_poll_t* handle);
  * Utilities.
  */
 void uv__util_init(void);
+void uv__util_cleanup(void);
 
 uint64_t uv__hrtime(unsigned int scale);
 __declspec(noreturn) void uv_fatal_error(const int errorno, const char* syscall);
@@ -297,6 +304,7 @@ void uv__winapi_init(void);
  * Winsock utility functions
  */
 void uv__winsock_init(void);
+void uv__winsock_cleanup(void);
 
 int uv__ntstatus_to_winsock_error(NTSTATUS status);
 
@@ -331,6 +339,7 @@ void uv__wake_all_loops(void);
  * Init system wake-up detection
  */
 void uv__init_detect_system_wakeup(void);
+void uv__detect_system_wakeup_cleanup(void);
 
 int uv_translate_write_sys_error(int sys_errno);
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -218,7 +218,6 @@ void uv__process_async_wakeup_req(uv_loop_t* loop, uv_async_t* handle,
  * Signal watcher
  */
 void uv__signals_init(void);
-void uv__signals_cleanup(void);
 int uv__signal_dispatch(int signum);
 
 void uv__signal_close(uv_loop_t* loop, uv_signal_t* handle);

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -156,7 +156,6 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle);
  */
 void uv__console_init(void);
 void uv__console_cleanup(void);
-void uv__poll_cleanup(void);
 void uv__thread_cleanup(void);
 
 int uv__tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -69,20 +69,6 @@ static OVERLAPPED* uv__get_overlapped_dummy(void) {
 }
 
 
-void uv__poll_cleanup(void) {
-  uv_once_t reset = UV_ONCE_INIT;
-  HANDLE event;
-
-  /* The event is stored with its low bit set, see uv__init_overlapped_dummy(). */
-  event = (HANDLE) ((uintptr_t) overlapped_dummy_.hEvent & ~(uintptr_t) 1);
-  if (event != NULL) {
-    CloseHandle(event);
-    memset(&overlapped_dummy_, 0, sizeof(overlapped_dummy_));
-  }
-
-  overlapped_dummy_init_guard_ = reset;
-}
-
 
 static AFD_POLL_INFO* uv__get_afd_poll_info_dummy(void) {
   return &afd_poll_info_dummy_;

--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -69,6 +69,21 @@ static OVERLAPPED* uv__get_overlapped_dummy(void) {
 }
 
 
+void uv__poll_cleanup(void) {
+  uv_once_t reset = UV_ONCE_INIT;
+  HANDLE event;
+
+  /* The event is stored with its low bit set, see uv__init_overlapped_dummy(). */
+  event = (HANDLE) ((uintptr_t) overlapped_dummy_.hEvent & ~(uintptr_t) 1);
+  if (event != NULL) {
+    CloseHandle(event);
+    memset(&overlapped_dummy_, 0, sizeof(overlapped_dummy_));
+  }
+
+  overlapped_dummy_init_guard_ = reset;
+}
+
+
 static AFD_POLL_INFO* uv__get_afd_poll_info_dummy(void) {
   return &afd_poll_info_dummy_;
 }

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -66,23 +66,6 @@ static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
 
 
-void uv__process_cleanup(void) {
-  uv_once_t reset = UV_ONCE_INIT;
-
-  /* Closing this kills every process still assigned to the job, which is the
-   * same thing that happens when the process exits. uv_library_shutdown() is
-   * documented as being called with no loops or requests still active, so any
-   * process we are still responsible for is one nobody is waiting on.
-   */
-  if (uv_global_job_handle_ != NULL) {
-    CloseHandle(uv_global_job_handle_);
-    uv_global_job_handle_ = NULL;
-  }
-
-  uv_global_job_handle_init_guard_ = reset;
-}
-
-
 static void uv__init_global_job_handle(void) {
   /* Create a job object and set it up to kill all contained processes when
    * it's closed. Since this handle is made non-inheritable and we're not

--- a/src/win/process.c
+++ b/src/win/process.c
@@ -66,6 +66,23 @@ static HANDLE uv_global_job_handle_;
 static uv_once_t uv_global_job_handle_init_guard_ = UV_ONCE_INIT;
 
 
+void uv__process_cleanup(void) {
+  uv_once_t reset = UV_ONCE_INIT;
+
+  /* Closing this kills every process still assigned to the job, which is the
+   * same thing that happens when the process exits. uv_library_shutdown() is
+   * documented as being called with no loops or requests still active, so any
+   * process we are still responsible for is one nobody is waiting on.
+   */
+  if (uv_global_job_handle_ != NULL) {
+    CloseHandle(uv_global_job_handle_);
+    uv_global_job_handle_ = NULL;
+  }
+
+  uv_global_job_handle_init_guard_ = reset;
+}
+
+
 static void uv__init_global_job_handle(void) {
   /* Create a job object and set it up to kill all contained processes when
    * it's closed. Since this handle is made non-inheritable and we're not

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -46,14 +46,9 @@ void uv__signals_init(void) {
 }
 
 
-void uv__signals_cleanup(void) {
+void uv__signal_cleanup(void) {
   SetConsoleCtrlHandler(uv__signal_control_handler, FALSE);
   DeleteCriticalSection(&uv__signal_lock);
-}
-
-
-void uv__signal_cleanup(void) {
-  /* TODO(bnoordhuis) Undo effects of uv_signal_init()? */
 }
 
 

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -39,14 +39,26 @@ int uv__signal_start(uv_signal_t* handle,
                      int signum,
                      int oneshot);
 
+/* uv__signal_cleanup() runs whether or not uv__signals_init() ever did, so it
+ * needs to know: uv_library_shutdown() may be called by a process that never
+ * used a loop, and neither the handler nor the lock would exist yet.
+ */
+static int uv__signals_initialized;
+
+
 void uv__signals_init(void) {
   InitializeCriticalSection(&uv__signal_lock);
   if (!SetConsoleCtrlHandler(uv__signal_control_handler, TRUE))
     abort();
+  uv__signals_initialized = 1;
 }
 
 
 void uv__signal_cleanup(void) {
+  if (!uv__signals_initialized)
+    return;
+
+  uv__signals_initialized = 0;
   SetConsoleCtrlHandler(uv__signal_control_handler, FALSE);
   DeleteCriticalSection(&uv__signal_lock);
 }

--- a/src/win/signal.c
+++ b/src/win/signal.c
@@ -46,6 +46,12 @@ void uv__signals_init(void) {
 }
 
 
+void uv__signals_cleanup(void) {
+  SetConsoleCtrlHandler(uv__signal_control_handler, FALSE);
+  DeleteCriticalSection(&uv__signal_lock);
+}
+
+
 void uv__signal_cleanup(void) {
   /* TODO(bnoordhuis) Undo effects of uv_signal_init()? */
 }

--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -56,6 +56,12 @@ void uv_once(uv_once_t* guard, uv__once_cb callback) {
 STATIC_ASSERT(sizeof(uv_thread_t) <= sizeof(void*));
 
 static uv_key_t uv__current_thread_key;
+/* Set for threads whose handle in uv__current_thread_key is a duplicate that
+ * uv_thread_self() made, and so is ours to close. Threads started by
+ * uv_thread_create() store the handle the creator owns, which uv_thread_join()
+ * or uv_thread_detach() closes instead.
+ */
+static uv_key_t uv__current_thread_is_dup_key;
 static uv_once_t uv__current_thread_init_guard = UV_ONCE_INIT;
 static uv_once_t uv__thread_name_once = UV_ONCE_INIT;
 HRESULT (WINAPI *pGetThreadDescription)(HANDLE, PWSTR*);
@@ -65,6 +71,36 @@ HRESULT (WINAPI *pSetThreadDescription)(HANDLE, PCWSTR);
 static void uv__init_current_thread_key(void) {
   if (uv_key_create(&uv__current_thread_key))
     abort();
+  if (uv_key_create(&uv__current_thread_is_dup_key))
+    abort();
+}
+
+
+void uv__thread_cleanup(void) {
+  uv_once_t reset = UV_ONCE_INIT;
+  uv_thread_t self;
+  BOOL pending;
+
+  /* The keys exist only if the guard has run; see uv__once_cleanup(). */
+  if (!InitOnceBeginInitialize(&uv__current_thread_init_guard.init_once,
+                               INIT_ONCE_CHECK_ONLY,
+                               &pending,
+                               NULL))
+    return;
+
+  /* Only this thread's slot can be reached from here, which is all there is to
+   * do: uv_library_shutdown() is documented as being called once no other
+   * libuv thread is running.
+   */
+  if (uv_key_get(&uv__current_thread_is_dup_key) != NULL) {
+    self = uv_key_get(&uv__current_thread_key);
+    if (self != NULL)
+      CloseHandle(self);
+  }
+
+  uv_key_delete(&uv__current_thread_key);
+  uv_key_delete(&uv__current_thread_is_dup_key);
+  uv__current_thread_init_guard = reset;
 }
 
 
@@ -259,6 +295,7 @@ uv_thread_t uv_thread_self(void) {
           uv_fatal_error(GetLastError(), "DuplicateHandle");
       }
       uv_key_set(&uv__current_thread_key, key);
+      uv_key_set(&uv__current_thread_is_dup_key, (void*) 1);
   }
   return key;
 }

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -237,12 +237,6 @@ void uv__console_cleanup(void) {
   }
 
   /* Nothing else is looking at the console now. */
-  if (uv__tty_console_hook != NULL) {
-    if (pUnhookWinEvent != NULL)
-      pUnhookWinEvent(uv__tty_console_hook);
-    uv__tty_console_hook = NULL;
-  }
-
   if (uv__tty_console_resized != INVALID_HANDLE_VALUE &&
       uv__tty_console_resized != NULL) {
     CloseHandle(uv__tty_console_resized);
@@ -2491,11 +2485,16 @@ static void uv__tty_console_resize_message_loop_thread(void* param) {
 
     while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
       if (msg.message == WM_QUIT)
-        return;
+        goto done;
       TranslateMessage(&msg);
       DispatchMessage(&msg);
     }
   }
+
+done:
+  if (pUnhookWinEvent != NULL)
+    pUnhookWinEvent(uv__tty_console_hook);
+  uv__tty_console_hook = NULL;
 }
 
 static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -131,7 +131,18 @@ static int uv__tty_console_width = -1;
 static HANDLE uv__tty_console_resized = INVALID_HANDLE_VALUE;
 static uv_mutex_t uv__tty_console_resize_mutex;
 
-static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param);
+/* Signalled by uv__console_cleanup() to bring the two threads below down. Both
+ * of them touch state that cleanup goes on to destroy, so they are joined
+ * rather than left to the process teardown.
+ */
+static HANDLE uv__tty_console_stop = INVALID_HANDLE_VALUE;
+static uv_thread_t uv__tty_console_message_loop;
+static uv_thread_t uv__tty_console_watcher;
+static int uv__tty_console_message_loop_started;
+static int uv__tty_console_watcher_started;
+static HWINEVENTHOOK uv__tty_console_hook;
+
+static void uv__tty_console_resize_message_loop_thread(void* param);
 static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,
                                                   DWORD event,
                                                   HWND hwnd,
@@ -139,7 +150,7 @@ static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,
                                                   LONG idChild,
                                                   DWORD dwEventThread,
                                                   DWORD dwmsEventTime);
-static DWORD WINAPI uv__tty_console_resize_watcher_thread(void* param);
+static void uv__tty_console_resize_watcher_thread(void* param);
 static void uv__tty_console_signal_resize(void);
 
 /* We use a semaphore rather than a mutex or critical section because in some
@@ -183,9 +194,13 @@ void uv__console_init(void) {
       uv__tty_console_width = sb_info.dwSize.X;
       uv__tty_console_height = sb_info.srWindow.Bottom - sb_info.srWindow.Top + 1;
     }
-    QueueUserWorkItem(uv__tty_console_resize_message_loop_thread,
-                      NULL,
-                      WT_EXECUTELONGFUNCTION);
+    uv__tty_console_stop = CreateEvent(NULL, TRUE, FALSE, NULL);
+    if (uv__tty_console_stop != NULL &&
+        uv_thread_create(&uv__tty_console_message_loop,
+                         uv__tty_console_resize_message_loop_thread,
+                         NULL) == 0) {
+      uv__tty_console_message_loop_started = 1;
+    }
   }
   uv__tty_console_handle_in = CreateFileW(L"CONIN$",
                                           GENERIC_READ | GENERIC_WRITE,
@@ -199,6 +214,68 @@ void uv__console_init(void) {
       uv__tty_console_in_original_mode = dwMode;
     }
   }
+}
+
+
+void uv__console_cleanup(void) {
+  if (uv__tty_console_stop != INVALID_HANDLE_VALUE &&
+      uv__tty_console_stop != NULL)
+    SetEvent(uv__tty_console_stop);
+
+  /* Join the message loop first. It is the thread that starts the watcher and
+   * sets uv__tty_console_watcher_started, so that flag can only be read once it
+   * has exited.
+   */
+  if (uv__tty_console_message_loop_started) {
+    uv_thread_join(&uv__tty_console_message_loop);
+    uv__tty_console_message_loop_started = 0;
+  }
+
+  if (uv__tty_console_watcher_started) {
+    uv_thread_join(&uv__tty_console_watcher);
+    uv__tty_console_watcher_started = 0;
+  }
+
+  /* Nothing else is looking at the console now. */
+  if (uv__tty_console_hook != NULL) {
+    if (pUnhookWinEvent != NULL)
+      pUnhookWinEvent(uv__tty_console_hook);
+    uv__tty_console_hook = NULL;
+  }
+
+  if (uv__tty_console_resized != INVALID_HANDLE_VALUE &&
+      uv__tty_console_resized != NULL) {
+    CloseHandle(uv__tty_console_resized);
+    uv__tty_console_resized = INVALID_HANDLE_VALUE;
+  }
+
+  if (uv__tty_console_stop != INVALID_HANDLE_VALUE &&
+      uv__tty_console_stop != NULL) {
+    CloseHandle(uv__tty_console_stop);
+    uv__tty_console_stop = INVALID_HANDLE_VALUE;
+  }
+
+  if (uv__tty_console_handle_out != INVALID_HANDLE_VALUE) {
+    uv_mutex_destroy(&uv__tty_console_resize_mutex);
+    CloseHandle(uv__tty_console_handle_out);
+    uv__tty_console_handle_out = INVALID_HANDLE_VALUE;
+    uv__tty_console_width = -1;
+    uv__tty_console_height = -1;
+  }
+
+  if (uv__tty_console_handle_in != INVALID_HANDLE_VALUE) {
+    /* Put the mode back if a uv_tty_t changed it and never got closed. */
+    if (uv__tty_console_in_original_mode != (DWORD)-1 &&
+        InterlockedExchange(&uv__tty_console_in_need_mode_reset, 0) != 0) {
+      SetConsoleMode(uv__tty_console_handle_in,
+                     uv__tty_console_in_original_mode);
+    }
+    CloseHandle(uv__tty_console_handle_in);
+    uv__tty_console_handle_in = INVALID_HANDLE_VALUE;
+    uv__tty_console_in_original_mode = (DWORD)-1;
+  }
+
+  uv_sem_destroy(&uv_tty_output_lock);
 }
 
 
@@ -2358,13 +2435,13 @@ static void uv__determine_vterm_state(HANDLE handle) {
   uv__vterm_state = UV_TTY_SUPPORTED;
 }
 
-static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param) {
+static void uv__tty_console_resize_message_loop_thread(void* param) {
   NTSTATUS status;
   ULONG_PTR conhost_pid;
   MSG msg;
 
   if (pSetWinEventHook == NULL || pNtQueryInformationProcess == NULL)
-    return 0;
+    return;
 
   status = pNtQueryInformationProcess(GetCurrentProcess(),
                                       ProcessConsoleHostProcess,
@@ -2376,7 +2453,7 @@ static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param) {
     /* We couldn't retrieve our console host process, probably because this
      * is a 32-bit process running on 64-bit Windows. Fall back to receiving
      * console events from the input stream only. */
-    return 0;
+    return;
   }
 
   /* Ensure the PID is a multiple of 4, which is required by SetWinEventHook */
@@ -2384,26 +2461,41 @@ static DWORD WINAPI uv__tty_console_resize_message_loop_thread(void* param) {
 
   uv__tty_console_resized = CreateEvent(NULL, TRUE, FALSE, NULL);
   if (uv__tty_console_resized == NULL)
-    return 0;
-  if (QueueUserWorkItem(uv__tty_console_resize_watcher_thread,
-                        NULL,
-                        WT_EXECUTELONGFUNCTION) == 0)
-    return 0;
+    return;
+  if (uv_thread_create(&uv__tty_console_watcher,
+                       uv__tty_console_resize_watcher_thread,
+                       NULL) != 0)
+    return;
+  uv__tty_console_watcher_started = 1;
 
-  if (!pSetWinEventHook(EVENT_CONSOLE_LAYOUT,
-                        EVENT_CONSOLE_LAYOUT,
-                        NULL,
-                        uv__tty_console_resize_event,
-                        (DWORD)conhost_pid,
-                        0,
-                        WINEVENT_OUTOFCONTEXT))
-    return 0;
+  uv__tty_console_hook = pSetWinEventHook(EVENT_CONSOLE_LAYOUT,
+                                          EVENT_CONSOLE_LAYOUT,
+                                          NULL,
+                                          uv__tty_console_resize_event,
+                                          (DWORD)conhost_pid,
+                                          0,
+                                          WINEVENT_OUTOFCONTEXT);
+  if (uv__tty_console_hook == NULL)
+    return;
 
-  while (GetMessage(&msg, NULL, 0, 0)) {
-    TranslateMessage(&msg);
-    DispatchMessage(&msg);
+  /* Wait on the stop event as well as the message queue, so that cleanup does
+   * not have to reach into this thread's queue to end the loop.
+   */
+  for (;;) {
+    if (MsgWaitForMultipleObjects(1,
+                                  &uv__tty_console_stop,
+                                  FALSE,
+                                  INFINITE,
+                                  QS_ALLINPUT) == WAIT_OBJECT_0)
+      break;
+
+    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+      if (msg.message == WM_QUIT)
+        return;
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
+    }
   }
-  return 0;
 }
 
 static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,
@@ -2416,15 +2508,22 @@ static void CALLBACK uv__tty_console_resize_event(HWINEVENTHOOK hWinEventHook,
   SetEvent(uv__tty_console_resized);
 }
 
-static DWORD WINAPI uv__tty_console_resize_watcher_thread(void* param) {
+static void uv__tty_console_resize_watcher_thread(void* param) {
+  HANDLE wait_handles[2];
+
+  wait_handles[0] = uv__tty_console_stop;
+  wait_handles[1] = uv__tty_console_resized;
+
   for (;;) {
     /* Make sure to not overwhelm the system with resize events */
-    Sleep(33);
-    WaitForSingleObject(uv__tty_console_resized, INFINITE);
+    if (WaitForSingleObject(uv__tty_console_stop, 33) == WAIT_OBJECT_0)
+      return;
+    if (WaitForMultipleObjects(2, wait_handles, FALSE, INFINITE) ==
+        WAIT_OBJECT_0)
+      return;
     ResetEvent(uv__tty_console_resized);
     uv__tty_console_signal_resize();
   }
-  return 0;
 }
 
 static void uv__tty_console_signal_resize(void) {

--- a/src/win/util.c
+++ b/src/win/util.c
@@ -77,6 +77,11 @@ static uint64_t hrtime_frequency_ = 0;
 /*
  * One-time initialization code for functionality defined in util.c.
  */
+void uv__util_cleanup(void) {
+  DeleteCriticalSection(&process_title_lock);
+}
+
+
 void uv__util_init(void) {
   LARGE_INTEGER perf_frequency;
 

--- a/src/win/winapi.c
+++ b/src/win/winapi.c
@@ -38,12 +38,14 @@ sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Powrprof.dll function pointer */
 sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
+sPowerUnregisterSuspendResumeNotification pPowerUnregisterSuspendResumeNotification;
 
 /* bcryptprimitives.dll function pointer */
 sProcessPrng pProcessPrng;
 
 /* User32.dll function pointer */
 sSetWinEventHook pSetWinEventHook;
+sUnhookWinEvent pUnhookWinEvent;
 
 /* ws2_32.dll function pointer */
 uv_sGetHostNameW pGetHostNameW;
@@ -71,8 +73,10 @@ void uv__winapi_init(void) {
     sNtQuerySystemInformation pNtQuerySystemInformation;
     sNtQueryInformationProcess pNtQueryInformationProcess;
     sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
+    sPowerUnregisterSuspendResumeNotification pPowerUnregisterSuspendResumeNotification;
     sProcessPrng pProcessPrng;
     sSetWinEventHook pSetWinEventHook;
+    sUnhookWinEvent pUnhookWinEvent;
     uv_sGetHostNameW pGetHostNameW;
     sGetFileInformationByName pGetFileInformationByName;
   } u;
@@ -141,6 +145,11 @@ void uv__winapi_init(void) {
                             "PowerRegisterSuspendResumeNotification");
     pPowerRegisterSuspendResumeNotification =
         u.pPowerRegisterSuspendResumeNotification;
+
+    u.proc = GetProcAddress(powrprof_module,
+                            "PowerUnregisterSuspendResumeNotification");
+    pPowerUnregisterSuspendResumeNotification =
+        u.pPowerUnregisterSuspendResumeNotification;
   }
 
   bcryptprimitives_module = LoadLibraryExA("bcryptprimitives.dll",
@@ -155,6 +164,9 @@ void uv__winapi_init(void) {
   if (user32_module != NULL) {
     u.proc = GetProcAddress(user32_module, "SetWinEventHook");
     pSetWinEventHook = u.pSetWinEventHook;
+
+    u.proc = GetProcAddress(user32_module, "UnhookWinEvent");
+    pUnhookWinEvent = u.pUnhookWinEvent;
   }
 
   ws2_32_module = GetModuleHandleW(L"ws2_32.dll");

--- a/src/win/winapi.h
+++ b/src/win/winapi.h
@@ -4758,6 +4758,9 @@ typedef DWORD (WINAPI *sPowerRegisterSuspendResumeNotification)
                HANDLE        Recipient,
                _PHPOWERNOTIFY RegistrationHandle);
 
+typedef DWORD (WINAPI *sPowerUnregisterSuspendResumeNotification)
+              (_HPOWERNOTIFY RegistrationHandle);
+
 typedef BOOL (WINAPI *sProcessPrng)(/*_Out_*/PBYTE pbData, SIZE_T cbData);
 
 /* from Winuser.h */
@@ -4778,6 +4781,8 @@ typedef HWINEVENTHOOK (WINAPI *sSetWinEventHook)
                        DWORD        idProcess,
                        DWORD        idThread,
                        UINT         dwflags);
+
+typedef BOOL (WINAPI *sUnhookWinEvent)(HWINEVENTHOOK hWinEventHook);
 
 /* From mstcpip.h */
 typedef struct _TCP_INITIAL_RTO_PARAMETERS {
@@ -4826,12 +4831,14 @@ extern sNtQueryInformationProcess pNtQueryInformationProcess;
 
 /* Powrprof.dll function pointer */
 extern sPowerRegisterSuspendResumeNotification pPowerRegisterSuspendResumeNotification;
+extern sPowerUnregisterSuspendResumeNotification pPowerUnregisterSuspendResumeNotification;
 
 /* bcryptprimitives.dll function pointer */
 extern sProcessPrng pProcessPrng;
 
 /* User32.dll function pointer */
 extern sSetWinEventHook pSetWinEventHook;
+extern sUnhookWinEvent pUnhookWinEvent;
 
 /* api-ms-win-core-file-l2-1-4.dll function pointers */
 extern sGetFileInformationByName pGetFileInformationByName;

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -75,6 +75,24 @@ BOOL uv__get_connectex_function(SOCKET socket, LPFN_CONNECTEX* target) {
 
 
 
+/* Whether WSAStartup() was reached, which the safe mode path below skips. */
+static int uv__winsock_started;
+
+
+void uv__winsock_cleanup(void) {
+  if (!uv__winsock_started)
+    return;
+
+  uv__winsock_started = 0;
+
+  /* WSAStartup() reference counts per process, so this only gives up the
+   * reference uv__winsock_init() took. Anything else in the process that
+   * started winsock for itself keeps it up.
+   */
+  WSACleanup();
+}
+
+
 void uv__winsock_init(void) {
   WSADATA wsa_data;
   int errorno;
@@ -99,6 +117,7 @@ void uv__winsock_init(void) {
   if (errorno != 0) {
     uv_fatal_error(errorno, "WSAStartup");
   }
+  uv__winsock_started = 1;
 
   /* Try to detect non-IFS LSPs */
   uv_tcp_non_ifs_lsp_ipv4 = 1;


### PR DESCRIPTION
Only really necessary when using libuv as library, since otherwise the OS would clean these up. But it helps for checking with unintentional leaks to know that libuv was careful and accurate to clean up the intentional globals.

Assisted-by: Claude Opus 5