### PR TITLE
test: make the check_utime_ex fallthrough actually fail

### DIFF
--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -893,7 +893,7 @@ static void check_utime(const char* path,
      */
       ASSERT_GT(s->st_atim.tv_sec, 1739710000);
   } else {
-    ASSERT_OK(0);
+    ASSERT(0);
   }
 
   if (isfinite(mtime)) {
@@ -925,7 +925,7 @@ static void check_utime(const char* path,
      */
       ASSERT_GT(s->st_mtim.tv_sec, 1739710000);
   } else {
-    ASSERT_OK(0);
+    ASSERT(0);
   }
 
   uv_fs_req_cleanup(&req);


### PR DESCRIPTION
`ASSERT_OK(0)` asserts that zero is zero, so it never fires: a `NAN` reaching the `atime`/`mtime` fallthrough in `check_utime_ex()` was silently accepted.

Dates from 85b526f56ac0ca5e76de5cbc0e1e9452f73a01d5, which split the single combined atime/mtime branch in two and added these fallthroughs.

Assisted-by: Claude Opus 5