### PR TITLE
win: cancel poll requests with modern `CancelIoEx()`

### DIFF
--- a/src/win/poll.c
+++ b/src/win/poll.c
@@ -45,35 +45,6 @@ typedef struct uv_single_fd_set_s {
 } uv_single_fd_set_t;
 
 
-static OVERLAPPED overlapped_dummy_;
-static uv_once_t overlapped_dummy_init_guard_ = UV_ONCE_INIT;
-
-static AFD_POLL_INFO afd_poll_info_dummy_;
-
-
-static void uv__init_overlapped_dummy(void) {
-  HANDLE event;
-
-  event = CreateEvent(NULL, TRUE, TRUE, NULL);
-  if (event == NULL)
-    uv_fatal_error(GetLastError(), "CreateEvent");
-
-  memset(&overlapped_dummy_, 0, sizeof overlapped_dummy_);
-  overlapped_dummy_.hEvent = (HANDLE) ((uintptr_t) event | 1);
-}
-
-
-static OVERLAPPED* uv__get_overlapped_dummy(void) {
-  uv_once(&overlapped_dummy_init_guard_, uv__init_overlapped_dummy);
-  return &overlapped_dummy_;
-}
-
-
-static AFD_POLL_INFO* uv__get_afd_poll_info_dummy(void) {
-  return &afd_poll_info_dummy_;
-}
-
-
 static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
   uv_req_t* req;
   AFD_POLL_INFO* afd_poll_info;
@@ -531,10 +502,6 @@ void uv__process_poll_req(uv_loop_t* loop, uv_poll_t* handle, uv_req_t* req) {
 
 
 int uv__poll_close(uv_loop_t* loop, uv_poll_t* handle) {
-  AFD_POLL_INFO afd_poll_info;
-  DWORD error;
-  int result;
-
   handle->events = 0;
   uv__handle_closing(handle);
 
@@ -547,25 +514,21 @@ int uv__poll_close(uv_loop_t* loop, uv_poll_t* handle) {
   if (handle->flags & UV_HANDLE_POLL_SLOW)
     return 0;
 
-  /* Cancel outstanding poll requests by executing another, unique poll
-   * request that forces the outstanding ones to return. */
-  afd_poll_info.Exclusive = TRUE;
-  afd_poll_info.NumberOfHandles = 1;
-  afd_poll_info.Timeout.QuadPart = INT64_MAX;
-  afd_poll_info.Handles[0].Handle = (HANDLE) handle->socket;
-  afd_poll_info.Handles[0].Status = 0;
-  afd_poll_info.Handles[0].Events = AFD_POLL_ALL;
+  /* Cancel the outstanding poll requests. They were issued on the peer socket,
+   * not on the watched socket, which only appears in the poll info, so that is
+   * the handle CancelIoEx() has to name; cancelling therefore still even works
+   * when the caller has already closed the watched socket. Peer sockets are
+   * shared between poll handles, so each request is cancelled by its own
+   * overlapped. They come back with handle->events zero, so nothing is
+   * reported and the handle proceeds to its endgame.
+   */
+  if (handle->submitted_events_1 != 0)
+    CancelIoEx((HANDLE) handle->peer_socket,
+               &handle->poll_req_1.u.io.overlapped);
 
-  result = uv__msafd_poll(handle->socket,
-                          &afd_poll_info,
-                          uv__get_afd_poll_info_dummy(),
-                          uv__get_overlapped_dummy());
-
-  if (result == SOCKET_ERROR) {
-    error = WSAGetLastError();
-    if (error != WSA_IO_PENDING)
-      return uv_translate_sys_error(error);
-  }
+  if (handle->submitted_events_2 != 0)
+    CancelIoEx((HANDLE) handle->peer_socket,
+               &handle->poll_req_2.u.io.overlapped);
 
   return 0;
 }

--- a/src/win/winsock.c
+++ b/src/win/winsock.c
@@ -462,66 +462,24 @@ int WSAAPI uv__wsarecvfrom_workaround(SOCKET socket, WSABUF* buffers,
 
 int WSAAPI uv__msafd_poll(SOCKET socket, AFD_POLL_INFO* info_in,
     AFD_POLL_INFO* info_out, OVERLAPPED* overlapped) {
-  IO_STATUS_BLOCK iosb;
   IO_STATUS_BLOCK* iosb_ptr;
-  HANDLE event = NULL;
-  void* apc_context;
   NTSTATUS status;
   DWORD error;
 
-  if (overlapped != NULL) {
-    /* Overlapped operation. */
-    iosb_ptr = (IO_STATUS_BLOCK*) &overlapped->Internal;
-    event = overlapped->hEvent;
-
-    /* Do not report iocp completion if hEvent is tagged. */
-    if ((uintptr_t) event & 1) {
-      event = (HANDLE)((uintptr_t) event & ~(uintptr_t) 1);
-      apc_context = NULL;
-    } else {
-      apc_context = overlapped;
-    }
-
-  } else {
-    /* Blocking operation. */
-    iosb_ptr = &iosb;
-    event = CreateEvent(NULL, FALSE, FALSE, NULL);
-    if (event == NULL) {
-      return SOCKET_ERROR;
-    }
-    apc_context = NULL;
-  }
-
+  assert(overlapped != NULL);
+  iosb_ptr = (IO_STATUS_BLOCK*) &overlapped->Internal;
   iosb_ptr->Status = STATUS_PENDING;
+
   status = pNtDeviceIoControlFile((HANDLE) socket,
-                                  event,
+                                  overlapped->hEvent,
                                   NULL,
-                                  apc_context,
+                                  overlapped,
                                   iosb_ptr,
                                   IOCTL_AFD_POLL,
                                   info_in,
                                   sizeof *info_in,
                                   info_out,
                                   sizeof *info_out);
-
-  if (overlapped == NULL) {
-    /* If this is a blocking operation, wait for the event to become signaled,
-     * and then grab the real status from the io status block. */
-    if (status == STATUS_PENDING) {
-      DWORD r = WaitForSingleObject(event, INFINITE);
-
-      if (r == WAIT_FAILED) {
-        DWORD saved_error = GetLastError();
-        CloseHandle(event);
-        WSASetLastError(saved_error);
-        return SOCKET_ERROR;
-      }
-
-      status = iosb.Status;
-    }
-
-    CloseHandle(event);
-  }
 
   switch (status) {
     case STATUS_SUCCESS:


### PR DESCRIPTION
`uv__poll_close(`) cancelled the outstanding AFD poll requests by submitting one more, exclusive, poll request, whose only purpose was the side effect of making the others return. That request was issued with a process-wide `OVERLAPPED` and `AFD_POLL_INFO` and with its event tagged so that no completion would be reported, which means nothing ever observed it finish. Two sockets closing at once had the kernel writing the same `IO_STATUS_BLOCK` and the same output buffer, and because no one could know when the last such request had completed, neither buffer could ever be released.

`CancelIoEx()` has been available since Vista and does this directly. Cancel each request by its own overlapped rather than everything on the socket, since peer sockets are shared between poll handles, and name the peer socket rather than the watched one, because that is where the request was issued; the watched socket only ever appears in the poll info. The requests come back with `handle->events` already zero, so `uv__fast_poll_process_poll_req()` reports nothing and the handle proceeds to its endgame, exactly as before.

This leaves `uv__msafd_poll()` with no caller that tags hEvent and none that asks for a blocking poll, so both of those paths are dead now too.