### PR TITLE
darwin: report physical footprint as rss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,7 @@ if(LIBUV_BUILD_TESTS)
        test/test-mutexes.c
        test/test-not-readable-nor-writable-on-read-error.c
        test/test-not-writable-after-shutdown.c
+       test/test-osx-resident-set-memory.c
        test/test-osx-select.c
        test/test-pass-always.c
        test/test-ping-pong.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -218,6 +218,7 @@ test_run_tests_SOURCES = test/blackhole-server.c \
                          test/test-mutexes.c \
                          test/test-not-readable-nor-writable-on-read-error.c \
                          test/test-not-writable-after-shutdown.c \
+                         test/test-osx-resident-set-memory.c \
                          test/test-osx-select.c \
                          test/test-pass-always.c \
                          test/test-ping-pong.c \

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -355,14 +355,6 @@ API
 
     Gets the resident set size (RSS) for the current process.
 
-    On macOS this returns the physical footprint (the number Activity
-    Monitor and ``footprint(1)`` show). The resident set size on macOS
-    keeps counting memory the process has already freed until the kernel
-    reclaims those pages, so it only ever reports the high-water mark.
-
-    .. versionchanged:: 1.53.0 the physical footprint is reported on
-                       macOS.
-
 .. c:function:: int uv_uptime(double* uptime)
 
     Gets the current system uptime. Depending on the system full or fractional seconds are returned.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -355,6 +355,14 @@ API
 
     Gets the resident set size (RSS) for the current process.
 
+    On macOS this returns the physical footprint (the number Activity
+    Monitor and :man:`footprint(1)` show). The resident set size on macOS
+    keeps counting memory the process has already freed until the kernel
+    reclaims those pages, so it only ever reports the high-water mark.
+
+    .. versionchanged:: 1.53.0 the physical footprint is reported on
+                       macOS.
+
 .. c:function:: int uv_uptime(double* uptime)
 
     Gets the current system uptime. Depending on the system full or fractional seconds are returned.

--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -356,7 +356,7 @@ API
     Gets the resident set size (RSS) for the current process.
 
     On macOS this returns the physical footprint (the number Activity
-    Monitor and :man:`footprint(1)` show). The resident set size on macOS
+    Monitor and ``footprint(1)`` show). The resident set size on macOS
     keeps counting memory the process has already freed until the kernel
     reclaims those pages, so it only ever reports the high-water mark.
 

--- a/src/unix/darwin.c
+++ b/src/unix/darwin.c
@@ -153,20 +153,23 @@ void uv_loadavg(double avg[3]) {
 
 int uv_resident_set_memory(size_t* rss) {
   mach_msg_type_number_t count;
-  task_basic_info_data_t info;
+  task_vm_info_data_t info;
   kern_return_t err;
 
-  count = TASK_BASIC_INFO_COUNT;
+  /* phys_footprint, not resident_size: the latter keeps counting pages
+   * freed with madvise(MADV_FREE_REUSABLE), i.e. it never comes down.
+   */
+  count = TASK_VM_INFO_REV1_COUNT;
   err = task_info(mach_task_self(),
-                  TASK_BASIC_INFO,
+                  TASK_VM_INFO,
                   (task_info_t) &info,
                   &count);
   (void) &err;
-  /* task_info(TASK_BASIC_INFO) cannot really fail. Anything other than
+  /* task_info(TASK_VM_INFO) cannot really fail. Anything other than
    * KERN_SUCCESS implies a libuv bug.
    */
   assert(err == KERN_SUCCESS);
-  *rss = info.resident_size;
+  *rss = info.phys_footprint;
 
   return 0;
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -565,6 +565,7 @@ TEST_DECLARE   (signal_pending_on_close)
 TEST_DECLARE   (signal_close_loop_alive)
 #endif
 #ifdef __APPLE__
+TEST_DECLARE   (osx_resident_set_memory)
 TEST_DECLARE   (osx_select)
 TEST_DECLARE   (osx_select_many_fds)
 #endif
@@ -1122,6 +1123,7 @@ TASK_LIST_START
 #endif
 
 #ifdef __APPLE__
+  TEST_ENTRY (osx_resident_set_memory)
   TEST_ENTRY (osx_select)
   TEST_ENTRY (osx_select_many_fds)
 #endif

--- a/test/test-osx-resident-set-memory.c
+++ b/test/test-osx-resident-set-memory.c
@@ -1,0 +1,64 @@
+/* Copyright libuv project contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "task.h"
+
+#ifdef __APPLE__
+
+#include <string.h>
+#include <sys/mman.h>
+
+TEST_IMPL(osx_resident_set_memory) {
+  size_t before;
+  size_t during;
+  size_t after;
+  size_t size;
+  char* mem;
+
+  size = 64 << 20;
+
+  ASSERT_OK(uv_resident_set_memory(&before));
+
+  mem = mmap(NULL,
+             size,
+             PROT_READ | PROT_WRITE,
+             MAP_ANON | MAP_PRIVATE,
+             -1,
+             0);
+  ASSERT_PTR_NE(mem, MAP_FAILED);
+  memset(mem, 42, size);
+
+  ASSERT_OK(uv_resident_set_memory(&during));
+  ASSERT_GE(during, before + size / 2);
+
+  /* How allocators free memory on macOS; the pages stay resident. */
+  ASSERT_OK(madvise(mem, size, MADV_FREE_REUSABLE));
+
+  ASSERT_OK(uv_resident_set_memory(&after));
+  ASSERT_LT(after, before + size / 2);
+
+  ASSERT_OK(munmap(mem, size));
+
+  return 0;
+}
+
+#endif /* __APPLE__ */


### PR DESCRIPTION
On macOS, `uv_resident_set_memory()` reads `task_basic_info.resident_size`.
That number does not come back down after memory is freed: macOS allocators
release pages with `madvise(MADV_FREE_REUSABLE)`, which keeps them resident
until the kernel needs them. In practice it reports the process's high-water
mark, not what it is currently using.

This switches darwin to `task_vm_info.phys_footprint` — the number Activity
Monitor and `footprint(1)` show, and the one jetsam uses. Nothing changes on
other platforms.

## Benchmark

Same process, both numbers sampled from `task_info` at each step. First
`mmap` 256 MB, touch it and `madvise(MADV_FREE_REUSABLE)`; then, with the
system allocator, `malloc` 128k × 4 KB and `free` it all:

| step | resident_size | phys_footprint |
|---|---:|---:|
| baseline | 1.4 MB | 1.0 MB |
| touched | 257.4 MB | 257.1 MB |
| madvised | **257.4 MB** | **1.1 MB** |
| allocated | 516.4 MB | 516.3 MB |
| freed | **516.7 MB** | **21.2 MB** |

<details>
<summary>demo.c</summary>

```c
#include <mach/mach.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>

static double mb(size_t n) { return n / 1048576.0; }

static size_t resident_size(void) {
  task_basic_info_data_t info;
  mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
  task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t) &info, &count);
  return info.resident_size;
}

static size_t phys_footprint(void) {
  task_vm_info_data_t info;
  mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
  task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &info, &count);
  return info.phys_footprint;
}

static void row(const char* step) {
  printf("%-12s resident_size=%8.1f MB  phys_footprint=%8.1f MB\n",
         step, mb(resident_size()), mb(phys_footprint()));
}

int main(void) {
  size_t size = 256u << 20;
  size_t i, n = 128u << 10;
  char** blocks;
  char* mem;

  row("baseline");
  mem = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE,
             -1, 0);
  memset(mem, 42, size);
  row("touched");
  madvise(mem, size, MADV_FREE_REUSABLE);
  row("madvised");
  munmap(mem, size);

  blocks = calloc(n, sizeof(*blocks));
  for (i = 0; i < n; i++) {
    blocks[i] = malloc(4096);
    memset(blocks[i], 42, 4096);
  }
  row("allocated");
  for (i = 0; i < n; i++)
    free(blocks[i]);
  row("freed");
  return 0;
}
```

</details>

Node.js, 100k × 5 KB `Buffer`s, freed and `global.gc()`'d:
`process.memoryUsage().rss` 592 MB, `footprint(1)` 230 MB.

Cost of the call is unchanged: `task_info(TASK_VM_INFO)` ~390 ns vs
`TASK_BASIC_INFO` ~360 ns per call on an M-series machine.

## Compatibility

- `phys_footprint` is filled from `TASK_VM_INFO` revision 1 onward, so this
  requests `TASK_VM_INFO_REV1_COUNT`; it is public SDK API
  (`<mach/task_info.h>`), not private.
- This is a behavior change: reported values on macOS will generally be
  lower, and will now fall after memory is released. Anyone comparing the
  new number against RSS from `ps`/`top` will see them diverge; that
  divergence is the freed-but-still-resident memory.

## Context

This came out of a flaky memory-leak test in Bun: the test freed everything
correctly, but `process.memoryUsage.rss()` on the macOS runners kept
climbing because rss on darwin never gives freed pages back to the
measurement. Bun deliberately reports the same `rss()` as Node.js (which is
this function) so that people comparing the two are comparing the same
number — so we'd rather fix the definition here than diverge from it.

New test: `osx_resident_set_memory` — maps and touches 64 MB, releases it with
`MADV_FREE_REUSABLE`, asserts the reported value falls back near baseline.
It fails against the current implementation and passes with this change.

---

Disclosure: the code, test, measurements and this description were written
by Claude Code, directed and reviewed by @Jarred-Sumner. Happy to rework
anything to fit the project's preferences.
