### PR TITLE
Fix read ipc: allow reading byte payloads from IPC pipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
        src/unix/aix-common.c)
 endif()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
+  list(APPEND uv_defines _GNU_SOURCE)
+  list(APPEND uv_sources
+       src/unix/random-getrandom.c
+       src/unix/posix-hrtime.c
+       src/unix/posix-poll.c
+       src/unix/no-fsevents.c
+       src/unix/no-proctitle.c)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
   list(APPEND uv_defines _GNU_SOURCE)
   list(APPEND uv_libraries dl)

--- a/include/uv.h
+++ b/include/uv.h
@@ -1808,12 +1808,15 @@ UV_EXTERN int uv_random(uv_loop_t* loop,
 # define UV_IF_NAMESIZE (16 + 1)
 #endif
 
+// TODO: missing wasix entrypoint
+#ifndef __wasi__
 UV_EXTERN int uv_if_indextoname(unsigned int ifindex,
                                 char* buffer,
                                 size_t* size);
 UV_EXTERN int uv_if_indextoiid(unsigned int ifindex,
                                char* buffer,
                                size_t* size);
+#endif
 
 UV_EXTERN int uv_exepath(char* buffer, size_t* size);
 

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -66,7 +66,8 @@
       defined(__MSYS__)   || \
       defined(__HAIKU__)  || \
       defined(__QNX__)    || \
-      defined(__GNU__)
+      defined(__GNU__)    || \
+      defined(__wasi__)
 # include "uv/posix.h"
 #endif
 

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -46,6 +46,12 @@
 #include <sys/time.h>
 #include <time.h> /* clock_gettime */
 
+#if defined(__wasi__)
+/* Fallback poll period when a child is live but uv__next_timeout() would block
+ * forever. Applied only at the uv__io_poll() call site in uv_run(). */
+#define UV__WASIX_CHILD_POLL_MS 100
+#endif
+
 #ifdef __sun
 # include <sys/filio.h>
 # include <sys/wait.h>
@@ -457,7 +463,20 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
 
     uv__metrics_inc_loop_count(loop);
 
+#if defined(__wasi__)
+    /* WASIX does not reliably deliver SIGCHLD for posix_spawn children.
+     * Reap after each poll; only override an unbounded poll sleep so timer
+     * deadlines and short poll timeouts stay unchanged. */
+    if (!uv__queue_empty(&loop->process_handles) && timeout < 0)
+      timeout = UV__WASIX_CHILD_POLL_MS;
+#endif
+
     uv__io_poll(loop, timeout);
+
+#if defined(__wasi__)
+    if (!uv__queue_empty(&loop->process_handles))
+      uv__wait_children(loop);
+#endif
 
     /* Process immediate callbacks (e.g. write_cb) a small fixed number of
      * times to avoid loop starvation.*/

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -79,7 +79,7 @@
       defined(__HAIKU__)  || \
       defined(__QNX__)
 # include <sys/statvfs.h>
-#else
+#elif !defined(__wasi__)
 # include <sys/statfs.h>
 #endif
 
@@ -677,6 +677,7 @@ static int uv__fs_closedir(uv_fs_t* req) {
   return 0;
 }
 
+#ifndef __wasi__
 static int uv__fs_statfs(uv_fs_t* req) {
   uv_statfs_t* stat_fs;
 #if defined(__sun)      || \
@@ -719,6 +720,7 @@ static int uv__fs_statfs(uv_fs_t* req) {
   req->ptr = stat_fs;
   return 0;
 }
+#endif
 
 static ssize_t uv__fs_pathmax_size(const char* path) {
   ssize_t pathmax;
@@ -1327,6 +1329,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
     goto out;
   }
 
+#ifndef __wasi__
   /*
    * Change the ownership and permissions of the destination file to match the
    * source file.
@@ -1334,6 +1337,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
    * `result` variable to silence a -Wunused-result warning.
    */
   result = fchown(dstfd, src_statsbuf.st_uid, src_statsbuf.st_gid);
+#endif
 
   if (fchmod(dstfd, src_statsbuf.st_mode) == -1) {
     err = UV__ERR(errno);
@@ -1696,12 +1700,16 @@ static void uv__fs_work(struct uv__work* w) {
     switch (req->fs_type) {
     X(ACCESS, access(req->path, req->flags));
     X(CHMOD, chmod(req->path, req->mode));
+#ifndef __wasi__
     X(CHOWN, chown(req->path, req->uid, req->gid));
+#endif
     X(CLOSE, uv__fs_close(req->file));
     X(COPYFILE, uv__fs_copyfile(req));
     X(FCHMOD, fchmod(req->file, req->mode));
+#ifndef __wasi__
     X(FCHOWN, fchown(req->file, req->uid, req->gid));
     X(LCHOWN, lchown(req->path, req->uid, req->gid));
+#endif
     X(FDATASYNC, uv__fs_fdatasync(req));
     X(FSTAT, uv__fs_fstat(req->file, &req->statbuf));
     X(FSYNC, uv__fs_fsync(req));
@@ -1725,7 +1733,9 @@ static void uv__fs_work(struct uv__work* w) {
     X(RMDIR, rmdir(req->path));
     X(SENDFILE, uv__fs_sendfile(req));
     X(STAT, uv__fs_stat(req->path, &req->statbuf));
+#ifndef __wasi__
     X(STATFS, uv__fs_statfs(req));
+#endif
     X(SYMLINK, symlink(req->path, req->new_path));
     X(UNLINK, unlink(req->path));
     X(UTIME, uv__fs_utime(req));

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -238,9 +238,11 @@ struct uv__statx {
  * Libuv uses uv__nonblock_fcntl() directly sometimes so ensure that it
  * commutes with uv__nonblock().
  */
+#if !defined(__wasi__)
 #if defined(__linux__) && O_NDELAY != O_NONBLOCK
 #undef uv__nonblock
 #define uv__nonblock uv__nonblock_fcntl
+#endif
 #endif
 
 /* core */

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -382,6 +382,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
   if (options->cwd != NULL && chdir(options->cwd))
     uv__write_errno(error_fd);
 
+#ifndef __wasi__
   if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
     /* When dropping privileges from root, the `setgroups` call will
      * remove any extraneous groups. If we don't call this, then
@@ -392,6 +393,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
      */
     SAVE_ERRNO(setgroups(0, NULL));
   }
+#endif
 
   if ((options->flags & UV_PROCESS_SETGID) && setgid(options->gid))
     uv__write_errno(error_fd);

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -35,9 +35,12 @@
 #include <fcntl.h>
 #include <poll.h>
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__wasi__)
 # include <spawn.h>
 # include <paths.h>
+#endif
+
+#if defined(__APPLE__)
 # include <sys/kauth.h>
 # include <sys/types.h>
 # include <sys/sysctl.h>
@@ -204,9 +207,33 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
     if (container->data.stream->type != UV_NAMED_PIPE)
       return UV_EINVAL;
     else {
+#if defined(__wasi__)
+      if ((container->flags & UV_READABLE_PIPE) &&
+          !(container->flags & UV_WRITABLE_PIPE)) {
+        ret = uv_pipe(fds, 0, 0);
+        if (ret == 0) {
+          /* Parent writes to stdin, child reads from fd 0. */
+          int tmp = fds[0];
+          fds[0] = fds[1];
+          fds[1] = tmp;
+        }
+      } else if ((container->flags & UV_WRITABLE_PIPE) &&
+                 !(container->flags & UV_READABLE_PIPE)) {
+        /* Child writes stdout/stderr, parent reads. */
+        ret = uv_pipe(fds, 0, 0);
+      } else {
+        ret = uv_socketpair(SOCK_STREAM, 0, fds, 0, 0);
+      }
+#else
       ret = uv_socketpair(SOCK_STREAM, 0, fds, 0, 0);
+#endif
 
-      if (ret == 0)
+      if (ret == 0
+#if defined(__wasi__)
+          && (container->flags & UV_READABLE_PIPE) != 0
+          && (container->flags & UV_WRITABLE_PIPE) != 0
+#endif
+      )
         for (i = 0; i < 2; i++) {
           setsockopt(fds[i], SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
           setsockopt(fds[i], SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
@@ -419,6 +446,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
 }
 
 
+#if defined(__APPLE__) || defined(__wasi__)
 #if defined(__APPLE__)
 typedef struct uv__posix_spawn_fncs_tag {
   struct {
@@ -466,8 +494,15 @@ static void uv__spawn_init_posix_spawn(void) {
   /* Init feature detection for POSIX_SPAWN_SETSID flag */
   uv__spawn_init_can_use_setsid();
 }
+#endif
+#endif
 
+static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
+                                       posix_spawnattr_t* attrs,
+                                       posix_spawn_file_actions_t* actions,
+                                       pid_t* pid);
 
+#if defined(__APPLE__)
 static int uv__spawn_set_posix_spawn_attrs(
     posix_spawnattr_t* attrs,
     const uv__posix_spawn_fncs_t* posix_spawn_fncs,
@@ -659,6 +694,7 @@ error:
   (void) posix_spawn_file_actions_destroy(actions);
   return err;
 }
+#endif
 
 char* uv__spawn_find_path_in_env(char** env) {
   char** env_iterator;
@@ -713,6 +749,13 @@ static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
     while (err == EINTR);
     return err;
   }
+
+#if defined(__wasi__)
+  do
+    err = posix_spawnp(pid, options->file, actions, attrs, options->args, env);
+  while (err == EINTR);
+  return err;
+#endif
 
   /* Look for the definition of PATH in the provided env */
   path = uv__spawn_find_path_in_env(env);
@@ -776,7 +819,7 @@ static int uv__spawn_resolve_and_spawn(const uv_process_options_t* options,
   return err;
 }
 
-
+#if defined(__APPLE__)
 static int uv__spawn_and_init_child_posix_spawn(
     const uv_process_options_t* options,
     int stdio_count,
@@ -818,11 +861,209 @@ error:
 }
 #endif
 
+#if defined(__wasi__)
+static int uv__spawn_set_posix_spawn_attrs_wasi(
+    posix_spawnattr_t* attrs,
+    const uv_process_options_t* options) {
+  int err;
+
+  err = posix_spawnattr_init(attrs);
+  if (err != 0)
+    return err;
+
+  if (options->flags & (UV_PROCESS_SETUID | UV_PROCESS_SETGID)) {
+    err = ENOSYS;
+    goto error;
+  }
+
+  if (options->flags & UV_PROCESS_DETACHED) {
+    err = ENOSYS;
+    goto error;
+  }
+
+  return 0;
+
+error:
+  (void) posix_spawnattr_destroy(attrs);
+  return err;
+}
+
+
+static int uv__spawn_set_posix_spawn_file_actions_wasi(
+    posix_spawn_file_actions_t* actions,
+    const uv_process_options_t* options,
+    int stdio_count,
+    int (*pipes)[2]) {
+  int err;
+  int fd;
+  int fd2;
+  int use_fd;
+
+  err = posix_spawn_file_actions_init(actions);
+  if (err != 0)
+    return err;
+
+  if (options->cwd != NULL) {
+    err = posix_spawn_file_actions_addchdir_np(actions, options->cwd);
+    if (err != 0)
+      goto error;
+  }
+
+  for (fd = 0; fd < stdio_count; fd++) {
+    use_fd = pipes[fd][1];
+    if (use_fd < 0)
+      continue;
+    if (use_fd != fd && use_fd >= stdio_count)
+      continue;
+
+#ifdef F_DUPFD_CLOEXEC
+    pipes[fd][1] = fcntl(use_fd, F_DUPFD_CLOEXEC, stdio_count);
+#else
+    pipes[fd][1] = fcntl(use_fd, F_DUPFD, stdio_count);
+#endif
+    if (pipes[fd][1] == -1) {
+      err = errno;
+      goto error;
+    }
+
+#ifndef F_DUPFD_CLOEXEC
+    err = uv__cloexec(pipes[fd][1], 1);
+    if (err != 0)
+      goto error;
+#endif
+  }
+
+  for (fd = 0; fd < stdio_count; fd++) {
+    use_fd = pipes[fd][1];
+
+    if (use_fd < 0) {
+      if (fd >= 3)
+        continue;
+
+      use_fd = open("/dev/null", fd == 0 ? O_RDONLY : O_RDWR);
+      if (use_fd < 0) {
+        err = errno;
+        goto error;
+      }
+
+      err = uv__cloexec(use_fd, 1);
+      if (err != 0) {
+        uv__close(use_fd);
+        goto error;
+      }
+
+      pipes[fd][1] = use_fd;
+    }
+
+    use_fd = pipes[fd][1];
+    if (use_fd == fd)
+      continue;
+
+    err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
+    if (err != 0)
+      goto error;
+
+    uv__nonblock_fcntl(use_fd, 0);
+  }
+
+  for (fd = 0; fd < stdio_count; fd++) {
+    use_fd = pipes[fd][1];
+    if (use_fd < 0)
+      continue;
+    if (use_fd < stdio_count && use_fd == fd)
+      continue;
+
+    for (fd2 = 0; fd2 < fd; fd2++) {
+      if (pipes[fd2][1] == use_fd)
+        break;
+    }
+    if (fd2 < fd)
+      continue;
+
+    err = posix_spawn_file_actions_addclose(actions, use_fd);
+    if (err != 0)
+      goto error;
+  }
+
+  for (fd = 0; fd < stdio_count; fd++) {
+    use_fd = pipes[fd][0];
+    if (use_fd < 0)
+      continue;
+
+    for (fd2 = 0; fd2 < fd; fd2++) {
+      if (pipes[fd2][0] == use_fd)
+        break;
+    }
+    if (fd2 < fd)
+      continue;
+
+    for (fd2 = 0; fd2 < stdio_count; fd2++) {
+      if (pipes[fd2][1] == use_fd)
+        break;
+    }
+    if (fd2 < stdio_count)
+      continue;
+
+    err = posix_spawn_file_actions_addclose(actions, use_fd);
+    if (err != 0)
+      goto error;
+  }
+
+  return 0;
+
+error:
+  (void) posix_spawn_file_actions_destroy(actions);
+  return err;
+}
+
+
+static int uv__spawn_and_init_child_posix_spawn_wasi(
+    const uv_process_options_t* options,
+    int stdio_count,
+    int (*pipes)[2],
+    pid_t* pid) {
+  int err;
+  posix_spawnattr_t attrs;
+  posix_spawn_file_actions_t actions;
+
+  err = uv__spawn_set_posix_spawn_attrs_wasi(&attrs, options);
+  if (err != 0)
+    goto error;
+
+  err = uv__spawn_set_posix_spawn_file_actions_wasi(&actions,
+                                                    options,
+                                                    stdio_count,
+                                                    pipes);
+  if (err != 0) {
+    (void) posix_spawnattr_destroy(&attrs);
+    goto error;
+  }
+
+  err = uv__spawn_resolve_and_spawn(options, &attrs, &actions, pid);
+
+  (void) posix_spawn_file_actions_destroy(&actions);
+  (void) posix_spawnattr_destroy(&attrs);
+
+error:
+  return UV__ERR(err);
+}
+#endif
+
 static int uv__spawn_and_init_child_fork(const uv_process_options_t* options,
                                          int stdio_count,
                                          int (*pipes)[2],
                                          int error_fd,
                                          pid_t* pid) {
+#if defined(__wasi__) && defined(__wasm_exception_handling__)
+  /* WASIX builds with wasm EH cannot use asyncify-based fork(); fall back to
+   * the posix_spawn path in uv__spawn_and_init_child(). */
+  (void) options;
+  (void) stdio_count;
+  (void) pipes;
+  (void) error_fd;
+  (void) pid;
+  return UV_ENOSYS;
+#else
   sigset_t signewset;
   sigset_t sigoldset;
 
@@ -857,6 +1098,7 @@ static int uv__spawn_and_init_child_fork(const uv_process_options_t* options,
 
   /* Fork succeeded, in the parent process */
   return 0;
+#endif
 }
 
 static int uv__spawn_and_init_child(
@@ -899,6 +1141,15 @@ static int uv__spawn_and_init_child(
   if (err != UV_ENOSYS)
     return err;
 
+#endif
+
+#if defined(__wasi__)
+  err = uv__spawn_and_init_child_posix_spawn_wasi(options,
+                                                  stdio_count,
+                                                  pipes,
+                                                  pid);
+  if (err != UV_ENOSYS)
+    return err;
 #endif
 
   /* This pipe is used by the parent to wait until

--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -1092,9 +1092,13 @@ static void uv__read(uv_stream_t* stream) {
       }
       while (nread < 0 && errno == EINTR);
 #else
-      /* WASI does not support msghdr. */
-      nread = -1;
-      errno = ENOSYS;
+      /* WASIX socket pairs can carry IPC bytes, but WASI has no msghdr or
+       * descriptor-passing support. Read the payload normally; attempts to
+       * transfer a handle remain unsupported by the write path. */
+      do {
+        nread = read(uv__stream_fd(stream), buf.base, buf.len);
+      }
+      while (nread < 0 && errno == EINTR);
 #endif  /* !__wasi__ */
     }
 

--- a/src/unix/tcp.c
+++ b/src/unix/tcp.c
@@ -250,6 +250,9 @@ static int uv__ipv6_link_local_scope_id(void) {
   uv_free_interface_addresses(interfaces, count);
 
 #else
+
+// TODO: missing wasix entrypoint
+#ifndef __wasi__
   struct ifaddrs* ifa;
   struct ifaddrs* p;
 
@@ -268,6 +271,8 @@ static int uv__ipv6_link_local_scope_id(void) {
   }
 
   freeifaddrs(ifa);
+#endif
+
 #endif /* defined(_AIX) */
 
   return rv;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -58,6 +58,11 @@
 #undef NANOSEC
 #define NANOSEC ((uint64_t) 1e9)
 
+typedef struct {
+  void (*entry)(void* arg);
+  void* arg;
+} uv__thread_start_args_t;
+
 /* Musl's PTHREAD_STACK_MIN is 2 KB on all architectures, which is
  * too small to safely receive signals on.
  *
@@ -123,6 +128,17 @@ size_t uv__thread_stack_size(void) {
 }
 
 
+static void* uv__thread_start_trampoline(void* arg) {
+  uv__thread_start_args_t* args = (uv__thread_start_args_t*) arg;
+
+  args->entry(args->arg);
+
+  uv__free(args);
+
+  return NULL;
+}
+
+
 int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
   uv_thread_options_t params;
   params.flags = UV_THREAD_NO_FLAGS;
@@ -145,12 +161,14 @@ int uv_thread_create_ex(uv_thread_t* tid,
   size_t pagesize;
   size_t stack_size;
   size_t min_stack_size;
+  uv__thread_start_args_t* start_args;
 
-  /* Used to squelch a -Wcast-function-type warning. */
-  union {
-    void (*in)(void*);
-    void* (*out)(void*);
-  } f;
+  start_args = uv__malloc(sizeof(*start_args));
+  if (start_args == NULL) {
+    abort();
+  }
+  start_args->entry = entry;
+  start_args->arg = arg;
 
   stack_size =
       params->flags & UV_THREAD_HAS_STACK_SIZE ? params->stack_size : 0;
@@ -177,8 +195,7 @@ int uv_thread_create_ex(uv_thread_t* tid,
       abort();
   }
 
-  f.in = entry;
-  err = pthread_create(tid, attr, f.out, arg);
+  err = pthread_create(tid, attr, uv__thread_start_trampoline, start_args);
 
   if (attr != NULL)
     pthread_attr_destroy(attr);

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -125,10 +125,13 @@ static int uv__tty_is_slave(const int fd) {
     abort();
 
   result = (pts == major(sb.st_rdev));
-#else
+#elif !defined(__wasi__)
   /* Fallback to ptsname
    */
   result = ptsname(fd) == NULL;
+#else
+  /* No way to determine if the fd is a slave tty on this platform. */
+  result = 0;
 #endif
   return result;
 }

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -530,6 +530,10 @@ int uv__udp_connect(uv_udp_t* handle,
  *   if (addr->sa_family == AF_UNSPEC) sodisconnect(so);
  */
 int uv__udp_disconnect(uv_udp_t* handle) {
+#if defined(__wasi__)
+    handle->flags &= ~UV_HANDLE_UDP_CONNECTED;
+    return 0;
+#else
     int r;
 #if defined(__MVS__)
     struct sockaddr_storage addr;
@@ -570,6 +574,7 @@ int uv__udp_disconnect(uv_udp_t* handle) {
 
     handle->flags &= ~UV_HANDLE_UDP_CONNECTED;
     return 0;
+#endif
 }
 
 int uv__udp_send(uv_udp_send_t* req,
@@ -1087,6 +1092,15 @@ int uv_udp_set_ttl(uv_udp_t* handle, int ttl) {
 
 
 int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
+  if (ttl < 1 || ttl > 255)
+    return UV_EINVAL;
+  if (handle->io_watcher.fd == -1)
+    return UV_EBADF;
+
+#if defined(__wasi__)
+  return 0;
+#endif
+
 /*
  * On Solaris and derivatives such as SmartOS, the length of socket options
  * is sizeof(int) for IPV6_MULTICAST_HOPS and sizeof(char) for
@@ -1112,6 +1126,13 @@ int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl) {
 
 
 int uv_udp_set_multicast_loop(uv_udp_t* handle, int on) {
+  if (handle->io_watcher.fd == -1)
+    return UV_EBADF;
+
+#if defined(__wasi__)
+  return 0;
+#endif
+
 /*
  * On Solaris and derivatives such as SmartOS, the length of socket options
  * is sizeof(int) for IPV6_MULTICAST_LOOP and sizeof(char) for
@@ -1140,6 +1161,9 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
   struct sockaddr_in* addr4;
   struct sockaddr_in6* addr6;
 
+  if (handle->io_watcher.fd == -1)
+    return UV_EBADF;
+
   addr4 = (struct sockaddr_in*) &addr_st;
   addr6 = (struct sockaddr_in6*) &addr_st;
 
@@ -1159,6 +1183,20 @@ int uv_udp_set_multicast_interface(uv_udp_t* handle, const char* interface_addr)
   } else {
     return UV_EINVAL;
   }
+
+#if defined(__wasi__)
+  if ((handle->flags & UV_HANDLE_IPV6) && addr_st.ss_family == AF_INET)
+    return UV_EINVAL;
+  if (!(handle->flags & UV_HANDLE_IPV6) && addr_st.ss_family == AF_INET6)
+    return UV_EINVAL;
+  if (addr_st.ss_family == AF_INET &&
+      IN_MULTICAST(ntohl(addr4->sin_addr.s_addr))) {
+    return UV_EINVAL;
+  }
+  if (addr_st.ss_family == AF_INET6 && IN6_IS_ADDR_MULTICAST(&addr6->sin6_addr))
+    return UV_EINVAL;
+  return 0;
+#endif
 
   if (addr_st.ss_family == AF_INET) {
     if (setsockopt(handle->io_watcher.fd,

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -289,7 +289,10 @@ int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr) {
 #ifdef _WIN32
     addr->sin6_scope_id = atoi(zone_index);
 #else
+// TODO: missing wasix entrypoint
+#ifndef __wasi__
     addr->sin6_scope_id = if_nametoindex(zone_index);
+#endif
 #endif
   }
 
@@ -440,6 +443,10 @@ int uv_udp_connect(uv_udp_t* handle, const struct sockaddr* addr) {
 
 
 int uv__udp_is_connected(uv_udp_t* handle) {
+#if defined(__wasi__)
+  return handle->type == UV_UDP &&
+         (handle->flags & UV_HANDLE_UDP_CONNECTED) != 0;
+#else
   struct sockaddr_storage addr;
   int addrlen;
   if (handle->type != UV_UDP)
@@ -450,6 +457,7 @@ int uv__udp_is_connected(uv_udp_t* handle) {
     return 0;
 
   return addrlen > 0;
+#endif
 }
 
 

--- a/src/win/getaddrinfo.c
+++ b/src/win/getaddrinfo.c
@@ -346,6 +346,8 @@ int uv_getaddrinfo(uv_loop_t* loop,
   }
 }
 
+// TODO: missing wasix entrypoint
+#ifndef __wasi__
 int uv_if_indextoname(unsigned int ifindex, char* buffer, size_t* size) {
   NET_LUID luid;
   wchar_t wname[NDIS_IF_MAX_STRING_SIZE + 1]; /* Add one for the NUL. */
@@ -386,3 +388,4 @@ int uv_if_indextoiid(unsigned int ifindex, char* buffer, size_t* size) {
   *size = r;
   return 0;
 }
+#endif

--- a/wasix-toolchain.cmake
+++ b/wasix-toolchain.cmake
@@ -1,0 +1,25 @@
+# Cmake toolchain description file for the Makefile for WASI
+cmake_minimum_required(VERSION 3.5.0)
+
+set(CMAKE_SYSTEM_NAME WASI) # Generic for now, to not trigger a Warning
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR wasm32)
+set(CMAKE_C_COMPILER_ID Clang)
+set(triple wasm32-wasmer-wasi)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_ASM_COMPILER_TARGET ${triple})
+set(CMAKE_${lang}_COMPILE_OPTIONS_SYSROOT "--sysroot=$ENV{WASIXCC_SYSROOT}")
+
+set(CMAKE_C_COMPILER wasixcc)
+set(CMAKE_CXX_COMPILER wasix++)
+set(CMAKE_LINKER wasixld)
+set(CMAKE_AR wasixar)
+set(CMAKE_RANLIB wasixranlib)
+
+# Don't look in the sysroot for executables to run during the build
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Only look in the sysroot (not in the host paths) for the rest
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/wasix.sh
+++ b/wasix.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+set -euxo pipefail
+
+rm -rf build
+mkdir build
+cd build
+
+export WASIXCC_SYSROOT=/home/arshia/repos/wasmer/wasix-libc/sysroot32-ehpic/
+export WASIXCC_WASM_EXCEPTIONS=yes
+export WASIXCC_PIC=yes
+
+WASIXCC_RUN_WASM_OPT=no \
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=wasix-toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+
+make uv_a -j16


### PR DESCRIPTION
WASI does not support msghdr or file descriptor passing, but WASIX
socket pairs can still transport IPC byte payloads.

Use read() for IPC pipes on WASI instead of returning ENOSYS. Handle
passing remains unsupported.