### PR TITLE
win: allow uv_try_write() from a write callback

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -1161,6 +1161,7 @@ done:
 
 void uv__process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
     uv_write_t* req) {
+  uv_shutdown_t* shutdown_req;
   int err;
 
   assert(handle->type == UV_TCP);
@@ -1182,6 +1183,16 @@ void uv__process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
     }
   }
 
+  /* Retire the request before running the callback. uv__tcp_try_write() bails
+   * out with UV_EAGAIN while writes are in flight and there is nothing left in
+   * flight when this was the last one. */
+  handle->stream.conn.write_reqs_pending--;
+
+  /* Only a shutdown request that is already pending is ours to dispatch below.
+   * One that the callback starts is queued by uv_shutdown() itself, because it
+   * now observes write_reqs_pending == 0. */
+  shutdown_req = handle->stream.conn.shutdown_req;
+
   if (req->cb) {
     err = uv_translate_sys_error(GET_REQ_SOCK_ERROR(req));
     if (err == UV_ECONNABORTED) {
@@ -1191,16 +1202,15 @@ void uv__process_tcp_write_req(uv_loop_t* loop, uv_tcp_t* handle,
     req->cb(req, err);
   }
 
-  handle->stream.conn.write_reqs_pending--;
   if (handle->stream.conn.write_reqs_pending == 0) {
-    if (handle->flags & UV_HANDLE_CLOSING) {
+    /* The socket is already gone when the callback called uv_close(). */
+    if (handle->flags & UV_HANDLE_CLOSING &&
+        handle->socket != INVALID_SOCKET) {
       closesocket(handle->socket);
       handle->socket = INVALID_SOCKET;
     }
-    if (uv__is_stream_shutting(handle))
-      uv__process_tcp_shutdown_req(loop,
-                                   handle,
-                                   handle->stream.conn.shutdown_req);
+    if (shutdown_req != NULL)
+      uv__process_tcp_shutdown_req(loop, handle, shutdown_req);
   }
 
   DECREASE_PENDING_REQ_COUNT(handle);

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -110,6 +110,7 @@ TEST_DECLARE   (tcp_write_after_connect)
 TEST_DECLARE   (tcp_writealot)
 TEST_DECLARE   (tcp_write_fail)
 TEST_DECLARE   (tcp_try_write)
+TEST_DECLARE   (tcp_try_write_in_write_cb)
 TEST_DECLARE   (tcp_write_in_a_row)
 TEST_DECLARE   (tcp_try_write_error)
 TEST_DECLARE   (tcp_write_queue_order)
@@ -748,6 +749,7 @@ TASK_LIST_START
   TEST_HELPER (tcp_write_fail, tcp4_echo_server)
 
   TEST_ENTRY  (tcp_try_write)
+  TEST_ENTRY  (tcp_try_write_in_write_cb)
   TEST_ENTRY  (tcp_write_in_a_row)
   TEST_ENTRY  (tcp_try_write_error)
 

--- a/test/test-tcp-try-write.c
+++ b/test/test-tcp-try-write.c
@@ -133,3 +133,106 @@ TEST_IMPL(tcp_try_write) {
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
+
+
+static uv_tcp_t wcb_server;
+static uv_tcp_t wcb_client;
+static uv_tcp_t wcb_incoming;
+static uv_write_t wcb_write_req;
+static int wcb_close_cb_called;
+static int wcb_connect_cb_called;
+static int wcb_connection_cb_called;
+static int wcb_write_cb_called;
+static int wcb_bytes_read;
+static int wcb_bytes_written;
+
+
+static void wcb_close_cb(uv_handle_t* handle) {
+  wcb_close_cb_called++;
+}
+
+
+static void wcb_read_cb(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf) {
+  if (nread < 0) {
+    uv_close((uv_handle_t*) tcp, wcb_close_cb);
+    uv_close((uv_handle_t*) &wcb_server, wcb_close_cb);
+    return;
+  }
+
+  wcb_bytes_read += nread;
+}
+
+
+static void wcb_connection_cb(uv_stream_t* tcp, int status) {
+  ASSERT_OK(status);
+
+  ASSERT_OK(uv_tcp_init(tcp->loop, &wcb_incoming));
+  ASSERT_OK(uv_accept(tcp, (uv_stream_t*) &wcb_incoming));
+
+  wcb_connection_cb_called++;
+  ASSERT_OK(uv_read_start((uv_stream_t*) &wcb_incoming, alloc_cb, wcb_read_cb));
+}
+
+
+static void wcb_write_cb(uv_write_t* req, int status) {
+  uv_buf_t buf;
+  int r;
+
+  ASSERT_OK(status);
+  wcb_write_cb_called++;
+
+  /* This callback completed the last pending write request, so nothing is in
+   * flight anymore and uv_try_write() must not report UV_EAGAIN. */
+  buf = uv_buf_init("PONG", 4);
+  r = uv_try_write((uv_stream_t*) &wcb_client, &buf, 1);
+  ASSERT_EQ(4, r);
+  wcb_bytes_written += r;
+
+  uv_close((uv_handle_t*) &wcb_client, wcb_close_cb);
+}
+
+
+static void wcb_connect_cb(uv_connect_t* req, int status) {
+  uv_buf_t buf;
+
+  ASSERT_OK(status);
+  wcb_connect_cb_called++;
+
+  buf = uv_buf_init("PING", 4);
+  ASSERT_OK(uv_write(&wcb_write_req,
+                     (uv_stream_t*) &wcb_client,
+                     &buf,
+                     1,
+                     wcb_write_cb));
+  wcb_bytes_written += 4;
+}
+
+
+TEST_IMPL(tcp_try_write_in_write_cb) {
+  uv_connect_t connect_req;
+  struct sockaddr_in addr;
+
+  ASSERT_OK(uv_ip4_addr("0.0.0.0", TEST_PORT, &addr));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &wcb_server));
+  ASSERT_OK(uv_tcp_bind(&wcb_server, (struct sockaddr*) &addr, 0));
+  ASSERT_OK(uv_listen((uv_stream_t*) &wcb_server, 128, wcb_connection_cb));
+
+  ASSERT_OK(uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
+  ASSERT_OK(uv_tcp_init(uv_default_loop(), &wcb_client));
+  ASSERT_OK(uv_tcp_connect(&connect_req,
+                           &wcb_client,
+                           (struct sockaddr*) &addr,
+                           wcb_connect_cb));
+
+  ASSERT_OK(uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT_EQ(1, wcb_connect_cb_called);
+  ASSERT_EQ(1, wcb_write_cb_called);
+  ASSERT_EQ(1, wcb_connection_cb_called);
+  ASSERT_EQ(3, wcb_close_cb_called);
+  ASSERT_EQ(8, wcb_bytes_written);
+  ASSERT_EQ(wcb_bytes_read, wcb_bytes_written);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}


### PR DESCRIPTION
`uv__process_tcp_write_req()` decremented `write_reqs_pending` after running the write callback, so `uv__tcp_try_write()` still saw the just-completed request as in flight and returned `UV_EAGAIN` unconditionally.

Moving the decrement up is not enough on its own: `uv_shutdown()` reads the same counter and self-queues when it sees zero, so a shutdown started from the callback would be dispatched twice. Hence the `shutdown_req` snapshot.

New test `tcp_try_write_in_write_cb` calls `uv_try_write()` from a write callback and asserts it does not return `UV_EAGAIN`. Full suite: 496 ok.

Fixes: https://github.com/libuv/libuv/issues/4183