### PR TITLE
win: fix crash when closing a pipe after a failed bind

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -730,7 +730,8 @@ void uv__pipe_endgame(uv_loop_t* loop, uv_pipe_t* handle) {
   }
 
   if (handle->flags & UV_HANDLE_PIPESERVER) {
-    assert(handle->pipe.serv.accept_reqs);
+    /* accept_reqs is NULL when uv_pipe_pending_instances() was called but
+     * the pipe was never successfully bound. */
     uv__free(handle->pipe.serv.accept_reqs);
     handle->pipe.serv.accept_reqs = NULL;
   }
@@ -1248,11 +1249,15 @@ void uv__pipe_close(uv_loop_t* loop, uv_pipe_t* handle) {
   }
 
   if (handle->flags & UV_HANDLE_PIPESERVER) {
-    for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
-      pipeHandle = handle->pipe.serv.accept_reqs[i].pipeHandle;
-      if (pipeHandle != INVALID_HANDLE_VALUE) {
-        CloseHandle(pipeHandle);
-        handle->pipe.serv.accept_reqs[i].pipeHandle = INVALID_HANDLE_VALUE;
+    /* accept_reqs is NULL when uv_pipe_pending_instances() was called but
+     * the pipe was never successfully bound. */
+    if (handle->pipe.serv.accept_reqs != NULL) {
+      for (i = 0; i < handle->pipe.serv.pending_instances; i++) {
+        pipeHandle = handle->pipe.serv.accept_reqs[i].pipeHandle;
+        if (pipeHandle != INVALID_HANDLE_VALUE) {
+          CloseHandle(pipeHandle);
+          handle->pipe.serv.accept_reqs[i].pipeHandle = INVALID_HANDLE_VALUE;
+        }
       }
     }
     handle->handle = INVALID_HANDLE_VALUE;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -220,6 +220,7 @@ TEST_DECLARE   (udp_send_fail_nbufs)
 TEST_DECLARE   (udp_sendmmsg_error)
 TEST_DECLARE   (udp_try_send)
 TEST_DECLARE   (pipe_bind_error_addrinuse)
+TEST_DECLARE   (pipe_bind_error_addrinuse_pending_instances)
 TEST_DECLARE   (pipe_bind_error_addrnotavail)
 TEST_DECLARE   (pipe_bind_error_inval)
 TEST_DECLARE   (pipe_connect_close_multiple)
@@ -881,6 +882,7 @@ TASK_LIST_START
 #endif
 
   TEST_ENTRY  (pipe_bind_error_addrinuse)
+  TEST_ENTRY  (pipe_bind_error_addrinuse_pending_instances)
   TEST_ENTRY  (pipe_bind_error_addrnotavail)
   TEST_ENTRY  (pipe_bind_error_inval)
   TEST_ENTRY  (pipe_connect_close_multiple)

--- a/test/test-pipe-bind-error.c
+++ b/test/test-pipe-bind-error.c
@@ -73,6 +73,34 @@ TEST_IMPL(pipe_bind_error_addrinuse) {
 }
 
 
+TEST_IMPL(pipe_bind_error_addrinuse_pending_instances) {
+  uv_pipe_t server1, server2;
+  int r;
+
+  r = uv_pipe_init(uv_default_loop(), &server1, 0);
+  ASSERT_OK(r);
+  uv_pipe_pending_instances(&server1, 32);
+  r = uv_pipe_bind(&server1, TEST_PIPENAME);
+  ASSERT_OK(r);
+
+  r = uv_pipe_init(uv_default_loop(), &server2, 0);
+  ASSERT_OK(r);
+  uv_pipe_pending_instances(&server2, 32);
+  r = uv_pipe_bind(&server2, TEST_PIPENAME);
+  ASSERT_EQ(r, UV_EADDRINUSE);
+
+  uv_close((uv_handle_t*)&server1, close_cb);
+  uv_close((uv_handle_t*)&server2, close_cb);
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT_EQ(2, close_cb_called);
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+
+
 TEST_IMPL(pipe_bind_error_addrnotavail) {
   uv_pipe_t server;
   int r;


### PR DESCRIPTION
`uv_pipe_pending_instances()` sets the `UV_HANDLE_PIPESERVER` flag before the pipe is bound. When the subsequent bind fails (e.g. with `UV_EADDRINUSE` after losing a bind race on a well-known pipe name), `uv_pipe_bind2()` frees `accept_reqs` and resets it to `NULL`, but the flag stays set. Closing the handle then dereferences the `NULL` `accept_reqs` array in `uv__pipe_close()` — release builds crash with an access violation, debug builds trip the assert in `uv__pipe_endgame()`.

This PR tolerates `accept_reqs == NULL` at both cleanup sites and adds a regression test (`pipe_bind_error_addrinuse_pending_instances`), which crashes with 0xC0000005 without the fix and passes with it.

Refs: https://github.com/nodejs/node/issues/65057 (crash is reachable from Node.js via `NODE_PENDING_PIPE_INSTANCES`; reproduces on Node 22/24/26)