### PR TITLE
unix,process: never shrink the stdio socket pair buffers

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -209,6 +209,23 @@ void uv__wait_children(uv_loop_t* loop) {
  * avoided. Since this isn't called on those targets, the function
  * doesn't even need to be defined for them.
  */
+/* Raise a socket buffer to at least `size` bytes but never shrink it: the
+ * defaults differ wildly between platforms (8 KiB on macOS, ~208 KiB on Linux)
+ * and a smaller buffer means more wake-ups per bulk transfer over stdio.
+ */
+static void uv__process_stdio_bufsize(int fd, int opt, int size) {
+  socklen_t len;
+  int cur;
+
+  len = sizeof(cur);
+  if (getsockopt(fd, SOL_SOCKET, opt, &cur, &len))
+    cur = 0;
+
+  if (cur < size)
+    setsockopt(fd, SOL_SOCKET, opt, &size, sizeof(size));
+}
+
+
 static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
   int mask;
   int fd;
@@ -232,8 +249,8 @@ static int uv__process_init_stdio(uv_stdio_container_t* container, int fds[2]) {
 
       if (ret == 0)
         for (i = 0; i < 2; i++) {
-          setsockopt(fds[i], SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
-          setsockopt(fds[i], SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
+          uv__process_stdio_bufsize(fds[i], SO_RCVBUF, size);
+          uv__process_stdio_bufsize(fds[i], SO_SNDBUF, size);
         }
     }
 

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -346,6 +346,7 @@ TEST_DECLARE   (spawn_empty_env)
 TEST_DECLARE   (spawn_exit_code)
 TEST_DECLARE   (spawn_stdout)
 TEST_DECLARE   (spawn_stdin)
+TEST_DECLARE   (spawn_stdio_socket_buffer_size)
 TEST_DECLARE   (spawn_stdio_greater_than_3)
 TEST_DECLARE   (spawn_ignored_stdio)
 TEST_DECLARE   (spawn_and_kill)
@@ -1059,6 +1060,9 @@ TASK_LIST_START
   TEST_ENTRY  (spawn_exit_code)
   TEST_ENTRY  (spawn_stdout)
   TEST_ENTRY  (spawn_stdin)
+#ifndef _WIN32
+  TEST_ENTRY  (spawn_stdio_socket_buffer_size)
+#endif
   TEST_ENTRY  (spawn_stdio_greater_than_3)
   TEST_ENTRY  (spawn_ignored_stdio)
   TEST_ENTRY  (spawn_and_kill)

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -580,6 +580,73 @@ TEST_IMPL(spawn_stdout_and_stderr_to_file_swap) {
 }
 
 
+#ifndef _WIN32
+/* The stdio "pipes" handed to a child are AF_UNIX stream socket pairs whose
+ * buffers are raised to at least 64 KiB, but never shrunk below what the
+ * platform hands out by default.
+ */
+TEST_IMPL(spawn_stdio_socket_buffer_size) {
+  uv_stdio_container_t stdio[2];
+  uv_pipe_t in;
+  uv_pipe_t out;
+  uv_os_fd_t fd;
+  socklen_t len;
+  int defaults[2];
+  int sndbuf;
+  int rcvbuf;
+  int sv[2];
+  int r;
+
+  /* What does a fresh socket pair get on this system? */
+  ASSERT_OK(socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+  len = sizeof(defaults[0]);
+  ASSERT_OK(getsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &defaults[0], &len));
+  len = sizeof(defaults[1]);
+  ASSERT_OK(getsockopt(sv[0], SOL_SOCKET, SO_RCVBUF, &defaults[1], &len));
+  close(sv[0]);
+  close(sv[1]);
+
+  init_process_options("spawn_helper1", exit_cb);
+
+  uv_pipe_init(uv_default_loop(), &out, 0);
+  uv_pipe_init(uv_default_loop(), &in, 0);
+  options.stdio = stdio;
+  options.stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+  options.stdio[0].data.stream = (uv_stream_t*) &in;
+  options.stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+  options.stdio[1].data.stream = (uv_stream_t*) &out;
+  options.stdio_count = 2;
+
+  r = uv_spawn(uv_default_loop(), &process, &options);
+  ASSERT_OK(r);
+
+  ASSERT_OK(uv_fileno((uv_handle_t*) &in, &fd));
+  len = sizeof(sndbuf);
+  ASSERT_OK(getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, &len));
+  len = sizeof(rcvbuf);
+  ASSERT_OK(getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, &len));
+
+  ASSERT_GE(sndbuf, 64 * 1024);
+  ASSERT_GE(rcvbuf, 64 * 1024);
+  ASSERT_GE(sndbuf, defaults[0]);
+  ASSERT_GE(rcvbuf, defaults[1]);
+
+  r = uv_read_start((uv_stream_t*) &out, on_alloc, on_read);
+  ASSERT_OK(r);
+  uv_close((uv_handle_t*) &in, close_cb);
+
+  r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT_OK(r);
+
+  ASSERT_EQ(1, exit_cb_called);
+  ASSERT_EQ(3, close_cb_called); /* Once for process twice for the pipe. */
+
+  MAKE_VALGRIND_HAPPY(uv_default_loop());
+  return 0;
+}
+#endif
+
+
 TEST_IMPL(spawn_stdin) {
   int r;
   uv_pipe_t out;


### PR DESCRIPTION
**Large parent↔child stdio exchanges on Linux get 30% faster (1 MiB write-then-read-back round trip 456 → 305 µs, parent CPU −24%; through Node's `child_process` the same exchange is 8–9% faster) by no longer shrinking the socket pair buffers below the system default.**

## What

#4694 raised the `UV_CREATE_PIPE` socket pair buffers to 64 KiB for macOS'
benefit (8 KiB default there) but applied the `setsockopt()` unconditionally. On Linux, AF_UNIX stream sockets start at `net.core.wmem_default` = 212992 bytes, so the same call **shrinks** them to 128 KiB (the kernel doubles the 64 KiB you pass) and costs four system calls per pipe.

This reads the current value first and only ever raises it. macOS/BSD get byte-for-byte what #4694 intended; Linux keeps its default and swaps four `setsockopt()` for four `getsockopt()`.

## Numbers

Where it shows: a bulk `uv_write()` into the child's stdin followed by reading a bulk reply (language servers, MCP-style tool servers, formatters fed via stdin). Length-prefixed echo through a plain `read()/write()` child, parent on libuv with 64 KiB reads, p50 of two sessions × 30 interleaved runs, Linux 6.12 x86-64:

| message | v1.x | this | parent CPU |
|---|---|---|---|
| 64 KiB | 30.9 µs | 30.8 µs | n.s. |
| 256 KiB | 160 µs | 112 µs | −31% |
| 1 MiB | 456 µs | 305 µs | −24% |
| 4 MiB | 1120 µs | 984 µs | −7% |

One-directional bulk transfers and `uv_spawn()` latency are unchanged within noise — the effect is specific to write-then-read-back, where the smaller send buffer turns into extra POLLOUT/wake-up cycles on both sides. Node `child_process`, same libuv: 1 MiB exchange −8…−9% (p < 1e-5, both sessions); 4 MiB n.s. (per-chunk JS cost dominates).

## Test

`spawn_stdio_socket_buffer_size` asserts ≥ 64 KiB on all Unix and, using a fresh `socketpair()` as the reference, that we never go below the platform default (fails on current v1.x on Linux: 131072 < 212992).

## Disclosure

The code, test, measurements and this description were written by Claude Code, directed and reviewed by @codebytere.

