### PR TITLE
build: use Visual Studio 18 2026 on Windows Server 2025

### DIFF
--- a/.github/workflows/CI-win.yml
+++ b/.github/workflows/CI-win.yml
@@ -26,10 +26,10 @@ jobs:
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: ASAN}
           - {toolchain: Visual Studio 17 2022, arch: x64, server: 2022, config: UBSAN}
           - {toolchain: Visual Studio 17 2022, arch: arm64, server: 2022}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2025}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2025, config: ASAN}
-          - {toolchain: Visual Studio 17 2022, arch: x64, server: 2025, config: UBSAN}
-          - {toolchain: Visual Studio 17 2022, arch: arm64, server: 2025}
+          - {toolchain: Visual Studio 18 2026, arch: x64, server: 2025}
+          - {toolchain: Visual Studio 18 2026, arch: x64, server: 2025, config: ASAN}
+          - {toolchain: Visual Studio 18 2026, arch: x64, server: 2025, config: UBSAN}
+          - {toolchain: Visual Studio 18 2026, arch: arm64, server: 2025}
     steps:
       - uses: actions/checkout@v4
       - name: Build


### PR DESCRIPTION
Refs: https://github.com/libuv/libuv/pull/5229#pullrequestreview-4954123779

---
This will fix windows CI in `master`