### PR TITLE
win,fs: suppress CRT assertion on close

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -709,10 +709,13 @@ void fs__close(uv_fs_t* req) {
     }
   }
 
-  if (fd > 2)
+  if (fd > 2) {
+    UV_BEGIN_DISABLE_CRT_ASSERT();
     result = _close(fd);
-  else
+    UV_END_DISABLE_CRT_ASSERT();
+  } else {
     result = 0;
+  }
 
   /* _close doesn't set _doserrno on failure, but it does always set errno
    * to EBADF on failure.

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -35,6 +35,9 @@
 # include <winioctl.h>
 # include <direct.h>
 # include <io.h>
+# if defined(_DEBUG) && defined(_MSC_VER)
+#  include <crtdbg.h>
+# endif
 # ifndef ERROR_SYMLINK_NOT_SUPPORTED
 #  define ERROR_SYMLINK_NOT_SUPPORTED 1464
 # endif
@@ -1045,6 +1048,12 @@ TEST_FS_IMPL(fs_file_async) {
 
 static void fs_file_sync(int add_flags) {
   int r;
+#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+  HANDLE report_file;
+  LARGE_INTEGER report_size;
+  _HFILE old_report_file;
+  int old_report_mode;
+#endif
 
   /* Setup. */
   unlink("test_file");
@@ -1068,6 +1077,36 @@ static void fs_file_sync(int add_flags) {
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
   ASSERT_OK(r);
   ASSERT_OK(close_req.result);
+  uv_fs_req_cleanup(&close_req);
+
+#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+  /* Invalid descriptors must not trigger debug CRT assertions. */
+  report_file = CreateFileA("test_crt_report",
+                            GENERIC_READ | GENERIC_WRITE,
+                            0,
+                            NULL,
+                            CREATE_ALWAYS,
+                            FILE_ATTRIBUTE_TEMPORARY |
+                                FILE_FLAG_DELETE_ON_CLOSE,
+                            NULL);
+  ASSERT_NE(report_file, INVALID_HANDLE_VALUE);
+  old_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+  old_report_file = _CrtSetReportFile(_CRT_ASSERT, (_HFILE) report_file);
+#endif
+
+  r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
+
+#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+  _CrtSetReportFile(_CRT_ASSERT, old_report_file);
+  _CrtSetReportMode(_CRT_ASSERT, old_report_mode);
+  ASSERT_NE(FlushFileBuffers(report_file), 0);
+  ASSERT_NE(GetFileSizeEx(report_file, &report_size), 0);
+  ASSERT_EQ(0, report_size.QuadPart);
+  ASSERT_NE(CloseHandle(report_file), 0);
+#endif
+
+  ASSERT_EQ(UV_EBADF, r);
+  ASSERT_EQ(UV_EBADF, close_req.result);
   uv_fs_req_cleanup(&close_req);
 
   r = uv_fs_open(NULL, &open_req1, "test_file", UV_FS_O_RDWR | add_flags, 0,

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -35,7 +35,7 @@
 # include <winioctl.h>
 # include <direct.h>
 # include <io.h>
-# if defined(_DEBUG) && defined(_MSC_VER)
+# if defined(_MSC_VER)
 #  include <crtdbg.h>
 # endif
 # ifndef ERROR_SYMLINK_NOT_SUPPORTED
@@ -1048,7 +1048,7 @@ TEST_FS_IMPL(fs_file_async) {
 
 static void fs_file_sync(int add_flags) {
   int r;
-#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(_MSC_VER)
   HANDLE report_file;
   LARGE_INTEGER report_size;
   _HFILE old_report_file;
@@ -1079,7 +1079,7 @@ static void fs_file_sync(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(_MSC_VER)
   /* Invalid descriptors must not trigger debug CRT assertions. */
   report_file = CreateFileA("test_crt_report",
                             GENERIC_READ | GENERIC_WRITE,
@@ -1096,7 +1096,7 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
 
-#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(_MSC_VER)
   _CrtSetReportFile(_CRT_ASSERT, old_report_file);
   _CrtSetReportMode(_CRT_ASSERT, old_report_mode);
   ASSERT_NE(FlushFileBuffers(report_file), 0);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1089,7 +1089,7 @@ static void fs_file_sync(int add_flags) {
                             FILE_ATTRIBUTE_TEMPORARY |
                                 FILE_FLAG_DELETE_ON_CLOSE,
                             NULL);
-  ASSERT_NE(report_file, INVALID_HANDLE_VALUE);
+  ASSERT_PTR_NE(report_file, INVALID_HANDLE_VALUE);
   old_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
   old_report_file = _CrtSetReportFile(_CRT_ASSERT, (_HFILE) report_file);
 #endif

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -35,9 +35,7 @@
 # include <winioctl.h>
 # include <direct.h>
 # include <io.h>
-# if defined(_MSC_VER)
-#  include <crtdbg.h>
-# endif
+# include <crtdbg.h>
 # ifndef ERROR_SYMLINK_NOT_SUPPORTED
 #  define ERROR_SYMLINK_NOT_SUPPORTED 1464
 # endif
@@ -1048,7 +1046,7 @@ TEST_FS_IMPL(fs_file_async) {
 
 static void fs_file_sync(int add_flags) {
   int r;
-#if defined(_WIN32) && defined(_MSC_VER)
+#ifdef _WIN32
   HANDLE report_file;
   LARGE_INTEGER report_size;
   _HFILE old_report_file;
@@ -1079,7 +1077,7 @@ static void fs_file_sync(int add_flags) {
   ASSERT_OK(close_req.result);
   uv_fs_req_cleanup(&close_req);
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#ifdef _WIN32
   /* Invalid descriptors must not trigger debug CRT assertions. */
   report_file = CreateFileA("test_crt_report",
                             GENERIC_READ | GENERIC_WRITE,
@@ -1096,7 +1094,7 @@ static void fs_file_sync(int add_flags) {
 
   r = uv_fs_close(NULL, &close_req, open_req1.result, NULL);
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#ifdef _WIN32
   _CrtSetReportFile(_CRT_ASSERT, old_report_file);
   _CrtSetReportMode(_CRT_ASSERT, old_report_mode);
   ASSERT_NE(FlushFileBuffers(report_file), 0);


### PR DESCRIPTION
The Windows debug CRT emits an assertion when `_close()` receives an invalid descriptor, even though `_close()` then reports `EBADF`. In embedders that retain the default CRT report mode, that assertion can display a modal dialog and block the process.

Wrap `_close()` in libuv's existing thread-local CRT assertion suppression scope, matching the handling around `_get_osfhandle()`.

The regression test double-closes a descriptor, verifies `UV_EBADF`, and captures the CRT assertion destination to ensure no assertion report is emitted.

Tests:
- Debug MSVC build of `uv_run_tests` and `uv_run_tests_a`
- `uv_run_tests.exe fs_file_sync`
- `uv_run_tests_a.exe fs_file_sync`

A full `ctest` run was also attempted, but the non-interactive Windows shell left the existing `tty_raw` and `tty_duplicate_vt100_fn_key_winvt` tests waiting for console input.

Downstream report: https://github.com/oven-sh/bun/issues/39680