### PR TITLE
freebsd: add build CI

### DIFF
--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           copyback: false
+          cache-after-prepare: true
           prepare: pkg install -y autoconf automake libtool gmake
           run: |
             set -e -u -x

--- a/.github/workflows/CI-freebsd.yml
+++ b/.github/workflows/CI-freebsd.yml
@@ -1,0 +1,43 @@
+name: CI-freebsd
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-freebsd.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-freebsd:
+    runs-on: ubuntu-24.04
+    name: Build on FreeBSD ${{ matrix.release }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # The two supported branches. Only the leading part is given, so
+        # the newest release of each is picked up without an edit here.
+        release: ['14', '15']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build
+        uses: vmactions/freebsd-vm@f0552d3b69211736abd97f02ff3d4674c56b73b1 # v1.5.5
+        with:
+          release: ${{ matrix.release }}
+          copyback: false
+          prepare: pkg install -y autoconf automake libtool gmake
+          run: |
+            set -e -u -x
+            ./autogen.sh
+            mkdir build
+            cd build
+            ../configure
+            gmake -j2

--- a/.github/workflows/CI-netbsd.yml
+++ b/.github/workflows/CI-netbsd.yml
@@ -1,0 +1,41 @@
+name: CI-netbsd
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-netbsd.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-netbsd:
+    runs-on: ubuntu-24.04
+    name: Build on NetBSD
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build
+        uses: vmactions/netbsd-vm@6334c835de4c04a59fe59f0f8f071e02a2f0bab3 # v1.4.7
+        with:
+          copyback: false
+          prepare: |
+            # The image's default PKG_PATH falls back to a 9.0 package set;
+            # point it at the running release instead.
+            PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
+            export PKG_PATH
+            pkg_add autoconf automake libtool gmake
+          run: |
+            set -e -u -x
+            ./autogen.sh
+            mkdir build
+            cd build
+            ../configure
+            gmake -j2

--- a/.github/workflows/CI-netbsd.yml
+++ b/.github/workflows/CI-netbsd.yml
@@ -26,12 +26,19 @@ jobs:
         uses: vmactions/netbsd-vm@6334c835de4c04a59fe59f0f8f071e02a2f0bab3 # v1.4.7
         with:
           copyback: false
+          cache-after-prepare: true
           prepare: |
-            # The image's default PKG_PATH falls back to a 9.0 package set;
-            # point it at the running release instead.
-            PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
-            export PKG_PATH
-            pkg_add autoconf automake libtool gmake
+            # The image's default PKG_PATH falls back to a 9.0 package set,
+            # so point it at the running release.  The NetBSD.org package
+            # hosts have outages (cdn and ftp were down together on
+            # 2026-08-30), so fall back to the official French mirror,
+            # which is http-only.
+            for base in https://cdn.NetBSD.org https://ftp.NetBSD.org http://ftp.fr.NetBSD.org; do
+              PKG_PATH="$base/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
+              export PKG_PATH
+              if pkg_add autoconf automake libtool gmake; then break; fi
+            done
+            for t in autoconf automake libtool gmake; do command -v "$t"; done
           run: |
             set -e -u -x
             ./autogen.sh

--- a/.github/workflows/CI-netbsd.yml
+++ b/.github/workflows/CI-netbsd.yml
@@ -23,21 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build
-        uses: vmactions/netbsd-vm@6334c835de4c04a59fe59f0f8f071e02a2f0bab3 # v1.4.7
+        uses: vmactions/netbsd-vm@07366ff288a2661e3998b69c5d48eda270050635 # v1.4.8
         with:
           copyback: false
           cache-after-prepare: true
           prepare: |
-            # The image's default PKG_PATH falls back to a 9.0 package set,
-            # so point it at the running release.  The NetBSD.org package
-            # hosts have outages (cdn and ftp were down together on
-            # 2026-08-30), so fall back to the official French mirror,
-            # which is http-only.
-            for base in https://cdn.NetBSD.org https://ftp.NetBSD.org http://ftp.fr.NetBSD.org; do
-              PKG_PATH="$base/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
-              export PKG_PATH
-              if pkg_add autoconf automake libtool gmake; then break; fi
-            done
+            # netbsd-vm v1.4.8 probes the package mirrors at VM start and
+            # points pkg_add at the live ones, so no PKG_PATH juggling is
+            # needed here.
+            pkg_add autoconf automake libtool gmake
             for t in autoconf automake libtool gmake; do command -v "$t"; done
           run: |
             set -e -u -x

--- a/.github/workflows/CI-openbsd.yml
+++ b/.github/workflows/CI-openbsd.yml
@@ -26,6 +26,7 @@ jobs:
         uses: vmactions/openbsd-vm@86cdc08415d9d0865267e686561e276c52d62530 # v1.4.7
         with:
           copyback: false
+          cache-after-prepare: true
           # A bare "pkg_add autoconf" prints an "Ambiguous: ..." list and
           # still exits 0 without installing anything, so pin the branches.
           prepare: pkg_add -I autoconf%2.72 automake%1.18 libtool gmake

--- a/.github/workflows/CI-openbsd.yml
+++ b/.github/workflows/CI-openbsd.yml
@@ -1,0 +1,40 @@
+name: CI-openbsd
+
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!src/win/**'
+      - '!.**'
+      - '.github/workflows/CI-openbsd.yml'
+  push:
+    branches:
+      - v[0-9].*
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-openbsd:
+    runs-on: ubuntu-24.04
+    name: Build on OpenBSD
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build
+        uses: vmactions/openbsd-vm@86cdc08415d9d0865267e686561e276c52d62530 # v1.4.7
+        with:
+          copyback: false
+          # A bare "pkg_add autoconf" prints an "Ambiguous: ..." list and
+          # still exits 0 without installing anything, so pin the branches.
+          prepare: pkg_add -I autoconf%2.72 automake%1.18 libtool gmake
+          run: |
+            set -e -u -x
+            export AUTOCONF_VERSION=2.72
+            export AUTOMAKE_VERSION=1.18
+            ./autogen.sh
+            mkdir build
+            cd build
+            ../configure
+            gmake -j2


### PR DESCRIPTION
FreeBSD is Tier 2 in SUPPORTED_PLATFORMS.md -- "Officially supported,
but not necessarily tested with CI" -- and there is no BSD job today.
What a commit carries now is Linux, macOS, Windows, Android, the qemu
cross builds, the sanitizers and Solaris.

The build has broken unnoticed and been reported from the outside
afterwards more than once: #4734, #4794, #4864.

This adds one workflow, modelled on CI-solaris.yml: same on: block,
permissions: read-all, actions pinned to commit SHAs.  It builds in a
FreeBSD VM on ubuntu-24.04, over both branches FreeBSD currently
supports, 14.x and 15.x.  The release input is the major only, so the
newest release of each branch keeps being picked up without editing
this file.

Green on a fork, about a minute per job:

    https://github.com/neilpang/libuv/actions/runs/32929792861

    Build on FreeBSD 14   release 14 -> 14.4   36 CC, 1 CCLD, libuv.la
    Build on FreeBSD 15   release 15 -> 15.1   36 CC, 1 CCLD, libuv.la

Build only, no gmake check.  The suite does not pass on FreeBSD today
-- 444 ok, 28 not ok -- and 25 of those failures are uv_pipe_bind()
returning EINVAL, which is #5134.  Running the tests makes sense once
that lands.

Only autoconf, automake, libtool and gmake are installed: autogen.sh
needs nothing else, and the source arrives by rsync, so git is not
needed inside the VM.
