### PR TITLE
deliver ICMP errors to windows callbacks when UV_UDP_RECVERR is set

### DIFF
--- a/docs/src/udp.rst
+++ b/docs/src/udp.rst
@@ -56,13 +56,24 @@ Data types
              */
             UV_UDP_MMSG_FREE = 16,
             /*
-             * Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
-             * This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
-             * Linux. This stops the Linux kernel from suppressing some ICMP error messages
-             * and enables full ICMP error reporting for faster failover.
-             * This flag is no-op on platforms other than Linux.
+             * Indicates that ICMP errors should be reported to the receive callback,
+             * which receives them as a negative nread with UV_UDP_RECVERR set in flags.
+             *
+             * On Linux this sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP
+             * sockets when binding the handle. This stops the Linux kernel from
+             * suppressing some ICMP error messages and enables full ICMP error reporting
+             * for faster failover.
+             *
+             * On Windows this stops WSAECONNRESET and WSAENETRESET, which the OS reports
+             * on a receive when a preceding send elicited an ICMP error, from being
+             * discarded. Unlike a genuine receive error these do not stop the handle from
+             * receiving, since the socket remains usable.
+             *
+             * This flag is a no-op on other platforms.
              */
-            UV_UDP_LINUX_RECVERR = 32,
+            UV_UDP_RECVERR = 32,
+            /* Alias for UV_UDP_RECVERR, which is no longer Linux-only. */
+            UV_UDP_LINUX_RECVERR = UV_UDP_RECVERR,
             /*
              * Indicates if SO_REUSEPORT will be set when binding the handle.
              * This sets the SO_REUSEPORT socket option on supported platforms.
@@ -228,6 +239,10 @@ API
     :returns: 0 on success, or an error code < 0 on failure.
 
     .. versionchanged:: 1.49.0 added the ``UV_UDP_REUSEPORT`` flag.
+
+    .. versionchanged:: 1.53.0 ``UV_UDP_RECVERR`` was added as a platform-neutral
+        name for ``UV_UDP_LINUX_RECVERR``, and now also reports ICMP errors on
+        Windows, where they used to be discarded.
 
     .. note::
         ``UV_UDP_REUSEPORT`` flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,

--- a/include/uv.h
+++ b/include/uv.h
@@ -700,13 +700,24 @@ enum uv_udp_flags {
    */
   UV_UDP_MMSG_FREE = 16,
   /*
-   * Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
-   * This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
-   * Linux. This stops the Linux kernel from suppressing some ICMP error
-   * messages and enables full ICMP error reporting for faster failover.
-   * This flag is no-op on platforms other than Linux.
+   * Indicates that ICMP errors should be reported to the receive callback,
+   * which receives them as a negative nread with UV_UDP_RECVERR set in flags.
+   *
+   * On Linux this sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP
+   * sockets when binding the handle. This stops the Linux kernel from
+   * suppressing some ICMP error messages and enables full ICMP error reporting
+   * for faster failover.
+   *
+   * On Windows this stops WSAECONNRESET and WSAENETRESET, which the OS reports
+   * on a receive when a preceding send elicited an ICMP error, from being
+   * discarded. Unlike a genuine receive error these do not stop the handle from
+   * receiving, since the socket remains usable.
+   *
+   * This flag is a no-op on other platforms.
    */
-  UV_UDP_LINUX_RECVERR = 32,
+  UV_UDP_RECVERR = 32,
+  /* Alias for UV_UDP_RECVERR, which is no longer Linux-only. */
+  UV_UDP_LINUX_RECVERR = UV_UDP_RECVERR,
   /*
    * Indicates if SO_REUSEPORT will be set when binding the handle.
    * This sets the SO_REUSEPORT socket option on supported platforms.

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -159,8 +159,11 @@ static int uv__udp_recvmsg_errqueue(uv_udp_t* handle,
       serr = (struct sock_extended_err*) CMSG_DATA(cmsg);
 
       offender = SO_EE_OFFENDER(serr);
+      /* ee_errno is a __u32; negate it as a signed int so that nread reaches
+       * the callback as a negative error code instead of a huge positive
+       * number. */
       handle->recv_cb(handle,
-                      UV__ERR(serr->ee_errno),
+                      UV__ERR((int) serr->ee_errno),
                       buf,
                       offender,
                       flags);

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -110,6 +110,7 @@ enum {
   UV_HANDLE_UDP_PROCESSING              = 0x01000000,
   UV_HANDLE_UDP_CONNECTED               = 0x02000000,
   UV_HANDLE_UDP_RECVMMSG                = 0x04000000,
+  UV_HANDLE_UDP_RECVERR                 = 0x08000000,
 
   /* Only used by uv_pipe_t handles. */
   UV_HANDLE_NON_OVERLAPPED_PIPE         = 0x01000000,

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -234,6 +234,9 @@ static int uv__udp_maybe_bind(uv_udp_t* handle,
     }
   }
 
+  if (flags & UV_UDP_RECVERR)
+    handle->flags |= UV_HANDLE_UDP_RECVERR;
+
   if (addr->sa_family == AF_INET6)
     handle->flags |= UV_HANDLE_IPV6;
 
@@ -412,11 +415,23 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
       /* Not a real error, it just indicates that the received packet was
        * bigger than the receive buffer. */
     } else if (err == WSAECONNRESET || err == WSAENETRESET) {
-      /* A previous sendto operation failed; ignore this error. If zero-reading
-       * we need to call WSARecv/WSARecvFrom _without_ the. MSG_PEEK flag to
-       * clear out the error queue. For nonzero reads, immediately queue a new
+      /* A previous sendto operation failed. It is only reported to the user if
+       * they asked for ICMP errors with UV_UDP_RECVERR, and it does not stop
+       * the handle from reading: unlike a genuine receive error, the socket
+       * remains usable. If zero-reading we need to call WSARecv/WSARecvFrom
+       * _without_ the. MSG_PEEK flag to clear out the error queue, which
+       * reports the error below. For nonzero reads, immediately queue a new
        * receive. */
       if (!(handle->flags & UV_HANDLE_ZERO_READ)) {
+        if ((handle->flags & UV_HANDLE_UDP_RECVERR) &&
+            (handle->flags & UV_HANDLE_READING)) {
+          buf = handle->recv_buffer;
+          handle->recv_cb(handle,
+                          uv_translate_sys_error(err),
+                          &buf,
+                          NULL,
+                          UV_UDP_RECVERR);
+        }
         goto done;
       }
     } else {
@@ -490,10 +505,19 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
           /* Kernel buffer empty */
           handle->recv_cb(handle, 0, &buf, NULL, 0);
         } else if (err == WSAECONNRESET || err == WSAENETRESET) {
-          /* WSAECONNRESET/WSANETRESET is ignored because this just indicates
-           * that a previous sendto operation failed.
+          /* WSAECONNRESET/WSAENETRESET just indicates that a previous sendto
+           * operation failed, so it is only reported to the user if they asked
+           * for ICMP errors with UV_UDP_RECVERR. Either way the handle keeps
+           * reading, because the socket itself is still usable.
            */
-          handle->recv_cb(handle, 0, &buf, NULL, 0);
+          if (handle->flags & UV_HANDLE_UDP_RECVERR)
+            handle->recv_cb(handle,
+                            uv_translate_sys_error(err),
+                            &buf,
+                            NULL,
+                            UV_UDP_RECVERR);
+          else
+            handle->recv_cb(handle, 0, &buf, NULL, 0);
         } else {
           /* Any other error that we want to report back to the user. */
           uv_udp_recv_stop(handle);

--- a/test/test-udp-recv-cb-close-pollerr.c
+++ b/test/test-udp-recv-cb-close-pollerr.c
@@ -49,10 +49,16 @@ static void send_cb(uv_udp_send_t* req, int status) {
   uv_close((uv_handle_t*) req->handle, NULL);
 }
 
-/* Refs: https://github.com/libuv/libuv/issues/5030 */
+/* Both tests connect the socket, which is what lets macOS take part: it
+ * reports ICMP errors on connected UDP sockets natively, as a plain
+ * ECONNREFUSED with no flag set and no UV_UDP_RECVERR involved. Unconnected
+ * sockets there report nothing, which is why the errqueue test next door
+ * stays Linux- and Windows-only.
+ *
+ * Refs: https://github.com/libuv/libuv/issues/5030 */
 TEST_IMPL(udp_recv_cb_close_pollerr) {
-#if !defined(__linux__) && !defined(_WIN32)
-  RETURN_SKIP("ICMP error handling is Linux- and Windows-specific");
+#if !defined(__linux__) && !defined(_WIN32) && !defined(__APPLE__)
+  RETURN_SKIP("ICMP error reporting for UDP is platform-specific");
 #endif
   struct sockaddr_in any_addr;
   struct sockaddr_in addr;
@@ -85,8 +91,8 @@ TEST_IMPL(udp_recv_cb_close_pollerr) {
  * The ICMP POLLERR still fires on the fd; uv__udp_io must not crash when
  * no recv/alloc callback is installed. */
 TEST_IMPL(udp_send_pollerr_no_recv) {
-#if !defined(__linux__) && !defined(_WIN32)
-  RETURN_SKIP("ICMP error handling is Linux- and Windows-specific");
+#if !defined(__linux__) && !defined(_WIN32) && !defined(__APPLE__)
+  RETURN_SKIP("ICMP error reporting for UDP is platform-specific");
 #endif
   struct sockaddr_in any_addr;
   struct sockaddr_in addr;

--- a/test/test-udp-recv-cb-close-pollerr.c
+++ b/test/test-udp-recv-cb-close-pollerr.c
@@ -28,9 +28,10 @@ static int recv_cb_called;
 static int send_cb_called;
 
 static void alloc_cb(uv_handle_t* handle, size_t sz, uv_buf_t* buf) {
+  static char storage[2];
   alloc_cb_called++;
-  buf->base = "uv";
-  buf->len = 2;
+  buf->base = storage;
+  buf->len = sizeof(storage);
 }
 
 static void recv_cb(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
@@ -50,8 +51,8 @@ static void send_cb(uv_udp_send_t* req, int status) {
 
 /* Refs: https://github.com/libuv/libuv/issues/5030 */
 TEST_IMPL(udp_recv_cb_close_pollerr) {
-#ifndef __linux__
-  RETURN_SKIP("ICMP error handling is Linux-specific");
+#if !defined(__linux__) && !defined(_WIN32)
+  RETURN_SKIP("ICMP error handling is Linux- and Windows-specific");
 #endif
   struct sockaddr_in any_addr;
   struct sockaddr_in addr;
@@ -61,7 +62,7 @@ TEST_IMPL(udp_recv_cb_close_pollerr) {
 
   ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &any_addr));
   ASSERT_OK(uv_udp_bind(&client, (const struct sockaddr*) &any_addr,
-                        UV_UDP_LINUX_RECVERR));
+                        UV_UDP_RECVERR));
 
   ASSERT_OK(uv_ip4_addr("127.0.0.1", 9999, &addr));
   ASSERT_OK(uv_udp_connect(&client, (const struct sockaddr*) &addr));
@@ -84,8 +85,8 @@ TEST_IMPL(udp_recv_cb_close_pollerr) {
  * The ICMP POLLERR still fires on the fd; uv__udp_io must not crash when
  * no recv/alloc callback is installed. */
 TEST_IMPL(udp_send_pollerr_no_recv) {
-#ifndef __linux__
-  RETURN_SKIP("ICMP error handling is Linux-specific");
+#if !defined(__linux__) && !defined(_WIN32)
+  RETURN_SKIP("ICMP error handling is Linux- and Windows-specific");
 #endif
   struct sockaddr_in any_addr;
   struct sockaddr_in addr;
@@ -95,7 +96,7 @@ TEST_IMPL(udp_send_pollerr_no_recv) {
 
   ASSERT_OK(uv_ip4_addr("0.0.0.0", 0, &any_addr));
   ASSERT_OK(uv_udp_bind(&client, (const struct sockaddr*) &any_addr,
-                        UV_UDP_LINUX_RECVERR));
+                        UV_UDP_RECVERR));
 
   ASSERT_OK(uv_ip4_addr("127.0.0.1", 9999, &addr));
   ASSERT_OK(uv_udp_connect(&client, (const struct sockaddr*) &addr));

--- a/test/test-udp-recvmsg-unreachable-error.c
+++ b/test/test-udp-recvmsg-unreachable-error.c
@@ -30,9 +30,12 @@
 #define RECV_CB_MAX_CALL 3 /* ECONNREFUSED, EAGAIN/EWOULDBLOCK, ICMP delivery */
 
 static int recv_cb_called = 0;
+static int recverr_cb_called = 0;
 
 static void udp_send_cb(uv_udp_send_t* req, int status) {
-  ASSERT_EQ(status, 0);
+  /* Windows reports the ICMP error as ECONNRESET, and on the send when it is
+   * the send that runs into it first. */
+  ASSERT(status == 0 || status == UV_ECONNRESET);
 }
 
 static void alloc_cb(uv_handle_t* handle,
@@ -48,8 +51,14 @@ static void read_cb(uv_udp_t* handle,
                     const uv_buf_t* buf,
                     const struct sockaddr* addr,
                     unsigned flags) {
-  ASSERT(flags == 0 || (flags & UV_UDP_LINUX_RECVERR));
   recv_cb_called++;
+  /* Errors also reach us without UV_UDP_RECVERR: with IP_RECVERR set, a plain
+   * recvmsg reports the pending socket error too. Only the errqueue delivery
+   * carries the flag. */
+  if (flags & UV_UDP_RECVERR) {
+    ASSERT_LT(nread, 0);
+    recverr_cb_called++;
+  }
 }
 
 static void timer_cb(uv_timer_t* handle) {
@@ -58,8 +67,8 @@ static void timer_cb(uv_timer_t* handle) {
 }
 
 TEST_IMPL(udp_recvmsg_unreachable_error) {
-#if !defined(__linux__)
-  RETURN_SKIP("This test is Linux-specific");
+#if !defined(__linux__) && !defined(_WIN32)
+  RETURN_SKIP("ICMP error reporting is Linux- and Windows-specific");
 #endif
   struct sockaddr_in server_addr, client_addr;
   uv_udp_t client;
@@ -72,7 +81,7 @@ TEST_IMPL(udp_recvmsg_unreachable_error) {
   ASSERT_OK(uv_timer_init(uv_default_loop(), &timer));
   ASSERT_OK(uv_udp_bind(&client,
                         (const struct sockaddr*) &client_addr,
-                        UV_UDP_LINUX_RECVERR));
+                        UV_UDP_RECVERR));
   ASSERT_OK(uv_udp_recv_start(&client, alloc_cb, read_cb));
   timer.data = &client;
   ASSERT_OK(uv_timer_start(&timer, timer_cb, 3000, 0));
@@ -83,15 +92,20 @@ TEST_IMPL(udp_recvmsg_unreachable_error) {
                         (const struct sockaddr*) &server_addr,
                         udp_send_cb));
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  ASSERT_GE(recverr_cb_called, 1);
+#ifdef __linux__
+  /* Windows makes no such promise: the zero-read drain loop delivers once
+   * and re-queues. */
   ASSERT_EQ(recv_cb_called, RECV_CB_MAX_CALL);
+#endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;
 }
 
 TEST_IMPL(udp_recvmsg_unreachable_error6) {
-#if !defined(__linux__)
-  RETURN_SKIP("This test is Linux-specific");
+#if !defined(__linux__) && !defined(_WIN32)
+  RETURN_SKIP("ICMP error reporting is Linux- and Windows-specific");
 #endif
   if (!can_ipv6())
     RETURN_SKIP("IPv6 not supported");
@@ -110,7 +124,7 @@ TEST_IMPL(udp_recvmsg_unreachable_error6) {
 
   ASSERT_OK(uv_udp_bind(&client,
                         (const struct sockaddr*) &client_addr,
-                        UV_UDP_LINUX_RECVERR));
+                        UV_UDP_RECVERR));
   ASSERT_OK(uv_udp_recv_start(&client, alloc_cb, read_cb));
 
   timer.data = &client;
@@ -125,7 +139,12 @@ TEST_IMPL(udp_recvmsg_unreachable_error6) {
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
+  ASSERT_GE(recverr_cb_called, 1);
+#ifdef __linux__
+  /* Windows makes no such promise: the zero-read drain loop delivers once
+   * and re-queues. */
   ASSERT_EQ(recv_cb_called, RECV_CB_MAX_CALL);
+#endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
   return 0;

--- a/test/test-udp-recvmsg-unreachable-error.c
+++ b/test/test-udp-recvmsg-unreachable-error.c
@@ -104,9 +104,13 @@ TEST_IMPL(udp_recvmsg_unreachable_error) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
   ASSERT_GE(recverr_cb_called, 1);
 #ifdef __linux__
-  /* Windows makes no such promise: the zero-read drain loop delivers once
-   * and re-queues. */
   ASSERT_EQ(recv_cb_called, RECV_CB_MAX_CALL);
+#else
+  /* Windows makes no such promise. The zero-read completes with
+   * WSAECONNRESET, the drain loop delivers it once and then exits on
+   * err != ERROR_SUCCESS, and the re-queued zero-read finds nothing. */
+  ASSERT_EQ(recv_cb_called, 1);
+  ASSERT_EQ(recverr_cb_called, 1);
 #endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());
@@ -151,9 +155,13 @@ TEST_IMPL(udp_recvmsg_unreachable_error6) {
 
   ASSERT_GE(recverr_cb_called, 1);
 #ifdef __linux__
-  /* Windows makes no such promise: the zero-read drain loop delivers once
-   * and re-queues. */
   ASSERT_EQ(recv_cb_called, RECV_CB_MAX_CALL);
+#else
+  /* Windows makes no such promise. The zero-read completes with
+   * WSAECONNRESET, the drain loop delivers it once and then exits on
+   * err != ERROR_SUCCESS, and the re-queued zero-read finds nothing. */
+  ASSERT_EQ(recv_cb_called, 1);
+  ASSERT_EQ(recverr_cb_called, 1);
 #endif
 
   MAKE_VALGRIND_HAPPY(uv_default_loop());

--- a/test/test-udp-recvmsg-unreachable-error.c
+++ b/test/test-udp-recvmsg-unreachable-error.c
@@ -56,7 +56,17 @@ static void read_cb(uv_udp_t* handle,
    * recvmsg reports the pending socket error too. Only the errqueue delivery
    * carries the flag. */
   if (flags & UV_UDP_RECVERR) {
+#ifdef _WIN32
+    /* uv_translate_sys_error() maps the WSAECONNRESET the OS reports for the
+     * ICMP error, so the exact value is libuv's to get right. */
+    ASSERT_EQ(nread, UV_ECONNRESET);
+#else
+    /* Only the sign. ee_errno is numbered for the running kernel rather than
+     * for the target libuv was built for, and the two disagree under
+     * qemu-user: on MIPS the host sends 111, where the target's ECONNREFUSED
+     * is 146 and 111 is not assigned at all. */
     ASSERT_LT(nread, 0);
+#endif
     recverr_cb_called++;
   }
 }

--- a/test/test-udp-send-unreachable.c
+++ b/test/test-udp-send-unreachable.c
@@ -69,7 +69,9 @@ static void send_cb(uv_udp_send_t* req, int status) {
 
 static void send_cb_recverr(uv_udp_send_t* req, int status) {
   ASSERT_PTR_NE(req, NULL);
-  ASSERT(status == 0 || status == UV_ECONNREFUSED);
+  /* Windows reports the ICMP error as ECONNRESET, and on a send when it is the
+   * send that runs into it first. */
+  ASSERT(status == 0 || status == UV_ECONNREFUSED || status == UV_ECONNRESET);
   CHECK_HANDLE(req->handle);
   send_cb_called++;
 }
@@ -84,7 +86,7 @@ static void recv_cb(uv_udp_t* handle,
 
   if (nread < 0) {
     if (flags && can_recverr)
-      ASSERT(flags & UV_UDP_LINUX_RECVERR);
+      ASSERT(flags & UV_UDP_RECVERR);
     else
       ASSERT(0 && "unexpected error");
   } else if (nread == 0) {
@@ -114,7 +116,7 @@ TEST_IMPL(udp_send_unreachable) {
   uv_buf_t buf;
   int r;
 
-#ifdef __linux__
+#if defined(__linux__) || defined(_WIN32)
   can_recverr = 1;
 #endif
 
@@ -164,7 +166,7 @@ TEST_IMPL(udp_send_unreachable) {
 
     r = uv_udp_bind(&client2,
                     (const struct sockaddr*) &addr3,
-                    UV_UDP_LINUX_RECVERR);
+                    UV_UDP_RECVERR);
     ASSERT_OK(r);
 
     r = uv_udp_recv_start(&client2, alloc_cb, recv_cb);


### PR DESCRIPTION
Fixes #5242 