### PR TITLE
win: cache Windows version check

### DIFF
--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -52,20 +52,34 @@ static int uv__tcp_nodelay(uv_tcp_t* handle, SOCKET socket, int enable) {
 /*
  * Check if Windows version is 10.0.16299 (Windows 10, version 1709) or later.
  */
-static int uv__windows10_version1709(void) {
+static uv_once_t uv__windows10_version1709_once = UV_ONCE_INIT;
+static int uv__windows10_version1709_result;
+
+
+static void uv__windows10_version1709_init(void) {
   OSVERSIONINFOW os_info;
+
   if (!pRtlGetVersion)
-    return 0;
+    return;
+
   os_info.dwOSVersionInfoSize = sizeof(os_info);
   os_info.szCSDVersion[0] = L'\0';
-  pRtlGetVersion(&os_info);
+
+  if (pRtlGetVersion(&os_info) != STATUS_SUCCESS)
+    abort();
+
   if (os_info.dwMajorVersion < 10)
-    return 0;
-  if (os_info.dwMajorVersion > 10)
-    return 1;
-  if (os_info.dwMinorVersion > 0)
-    return 1;
-  return os_info.dwBuildNumber >= 16299;
+    return;
+
+  uv__windows10_version1709_result = os_info.dwMajorVersion > 10 ||
+                                       os_info.dwMinorVersion > 0 ||
+                                       os_info.dwBuildNumber >= 16299;
+}
+
+
+static int uv__windows10_version1709(void) {
+  uv_once(&uv__windows10_version1709_once, uv__windows10_version1709_init);
+  return uv__windows10_version1709_result;
 }
 
 


### PR DESCRIPTION
Cache the Windows 10 version probe with `uv_once` so TCP connect and keepalive paths call `RtlGetVersion` only once per process.

Abort if `RtlGetVersion` returns an unexpected status instead of trusting the output structure.

Tests:

- Debug and Release, shared and static: `uv_run_tests[_a].exe tcp_flags`

Fixes: https://github.com/libuv/libuv/issues/5235