### PR TITLE
build: distribute Windows long path manifest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,7 +128,8 @@ EXTRA_DIST = test/fixtures/empty_file \
              CONTRIBUTING.md \
              LICENSE \
              LICENSE-extra \
-             README.md
+             README.md \
+             uv_win_longpath.manifest
 
 
 


### PR DESCRIPTION
Include `uv_win_longpath.manifest` in autotools source archives. CMake already references this file for Windows test runners, but `make dist` did not package it.

Verification:

- Before: `make dist` omitted `libuv-1.52.2-dev/uv_win_longpath.manifest`.
- After: the archive contains that path exactly once.
- `make distcheck` passes in a non-root Debian container.

Fixes: https://github.com/libuv/libuv/issues/4206