### PR TITLE
win: remove UV_HANDLE_READING flag

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -1074,13 +1074,8 @@ int uv_read_start(uv_stream_t* stream,
   if (stream->flags & UV_HANDLE_CLOSING)
     return UV_EINVAL;
 
-#ifdef _WIN32
-   if (stream->flags & UV_HANDLE_READING)
-     return UV_EALREADY;
-#else
   if (stream->read_cb != NULL)
     return UV_EALREADY;
-#endif
 
   if (!(stream->flags & UV_HANDLE_READABLE))
     return UV_ENOTCONN;

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -90,8 +90,6 @@ enum {
   UV_HANDLE_SHUT                        = 0x00000200,
   UV_HANDLE_READ_EOF                    = 0x00000800,
 
-  /* Used by streams and UDP handles. */
-  UV_HANDLE_READING                     = 0x00001000,
   UV_HANDLE_BOUND                       = 0x00002000,
   UV_HANDLE_READABLE                    = 0x00004000,
   UV_HANDLE_WRITABLE                    = 0x00008000,

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1111,7 +1111,8 @@ void uv__pipe_interrupt_read(uv_pipe_t* handle) {
 
 
 void uv__pipe_read_stop(uv_pipe_t* handle) {
-  handle->flags &= ~UV_HANDLE_READING;
+  handle->read_cb = NULL;
+  handle->alloc_cb = NULL;
   DECREASE_ACTIVE_COUNT(handle->loop, handle);
   uv__pipe_interrupt_read(handle);
 }
@@ -1227,8 +1228,9 @@ void uv__pipe_close(uv_loop_t* loop, uv_pipe_t* handle) {
   int i;
   HANDLE pipeHandle;
 
-  if (handle->flags & UV_HANDLE_READING) {
-    handle->flags &= ~UV_HANDLE_READING;
+  if (handle->read_cb != NULL) {
+    handle->read_cb = NULL;
+    handle->alloc_cb = NULL;
     DECREASE_ACTIVE_COUNT(loop, handle);
   }
 
@@ -1398,7 +1400,7 @@ int uv__pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb) {
     return WSAEINVAL;
   }
 
-  if (handle->flags & UV_HANDLE_READING) {
+  if (handle->read_cb != NULL) {
     return WSAEISCONN;
   }
 
@@ -1608,7 +1610,7 @@ static void uv__pipe_queue_read(uv_loop_t* loop, uv_pipe_t* handle) {
   uv_read_t* req;
   int result;
 
-  assert(handle->flags & UV_HANDLE_READING);
+  assert(handle->read_cb != NULL);
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
 
   assert(handle->handle != INVALID_HANDLE_VALUE);
@@ -1671,10 +1673,9 @@ int uv__pipe_read_start(uv_pipe_t* handle,
                         uv_read_cb read_cb) {
   uv_loop_t* loop = handle->loop;
 
-  handle->flags |= UV_HANDLE_READING;
-  INCREASE_ACTIVE_COUNT(loop, handle);
   handle->read_cb = read_cb;
   handle->alloc_cb = alloc_cb;
+  INCREASE_ACTIVE_COUNT(loop, handle);
 
   if (handle->read_req.event_handle == NULL) {
     handle->read_req.event_handle = CreateEvent(NULL, 0, 0, NULL);
@@ -2066,25 +2067,31 @@ int uv__pipe_write(uv_loop_t* loop,
 
 static void uv__pipe_read_eof(uv_loop_t* loop, uv_pipe_t* handle,
     uv_buf_t buf) {
+  uv_read_cb read_cb;
+
   /* If there is an eof timer running, we don't need it any more, so discard
    * it. */
   eof_timer_destroy(handle);
 
+  read_cb = handle->read_cb;
   uv_read_stop((uv_stream_t*) handle);
 
-  handle->read_cb((uv_stream_t*) handle, UV_EOF, &buf);
+  read_cb((uv_stream_t*) handle, UV_EOF, &buf);
 }
 
 
 static void uv__pipe_read_error(uv_loop_t* loop, uv_pipe_t* handle, int error,
     uv_buf_t buf) {
+  uv_read_cb read_cb;
+
   /* If there is an eof timer running, we don't need it any more, so discard
    * it. */
   eof_timer_destroy(handle);
 
+  read_cb = handle->read_cb;
   uv_read_stop((uv_stream_t*) handle);
 
-  handle->read_cb((uv_stream_t*)handle, uv_translate_sys_error(error), &buf);
+  read_cb((uv_stream_t*) handle, uv_translate_sys_error(error), &buf);
 }
 
 
@@ -2337,7 +2344,7 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
   /* At this point, we're done with bookkeeping. If the user has stopped
    * reading the pipe in the meantime, there is nothing left to do, since there
    * is no callback that we can call. */
-  if (!(handle->flags & UV_HANDLE_READING))
+  if (handle->read_cb == NULL)
     return;
 
   if (!REQ_SUCCESS(req)) {
@@ -2353,7 +2360,7 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
   } else {
     /* The zero-read completed without error, indicating there is data
      * available in the kernel buffer. */
-    while (handle->flags & UV_HANDLE_READING &&
+    while (handle->read_cb != NULL &&
            !(handle->flags & UV_HANDLE_READ_PENDING)) {
       bytes_requested = 65536;
       /* Depending on the type of pipe, read either IPC frames or raw data. */
@@ -2370,7 +2377,7 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
   }
 
   /* Start another zero-read request if necessary. */
-  if ((handle->flags & UV_HANDLE_READING) &&
+  if (handle->read_cb != NULL &&
       !(handle->flags & UV_HANDLE_READ_PENDING)) {
     uv__pipe_queue_read(loop, handle);
   }

--- a/src/win/stream-inl.h
+++ b/src/win/stream-inl.h
@@ -36,6 +36,8 @@ INLINE static void uv__stream_init(uv_loop_t* loop,
   uv__handle_init(loop, (uv_handle_t*) handle, type);
   handle->write_queue_size = 0;
   handle->activecnt = 0;
+  handle->alloc_cb = NULL;
+  handle->read_cb = NULL;
   handle->stream.conn.shutdown_req = NULL;
   handle->stream.conn.write_reqs_pending = 0;
 

--- a/src/win/stream.c
+++ b/src/win/stream.c
@@ -94,7 +94,7 @@ int uv__read_start(uv_stream_t* handle,
 int uv_read_stop(uv_stream_t* handle) {
   int err;
 
-  if (!(handle->flags & UV_HANDLE_READING))
+  if (handle->read_cb == NULL)
     return 0;
 
   err = 0;
@@ -103,7 +103,8 @@ int uv_read_stop(uv_stream_t* handle) {
   } else if (handle->type == UV_NAMED_PIPE) {
     uv__pipe_read_stop((uv_pipe_t*) handle);
   } else {
-    handle->flags &= ~UV_HANDLE_READING;
+    handle->read_cb = NULL;
+    handle->alloc_cb = NULL;
     DECREASE_ACTIVE_COUNT(handle->loop, handle);
   }
 

--- a/src/win/tcp.c
+++ b/src/win/tcp.c
@@ -542,7 +542,7 @@ static void uv__tcp_queue_read(uv_loop_t* loop, uv_tcp_t* handle) {
   int result;
   DWORD bytes, flags;
 
-  assert(handle->flags & UV_HANDLE_READING);
+  assert(handle->read_cb != NULL);
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
 
   req = &handle->read_req;
@@ -619,7 +619,7 @@ int uv__tcp_listen(uv_tcp_t* handle, int backlog, uv_connection_cb cb) {
     handle->stream.serv.connection_cb = cb;
   }
 
-  if (handle->flags & UV_HANDLE_READING) {
+  if (handle->read_cb != NULL) {
     return WSAEISCONN;
   }
 
@@ -770,7 +770,6 @@ int uv__tcp_read_start(uv_tcp_t* handle, uv_alloc_cb alloc_cb,
     uv_read_cb read_cb) {
   uv_loop_t* loop = handle->loop;
 
-  handle->flags |= UV_HANDLE_READING;
   handle->read_cb = read_cb;
   handle->alloc_cb = alloc_cb;
   INCREASE_ACTIVE_COUNT(loop, handle);
@@ -1032,6 +1031,7 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
     uv_req_t* req) {
   DWORD bytes, flags, err;
   uv_buf_t buf;
+  uv_read_cb read_cb;
   int count;
 
   assert(handle->type == UV_TCP);
@@ -1040,9 +1040,10 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
 
   if (!REQ_SUCCESS(req)) {
     /* An error occurred doing the read. */
-    if ((handle->flags & UV_HANDLE_READING) ||
-        !(handle->flags & UV_HANDLE_ZERO_READ)) {
-      handle->flags &= ~UV_HANDLE_READING;
+    if (handle->read_cb != NULL) {
+      read_cb = handle->read_cb;
+      handle->read_cb = NULL;
+      handle->alloc_cb = NULL;
       DECREASE_ACTIVE_COUNT(loop, handle);
       buf = (handle->flags & UV_HANDLE_ZERO_READ) ?
             uv_buf_init(NULL, 0) : handle->tcp.conn.read_buffer;
@@ -1056,12 +1057,10 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
       }
       handle->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
 
-      handle->read_cb((uv_stream_t*)handle,
-                      uv_translate_sys_error(err),
-                      &buf);
+      read_cb((uv_stream_t*) handle, uv_translate_sys_error(err), &buf);
     }
   } else {
-    if (!(handle->flags & UV_HANDLE_ZERO_READ)) {
+    if (!(handle->flags & UV_HANDLE_ZERO_READ) && handle->read_cb != NULL) {
       /* The read was done with a non-zero buffer length. */
       if (req->u.io.overlapped.InternalHigh > 0) {
         /* Successful read */
@@ -1074,21 +1073,23 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
         }
       } else {
         /* Connection closed */
-        if (handle->flags & UV_HANDLE_READING) {
-          handle->flags &= ~UV_HANDLE_READING;
-          DECREASE_ACTIVE_COUNT(loop, handle);
-        }
+        read_cb = handle->read_cb;
+        handle->read_cb = NULL;
+        handle->alloc_cb = NULL;
+        DECREASE_ACTIVE_COUNT(loop, handle);
 
         buf.base = 0;
         buf.len = 0;
-        handle->read_cb((uv_stream_t*)handle, UV_EOF, &handle->tcp.conn.read_buffer);
+        read_cb((uv_stream_t*) handle,
+                UV_EOF,
+                &handle->tcp.conn.read_buffer);
         goto done;
       }
     }
 
     /* Do nonblocking reads until the buffer is empty */
     count = 32;
-    while ((handle->flags & UV_HANDLE_READING) && (count-- > 0)) {
+    while (handle->read_cb != NULL && (count-- > 0)) {
       buf = uv_buf_init(NULL, 0);
       handle->alloc_cb((uv_handle_t*) handle, 65536, &buf);
       if (buf.base == NULL || buf.len == 0) {
@@ -1116,10 +1117,12 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
           }
         } else {
           /* Connection closed */
-          handle->flags &= ~UV_HANDLE_READING;
+          read_cb = handle->read_cb;
+          handle->read_cb = NULL;
+          handle->alloc_cb = NULL;
           DECREASE_ACTIVE_COUNT(loop, handle);
 
-          handle->read_cb((uv_stream_t*)handle, UV_EOF, &buf);
+          read_cb((uv_stream_t*) handle, UV_EOF, &buf);
           break;
         }
       } else {
@@ -1129,7 +1132,9 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
           handle->read_cb((uv_stream_t*)handle, 0, &buf);
         } else {
           /* Ouch! serious error. */
-          handle->flags &= ~UV_HANDLE_READING;
+          read_cb = handle->read_cb;
+          handle->read_cb = NULL;
+          handle->alloc_cb = NULL;
           DECREASE_ACTIVE_COUNT(loop, handle);
 
           if (err == WSAECONNABORTED) {
@@ -1139,9 +1144,7 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
           }
           handle->flags &= ~(UV_HANDLE_READABLE | UV_HANDLE_WRITABLE);
 
-          handle->read_cb((uv_stream_t*)handle,
-                          uv_translate_sys_error(err),
-                          &buf);
+          read_cb((uv_stream_t*) handle, uv_translate_sys_error(err), &buf);
         }
         break;
       }
@@ -1149,7 +1152,7 @@ void uv__process_tcp_read_req(uv_loop_t* loop, uv_tcp_t* handle,
 
 done:
     /* Post another read if still reading and not closing. */
-    if ((handle->flags & UV_HANDLE_READING) &&
+    if (handle->read_cb != NULL &&
         !(handle->flags & UV_HANDLE_READ_PENDING)) {
       uv__tcp_queue_read(loop, handle);
     }
@@ -1502,7 +1505,7 @@ static void uv__tcp_try_cancel_reqs(uv_tcp_t* tcp) {
 
 void uv__tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
   if (tcp->flags & UV_HANDLE_CONNECTION) {
-    if (tcp->flags & UV_HANDLE_READING) {
+    if (tcp->read_cb != NULL) {
       uv_read_stop((uv_stream_t*) tcp);
     }
     uv__tcp_try_cancel_reqs(tcp);
@@ -1519,7 +1522,7 @@ void uv__tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
         }
       }
     }
-    assert(!(tcp->flags & UV_HANDLE_READING));
+    assert(tcp->read_cb == NULL);
   }
 
   if (tcp->flags & UV_HANDLE_LISTENING) {

--- a/src/win/tty.c
+++ b/src/win/tty.c
@@ -399,7 +399,7 @@ int uv_tty_set_mode(uv_tty_t* tty, uv_tty_mode_t mode) {
   }
 
   /* If currently reading, stop, and restart reading. */
-  if (tty->flags & UV_HANDLE_READING) {
+  if (tty->read_cb != NULL) {
     was_reading = 1;
     alloc_cb = tty->alloc_cb;
     read_cb = tty->read_cb;
@@ -479,7 +479,7 @@ static void uv__tty_queue_read_raw(uv_loop_t* loop, uv_tty_t* handle) {
   uv_read_t* req;
   BOOL r;
 
-  assert(handle->flags & UV_HANDLE_READING);
+  assert(handle->read_cb != NULL);
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
 
   assert(handle->handle && handle->handle != INVALID_HANDLE_VALUE);
@@ -606,7 +606,7 @@ static void uv__tty_queue_read_line(uv_loop_t* loop, uv_tty_t* handle) {
   uv_read_t* req;
   BOOL r;
 
-  assert(handle->flags & UV_HANDLE_READING);
+  assert(handle->read_cb != NULL);
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
   assert(handle->handle && handle->handle != INVALID_HANDLE_VALUE);
 
@@ -724,35 +724,41 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 
   DWORD records_left, records_read;
   uv_buf_t buf;
+  uv_read_cb read_cb;
   _off_t buf_used;
 
   assert(handle->type == UV_TTY);
   assert(handle->flags & UV_HANDLE_TTY_READABLE);
   handle->flags &= ~UV_HANDLE_READ_PENDING;
 
-  if (!(handle->flags & UV_HANDLE_READING) ||
+  if (handle->read_cb == NULL ||
       !(uv__is_raw_tty_mode(handle->tty.rd.mode.mode))) {
     goto out;
   }
 
   if (!REQ_SUCCESS(req)) {
     /* An error occurred while waiting for the event. */
-    if ((handle->flags & UV_HANDLE_READING)) {
-      handle->flags &= ~UV_HANDLE_READING;
-      handle->read_cb((uv_stream_t*)handle,
-                      uv_translate_sys_error(GET_REQ_ERROR(req)),
-                      &uv_null_buf_);
+    if (handle->read_cb != NULL) {
+      read_cb = handle->read_cb;
+      handle->read_cb = NULL;
+      handle->alloc_cb = NULL;
+      DECREASE_ACTIVE_COUNT(loop, handle);
+      read_cb((uv_stream_t*) handle,
+              uv_translate_sys_error(GET_REQ_ERROR(req)),
+              &uv_null_buf_);
     }
     goto out;
   }
 
   /* Fetch the number of events  */
   if (!GetNumberOfConsoleInputEvents(handle->handle, &records_left)) {
-    handle->flags &= ~UV_HANDLE_READING;
+    read_cb = handle->read_cb;
+    handle->read_cb = NULL;
+    handle->alloc_cb = NULL;
     DECREASE_ACTIVE_COUNT(loop, handle);
-    handle->read_cb((uv_stream_t*)handle,
-                    uv_translate_sys_error(GetLastError()),
-                    &uv_null_buf_);
+    read_cb((uv_stream_t*) handle,
+            uv_translate_sys_error(GetLastError()),
+            &uv_null_buf_);
     goto out;
   }
 
@@ -762,18 +768,20 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
   buf_used = 0;
 
   while ((records_left > 0 || handle->tty.rd.last_key_len > 0) &&
-         (handle->flags & UV_HANDLE_READING)) {
+         handle->read_cb != NULL) {
     if (handle->tty.rd.last_key_len == 0) {
       /* Read the next input record */
       if (!ReadConsoleInputW(handle->handle,
                              &handle->tty.rd.last_input_record,
                              1,
                              &records_read)) {
-        handle->flags &= ~UV_HANDLE_READING;
+        read_cb = handle->read_cb;
+        handle->read_cb = NULL;
+        handle->alloc_cb = NULL;
         DECREASE_ACTIVE_COUNT(loop, handle);
-        handle->read_cb((uv_stream_t*) handle,
-                        uv_translate_sys_error(GetLastError()),
-                        &buf);
+        read_cb((uv_stream_t*) handle,
+                uv_translate_sys_error(GetLastError()),
+                &buf);
         goto out;
       }
       records_left--;
@@ -874,11 +882,13 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
         /* If the utf16 character(s) couldn't be converted something must be
          * wrong. */
         if (char_len == 0) {
-          handle->flags &= ~UV_HANDLE_READING;
+          read_cb = handle->read_cb;
+          handle->read_cb = NULL;
+          handle->alloc_cb = NULL;
           DECREASE_ACTIVE_COUNT(loop, handle);
-          handle->read_cb((uv_stream_t*) handle,
-                          uv_translate_sys_error(GetLastError()),
-                          &buf);
+          read_cb((uv_stream_t*) handle,
+                  uv_translate_sys_error(GetLastError()),
+                  &buf);
           goto out;
         }
 
@@ -963,7 +973,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 
  out:
   /* Wait for more input events. */
-  if ((handle->flags & UV_HANDLE_READING) &&
+  if (handle->read_cb != NULL &&
       !(handle->flags & UV_HANDLE_READ_PENDING)) {
     uv__tty_queue_read(loop, handle);
   }
@@ -978,6 +988,7 @@ void uv_process_tty_read_raw_req(uv_loop_t* loop, uv_tty_t* handle,
 void uv_process_tty_read_line_req(uv_loop_t* loop, uv_tty_t* handle,
     uv_req_t* req) {
   uv_buf_t buf;
+  uv_read_cb read_cb;
 
   assert(handle->type == UV_TTY);
   assert(handle->flags & UV_HANDLE_TTY_READABLE);
@@ -989,17 +1000,20 @@ void uv_process_tty_read_line_req(uv_loop_t* loop, uv_tty_t* handle,
 
   if (!REQ_SUCCESS(req)) {
     /* Read was not successful */
-    if (handle->flags & UV_HANDLE_READING) {
+    if (handle->read_cb != NULL) {
       /* Real error */
-      handle->flags &= ~UV_HANDLE_READING;
+      read_cb = handle->read_cb;
+      handle->read_cb = NULL;
+      handle->alloc_cb = NULL;
       DECREASE_ACTIVE_COUNT(loop, handle);
-      handle->read_cb((uv_stream_t*) handle,
-                      uv_translate_sys_error(GET_REQ_ERROR(req)),
-                      &buf);
+      read_cb((uv_stream_t*) handle,
+              uv_translate_sys_error(GET_REQ_ERROR(req)),
+              &buf);
     }
   } else {
     if (!(handle->flags & UV_HANDLE_READ_CANCELLATION_PENDING) &&
-        req->u.io.overlapped.InternalHigh != 0) {
+        req->u.io.overlapped.InternalHigh != 0 &&
+        handle->read_cb != NULL) {
       /* Read successful. TODO: read unicode, convert to utf-8 */
       DWORD bytes = req->u.io.overlapped.InternalHigh;
       handle->read_cb((uv_stream_t*) handle, bytes, &buf);
@@ -1008,7 +1022,7 @@ void uv_process_tty_read_line_req(uv_loop_t* loop, uv_tty_t* handle,
   }
 
   /* Wait for more input events. */
-  if ((handle->flags & UV_HANDLE_READING) &&
+  if (handle->read_cb != NULL &&
       !(handle->flags & UV_HANDLE_READ_PENDING)) {
     uv__tty_queue_read(loop, handle);
   }
@@ -1041,10 +1055,9 @@ int uv__tty_read_start(uv_tty_t* handle, uv_alloc_cb alloc_cb,
     return ERROR_INVALID_PARAMETER;
   }
 
-  handle->flags |= UV_HANDLE_READING;
-  INCREASE_ACTIVE_COUNT(loop, handle);
   handle->read_cb = read_cb;
   handle->alloc_cb = alloc_cb;
+  INCREASE_ACTIVE_COUNT(loop, handle);
 
   /* If reading was stopped and then started again, there could still be a read
    * request pending. */
@@ -1073,7 +1086,8 @@ int uv__tty_read_stop(uv_tty_t* handle) {
   INPUT_RECORD record;
   DWORD written, err;
 
-  handle->flags &= ~UV_HANDLE_READING;
+  handle->read_cb = NULL;
+  handle->alloc_cb = NULL;
   DECREASE_ACTIVE_COUNT(handle->loop, handle);
 
   if (!(handle->flags & UV_HANDLE_READ_PENDING))
@@ -2271,7 +2285,7 @@ void uv__process_tty_write_req(uv_loop_t* loop, uv_tty_t* handle,
 
 void uv__tty_close(uv_tty_t* handle) {
   assert(handle->u.fd == -1 || handle->u.fd > 2);
-  if (handle->flags & UV_HANDLE_READING)
+  if (handle->read_cb != NULL)
     uv__tty_read_stop(handle);
 
   if (handle->u.fd == -1)

--- a/src/win/udp.c
+++ b/src/win/udp.c
@@ -123,6 +123,8 @@ int uv__udp_init_ex(uv_loop_t* loop,
   handle->socket = INVALID_SOCKET;
   handle->reqs_pending = 0;
   handle->activecnt = 0;
+  handle->alloc_cb = NULL;
+  handle->recv_cb = NULL;
   handle->func_wsarecv = WSARecv;
   handle->func_wsarecvfrom = WSARecvFrom;
   handle->send_queue_size = 0;
@@ -268,7 +270,7 @@ static void uv__udp_queue_recv(uv_loop_t* loop, uv_udp_t* handle) {
   DWORD bytes, flags;
   int result;
 
-  assert(handle->flags & UV_HANDLE_READING);
+  assert(handle->recv_cb != NULL);
   assert(!(handle->flags & UV_HANDLE_READ_PENDING));
 
   req = &handle->recv_req;
@@ -312,7 +314,7 @@ int uv__udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb,
   uv_loop_t* loop = handle->loop;
   int err;
 
-  if (handle->flags & UV_HANDLE_READING) {
+  if (handle->recv_cb != NULL) {
     return UV_EALREADY;
   }
 
@@ -323,11 +325,9 @@ int uv__udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb,
   if (err)
     return uv_translate_sys_error(err);
 
-  handle->flags |= UV_HANDLE_READING;
-  INCREASE_ACTIVE_COUNT(loop, handle);
-
   handle->recv_cb = recv_cb;
   handle->alloc_cb = alloc_cb;
+  INCREASE_ACTIVE_COUNT(loop, handle);
 
   /* If reading was stopped and then started again, there could still be a recv
    * request pending. */
@@ -339,8 +339,9 @@ int uv__udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb,
 
 
 int uv__udp_recv_stop(uv_udp_t* handle) {
-  if (handle->flags & UV_HANDLE_READING) {
-    handle->flags &= ~UV_HANDLE_READING;
+  if (handle->recv_cb != NULL) {
+    handle->recv_cb = NULL;
+    handle->alloc_cb = NULL;
     DECREASE_ACTIVE_COUNT(loop, handle);
   }
 
@@ -401,6 +402,7 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
     uv_req_t* req) {
   uv_buf_t buf;
   int partial;
+  uv_udp_recv_cb recv_cb;
 
   assert(handle->type == UV_UDP);
 
@@ -422,17 +424,18 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
     } else {
       /* A real error occurred. Report the error to the user only if we're
        * currently reading. */
-      if (handle->flags & UV_HANDLE_READING) {
+      if (handle->recv_cb != NULL) {
+        recv_cb = handle->recv_cb;
         uv_udp_recv_stop(handle);
         buf = (handle->flags & UV_HANDLE_ZERO_READ) ?
               uv_buf_init(NULL, 0) : handle->recv_buffer;
-        handle->recv_cb(handle, uv_translate_sys_error(err), &buf, NULL, 0);
+        recv_cb(handle, uv_translate_sys_error(err), &buf, NULL, 0);
       }
       goto done;
     }
   }
 
-  if (!(handle->flags & UV_HANDLE_ZERO_READ)) {
+  if (!(handle->flags & UV_HANDLE_ZERO_READ) && handle->recv_cb != NULL) {
     /* Successful read */
     partial = !REQ_SUCCESS(req);
     handle->recv_cb(handle,
@@ -440,7 +443,7 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
                     &handle->recv_buffer,
                     (const struct sockaddr*) &handle->recv_from,
                     partial ? UV_UDP_PARTIAL : 0);
-  } else if (handle->flags & UV_HANDLE_READING) {
+  } else if (handle->recv_cb != NULL) {
     DWORD bytes, err, flags;
     struct sockaddr_storage from;
     int from_len;
@@ -496,21 +499,22 @@ void uv__process_udp_recv_req(uv_loop_t* loop, uv_udp_t* handle,
           handle->recv_cb(handle, 0, &buf, NULL, 0);
         } else {
           /* Any other error that we want to report back to the user. */
+          recv_cb = handle->recv_cb;
           uv_udp_recv_stop(handle);
-          handle->recv_cb(handle, uv_translate_sys_error(err), &buf, NULL, 0);
+          recv_cb(handle, uv_translate_sys_error(err), &buf, NULL, 0);
         }
       }
     }
     while (err == ERROR_SUCCESS &&
            count-- > 0 &&
            /* The recv_cb callback may decide to pause or close the handle. */
-           (handle->flags & UV_HANDLE_READING) &&
+           handle->recv_cb != NULL &&
            !(handle->flags & UV_HANDLE_READ_PENDING));
   }
 
 done:
   /* Post another read if still reading and not closing. */
-  if ((handle->flags & UV_HANDLE_READING) &&
+  if (handle->recv_cb != NULL &&
       !(handle->flags & UV_HANDLE_READ_PENDING)) {
     uv__udp_queue_recv(loop, handle);
   }


### PR DESCRIPTION
## Summary

- remove the remaining Windows uses of UV_HANDLE_READING
- use read_cb and recv_cb as the single source of read/receive state
- initialize and clear callback pointers consistently across TCP, pipes, TTY, and UDP
- clear terminal state before EOF/error callbacks to preserve stop/restart reentrancy and active-handle accounting

Fixes: https://github.com/libuv/libuv/issues/4995

## Tests

- MSVC Debug build, shared and static
- MSVC Release build, shared and static
- 72/72 focused cases across Debug/Release and shared/static, covering TCP read stop/start and errors, EOF restart, UDP receive stop, named-pipe reads/cancellation, and TTY read cancellation
- git diff --check

The aggregate CTest target was not usable in this non-interactive shell because tty_raw and tty_duplicate_vt100_fn_key_winvt wait on console input. The focused TTY cancellation test passes in every build variant, and upstream Windows CI can exercise the interactive console environment.