### PR TITLE
test: lower number of iterations

### DIFF
--- a/test/test-tty.c
+++ b/test/test-tty.c
@@ -524,7 +524,7 @@ TEST_IMPL(tty_pty_partial) {
   /* This test is not 100% deterministic. If the bug it is testing for is
    * present, then it fails about 1 in 3 times, that's why it runs in a loop.
    */
-  for (i = 0; i < 1000; i++) {
+  for (i = 0; i < 50; i++) {
     if (openpty(&master_fd, &slave_fd, NULL, NULL, NULL))
       RETURN_SKIP("No pty available, skipping.");
 


### PR DESCRIPTION
Commit 87493602 ("unix: drain tty reads on POLLHUP without POLLIN") from a few days ago fixed the failure but now it sometimes times out. Lower the number of iterations from 1,000 to 50.

Fixes: https://github.com/libuv/libuv/issues/5247